### PR TITLE
Pull request for Issue #150

### DIFF
--- a/include/socket/socket_helpers.cpp
+++ b/include/socket/socket_helpers.cpp
@@ -186,7 +186,7 @@ void socket_helpers::io::set_result(boost::optional<boost::system::error_code>* 
 void socket_helpers::connection_info::ssl_opts::configure_ssl_context(boost::asio::ssl::context &context, std::list<std::string> &errors) const {
 	boost::system::error_code er;
 	if (!certificate.empty() && certificate != "none") {
-		context.use_certificate_file(certificate, get_certificate_format(), er);
+		context.use_certificate_chain_file(certificate, er);
 		if (er)
 			errors.push_back("Failed to load certificate " + certificate + ": " + utf8::utf8_from_native(er.message()));
 		if (!certificate_key.empty() && certificate_key != "none") {


### PR DESCRIPTION
This fixes #150
Tested and working with `openssl s_client` and modified `check_nrpe` under linux.
Note that this causes only PEM-encoded certificates to be accepted which are the default anyway and there's nothing wrong with converting ASN1 certificates using
`openssl x509 -in infile.der -inform DER -out outfile.pem -outform PEM`