### PR TITLE
improve CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,17 @@
 # Project conventions
 
 ## Git commits
-- Always add a DCO `Signed-off-by` trailer to every commit (this project requires DCO):
-  `Signed-off-by: Michael Medin <michael@medin.name>`
-  Equivalent to committing with `git commit -s`.
-- The DCO bot requires the sign-off to match the commit author/committer.
-  Set the git identity so author = committer = sign-off:
-  `git config user.name "Michael Medin" && git config user.email "michael@medin.name"`
+- This project requires the [Developer Certificate of Origin](https://developercertificate.org/)
+  (DCO): every commit must carry a `Signed-off-by` trailer with **your own** real
+  name and email, for example:
+  `Signed-off-by: Jane Doe <jane@example.com>`
+  The easiest way is to commit with `git commit -s`, which appends the trailer
+  from your configured git identity.
+- The DCO bot accepts a `Signed-off-by` that matches **either** the commit's
+  author **or** its committer, so signing off with your own identity on work you
+  author is enough (and a cherry-picked commit that keeps the original author's
+  sign-off still passes). If you do not already have a git identity configured
+  (globally or for this repo), set one to your own name and email:
+  `git config user.name "Jane Doe" && git config user.email "jane@example.com"`
+  If you already have one, keep it and just make sure it is the name and email
+  you sign off with.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,3 +15,12 @@
   `git config user.name "Jane Doe" && git config user.email "jane@example.com"`
   If you already have one, keep it and just make sure it is the name and email
   you sign off with.
+- If an AI coding assistant helped produce a commit, declare it with an
+  `Assisted-by:` trailer, using the format codified by the [Linux kernel AI
+  coding-assistants policy](https://docs.kernel.org/process/coding-assistants.html):
+  `Assisted-by: AGENT_NAME:MODEL_VERSION [tool ...]`, for example
+  `Assisted-by: Claude Code:claude-opus-4-8`.
+  Do **not** use `Co-authored-by:` for AI assistance: only a human may certify
+  the DCO, so an AI must never carry a `Signed-off-by` (which co-authorship
+  implies). Keep `Signed-off-by:` as the final trailer — a human always reviews,
+  tests, and takes responsibility for the result.


### PR DESCRIPTION
The first commit improves the text related to sign-off to prevent Claude from making mistakes by using a fixed name of the example, and I've come up with other things to specify to try to avoid further unexpected issues.

It's not a guarantee of avoiding problems given how LLMs are designed. I knew they were probabilistic, and I've also seen how translators have gotten worse since they started using LLMs (who cut and modify sentences). But I'm encountering several cases where they violate simple memory rules, so they're even more unreliable than I thought. However, I think it's worth at least trying to avoid problems. Memory should give them at least a good chance of following these instructions, even if it's not as certain as normal programs (bugs and hardware problems excluded).

In second commit I propose to put also assisted-by in the commit, based on kernel policy that seem me good.

@mickem what do you think?