### PR TITLE
Dynamic paths for nscp.spec

### DIFF
--- a/nscp.spec.in
+++ b/nscp.spec.in
@@ -58,15 +58,15 @@ getent passwd nsclient >/dev/null || \
 %files
 %defattr(-,root,root,-)
 /lib/systemd/system/nscp.service
-/usr/bin/check_nrpe
-/usr/sbin/nscp
-/usr/sbin/reporter
-/usr/lib/libnscp*
-/usr/lib/libplugin_api*
-/usr/lib/libwhere_filter*
-/usr/lib/nsclient
-%attr(-,nsclient,nsclient) /usr/share/nsclient
-%attr(-,nsclient,nsclient) /etc/nsclient
+%{_bindir}/check_nrpe
+%{_sbindir}/nscp
+%{_sbindir}/reporter
+%{_libdir}/libnscp*
+%{_libdir}/libplugin_api*
+%{_libdir}/libwhere_filter*
+%{_libdir}/nsclient
+%attr(-,nsclient,nsclient) %_datadir/nsclient
+%attr(-,nsclient,nsclient) %{_sysconfdir}/nsclient
 %attr(-,nsclient,nsclient) /var/log/nsclient
 
 %changelog


### PR DESCRIPTION
Just a fly-by commit, since I am not in front of a machine that
can build this rpm package.

Attempting to make destination file in rpm package more dynamic.

This fixes an issue where nsclient gets installed in /usr/lib/
instead of /usr/lib64/ on 64 linux machines.

Please test and give feedback.
