### PR TITLE
Fix typo CRITCAL > CRITICAL

### DIFF
--- a/include/nscapi/nscapi_protobuf_functions.cpp
+++ b/include/nscapi/nscapi_protobuf_functions.cpp
@@ -723,7 +723,7 @@ namespace nscapi {
 			if (ret == NSCAPI::returnWARN)
 				return Plugin::Common_ResultCode_WARNING;
 			if (ret == NSCAPI::returnCRIT)
-				return Plugin::Common_ResultCode_CRITCAL;
+				return Plugin::Common_ResultCode_CRITICAL;
 			return Plugin::Common_ResultCode_UNKNOWN;
 		}
 
@@ -733,7 +733,7 @@ namespace nscapi {
 				return NSCAPI::returnOK;
 			if (ret == Plugin::Common_ResultCode_WARNING)
 				return NSCAPI::returnWARN;
-			if (ret == Plugin::Common_ResultCode_CRITCAL)
+			if (ret == Plugin::Common_ResultCode_CRITICAL)
 				return NSCAPI::returnCRIT;
 			return NSCAPI::returnUNKNOWN;
 		}
@@ -746,7 +746,7 @@ namespace nscapi {
 			if (lcstat == "w" || lcstat == "warn" || lcstat == "warning")
 				return Plugin::Common_ResultCode_WARNING;
 			if (lcstat == "c" || lcstat == "crit" || lcstat == "critical")
-				return Plugin::Common_ResultCode_CRITCAL;
+				return Plugin::Common_ResultCode_CRITICAL;
 			return Plugin::Common_ResultCode_UNKNOWN;
 		}
 

--- a/include/nscapi/nscapi_protobuf_functions.hpp
+++ b/include/nscapi/nscapi_protobuf_functions.hpp
@@ -139,7 +139,7 @@ namespace nscapi {
 				return Plugin::Common_ResultCode_UNKNOWN;
 			}
 			inline Plugin::Common::Status::StatusType gbp_to_nagios_gbp_status(Plugin::Common::ResultCode ret) {
-				if (ret == Plugin::Common_ResultCode_UNKNOWN||ret == Plugin::Common_ResultCode_WARNING||ret == Plugin::Common_ResultCode_CRITCAL)
+				if (ret == Plugin::Common_ResultCode_UNKNOWN||ret == Plugin::Common_ResultCode_WARNING||ret == Plugin::Common_ResultCode_CRITICAL)
 					return Plugin::Common_Status_StatusType_STATUS_ERROR;
 				return Plugin::Common_Status_StatusType_STATUS_OK;
 			}

--- a/include/nscapi/nscapi_settings_filter.cpp
+++ b/include/nscapi/nscapi_settings_filter.cpp
@@ -13,7 +13,7 @@ namespace nscapi {
 				"WARNING FILTER", "If any rows match this filter severity will escalated to WARNING")
 
 				("critical", sh::string_key(&filter_crit),
-				"CRITCAL FILTER", "If any rows match this filter severity will escalated to CRITCAL")
+				"CRITICAL FILTER", "If any rows match this filter severity will escalated to CRITICAL")
 
 				("ok", sh::string_key(&filter_ok),
 				"OK FILTER", "If any rows match this filter severity will escalated down to OK")

