### PR TITLE
VS 2010 Build Fixes

### DIFF
--- a/build/python/fetchdeps.py
+++ b/build/python/fetchdeps.py
@@ -193,7 +193,7 @@ class build_instruction:
 					cmd = cmd.replace('$$CMAKE_GENERATOR$$', cmake_generator[msver])
 					print('INFO Running: "%s" as "%s"'%(raw_cmd, cmd))
 					
-					if msver == '2012':
+					if msver == '2012' or msver == '2010':
 						cmd = cmd.replace('.vcproj', '.vcxproj')
 					ret = os.system(cmd)
 					if ret != 0:
@@ -288,9 +288,11 @@ build['protobuf-s'].pre_x64.append('python.exe $$NSCP_SOURCE_ROOT$$/build/python
 
 boost_version = {}
 boost_version['2005'] = "msvc-8.0"
+boost_version['2010'] = "msvc-10.0"
 boost_version['2012'] = "msvc-11.0"
 cmake_generator = {}
 cmake_generator['2005'] = "Visual Studio 8 2005"
+cmake_generator['2010'] = "Visual Studio 10"
 cmake_generator['2012'] = "Visual Studio 11"
 
 post_build['protobuf'] = """Be sure to install protocol buffers python library in your python installation (notice if you have multiple you need to do this for all of them):

--- a/build/python/msdev-to-x.py
+++ b/build/python/msdev-to-x.py
@@ -31,6 +31,10 @@ if sys.argv[1] == "2005":
 elif sys.argv[1] == "2008":
 	target_vc = '9.00'
 	target_sln = '10.00'
+elif sys.argv[1] == "2010":
+	convert_tool = True
+	target_vc = '10.00'
+	target_sln = '11.00'
 elif sys.argv[1] == "2012":
 	convert_tool = True
 	target_vc = '12.00'

--- a/include/charEx.h
+++ b/include/charEx.h
@@ -99,9 +99,9 @@ namespace charEx {
 			throw std::exception();
 		wchar_t *p = wcschr(buffer, split);
 		if (!p)
-			return token(buffer, NULL);
+			return token(buffer, (wchar_t*)NULL);
 		if (!p[1])
-			return token(std::wstring(buffer, p-buffer), NULL);
+			return token(std::wstring(buffer, p-buffer), (wchar_t*)NULL);
 		p++;
 		return token(std::wstring(buffer, p-buffer-1), p);
 	}


### PR DESCRIPTION
I wanted to build NSClient++ with VS 2010, but this wasn't supported by the build scripts (only 2005 or 2012 it seems). With these changes I was able to build the dependencies.

The problems with `include/charEx.h` are maybe not specific to VS 2010, but I think it's a very clear change given the `typedef` of `token`. Here are the errors:
```
4>c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\utility(163): error C2440: 'initializing' : cannot convert from 'int' to 'wchar_t *'
4>          Conversion from integral type to pointer type requires reinterpret_cast, C-style cast or function-style cast
4>          c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\utility(247) : see reference to function template instantiation 'std::_Pair_base<_Ty1,_Ty2>::_Pair_base<wchar_t*&,_Ty>(_Other1,_Other2 &&)' being compiled
4>          with
4>          [
4>              _Ty1=std::wstring,
4>              _Ty2=wchar_t *,
4>              _Ty=int,
4>              _Other1=wchar_t *&,
4>              _Other2=int
4>          ]
4>          C:\Users\Ben\Documents\Code\nscp\include\charEx.h(102) : see reference to function template instantiation 'std::pair<_Ty1,_Ty2>::pair<wchar_t*&,int>(_Other1,_Other2 &&)' being compiled
4>          with
4>          [
4>              _Ty1=std::wstring,
4>              _Ty2=wchar_t *,
4>              _Other1=wchar_t *&,
4>              _Other2=int
4>          ]
4>c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\utility(163): error C2439: 'std::_Pair_base<_Ty1,_Ty2>::second' : member could not be initialized
4>          with
4>          [
4>              _Ty1=std::wstring,
4>              _Ty2=wchar_t *
4>          ]
4>          c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\utility(167) : see declaration of 'std::_Pair_base<_Ty1,_Ty2>::second'
4>          with
4>          [
4>              _Ty1=std::wstring,
4>              _Ty2=wchar_t *
4>          ]
```