### PR TITLE
Drop in a .travis build file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 compiler:
   - gcc
-  - clang
 # Change this to your needs
 script: mkdir -p tmp && pushd tmp && cmake .. && make
 before_install:


### PR DESCRIPTION
This file creates hints for the Travis build engine, we can drop it later if we create a reasonable Makefile in the root of the repo, but until then it would be nice to have it here, so we can see right away if build on linux is failing.

You can watch the build here https://travis-ci.org/palli/nscp/jobs/12660659
