### PR TITLE
cmake: allow disabling the web layer via BUILD_MODULE_WEBServer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,18 @@ include(${BUILD_CMAKE_FOLDER}/GoogleProtoBuf.cmake)
 # functions.cmake so NSCP_CREATE_TEST can honour it.
 option(NSCP_BUILD_TESTS "Build the unit tests (requires Google Test)" ON)
 
+# WEBServer's per-module flag (the generic BUILD_MODULE_<name> option that
+# LOAD_SECTIONS declares for every module) is consumed *early* here — by the
+# HTTP backend selector in dependencies.cmake and by the libs/* glob that adds
+# its Beast/mongoose backend library (libs/mongoose-cpp -> nscp_mongoose) — long
+# before LOAD_SECTIONS would normally declare it. Declare it up front so those
+# early consumers see it (and its ON default); LOAD_SECTIONS' later option()
+# call for it is then a no-op. With -DBUILD_MODULE_WEBServer=OFF this turns off
+# the module, its HTTP backend library, the backend selector and the mongoose
+# wrapper test together — a build with no web/HTTP server at all (e.g. a
+# stripped-down agent package).
+option(BUILD_MODULE_WEBServer "Build module WEBServer" ON)
+
 include(${BUILD_CMAKE_FOLDER}/functions.cmake)
 
 # ##############################################################################
@@ -1020,6 +1032,8 @@ foreach(CURRENT_LIB ${ALL_LIB_PROJECTS})
         OR CURRENT_LIB_NAME
             STREQUAL
             "dotnet-plugin-api"
+        OR (NOT BUILD_MODULE_WEBServer
+            AND CURRENT_LIB_NAME STREQUAL "mongoose-cpp")
     )
         message(
             STATUS

--- a/build/cmake/dependencies.cmake
+++ b/build/cmake/dependencies.cmake
@@ -76,6 +76,12 @@ set(NSCP_ZIP_BACKEND
 # variable of the same name — silently reverting build.cmake's
 # `SET(NSCP_WEB_BACKEND "beast")` back to mongoose. That broke the Linux
 # (beast) package builds, which opt in via build.cmake rather than -D.
+#
+# The HTTP backend only matters when the WEBServer module is built; skip the
+# whole selector otherwise so a no-web build (-DBUILD_MODULE_WEBServer=OFF)
+# needs no backend at all — neither the vendored mongoose source nor
+# Beast/OpenSSL — and does not abort here.
+if(BUILD_MODULE_WEBServer)
 if(NOT DEFINED NSCP_WEB_BACKEND)
     set(NSCP_WEB_BACKEND "mongoose")
 endif()
@@ -121,6 +127,7 @@ elseif(NSCP_WEB_BACKEND STREQUAL "beast")
 else()
     message(FATAL_ERROR "Unknown NSCP_WEB_BACKEND='${NSCP_WEB_BACKEND}' (expected mongoose | beast)")
 endif()
+endif() # BUILD_MODULE_WEBServer (HTTP backend selector)
 # CMP0167 (CMake 3.30+) removes the bundled FindBoost module in favour of
 # upstream BoostConfig.
 if(POLICY CMP0167)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -453,6 +453,10 @@ NSCP_CREATE_TEST(
         ${CMAKE_SOURCE_DIR}/modules/IcingaClient
 )
 
+# The mongoose wrapper test links nscp_mongoose, which only exists when the
+# WEBServer module / HTTP backend is built. Skip it otherwise so the missing
+# target does not break configuration.
+if(BUILD_MODULE_WEBServer)
 set(MONGOOSE_CPP_DIR ${CMAKE_SOURCE_DIR}/libs/mongoose-cpp)
 
 # Shared (backend-independent) test sources.
@@ -565,6 +569,7 @@ if(WIN32)
         COMMAND_EXPAND_LISTS
     )
 endif()
+endif() # BUILD_MODULE_WEBServer (mongoose_wrapper_test)
 
 set(SETTINGS_INI_TEST_SOURCES
     ${NSCP_INCLUDEDIR}/settings/impl/settings_ini_test.cpp


### PR DESCRIPTION
Upstream always builds the Beast/mongoose HTTP backend library: libs/mongoose-cpp (nscp_mongoose) is added by the unconditional libs/* glob and installed by NSCP_MAKE_LIBRARY, the HTTP backend selector in dependencies.cmake runs and aborts when its mongoose default cannot find the Windows-only vendored source, and the mongoose wrapper test links nscp_mongoose. Disabling only the WEBServer module via the generic per-module flag (-DBUILD_MODULE_WEBServer=OFF) therefore still builds and
installs that library orphaned, still runs the backend selector and still
requires a backend.

Rather than add a new top-level option, reuse the existing per-module flag that LOAD_SECTIONS already declares for every module, so a single -DBUILD_MODULE_WEBServer=OFF turns off the whole web layer in one place (same flag name and spelling as every other module):

- CMakeLists.txt: declare option(BUILD_MODULE_WEBServer ...) up front, before dependencies.cmake and the libs/* glob, so those early consumers
see it (and its ON default). LOAD_SECTIONS' later option() call for the
  same name is then a no-op, and it keeps honouring the flag natively to
  skip the module itself - so modules/WEBServer/module.cmake needs no
  change.
- CMakeLists.txt: skip libs/mongoose-cpp in the libs glob when it is OFF.
- build/cmake/dependencies.cmake: run the HTTP backend selector only when
  it is ON, so a no-web build needs neither the vendored mongoose source nor Beast/OpenSSL and does not abort.
- tests/CMakeLists.txt: gate the mongoose wrapper test, which links nscp_mongoose (no longer built).

With BUILD_MODULE_WEBServer=ON (the default) nothing changes: configure on Debian sid still selects the backend (e.g. beast) and adds the mongoose library as before. With -DBUILD_MODULE_WEBServer=OFF the backend
selector is skipped, no mongoose backend library is built, and the WEBServer module is reported as disabled - a build with no web/HTTP server at all (e.g. a stripped-down agent package).

Assisted-by: Claude Code (Opus 4.8)