### PR TITLE
Alpine/musl compatibility

### DIFF
--- a/build/docker/alpine-3.4/Dockerfile
+++ b/build/docker/alpine-3.4/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine:3.4
+
+RUN mkdir -p /src/nscp
+ADD . /src/nscp/
+
+# fix possibly lost exec bit
+RUN chmod +x /src/nscp/ext/md-protobuf/protoc-gen-md
+
+RUN apk update && \
+    apk add cmake make gcc build-base python py-pip python-dev protobuf-dev openssl-dev boost-dev
+
+# install python dependencies (installing mkdocs and mkdocs-material here will
+# break running make because of "logger Invalid log level: no-std-err" when
+# building the documentation)
+#RUN pip install protobuf jinja2 mkdocs mkdocs-material
+RUN pip install protobuf jinja2
+
+RUN mkdir -p /src/build

--- a/include/nrpe/packet.hpp
+++ b/include/nrpe/packet.hpp
@@ -44,7 +44,7 @@ namespace nrpe {
 		struct packet {
 			int16_t   packet_version;
 			int16_t   packet_type;
-			u_int32_t crc32_value;
+			uint32_t crc32_value;
 			int16_t   result_code;
 		};
 	};
@@ -185,7 +185,7 @@ namespace nrpe {
 				throw nrpe::nrpe_exception("To much data cant create return packet (truncate data)");
 			update_payload(p, payload_);
 			p->crc32_value = 0;
-			crc32_ = p->crc32_value = swap_bytes::hton<u_int32_t>(calculate_crc32(tmpBuffer, packet_length));
+			crc32_ = p->crc32_value = swap_bytes::hton<uint32_t>(calculate_crc32(tmpBuffer, packet_length));
 			return tmpBuffer;
 		}
 
