### PR TITLE
docs: document filter_perf for top-N processes and clarify check_process --delta

### DIFF
--- a/docs/samples/CheckSystem_check_process_desc.md
+++ b/docs/samples/CheckSystem_check_process_desc.md
@@ -1,0 +1,38 @@
+#### Showing only the top processes (sorting and limiting)
+
+`check_process` does not sort or limit its output: every matching process is evaluated and
+returned. To report only the few most interesting processes (for example the 10 biggest CPU
+or memory consumers) wrap the check in
+[`filter_perf`](../check/CheckHelpers.md#filter_perf), which post-processes the performance
+data produced by a check, sorting it (`sort=normal`, biggest first) and limiting it
+(`limit=N`).
+
+For example, the top 10 processes by working set (RAM), excluding SQL Server:
+
+```
+filter_perf sort=normal limit=10 command=check_process arguments "filter=working_set > 0 and exe not in ('sqlservr.exe')" "warn=working_set > 3G" "crit=working_set > 5G" "detail-syntax=%(exe) ws=%(working_set)"
+```
+
+...and the top 10 by CPU usage (see `--delta` below):
+
+```
+filter_perf sort=normal limit=10 command=check_process arguments --delta "filter=time > 0" "warn=time > 50" "crit=time > 80" "detail-syntax=%(exe) cpu=%(time)%"
+```
+
+Note that `limit` only trims the performance data; the warning/critical status is still
+evaluated against every matching process, so an alert is raised even if the offending
+process is not among the items shown.
+
+#### Measuring CPU usage (`--delta`)
+
+By default the `kernel`, `user` and `time` keywords report the *accumulated* CPU time each
+process has used since it started, in seconds. To measure *current* CPU usage instead, pass
+`--delta`: the check samples the CPU times, waits one second, samples again and reports the
+difference.
+
+In `--delta` mode these three keywords are no longer seconds but a **percentage of the total
+CPU capacity of the whole machine** (the sum of all cores / vCPUs). As a consequence the same
+load reads differently depending on how many cores the machine has: a single-threaded process
+saturating one core shows roughly `100 / number_of_cores` percent — about 50% on a 2-vCPU
+machine but only ~8% on a 12-vCPU machine. Keep this in mind when choosing thresholds,
+especially when the same threshold is reused across machines with different core counts.

--- a/modules/CheckSystem/check_process.cpp
+++ b/modules/CheckSystem/check_process.cpp
@@ -275,7 +275,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
     ("process", po::value<std::vector<std::string>>(&processes), "The service to check, set this to * to check all services")
     ("scan-info", po::value<bool>(&deep_scan), "If all process metrics should be fetched (otherwise only status is fetched)")
     ("scan-16bit", po::value<bool>(&vdm_scan), "If 16bit processes should be included")
-    ("delta", po::value<bool>(&delta_scan), "Calculate delta over one elapsed second.\nThis call will measure values and then sleep for 2 second and then measure again calculating deltas.")
+    ("delta", po::value<bool>(&delta_scan), "Calculate delta over one elapsed second.\nThis call will measure values, sleep for one second and then measure again, calculating deltas.\nIn this mode the 'kernel', 'user' and 'time' keywords are expressed as a percentage of the total CPU time across all cores instead of seconds.")
     ("scan-unreadable", po::value<bool>(&unreadable_scan), "If unreadable processes should be included (will not have information)")
     ("total", po::bool_switch(&total), "Include the total of all matching files")
     ;


### PR DESCRIPTION
Today I had to add a check similar related to the ram (but for cpu).
I didn't find it from a quick look at the documentation, but I remembered what [mickem wrote a while ago about RAM](https://github.com/mickem/nscp/issues/1076), so I haven't had problems. Other users may have trouble finding the same things, which would risk to wasting time and creating custom scripts.
So I tried to have Claude improve the documentation a bit; it also found something wrong with the description of --delta. Unfortunately, I don't have enough time today to generate updated documentation and check it carefully, so it probably needs improving or fixing.