### PR TITLE
Add "make test" do travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
 script:
   - mkdir -p tmp
   - pushd tmp
-  - cmake
+  - cmake ..
   - make
 after_success:
   - make test


### PR DESCRIPTION
Since make test now runs successfully with json-spirit, I suggest we have the tests run in travis after the build process.

It would be nice if the nsca tests ran faster, because faster tests mean developers are more willing to actually run them before commit, but right now this is better than nothing.

I notice that check_nrpe_lua is a new one, and the tests for that fail for some reason. However make test still returns status OK. 

I will create a seperate bug report for that.
