### PR TITLE
WEBServer / query.execute / Result as string (OK/WARNING/...)

### DIFF
--- a/modules/WEBServer/query_controller.cpp
+++ b/modules/WEBServer/query_controller.cpp
@@ -149,7 +149,7 @@ void query_controller::execute_query(std::string module, arg_vector args, Mongoo
 	json_spirit::Object node;
 	BOOST_FOREACH(const Plugin::QueryResponseMessage::Response &r, response.payload()) {
 		node["command"] = r.command();
-		node["result"] = r.result();
+		node["result"] = nscapi::plugin_helper::translateReturn(r.result());
 		json_spirit::Array lines;
 		BOOST_FOREACH(const Plugin::QueryResponseMessage::Response::Line &l, r.lines()) {
 			json_spirit::Object line;


### PR DESCRIPTION
With current version, /api/v1/queries/check_xxx/commands/execute returns "result" field as an int (0/1/2/...), whereas /api/v1/queries/check_xxx/commands/execute_nagios returns "result" as a string (OK/WARNING/...), like in legacy API.
This modification makes the behaviour consistent by always returning the string.

Note that I did not test the proposed modification.