### PR TITLE
Fix perf-config=none reporting "Failed to parse syntax"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# Project conventions
+
+## Git commits
+- Always add a DCO `Signed-off-by` trailer to every commit (this project requires DCO):
+  `Signed-off-by: Michael Medin <michael@medin.name>`
+  Equivalent to committing with `git commit -s`.
+- The DCO bot requires the sign-off to match the commit author/committer.
+  Set the git identity so author = committer = sign-off:
+  `git config user.name "Michael Medin" && git config user.email "michael@medin.name"`

--- a/include/parsers/filter/modern_filter.hpp
+++ b/include/parsers/filter/modern_filter.hpp
@@ -191,6 +191,7 @@ struct perf_config_parser {
   perf_config_parser() {}
 
   bool parse(std::shared_ptr<TFactory> context, const std::string &str, const error_handler &error) {
+    if (str.empty() || str == "none") return true;
     parsers::perfconfig::result_type keys;
     parsers::perfconfig parser;
     if (!parser.parse(str, keys)) {

--- a/include/parsers/filter/modern_filter_test.cpp
+++ b/include/parsers/filter/modern_filter_test.cpp
@@ -264,3 +264,59 @@ TEST(ErrorHandlerImpl, PolymorphicUsageThroughInterface) {
   EXPECT_TRUE(impl->has_errors());
   EXPECT_EQ(impl->get_errors(), "interface error");
 }
+
+// ============================================================================
+// perf_config_parser tests
+// ============================================================================
+
+// Minimal factory exposing only what perf_config_parser::parse needs.
+struct mock_perf_factory {
+  std::map<std::string, std::map<std::string, std::string> > configs;
+  void add_perf_config(const std::string &name, const std::map<std::string, std::string> &options) { configs[name] = options; }
+};
+
+namespace {
+std::shared_ptr<parsers::where::error_handler_interface> make_error_handler() {
+  return std::shared_ptr<parsers::where::error_handler_interface>(new modern_filter::error_handler_impl(false));
+}
+}  // namespace
+
+// Regression test for "perf-config=none" reporting "Failed to parse syntax".
+// "none" (and an empty string) must be accepted as "no perf-config" rather
+// than fed to the grammar, which only accepts keyword(options) form.
+TEST(PerfConfigParser, NoneIsAcceptedAndAddsNoConfig) {
+  modern_filter::perf_config_parser<mock_perf_factory> parser;
+  std::shared_ptr<mock_perf_factory> factory(new mock_perf_factory());
+  auto error = make_error_handler();
+
+  EXPECT_TRUE(parser.parse(factory, "none", error));
+  EXPECT_TRUE(factory->configs.empty());
+  EXPECT_FALSE(error->is_debug());
+}
+
+TEST(PerfConfigParser, EmptyStringIsAccepted) {
+  modern_filter::perf_config_parser<mock_perf_factory> parser;
+  std::shared_ptr<mock_perf_factory> factory(new mock_perf_factory());
+
+  EXPECT_TRUE(parser.parse(factory, "", make_error_handler()));
+  EXPECT_TRUE(factory->configs.empty());
+}
+
+TEST(PerfConfigParser, ValidConfigIsParsedAndStored) {
+  modern_filter::perf_config_parser<mock_perf_factory> parser;
+  std::shared_ptr<mock_perf_factory> factory(new mock_perf_factory());
+
+  EXPECT_TRUE(parser.parse(factory, "cpu(unit:%)", make_error_handler()));
+  ASSERT_EQ(1u, factory->configs.size());
+  ASSERT_EQ(1u, factory->configs.count("cpu"));
+  EXPECT_EQ("%", factory->configs["cpu"]["unit"]);
+}
+
+TEST(PerfConfigParser, InvalidConfigStillFails) {
+  modern_filter::perf_config_parser<mock_perf_factory> parser;
+  std::shared_ptr<mock_perf_factory> factory(new mock_perf_factory());
+  auto error = make_error_handler();
+
+  // Bare keyword without "(options)" is not "none" and is not valid syntax.
+  EXPECT_FALSE(parser.parse(factory, "bogus", error));
+}


### PR DESCRIPTION
perf_config_parser::parse fed "none" directly to the perfconfig spirit
grammar, which only accepts keyword(options) form, so "perf-config=none"
failed with "Failed to parse: none" / "Failed to parse syntax".

Treat "none" (and an empty string) as "no perf-config", mirroring the
existing behavior of filter_text_renderer::parse for the syntax options.
This restores the documented way to disable performance-data formatting.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E6u8Pg1FoQBeFtnHCC3ofD