### PR TITLE
docs: cross-reference filter_perf from check_process for top-N processes

### DIFF
--- a/docs/samples/CheckSystem_check_process_desc.md
+++ b/docs/samples/CheckSystem_check_process_desc.md
@@ -1,0 +1,26 @@
+#### Showing only the top processes (sorting and limiting)
+
+`check_process` does not sort or limit its output: every matching process is evaluated and
+returned. To report only the few most interesting processes (for example the 10 biggest
+memory consumers) wrap the check in
+[`filter_perf`](../check/CheckHelpers.md#filter_perf), which post-processes the performance
+data produced by a check, sorting it (`sort=normal`, biggest first) and limiting it
+(`limit=N`).
+
+For example, the top 10 processes by working set (RAM), excluding SQL Server:
+
+```
+filter_perf sort=normal limit=10 command=check_process arguments "filter=working_set > 0 and exe not in ('sqlservr.exe')" "warn=working_set > 3G" "crit=working_set > 5G" "detail-syntax=%(exe) ws=%(working_set)"
+```
+
+The same approach works for CPU usage. Pass `delta=true` so that `%(time)` reports the CPU
+time consumed since the previous check (a percentage-like rate) rather than the total CPU
+time since the process started, for example the top 10 processes by CPU:
+
+```
+filter_perf sort=normal limit=10 command=check_process arguments delta=true "warn=time > 50" "crit=time > 90" "detail-syntax=%(exe) cpu=%(time)%"
+```
+
+Note that `limit` only trims the performance data; the warning/critical status is still
+evaluated against every matching process, so an alert is raised even if the offending
+process is not among the items shown.


### PR DESCRIPTION
done again, rebased and removed delta part (delta desc already fixed by mickem)
@mickem I wanted to try checking the regenerated documentation and looking at it locally, but it seems like it doesn't generate the Windows-only parts like that from my Linux workstation.
So I quickly checked the text and it doesn't seem to have any errors (unlike the last time), but I haven't checked the regenerated documentation.