### PR TITLE
cmake: derive the default python lib name instead of hardcoding versions

### DIFF
--- a/modules/PythonScript/CMakeLists.txt
+++ b/modules/PythonScript/CMakeLists.txt
@@ -34,30 +34,13 @@ if(WIN32)
         ${NSCP_DEF_PLUGIN_HPP}
     )
 else()
-    if(NSCP_BOOST_PYTHON_VERSION STREQUAL "python313")
+    # Derive the runtime python library name (the default of the "python lib"
+    # setting) from the Boost.Python component name, e.g. python314 ->
+    # libpython3.14.so, so new python releases work without touching this list.
+    if(NSCP_BOOST_PYTHON_VERSION MATCHES "^python3([0-9]+)$")
         add_definitions(
             ${NSCP_GLOBAL_DEFINES}
-            -DDEFAULT_PYTHON_LIB="libpython3.13.so"
-        )
-    elseif(NSCP_BOOST_PYTHON_VERSION STREQUAL "python312")
-        add_definitions(
-            ${NSCP_GLOBAL_DEFINES}
-            -DDEFAULT_PYTHON_LIB="libpython3.12.so"
-        )
-    elseif(NSCP_BOOST_PYTHON_VERSION STREQUAL "python311")
-        add_definitions(
-            ${NSCP_GLOBAL_DEFINES}
-            -DDEFAULT_PYTHON_LIB="libpython3.11.so"
-        )
-    elseif(NSCP_BOOST_PYTHON_VERSION STREQUAL "python310")
-        add_definitions(
-            ${NSCP_GLOBAL_DEFINES}
-            -DDEFAULT_PYTHON_LIB="libpython3.10.so"
-        )
-    elseif(NSCP_BOOST_PYTHON_VERSION STREQUAL "python39")
-        add_definitions(
-            ${NSCP_GLOBAL_DEFINES}
-            -DDEFAULT_PYTHON_LIB="libpython3.9.so"
+            -DDEFAULT_PYTHON_LIB="libpython3.${CMAKE_MATCH_1}.so"
         )
     else()
         message(

--- a/modules/PythonScript/CMakeLists.txt
+++ b/modules/PythonScript/CMakeLists.txt
@@ -36,11 +36,14 @@ if(WIN32)
 else()
     # Derive the runtime python library name (the default of the "python lib"
     # setting) from the Boost.Python component name, e.g. python314 ->
-    # libpython3.14.so, so new python releases work without touching this list.
+    # libpython3.14.so.1.0, so new python releases work without touching this
+    # list. Use the soname: the bare .so symlink only exists on systems with
+    # the python development package installed, while the soname is shipped
+    # with the runtime library the module already links against.
     if(NSCP_BOOST_PYTHON_VERSION MATCHES "^python3([0-9]+)$")
         add_definitions(
             ${NSCP_GLOBAL_DEFINES}
-            -DDEFAULT_PYTHON_LIB="libpython3.${CMAKE_MATCH_1}.so"
+            -DDEFAULT_PYTHON_LIB="libpython3.${CMAKE_MATCH_1}.so.1.0"
         )
     else()
         message(


### PR DESCRIPTION
On Linux PythonScript resolves NSCP_BOOST_PYTHON_VERSION through a hardcoded if/elseif chain (python39 ... python313) whose only purpose is to define DEFAULT_PYTHON_LIB, the default value of the "python lib" setting (the libpython loaded at runtime). Any Python release newer than the chain aborts configure: with Python 3.14 (now the default python3 in Debian sid, with Boost 1.90 shipping libboost_python314) it fails with 'Unknown python version: python314'.

Replace the chain with a generic match that derives the library name from the component name (python3XX -> libpython3.XX.so). Behaviour is identical for every version the chain listed, future Python releases work without touching this file again, and a component name that does not match the pattern still fails configure with the same error message.