### PR TITLE
Fix unreliable per-process CPU% from check_process delta=true

### DIFF
--- a/include/win/processes.cpp
+++ b/include/win/processes.cpp
@@ -445,39 +445,59 @@ process_list enumerate_processes_delta(bool ignore_unreadable, error_reporter *e
     if (error_interface != nullptr) error_interface->report_error(e.reason());
   }
 
-  unsigned long long kernel_time = 0;
-  unsigned long long user_time = 0;
-  unsigned long long idle_time = 0;
+  // Convert a FILETIME (split 64-bit value) into a single 64-bit tick count.
+  const auto filetime_to_u64 = [](const FILETIME &ft) -> unsigned long long {
+    return (static_cast<unsigned long long>(ft.dwHighDateTime) << 32) + static_cast<unsigned long long>(ft.dwLowDateTime);
+  };
+
+  // Bracket both per-process samples with the system-time measurements so the
+  // numerator (per-process CPU) and denominator (system CPU) cover the same
+  // wall-clock window. Previously the second GetSystemTimes() was taken before
+  // the second process snapshot, leaving the two windows misaligned.
   FILETIME idleTime;
   FILETIME kernelTime;
   FILETIME userTime;
+  unsigned long long kernel_time = 0;
+  unsigned long long user_time = 0;
   if (GetSystemTimes(&idleTime, &kernelTime, &userTime)) {
-    kernel_time = (kernelTime.dwHighDateTime * (static_cast<unsigned long long>(MAXDWORD) + 1)) + static_cast<unsigned long long>(kernelTime.dwLowDateTime);
-    user_time = (userTime.dwHighDateTime * (static_cast<unsigned long long>(MAXDWORD) + 1)) + static_cast<unsigned long long>(userTime.dwLowDateTime);
-    idle_time = (idleTime.dwHighDateTime * (static_cast<unsigned long long>(MAXDWORD) + 1)) + static_cast<unsigned long long>(idleTime.dwLowDateTime);
+    kernel_time = filetime_to_u64(kernelTime);
+    user_time = filetime_to_u64(userTime);
   }
 
   const process_map p1 = get_process_data(ignore_unreadable, error_interface);
   Sleep(1000);
-  if (GetSystemTimes(&idleTime, &kernelTime, &userTime)) {
-    kernel_time =
-        (kernelTime.dwHighDateTime * (static_cast<unsigned long long>(MAXDWORD) + 1)) + static_cast<unsigned long long>(kernelTime.dwLowDateTime) - kernel_time;
-    user_time =
-        (userTime.dwHighDateTime * (static_cast<unsigned long long>(MAXDWORD) + 1)) + static_cast<unsigned long long>(userTime.dwLowDateTime) - user_time;
-    idle_time =
-        (idleTime.dwHighDateTime * (static_cast<unsigned long long>(MAXDWORD) + 1)) + static_cast<unsigned long long>(idleTime.dwLowDateTime) - idle_time;
-  }
-  const unsigned long long total_time = kernel_time + user_time + idle_time;
-
   process_map p2 = get_process_data(ignore_unreadable, error_interface);
+
+  if (GetSystemTimes(&idleTime, &kernelTime, &userTime)) {
+    kernel_time = filetime_to_u64(kernelTime) - kernel_time;
+    user_time = filetime_to_u64(userTime) - user_time;
+  }
+  // Capacity = kernel + user. GetSystemTimes() already folds idle time into the
+  // kernel figure, so idle is NOT added again here (doing so used to inflate
+  // the denominator and bias every per-process percentage low).
+
   for (const auto &v1 : p1) {
     auto v2 = p2.find(v1.first);
     if (v2 == p2.end()) {
       if (error_interface != nullptr) error_interface->report_debug("process died: " + str::xtos(v1.first));
       continue;
     }
+    // Guard against PID reuse: if a process exited during the sample window and
+    // its PID was handed to a brand new process, the two snapshots describe
+    // different programs and any delta between them is meaningless. The
+    // creation time uniquely identifies the incarnation.
+    if (v2->second.get_creation_time() != v1.second.get_creation_time()) {
+      if (error_interface != nullptr) error_interface->report_debug("pid reused, skipping: " + str::xtos(v1.first));
+      continue;
+    }
     v2->second -= v1.second;
-    v2->second.make_cpu_delta(kernel_time, user_time, total_time);
+    // make_cpu_delta() also defends against the counters moving backwards; if it
+    // reports the delta is not meaningful we drop the process rather than emit a
+    // bogus percentage.
+    if (!v2->second.make_cpu_delta(v1.second, kernel_time, user_time)) {
+      if (error_interface != nullptr) error_interface->report_debug("cpu counter went backwards, skipping: " + str::xtos(v1.first));
+      continue;
+    }
     ret.push_back(v2->second);
   }
 

