### PR TITLE
Fix installer deleting nsclient.ini on upgrade

### DIFF
--- a/installers/installer-NSCP/Product.wxs
+++ b/installers/installer-NSCP/Product.wxs
@@ -70,12 +70,6 @@
             </File>
             <Condition>USER_WRITABLE_CONFIG AND NOT ALLOW_CONFIGURATION="0"</Condition>
           </Component>
-          <Component Id="PurgeConfig" Guid="E5A2F1C3-9B84-4D67-A1E0-3C7F28D59B12" Win64="$(var.Win64)">
-            <RegistryValue Root="HKCU" Key="Software\NSClient++\Installer" Name="purge config" Type="integer" Value="1" KeyPath="yes"/>
-            <RemoveFile Id="PurgeConfigFiles" Name="*.ini" On="uninstall" />
-            <Condition>NOT ALLOW_CONFIGURATION="0" AND NOT OLDERVERSIONBEINGUPGRADED</Condition>
-          </Component>
-
           <Component Id="RandomFiles" Guid="E23865C3-C11F-4d11-BE63-C670D60B0CD0" Win64="$(var.Win64)">
             <File Id="License" Name="license.txt" DiskId="1" Source="$(var.Source)/license.txt" Vital="no" KeyPath="yes" />
             <File Id="settingsMap" Name="old-settings.map" DiskId="1" Source="$(var.Source)/old-settings.map" Vital="no" />
@@ -216,7 +210,6 @@
 
         <ComponentRef Id="NSClientConfig" />
         <ComponentRef Id="NSClientConfigUser" />
-        <ComponentRef Id="PurgeConfig" />
 
         <?if "$(var.Runtime)" = "dynamic"?>
         <MergeRef Id="VCRedist110"/>


### PR DESCRIPTION
## Problem

The `PurgeConfig` component in `installers/installer-NSCP/Product.wxs` carried:

```xml
<Component Id="PurgeConfig" ...>
  <RemoveFile Id="PurgeConfigFiles" Name="*.ini" On="uninstall" />
  <Condition>NOT ALLOW_CONFIGURATION="0" AND NOT OLDERVERSIONBEINGUPGRADED</Condition>
</Component>
```

The `*.ini` glob also matches the user's **`nsclient.ini`**, so this rule can wipe out the live configuration.

Two things make this fire during a **major upgrade** (not just a real uninstall):

1. **`RemoveFile` bypasses reference counting.** Unlike installed key files, `RemoveFile`-table entries delete by name and are not reference-counted against the new product that also owns `nsclient.ini`. So when `RemoveExistingProducts` uninstalls the previous version, the old product's purge deletes `nsclient.ini` even though the new product ships it too. With `RemoveExistingProducts` scheduled `After InstallExecute` (late), this happens **after** `BackupConfig` / `ExecWriteConfig` have already restored the config — so the just-restored file is deleted, and `NeverOverwrite="yes"` on the config component prevents a fresh copy from being laid down. Net result: config is gone.

2. **The `NOT OLDERVERSIONBEINGUPGRADED` guard does the opposite of what it looks like.** In MSI, a component whose `<Condition>` evaluates false is set to *absent*, and an `On="uninstall"` `RemoveFile` fires exactly when a component goes absent. So gating the purge *off* during upgrade actively *triggers* the purge.

## Fix

Remove the `PurgeConfig` component and its `ComponentRef`.

There is no purely declarative way for an `On="uninstall"` `RemoveFile` to distinguish a genuine uninstall from the upgrade-time removal of the old product — both are uninstalls from the old package's perspective. Since NSClient++ already goes to some length (`BackupConfig` / `ExecWriteConfig`) to *preserve* configuration across upgrades, the purge was working directly against that design. Dropping it keeps `nsclient.ini` intact on upgrade and leaves the user's config in place on uninstall (the conventional, safe behavior).

## Notes / follow-ups

- **Upgrading *from* an already-shipped buggy build**: the deletion is baked into that older MSI's `RemoveFile` table, so it can still fire once during the upgrade that removes it. If protecting those users matters, scheduling `RemoveExistingProducts` earlier (so `ExecWriteConfig` restores config *after* the old product — and its purge — is removed) would mitigate it. Left out here to keep this change minimal and low-risk.
- **If purge-on-real-uninstall is still wanted**, it should be a deferred custom action gated on `REMOVE="ALL" AND NOT UPGRADINGPRODUCTCODE`, not a component-condition + `RemoveFile`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HECpAN7Vr56M1Keoemd8kq)_