@@ -207,7 +207,7 @@ namespace nrpe {
 			version_ = swap_bytes::ntoh<int16_t>(p->packet_version);
 			if (version_ != nrpe::data::version2)
 				throw nrpe::nrpe_exception("Invalid packet version." + str::xtos(version_));
-			crc32_ = swap_bytes::ntoh<u_int32_t>(p->crc32_value);
+			crc32_ = swap_bytes::ntoh<uint32_t>(p->crc32_value);
 			// Verify CRC32
 			// @todo Fix this, currently we need a const buffer so we cannot change the CRC to 0.
 			char * tb = new char[length + 1];

--- a/include/nrpe/packet.hpp
+++ b/include/nrpe/packet.hpp
@@ -42,10 +42,10 @@ namespace nrpe {
 		static const std::size_t buffer_offset = 10;
 
 		struct packet {
-			int16_t   packet_version;
-			int16_t   packet_type;
+			int16_t  packet_version;
+			int16_t  packet_type;
 			uint32_t crc32_value;
-			int16_t   result_code;
+			int16_t  result_code;
 		};
 	};
 

--- a/include/nsca/nsca_packet.hpp
+++ b/include/nsca/nsca_packet.hpp
@@ -35,15 +35,15 @@ namespace nsca {
 		static const int16_t version3 = 3;
 
 		typedef struct data_packet : public boost::noncopyable {
-			int16_t   packet_version;
+			int16_t  packet_version;
 			uint32_t crc32_value;
 			uint32_t timestamp;
-			int16_t   return_code;
-			char      data[];
+			int16_t  return_code;
+			char     data[];
 			/*
-			char      host_name[];
-			char      svc_description[];
-			char      plugin_output[];
+			char     host_name[];
+			char     svc_description[];
+			char     plugin_output[];
 			*/
 			//data_packet_struct() : packet_version(NSCA_PACKET_VERSION_3) {}
 
@@ -75,7 +75,7 @@ namespace nsca {
 
 		/* initialization packet containing IV and timestamp */
 		typedef struct iv_packet {
-			char      iv[transmitted_iuv_size];
+			char     iv[transmitted_iuv_size];
 			uint32_t timestamp;
 		} init_packet;
 	};

--- a/include/nsca/nsca_packet.hpp
+++ b/include/nsca/nsca_packet.hpp
@@ -36,8 +36,8 @@ namespace nsca {
 
 		typedef struct data_packet : public boost::noncopyable {
 			int16_t   packet_version;
-			u_int32_t crc32_value;
-			u_int32_t timestamp;
+			uint32_t crc32_value;
+			uint32_t timestamp;
 			int16_t   return_code;
 			char      data[];
 			/*
@@ -76,7 +76,7 @@ namespace nsca {
 		/* initialization packet containing IV and timestamp */
 		typedef struct iv_packet {
 			char      iv[transmitted_iuv_size];
-			u_int32_t timestamp;
+			uint32_t timestamp;
 		} init_packet;
 	};
 
@@ -165,15 +165,15 @@ namespace nsca {
 			memcpy(tmp, buffer, buffer_len);
 			nsca::data::data_packet *data = reinterpret_cast<nsca::data::data_packet*>(tmp);
 			//packet_version=swap_bytes::ntoh<int16_t>(data->packet_version);
-			time = swap_bytes::ntoh<u_int32_t>(data->timestamp);
+			time = swap_bytes::ntoh<uint32_t>(data->timestamp);
 			code = swap_bytes::ntoh<int16_t>(data->return_code);
-			//data->crc32_value= swap_bytes::hton<u_int32_t>(0);
+			//data->crc32_value= swap_bytes::hton<uint32_t>(0);
 
 			host = data->get_host_ptr();
 			service = data->get_desc_ptr(nsca::length::host_length);
 			result = data->get_result_ptr(nsca::length::host_length, nsca::length::desc_length);
 
-			unsigned int crc32 = swap_bytes::ntoh<u_int32_t>(data->crc32_value);
+			unsigned int crc32 = swap_bytes::ntoh<uint32_t>(data->crc32_value);
 			data->crc32_value = 0;
 			unsigned int calculated_crc32 = calculate_crc32(tmp, buffer_len);
 			delete[] tmp;
@@ -201,18 +201,18 @@ namespace nsca {
 
 			data->packet_version = swap_bytes::hton<int16_t>(nsca::data::version3);
 			if (servertime != 0)
-				data->timestamp = swap_bytes::hton<u_int32_t>(static_cast<u_int32_t>(servertime));
+				data->timestamp = swap_bytes::hton<uint32_t>(static_cast<uint32_t>(servertime));
 			else
-				data->timestamp = swap_bytes::hton<u_int32_t>(static_cast<u_int32_t>(time));
+				data->timestamp = swap_bytes::hton<uint32_t>(static_cast<uint32_t>(time));
 			data->return_code = swap_bytes::hton<int16_t>(static_cast<int16_t>(code));
-			data->crc32_value = swap_bytes::hton<u_int32_t>(0);
+			data->crc32_value = swap_bytes::hton<uint32_t>(0);
 
 			copy_string(data->get_host_ptr(), host, nsca::length::host_length);
 			copy_string(data->get_desc_ptr(nsca::length::host_length), service, nsca::length::desc_length);
 			copy_string(data->get_result_ptr(nsca::length::host_length, nsca::length::desc_length), result, get_payload_length());
 
 			unsigned int calculated_crc32 = calculate_crc32(buffer.c_str(), static_cast<int>(buffer.size()));
-			data->crc32_value = swap_bytes::hton<u_int32_t>(calculated_crc32);
+			data->crc32_value = swap_bytes::hton<uint32_t>(calculated_crc32);
 		}
 		std::string get_buffer() const {
 			std::string buffer;
@@ -225,20 +225,20 @@ namespace nsca {
 
 	class iv_packet {
 		std::string iv;
-		u_int32_t time;
+		uint32_t time;
 	public:
-		iv_packet(std::string iv, u_int32_t time) : iv(iv), time(time) {}
+		iv_packet(std::string iv, uint32_t time) : iv(iv), time(time) {}
 		iv_packet(std::string iv, boost::posix_time::ptime now) : iv(iv), time(ptime_to_unixtime(now)) {}
 		iv_packet(std::string buffer) {
 			parse(buffer);
 		}
-		u_int32_t ptime_to_unixtime(boost::posix_time::ptime now) {
+		uint32_t ptime_to_unixtime(boost::posix_time::ptime now) {
 			//boost::posix_time::ptime now = boost::posix_time::second_clock::local_time();
 			boost::posix_time::ptime time_t_epoch(boost::gregorian::date(1970, 1, 1));
 			boost::posix_time::time_duration diff = now - time_t_epoch;
 			return diff.total_seconds();
 		}
-		u_int32_t get_time() const {
+		uint32_t get_time() const {
 			return time;
 		}
 		std::string get_iv() const {
@@ -250,7 +250,7 @@ namespace nsca {
 				throw nsca::nsca_exception("Invalid IV size: " + str::xtos(iv.size()) + " != " + str::xtos(nsca::length::iv::get_payload_length()));
 			nsca::data::iv_packet data;
 			memcpy(data.iv, iv.c_str(), iv.size());
-			data.timestamp = swap_bytes::hton<u_int32_t>(time);
+			data.timestamp = swap_bytes::hton<uint32_t>(time);
 			char *src = reinterpret_cast<char*>(&data);
 			std::string buffer(src, nsca::length::iv::get_packet_length());
 			return buffer;
@@ -260,7 +260,7 @@ namespace nsca {
 				throw nsca::nsca_exception("Buffer is to short: " + str::xtos(buffer.length()) + " > " + str::xtos(nsca::length::iv::get_packet_length()));
 			const nsca::data::iv_packet *data = reinterpret_cast<const nsca::data::iv_packet*>(buffer.c_str());
 			iv = std::string(data->iv, nsca::data::transmitted_iuv_size);
-			time = swap_bytes::ntoh<u_int32_t>(data->timestamp);
+			time = swap_bytes::ntoh<uint32_t>(data->timestamp);
 		}
 	};
 }

--- a/include/types.hpp
+++ b/include/types.hpp
@@ -29,7 +29,7 @@ typedef int BOOL;
 #endif
 #ifdef WIN32
 typedef short int16_t;
-typedef unsigned long u_int32_t;
+typedef unsigned long uint32_t;
 #endif
 
 


### PR DESCRIPTION
This PR makes it possible to at least _build_ nscp using Alpine. A few drackbacks still exist though:

* Building the documentation (the last step when running `make`) does not work because of a "logger Invalid log level: no-std-err" error.
* Current Alpine versions with GCC 6 fail to build libcrypto, which limits us to Alpine 3.4 with GCC 5.
* Installing the py-protobuf Alpine package does not make the build work, but manually installing protobuf via pip works as expected.
* Running tests (`make test`) does not work. With Alpine 3.4, it seems to be caused by boost 1.60, with Alpine 3.3 a bunch of

      core Module (PythonScript) was not found: Could not load library: Error relocating /nsclient/nscp-0.5.1-musl-compat/modules/libPythonScript.so: _ZN5boost6python6detail11init_moduleEPKcPFvvE: symbol not found: /nsclient/nscp-0.5.1-musl-compat/modules/libPythonScript.so

  errors are thrown.

Because I could not get the current master to build, this PR is targeted at the 0.5.1 branch.
  
  