### PR TITLE
Return result from check_nrpe

### DIFF
--- a/clients/nrpe/check_nrpe.cpp
+++ b/clients/nrpe/check_nrpe.cpp
@@ -21,6 +21,7 @@ int main(int argc, char* argv[]) {
 	std::string tmp = nscapi::protobuf::functions::build_performance_data(response);
 	if (!tmp.empty())
 		std::cout << '|' << tmp;
+	return response.result();
 }
 
 


### PR DESCRIPTION
It seems check_nrpe doesn't return like it should. I had a green critical in Nagios. Maybe I'm the only one with warnings and criticals :)

Without my commit :
```sh
bbigras@ubuntu:~/nscp$ ./check_nrpe host=myhost command=check_os_version
CRITICAL: Windows Server 2003 (5.2.3790)|'version'=52;50;50

bbigras@ubuntu:~/nscp$ echo $?
0
```

With my commit :
```sh
bbigras@ubuntu:~/nscp$ ./check_nrpe host=myhost command=check_os_version
Enter PEM pass phrase:
CRITICAL: Windows Server 2003 (5.2.3790)|'version'=52;50;50

bbigras@ubuntu:~/nscp$ echo $?
2
```