### PR TITLE
external script process stuck

### DIFF
--- a/include/process/execute_process_w32.cpp
+++ b/include/process/execute_process_w32.cpp
@@ -159,6 +159,9 @@ int process::execute_process(process::exec_arguments args, std::string &output) 
 				result = dwexitcode;
 			}
 		}
+		if(dwexitcode == STILL_ACTIVE){
+			TerminateProcess(pi.hProcess, 5);
+		}
 		CloseHandle(pi.hThread);
 		CloseHandle(pi.hProcess);
 		CloseHandle(hChildOutR);


### PR DESCRIPTION
process produce output, but stack on exit. need check this status before exit
example:
[image from server](https://snag.gy/M9cx3Y.jpg)
