### PR TITLE
Init script added for nscp on linux

### DIFF
--- a/files/nscp.init
+++ b/files/nscp.init
@@ -38,7 +38,7 @@ case "$1" in
         stop
         ;;
     status)
-	exit 1
+	status $NAME
         ;;
     restart)
         stop


### PR DESCRIPTION
I have a simple system-v style init script for running nscp on linux.

Right now it assumes nscp is installed under /usr/sbin/

This is related to my other pull request which is an rpm spec for nscp