--- a/libs/protobuf/plugin.proto
+++ b/libs/protobuf/plugin.proto
@@ -7,7 +7,7 @@ message Common {
 	enum ResultCode {
 		OK		= 0;
 		WARNING	= 1;
-		CRITCAL	= 2;
+		CRITICAL	= 2;
 		UNKNOWN	= 3;
 	};
 	enum DataType {

--- a/libs/protobuf_net/Plugin.cs
+++ b/libs/protobuf_net/Plugin.cs
@@ -654,7 +654,7 @@ namespace Plugin {
       public enum ResultCode {
         OK = 0,
         WARNING = 1,
-        CRITCAL = 2,
+        CRITICAL = 2,
         UNKNOWN = 3,
       }
       

--- a/modules/CheckHelpers/CheckHelpers.cpp
+++ b/modules/CheckHelpers/CheckHelpers.cpp
@@ -62,9 +62,9 @@ void escalate_result(Plugin::QueryResponseMessage::Response * response, ::Plugin
 		response->set_result(result);
 	else if (response->result() == Plugin::Common_ResultCode_WARNING)
 		return;
-	else if (response->result() == Plugin::Common_ResultCode_CRITCAL && result != Plugin::Common_ResultCode_CRITCAL)
+	else if (response->result() == Plugin::Common_ResultCode_CRITICAL && result != Plugin::Common_ResultCode_CRITICAL)
 		response->set_result(result);
-	else if (response->result() == Plugin::Common_ResultCode_CRITCAL)
+	else if (response->result() == Plugin::Common_ResultCode_CRITICAL)
 		return;
 	else if (response->result() == Plugin::Common_ResultCode_UNKNOWN && result != Plugin::Common_ResultCode_UNKNOWN)
 		response->set_result(result);
@@ -73,7 +73,7 @@ void escalate_result(Plugin::QueryResponseMessage::Response * response, ::Plugin
 }
 
 void CheckHelpers::check_critical(const Plugin::QueryRequestMessage::Request &request, Plugin::QueryResponseMessage::Response *response) {
-	check_simple_status(Plugin::Common_ResultCode_CRITCAL, request, response);
+	check_simple_status(Plugin::Common_ResultCode_CRITICAL, request, response);
 }
 void CheckHelpers::check_warning(const Plugin::QueryRequestMessage::Request &request, Plugin::QueryResponseMessage::Response *response) {
 	check_simple_status(Plugin::Common_ResultCode_WARNING, request, response);
@@ -125,7 +125,7 @@ void CheckHelpers::check_change_status(::Plugin::Common_ResultCode status, const
 	response->set_result(status);
 }
 void CheckHelpers::check_always_critical(const Plugin::QueryRequestMessage::Request &request, Plugin::QueryResponseMessage::Response *response) {
-	check_change_status(Plugin::Common_ResultCode_CRITCAL, request, response);
+	check_change_status(Plugin::Common_ResultCode_CRITICAL, request, response);
 }
 void CheckHelpers::check_always_warning(const Plugin::QueryRequestMessage::Request &request, Plugin::QueryResponseMessage::Response *response) {
 	check_change_status(Plugin::Common_ResultCode_WARNING, request, response);
@@ -157,7 +157,7 @@ void CheckHelpers::check_negate(const Plugin::QueryRequestMessage::Request &requ
 	response->CopyFrom(local_response);
 	::Plugin::Common_ResultCode new_o =  ::Plugin::Common_ResultCode_OK;
 	::Plugin::Common_ResultCode new_w =  ::Plugin::Common_ResultCode_WARNING;
-	::Plugin::Common_ResultCode new_c =  ::Plugin::Common_ResultCode_CRITCAL;
+	::Plugin::Common_ResultCode new_c =  ::Plugin::Common_ResultCode_CRITICAL;
 	::Plugin::Common_ResultCode new_u =  ::Plugin::Common_ResultCode_UNKNOWN;
 	
 	if (vm.count("ok"))
@@ -172,7 +172,7 @@ void CheckHelpers::check_negate(const Plugin::QueryRequestMessage::Request &requ
 		response->set_result(new_o);
 	if (response->result() == Plugin::Common_ResultCode_WARNING)
 		response->set_result(new_w);
-	if (response->result() == Plugin::Common_ResultCode_CRITCAL)
+	if (response->result() == Plugin::Common_ResultCode_CRITICAL)
 		response->set_result(new_c);
 	if (response->result() == Plugin::Common_ResultCode_UNKNOWN)
 		response->set_result(new_u);

--- a/modules/CheckNSCP/CheckNSCP.cpp
+++ b/modules/CheckNSCP/CheckNSCP.cpp
@@ -108,14 +108,14 @@ void CheckNSCP::check_nscp(const Plugin::QueryRequestMessage::Request &request, 
 	int crash_count = get_crashes(crashFolder, last);
 	format::append_list(message, strEx::s::xtos(crash_count) + " crash(es)", std::string(", "));
 	if (crash_count > 0){
-		response->set_result(Plugin::Common_ResultCode_CRITCAL);
+		response->set_result(Plugin::Common_ResultCode_CRITICAL);
 		format::append_list(message, std::string("last crash: " + last), std::string(", "));
 	}
 
 	int err_count = get_errors(last);
 	format::append_list(message, strEx::s::xtos(err_count) + " error(s)", std::string(", "));
 	if (err_count > 0) {
-		response->set_result(Plugin::Common_ResultCode_CRITCAL);
+		response->set_result(Plugin::Common_ResultCode_CRITICAL);
 		format::append_list(message, std::string("last error: " + last), std::string(", "));
 	}
 	boost::posix_time::ptime end = boost::posix_time::microsec_clock::local_time();;

--- a/modules/SyslogClient/SyslogClient.cpp
+++ b/modules/SyslogClient/SyslogClient.cpp
@@ -289,7 +289,7 @@ int SyslogClient::clp_handler_impl::submit(client::configuration::data_type data
 			severity = con.ok_severity;
 		if (payload.result() == ::Plugin::Common_ResultCode_WARNING)
 			severity = con.warn_severity;
-		if (payload.result() == ::Plugin::Common_ResultCode_CRITCAL)
+		if (payload.result() == ::Plugin::Common_ResultCode_CRITICAL)
 			severity = con.crit_severity;
 		if (payload.result() == ::Plugin::Common_ResultCode_UNKNOWN)
 			severity = con.unknown_severity;

--- a/web/queries.html
+++ b/web/queries.html
@@ -148,7 +148,7 @@
 											<!-- ko if: $root.result -->
 												<div data-bind="with: $root.result">
 													<hr/>
-													<h4>Result: <span class="label" data-bind="text: result, css: { 'label-success': result=='OK', 'label-danger': ( result=='UNKNOWN' || result=='CRITCAL'), 'label-warning': result=='WARNING' }"></span></h4>
+													<h4>Result: <span class="label" data-bind="text: result, css: { 'label-success': result=='OK', 'label-danger': ( result=='UNKNOWN' || result=='CRITICAL'), 'label-warning': result=='WARNING' }"></span></h4>
 													<pre data-bind="text: message"></pre>
 													<!-- ko if: perf.length > 0 -->
 														<h4>Performance data:</h4>

--- a/web/static/js/nscp.js
+++ b/web/static/js/nscp.js
@@ -4,7 +4,7 @@ function parseNagiosResult(id) {
 	if (id == 1)
 		return "WARNING"
 	if (id == 2)
-		return "CRITCAL"
+		return "CRITICAL"
 	if (id == 3)
 		return "UNKNOWN"
 	return "INVALID(" + id + ")"

--- a/web/static/js/query.js
+++ b/web/static/js/query.js
@@ -84,7 +84,7 @@ function parseNagiosResult(id) {
 	if (id == 1)
 		return "WARNING"
 	if (id == 2)
-		return "CRITCAL"
+		return "CRITICAL"
 	if (id == 3)
 		return "UNKNOWN"
 	return "INVALID(" + id + ")"


### PR DESCRIPTION
I noticed a probelm in CheckNSCP.cpp and CheckHelpers that
sometimes CRITCAL was being returned as a status.

Not sure if it was intentional or not, but I replaced all
occurances.

It looks like some of the source files have old DOS file endings
(^M) instead of unix-friendly linebreaks. My search replace stripped
some of them and I hope that does not cause any damage.

Please check it out and let me know if this was the right thing
to do.
