### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/docs/reference/check/CheckExternalScripts.md
+++ b/docs/docs/reference/check/CheckExternalScripts.md
@@ -27,7 +27,7 @@ There is an extensive guide on using external scripts with NSClient++ [here](../
 
 ## Enable module
 
-To enable this module and and allow using the commands you need to ass `CheckExternalScripts = enabled` to the `[/modules]` section in nsclient.ini:
+To enable this module and and allow using the commands you need to add `CheckExternalScripts = enabled` to the `[/modules]` section in nsclient.ini:
 
 ```
 [/modules]

--- a/docs/docs/reference/check/CheckHelpers.md
+++ b/docs/docs/reference/check/CheckHelpers.md
@@ -6,7 +6,7 @@ Various helper function to extend other checks.
 
 ## Enable module
 
-To enable this module and and allow using the commands you need to ass `CheckHelpers = enabled` to the `[/modules]` section in nsclient.ini:
+To enable this module and and allow using the commands you need to add `CheckHelpers = enabled` to the `[/modules]` section in nsclient.ini:
 
 ```
 [/modules]

--- a/docs/docs/reference/check/CheckLogFile.md
+++ b/docs/docs/reference/check/CheckLogFile.md
@@ -6,7 +6,7 @@ File for checking log files and various other forms of updating text files
 
 ## Enable module
 
-To enable this module and and allow using the commands you need to ass `CheckLogFile = enabled` to the `[/modules]` section in nsclient.ini:
+To enable this module and and allow using the commands you need to add `CheckLogFile = enabled` to the `[/modules]` section in nsclient.ini:
 
 ```
 [/modules]

--- a/docs/docs/reference/check/CheckNSCP.md
+++ b/docs/docs/reference/check/CheckNSCP.md
@@ -6,7 +6,7 @@ Use this module to check the health and status of NSClient++ it self
 
 ## Enable module
 
-To enable this module and and allow using the commands you need to ass `CheckNSCP = enabled` to the `[/modules]` section in nsclient.ini:
+To enable this module and and allow using the commands you need to add `CheckNSCP = enabled` to the `[/modules]` section in nsclient.ini:
 
 ```
 [/modules]


### PR DESCRIPTION
Fix typo added in https://github.com/mickem/nscp/commit/5e9a796498321e707eea7fd1b84b14f2989996ba  :smile: 