### PR TITLE
Add pct to check_pagefile

### DIFF
--- a/modules/CheckSystem/filter.cpp
+++ b/modules/CheckSystem/filter.cpp
@@ -60,7 +60,7 @@ namespace check_mem_filter {
 			("free", type_custom_free, boost::bind(&filter_obj::get_free, _1), "Free memory in bytes (g,m,k,b) or percentages %")
 			.add_scaled_byte(boost::bind(&get_zero), boost::bind(&filter_obj::get_total, _1))
 			.add_percentage(boost::bind(&filter_obj::get_total, _1), "", " %")
-			
+
 			("used", type_custom_used, boost::bind(&filter_obj::get_used, _1), "Used memory in bytes (g,m,k,b) or percentages %")
 			.add_scaled_byte(boost::bind(&get_zero), boost::bind(&filter_obj::get_total, _1))
 			.add_percentage(boost::bind(&filter_obj::get_total, _1), "", " %")
@@ -117,6 +117,8 @@ namespace check_page_filter {
 			("used", type_custom_used, boost::bind(&filter_obj::get_used, _1), "Used memory in bytes (g,m,k,b) or percentages %")
 			.add_scaled_byte(boost::bind(&get_zero), boost::bind(&filter_obj::get_total, _1))
 			.add_percentage(boost::bind(&filter_obj::get_total, _1), "", " %")
+			("free_pct", boost::bind(&filter_obj::get_free_pct, _1), "% free memory")
+			("used_pct", boost::bind(&filter_obj::get_used_pct, _1), "% used memory")
 			;
 		registry_.add_human_string()
 			("size", boost::bind(&filter_obj::get_total_human, _1), "")

--- a/modules/CheckSystem/filter.hpp
+++ b/modules/CheckSystem/filter.hpp
@@ -51,7 +51,7 @@ namespace check_cpu_filter {
 		}
 	};
 	typedef parsers::where::filter_handler_impl<boost::shared_ptr<filter_obj> > native_context;
-	
+
 	struct filter_obj_handler : public native_context {
 		filter_obj_handler();
 	};
@@ -124,6 +124,12 @@ namespace check_page_filter {
 		}
 		long long get_free() const {
 			return info.size-info.usage;
+		}
+		long long get_used_pct() const {
+			return total==0?0:get_used()*100/total;
+		}
+		long long get_free_pct() const {
+			return total==0?0:get_free()*100/total;
 		}
 		std::string get_name() const {
 			return info.name;

--- a/modules/CheckSystem/filter.hpp
+++ b/modules/CheckSystem/filter.hpp
@@ -126,10 +126,10 @@ namespace check_page_filter {
 			return info.size-info.usage;
 		}
 		long long get_used_pct() const {
-			return total==0?0:get_used()*100/total;
+			return info.size==0?0:get_used()*100/info.size;
 		}
 		long long get_free_pct() const {
-			return total==0?0:get_free()*100/total;
+			return info.size==0?0:get_free()*100/info.size;
 		}
 		std::string get_name() const {
 			return info.name;


### PR DESCRIPTION
This is basically a clone of f90ab0bf which added pct to check_memory.

I had issues building the source on my machine so I'm not sure this will work but I'm hopeful. Even if it doesn't work it is hopefully enough to give an idea of what I'm trying to achieve.

Currently, with check_memory this works well:

```check_memory show-all "filter=type = 'physical'" "detail-syntax=${type} memory: Total: ${size} - Used: ${used} (${used_pct}%) - Free: ${free} (${free_pct}%)"```

```OK: physical memory: Total: 4GB - Used: 1.14GB (28%) - Free: 2.859GB (71%)```

However with check_pagefile it does not:

```check_pagefile show-all "filter=name = 'total'" "detail-syntax=paged memory: Total: ${size} - Used: ${used} (${used_pct}%) - Free: ${free} (${free_pct}%)"```

```UNKNOWN: Invalid syntax: Invalid variable: used_pct```