### PR TITLE
Debian Dockerfile fixes

### DIFF
--- a/build/docker/debian-9/Dockerfile
+++ b/build/docker/debian-9/Dockerfile
@@ -6,16 +6,27 @@ ADD . /nscp/
 
 ARG DEBIAN_FRONTEND=noninteractive
 
+#Debian moved sources to archive, see https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found
+RUN sed -i -e 's/deb.debian.org/archive.debian.org/g' \
+           -e 's|security.debian.org/|archive.debian.org/|g' \
+           -e '/stretch-updates/d' /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y build-essential
 
-RUN apt-get install -y cmake python python-dev libssl-dev libboost-all-dev protobuf-compiler python-protobuf libprotobuf-dev python-sphinx libcrypto++-dev libcrypto++ liblua5.1-0-dev libgtest-dev
+RUN apt-get install -y cmake python python-dev libssl-dev libboost-all-dev protobuf-compiler python-protobuf libprotobuf-dev \
+python-sphinx libcrypto++-dev libcrypto++ liblua5.1-0-dev libgtest-dev
 RUN apt-get install -y git wget dos2unix debhelper dh-virtualenv python-pip zip devscripts 
 
 ENV GH_TOKEN=UPDATE_ME
 
-RUN chmod u+x /nscp/ext/md-protobuf/protoc-gen-md
+#get around Failed loading extension "toc(permalink=true)". 
+#see https://github.com/mkdocs/mkdocs/issues/1640#issue-364121171
+RUN pip install Markdown==2.6.11
+#mkdocs does not support python 2 after 0.16.x
+RUN pip install jinja2 mkdocs==0.16.3 mkdocs-material==1.4.1
 
-RUN pip install jinja2 mkdocs mkdocs-material github3.py
+# pip package wrapt on arm64 fails, lock to older version to get things to install correctly
+RUN apt-get install -y libffi-dev && pip install wrapt==1.12.1 cffi && pip install github3.py
 
 RUN mkdir -p /build
 RUN mkdir -p /packages
@@ -25,4 +36,3 @@ VOLUME /packages
 WORKDIR /build
 
 CMD /nscp/build/sh/build-debian.sh
-

--- a/docs/docs/api/rest/index.md
+++ b/docs/docs/api/rest/index.md
@@ -1,7 +1,7 @@
 # NSClient++ API
 
 NSClient++ provides its own HTTP API which can
-be enabled with the [WEBServer module](../reference/generic/WEBServer.md#WEBServer).
+be enabled with the [WEBServer module](../../reference/generic/WEBServer.md#WEBServer).
 
 The new API is described in separate pages (on per object):
 


### PR DESCRIPTION
Fixed the Dockerfile for Debian 9 to use archive.debian.org for packages.

Updated python packages to use specific versions as using packages with newest versions are broken because python 2.7 is deprecated. Tested on ARM64 and X64 platforms.
