### PR TITLE
Add info to enable module first

### DIFF
--- a/docs/docs/reference/windows/CheckWMI.md
+++ b/docs/docs/reference/windows/CheckWMI.md
@@ -3,6 +3,17 @@
 Check status via WMI
 
 
+## Enable module
+
+To enable this module and therefore the `check_wmi` check command, add `CheckWMI = 1` to the `[/modules]` section in nsclient.ini:
+
+```
+[...]
+; Modules
+[/modules]
+CheckWMI = 1
+[...]
+```
 
 
 ## Queries


### PR DESCRIPTION
This additional small note in the documentation should hopefully be helpful for users falling on their nose the first time they want to use `check_wmi` (like me). The additional info clearly states how to enable the module in order to enable the `check_wmi` command.
This should help avoid future questions as in https://forums.nsclient.org/t/unknown-command-s-check-wmi/4604