### PR TITLE
changes for issue #86 to #88

### DIFF
--- a/include/pdh/pdh_collectors.hpp
+++ b/include/pdh/pdh_collectors.hpp
@@ -210,13 +210,13 @@ namespace PDH {
 				boost::shared_lock<boost::shared_mutex> lock(mutex_);
 				if (!lock.owns_lock())
 					throw PDH::pdh_exception(get_name(), "Could not get mutex");
-				return values.front();
+				return values.back();
 			}
 			virtual long long get_int_value() {
 				boost::shared_lock<boost::shared_mutex> lock(mutex_);
 				if (!lock.owns_lock())
 					throw PDH::pdh_exception(get_name(), "Could not get mutex");
-				return values.front();
+				return values.back();
 			}
 
 			virtual void update(T value) {

--- a/modules/CheckSystem/CheckSystem.cpp
+++ b/modules/CheckSystem/CheckSystem.cpp
@@ -182,6 +182,7 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
 				counter.set_instances(object.instances);
 				counter.set_buffer_size(object.buffer_size);
 				counter.set_type(object.type);
+				counter.set_flags(object.flags);
 
 				collector->add_counter(counter);
 			} catch (const PDH::pdh_exception &e) {

--- a/modules/CheckSystem/check_pdh.cpp
+++ b/modules/CheckSystem/check_pdh.cpp
@@ -81,6 +81,8 @@ namespace check_pdh {
 			"BUFFER SIZE", "Size of buffer (in seconds) larger buffer use more memory")
 			("type", sh::string_key(&object.type),
 			"COUNTER TYPE", "The type of counter to use long, large and double")
+			("flags", sh::string_key(&object.flags),
+			"FLAGS", "Extra flags to configure the counter (nocap100, 1000, noscale)")
 			;
 
 		object.tpl.read_object(root_path);

--- a/modules/CheckSystem/check_pdh.hpp
+++ b/modules/CheckSystem/check_pdh.hpp
@@ -22,6 +22,7 @@ namespace check_pdh {
 		std::string instances;
 		std::string buffer_size;
 		std::string type;
+		std::string flags;
 
 		// Runtime items
 

--- a/modules/CheckSystem/pdh_thread.cpp
+++ b/modules/CheckSystem/pdh_thread.cpp
@@ -67,6 +67,7 @@ void pdh_thread::thread_proc() {
 				tmpPdh.open();
 				counters_.push_back(instance);
 				lookups_[instance->get_name()] = instance;
+				tmpPdh.close();
 			} catch (const std::exception &e) {
 				NSC_LOG_ERROR_EX("Failed to add counter " + obj.alias + ": ", e);
 				continue;


### PR DESCRIPTION
0.4.3.88 flags property of PDH counter can be specified as check_pdh argumnet, but not in INI
0.4.3.88 PDH counter with rrd buffer will return oldest value from buffer as current/actual value
0.4.3.88 Cannot add second PDH counter to INI