### PR TITLE
add codespell github workflow

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,17 @@
+name: Codespell
+on: [pull_request]
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+      - name: codespell
+        uses: codespell-project/actions-codespell@v2
+        with:
+          only_warn: 1
+          builtin: clear
+          skip: "*.vbs,rust"
+          ignore_words_list: "afterall" # Important note: ignored words must be lowercase


### PR DESCRIPTION
this help showing typo errors in the pull request
show also typo out of PR changes
setted to only warn, so will don't fails the check even if typo are present, thus it does not force to correct any typo, which may not even be introduced by that PR