--- a/include/win/processes.hpp
+++ b/include/win/processes.hpp
@@ -266,12 +266,13 @@ struct process_info {
     gdiHandleCount -= other.gdiHandleCount.get();
     userHandleCount -= other.userHandleCount.get();
 
-    // TImes
+    // Times. The CPU time counters are intentionally NOT subtracted here: the
+    // per-process CPU delta (together with its guards against PID reuse) is
+    // computed in make_cpu_delta() directly from the two raw snapshots.
+    // Subtracting the raw counters here as well would underflow the unsigned
+    // values whenever a PID is recycled mid-interval (the headline bug behind
+    // the absurd percentages such as "cpu=72562484370%").
     creation_time -= other.creation_time.get();
-    kernel_time -= other.kernel_time.get();
-    user_time -= other.user_time.get();
-    kernel_time_raw -= other.kernel_time_raw;
-    user_time_raw -= other.user_time_raw;
 
     // IO Counters
     readOperationCount -= other.readOperationCount.get();
@@ -297,10 +298,41 @@ struct process_info {
     return *this;
   }
 
-  void make_cpu_delta(const unsigned long long kernel, const unsigned long long user, const unsigned long long total) {
-    if (kernel > 0) kernel_time = kernel_time_raw * 100ull / kernel;
-    if (user > 0) user_time = user_time_raw * 100ull / user;
-    if (total > 0) total_time = (kernel_time_raw + user_time_raw) * 100ull / total;
+  // Compute `part * 100 / whole` rounded to the nearest whole percent rather
+  // than truncated. Plain truncation made every sub-1% process read 0% (and
+  // biased busier processes low), which is why repeated runs so often showed
+  // "everything at 0". Rounding keeps small-but-real usage visible.
+  static unsigned long long to_percent(const unsigned long long part, const unsigned long long whole) {
+    if (whole == 0) return 0;
+    return (part * 100ull + whole / 2ull) / whole;
+  }
+
+  // Turn this snapshot into per-process CPU usage over the sampling interval,
+  // using `previous` as the earlier snapshot of the SAME process. `sys_kernel`
+  // and `sys_user` are the system-wide kernel/user time consumed over the same
+  // interval; their sum is the total CPU capacity. On Windows GetSystemTimes()
+  // already folds idle time into the kernel figure, so idle must NOT be added a
+  // second time (doing so inflated the denominator and halved every result).
+  //
+  // On success kernel_time, user_time and total_time hold whole-percent CPU
+  // usage and the function returns true. It returns false - and zeroes the
+  // fields - when the delta is not meaningful and the caller should drop the
+  // process: when a raw counter moved backwards (the PID was recycled to a
+  // different process mid-interval) or when no capacity was measured.
+  bool make_cpu_delta(const process_info &previous, const unsigned long long sys_kernel, const unsigned long long sys_user) {
+    const unsigned long long capacity = sys_kernel + sys_user;
+    if (capacity == 0 || kernel_time_raw < previous.kernel_time_raw || user_time_raw < previous.user_time_raw) {
+      kernel_time = 0;
+      user_time = 0;
+      total_time = 0;
+      return false;
+    }
+    const unsigned long long kernel_delta = kernel_time_raw - previous.kernel_time_raw;
+    const unsigned long long user_delta = user_time_raw - previous.user_time_raw;
+    kernel_time = to_percent(kernel_delta, capacity);
+    user_time = to_percent(user_delta, capacity);
+    total_time = to_percent(kernel_delta + user_delta, capacity);
+    return true;
   }
   static std::shared_ptr<process_info> get_total();
 

--- a/modules/CheckSystem/check_process.cpp
+++ b/modules/CheckSystem/check_process.cpp
@@ -275,7 +275,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
     ("process", po::value<std::vector<std::string>>(&processes), "The service to check, set this to * to check all services")
     ("scan-info", po::value<bool>(&deep_scan), "If all process metrics should be fetched (otherwise only status is fetched)")
     ("scan-16bit", po::value<bool>(&vdm_scan), "If 16bit processes should be included")
-    ("delta", po::value<bool>(&delta_scan), "Calculate delta over one elapsed second.\nThis call will measure values and then sleep for 2 second and then measure again calculating deltas.")
+    ("delta", po::value<bool>(&delta_scan), "Measure CPU usage as a delta over a one second interval.\nThe check samples process and system CPU times, sleeps for one second, then samples again. With delta=true the 'time' (and 'kernel'/'user') fields report the process CPU usage during that second as a whole percentage of total CPU, instead of cumulative CPU seconds.")
     ("scan-unreadable", po::value<bool>(&unreadable_scan), "If unreadable processes should be included (will not have information)")
     ("total", po::bool_switch(&total), "Include the total of all matching files")
     ;

--- a/modules/CheckSystem/check_process_test.cpp
+++ b/modules/CheckSystem/check_process_test.cpp
@@ -23,8 +23,10 @@
 
 #include <list>
 #include <string>
+#include <win/processes.hpp>
 
 using process_checks::realtime::process_name_matches_any;
+using win_list_processes::process_info;
 
 // ============================================================================
 // process_name_matches_any — case-insensitive any-of match
@@ -88,4 +90,168 @@ TEST(ProcessNameMatchesAny, DuplicatesInListDoNotBreakSemantics) {
   const std::list<std::string> names = {"notepad.exe", "notepad.exe", "NOTEPAD.EXE"};
   EXPECT_TRUE(process_name_matches_any(names, "notepad.exe"));
   EXPECT_FALSE(process_name_matches_any(names, "calc.exe"));
+}
+
+// ============================================================================
+// Per-process CPU delta (process_info::make_cpu_delta / to_percent)
+//
+// `check_process ... delta=true` redefines the `time` field from "cumulative
+// CPU seconds" to "percent of total CPU consumed during the sample interval".
+// The implementation used to produce wildly unreliable results: absurd values
+// (e.g. cpu=72562484370%) from unsigned underflow on PID reuse, everything
+// reading 0% from integer truncation, and a denominator that double-counted
+// idle time. These tests pin the corrected behaviour.
+//
+// CPU times are in 100ns FILETIME ticks: one fully-busy core-second is
+// 10,000,000 ticks. A snapshot's raw counters are cumulative since process
+// start; the delta is the difference between two snapshots of the SAME process.
+// ============================================================================
+
+namespace {
+// One fully-busy core for one second, in 100ns FILETIME ticks.
+constexpr unsigned long long ticks_per_core_second = 10000000ull;
+
+process_info make_cpu_sample(unsigned long long kernel_raw, unsigned long long user_raw, long long creation_time = 1000) {
+  process_info p;
+  p.kernel_time_raw = kernel_raw;
+  p.user_time_raw = user_raw;
+  p.creation_time = creation_time;
+  return p;
+}
+}  // namespace
+
+// --- to_percent: rounding instead of truncation (the "everything at 0" fix) ---
+
+TEST(CpuDeltaToPercent, ZeroPartIsZero) { EXPECT_EQ(0ull, process_info::to_percent(0, 100)); }
+
+TEST(CpuDeltaToPercent, ExactPercentages) {
+  EXPECT_EQ(50ull, process_info::to_percent(50, 100));
+  EXPECT_EQ(100ull, process_info::to_percent(100, 100));
+  EXPECT_EQ(25ull, process_info::to_percent(2500000, ticks_per_core_second));
+}
+
+TEST(CpuDeltaToPercent, RoundsToNearestRatherThanTruncating) {
+  // 0.6% must round up to 1% — old code truncated it to 0, which is exactly why
+  // small-but-real processes used to disappear at "everything at 0".
+  EXPECT_EQ(1ull, process_info::to_percent(6, 1000));
+  // 0.4% still rounds down to 0%.
+  EXPECT_EQ(0ull, process_info::to_percent(4, 1000));
+  // 0.5% rounds up (round-half-up).
+  EXPECT_EQ(1ull, process_info::to_percent(5, 1000));
+}
+
+TEST(CpuDeltaToPercent, ZeroWholeIsGuarded) {
+  // No measured capacity -> 0, never a divide-by-zero.
+  EXPECT_EQ(0ull, process_info::to_percent(1234, 0));
+}
+
+// --- make_cpu_delta: the per-process percentage computation ------------------
+
+TEST(MakeCpuDelta, NormalUsageProducesPercentages) {
+  // Process burned 1,000,000 kernel + 1,000,000 user ticks against a capacity
+  // of 10,000,000 ticks (e.g. one busy core out of a one-second window).
+  process_info previous = make_cpu_sample(500, 700);
+  process_info current = make_cpu_sample(500 + 1000000, 700 + 1000000);
+
+  const bool ok = current.make_cpu_delta(previous, /*sys_kernel=*/6000000, /*sys_user=*/4000000);
+
+  EXPECT_TRUE(ok);
+  EXPECT_EQ(10, current.get_kernel_time());  // 1,000,000 / 10,000,000
+  EXPECT_EQ(10, current.get_user_time());    // 1,000,000 / 10,000,000
+  EXPECT_EQ(20, current.get_total_time());   // 2,000,000 / 10,000,000
+}
+
+TEST(MakeCpuDelta, SubOnePercentUsageIsNotLostToTruncation) {
+  // 0.6% of capacity. Old integer-truncating code reported 0; rounded result
+  // is 1, so the process is still visible / sortable.
+  process_info previous = make_cpu_sample(0, 0);
+  process_info current = make_cpu_sample(60000, 0);
+
+  EXPECT_TRUE(current.make_cpu_delta(previous, ticks_per_core_second, 0));
+  EXPECT_EQ(1, current.get_total_time());
+}
+
+TEST(MakeCpuDelta, DenominatorIsKernelPlusUserOnly) {
+  // The same total capacity split differently between the kernel and user
+  // arguments must give the same result: idle time is never a parameter, so it
+  // cannot be double-counted the way the old kernel+user+idle denominator did.
+  process_info previous = make_cpu_sample(0, 0);
+  process_info a = make_cpu_sample(2500000, 0);
+  process_info b = make_cpu_sample(2500000, 0);
+
+  EXPECT_TRUE(a.make_cpu_delta(previous, ticks_per_core_second, 0));
+  EXPECT_TRUE(b.make_cpu_delta(previous, ticks_per_core_second / 2, ticks_per_core_second / 2));
+  EXPECT_EQ(a.get_total_time(), b.get_total_time());
+  EXPECT_EQ(25, a.get_total_time());
+}
+
+TEST(MakeCpuDelta, PidReuseWithLowerCounterDoesNotUnderflow) {
+  // The headline bug: a PID is recycled to a new process whose cumulative CPU
+  // time is LOWER than the previous occupant's. The unsigned subtraction used
+  // to wrap around to a gigantic number (cpu=72562484370%). Now it is rejected.
+  process_info previous = make_cpu_sample(5000000, 5000000);
+  process_info current = make_cpu_sample(1000, 1000);
+  current.total_time = 999;  // sentinel: must be cleared on rejection
+
+  const bool ok = current.make_cpu_delta(previous, ticks_per_core_second, ticks_per_core_second);
+
+  EXPECT_FALSE(ok);
+  EXPECT_EQ(0, current.get_total_time());
+  EXPECT_EQ(0, current.get_kernel_time());
+  EXPECT_EQ(0, current.get_user_time());
+}
+
+TEST(MakeCpuDelta, UserCounterGoingBackwardsIsRejected) {
+  // Kernel advanced normally but user time regressed -> still not meaningful.
+  process_info previous = make_cpu_sample(1000, 5000000);
+  process_info current = make_cpu_sample(2000000, 1000);
+
+  EXPECT_FALSE(current.make_cpu_delta(previous, ticks_per_core_second, ticks_per_core_second));
+  EXPECT_EQ(0, current.get_total_time());
+}
+
+TEST(MakeCpuDelta, ZeroCapacityIsRejected) {
+  process_info previous = make_cpu_sample(0, 0);
+  process_info current = make_cpu_sample(1000000, 1000000);
+
+  EXPECT_FALSE(current.make_cpu_delta(previous, 0, 0));
+  EXPECT_EQ(0, current.get_total_time());
+}
+
+TEST(MakeCpuDelta, FullyBusyAcrossWholeCapacityIsHundredPercent) {
+  process_info previous = make_cpu_sample(0, 0);
+  process_info current = make_cpu_sample(6000000, 4000000);  // 10,000,000 total
+
+  EXPECT_TRUE(current.make_cpu_delta(previous, 6000000, 4000000));
+  EXPECT_EQ(100, current.get_total_time());
+}
+
+// --- operator-=: CPU raw counters must survive so make_cpu_delta can use them -
+
+TEST(ProcessInfoMinus, DoesNotTouchRawCpuCounters) {
+  // operator-= turns the gauge fields (working set, ...) into deltas for delta
+  // mode, but it must leave the raw CPU counters absolute — the per-process CPU
+  // delta is computed from the two raw snapshots in make_cpu_delta(), and
+  // subtracting them here too would underflow on PID reuse.
+  process_info later = make_cpu_sample(2000000, 1500000);
+  later.WorkingSetSize = 4096;
+  process_info earlier = make_cpu_sample(500000, 300000);
+  earlier.WorkingSetSize = 1024;
+
+  later -= earlier;
+
+  EXPECT_EQ(2000000ull, later.kernel_time_raw);  // unchanged (absolute)
+  EXPECT_EQ(1500000ull, later.user_time_raw);    // unchanged (absolute)
+  EXPECT_EQ(3072, later.get_WorkingSetSize());   // gauge became a delta
+}
+
+TEST(ProcessInfoMinus, RawCountersStillUsableByMakeCpuDeltaAfterSubtraction) {
+  // End-to-end: subtract (as enumerate_processes_delta does) then compute the
+  // CPU delta. The result must reflect the real per-process delta, not garbage.
+  process_info earlier = make_cpu_sample(500000, 300000);
+  process_info later = make_cpu_sample(500000 + 1000000, 300000 + 1000000);
+
+  later -= earlier;
+  ASSERT_TRUE(later.make_cpu_delta(earlier, 6000000, 4000000));
+  EXPECT_EQ(20, later.get_total_time());  // 2,000,000 / 10,000,000
 }


### PR DESCRIPTION
`check_process ... delta=true` redefines the `time` field to report
per-process CPU usage over a one-second interval, but the computation
was unreliable: it could return absurd values (e.g. cpu=72562484370%),
report everything at 0%, and systematically under-report.

Root causes, now fixed:

1. PID reuse -> unsigned underflow. The two snapshots were matched by
   PID and `operator-=` subtracted the raw CPU counters with unsigned
   arithmetic. When a PID was recycled mid-interval the subtraction
   wrapped to a gigantic number. CPU raw counters are no longer
   subtracted in `operator-=`; the delta is computed in `make_cpu_delta`
   straight from the two raw snapshots, guarded by a creation-time
   PID-reuse check and a backwards-counter check that drops the process
   instead of emitting garbage.

2. Denominator double-counted idle. The divisor was kernel+user+idle,
   but GetSystemTimes already folds idle into the kernel figure, so idle
   was counted twice and every percentage was biased low. The capacity
   is now kernel+user only.

3. Integer truncation -> 0%. Percentages were truncated, so sub-1% usage
   collapsed to 0. They are now rounded to the nearest whole percent.

4. Misaligned sampling windows. The second GetSystemTimes() was taken
   before the second process snapshot. It now brackets both per-process
   samples so numerator and denominator cover the same window.

Adds unit tests covering rounding, the kernel+user denominator, PID-reuse
/ backwards-counter rejection, zero-capacity handling, and that
`operator-=` leaves the raw CPU counters intact for make_cpu_delta.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PRDcGvQCBZKgPx1DsTt2A5