### PR TITLE
Fix REUSE third-party attributions and literal SPDX tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ and platform packaging help.
 
 NSClient++ is dual-licensed — you may use it under **either** the
 **Apache License 2.0** **or** the **GNU General Public License, version 2.0 (only)**,
-at your option (`SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only`). See
+at your option (SPDX: `Apache-2.0 OR GPL-2.0-only`). See
 [COPYING](COPYING) for the summary, the [`LICENSES/`](LICENSES) directory for the
 full license texts, and [THIRD-PARTY-NOTICES.md](THIRD-PARTY-NOTICES.md) for
 bundled third-party components.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -42,3 +42,42 @@ path = ["installers/ui/WixUI_MondoNSCP.wxs", "installers/installer-NSCP/WixUI_en
 precedence = "override"
 SPDX-FileCopyrightText = "Microsoft Corporation"
 SPDX-License-Identifier = "CPL-1.0"
+
+# CMake modules for C#/.NET/Mono, based on the GDCM project's (BSD-3-Clause).
+# override: the attribution line is wrapped mid-sentence, which the reuse
+# parser would otherwise pick up as an empty copyright holder.
+[[annotations]]
+path = [
+    "build/cmake/FindCSharp.cmake",
+    "build/cmake/FindDotNetFrameworkSdk.cmake",
+    "build/cmake/FindMono.cmake",
+    "build/cmake/UseCSharp.cmake",
+    "build/cmake/UseDotNetFrameworkSdk.cmake",
+    "build/cmake/UseMono.cmake",
+]
+precedence = "override"
+SPDX-FileCopyrightText = "2006-2010 Mathieu Malaterre <mathieu.malaterre@gmail.com>"
+SPDX-License-Identifier = "BSD-3-Clause"
+
+# Protobuf CMake modules; their header points at a COPYING-CMAKE-SCRIPTS file
+# (the stock BSD-3-Clause of KDE's cmake modules) that was never imported —
+# LICENSES/BSD-3-Clause.txt now provides the text.
+[[annotations]]
+path = ["build/cmake/FindProtoBuf.cmake", "build/cmake/GoogleProtoBuf.cmake"]
+precedence = "override"
+SPDX-FileCopyrightText = "2008 Ange Optimization ApS"
+SPDX-License-Identifier = "BSD-3-Clause"
+
+# Prebuilt third-party binaries checked into the tree (no readable inline
+# info, so without these the project-default annotation would claim them).
+[[annotations]]
+path = "installers/installer-NSCP/wixca.dll"
+precedence = "override"
+SPDX-FileCopyrightText = "Microsoft Corporation"
+SPDX-License-Identifier = "CPL-1.0"
+
+[[annotations]]
+path = "libs/protobuf_net/Google.Protobuf.dll"
+precedence = "override"
+SPDX-FileCopyrightText = "Google LLC"
+SPDX-License-Identifier = "BSD-3-Clause"

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -45,6 +45,10 @@ obligation applies wherever we actually ship the library.
 | SimpleIni (Brodie Thiesfield)                     | `include/simpleini/simpleini.h`                                                  | MIT                        |
 | asio ICMP/IPv4 headers (Christopher M. Kohlhoff)  | `include/net/icmp_header.hpp`, `include/net/ipv4_header.hpp`                     | Boost Software License 1.0 |
 | WiX standard installer UI (Microsoft Corporation) | `installers/ui/WixUI_MondoNSCP.wxs`, `installers/installer-NSCP/WixUI_en-us.wxl` | Common Public License 1.0  |
+| WiX custom action library, prebuilt (Microsoft Corporation) | `installers/installer-NSCP/wixca.dll`                                            | Common Public License 1.0  |
+| C#/.NET/Mono CMake modules, from GDCM (Mathieu Malaterre)   | `build/cmake/{Find,Use}{CSharp,Mono,DotNetFrameworkSdk}.cmake`                   | BSD-3-Clause               |
+| Protobuf CMake modules (Ange Optimization ApS)              | `build/cmake/FindProtoBuf.cmake`, `build/cmake/GoogleProtoBuf.cmake`             | BSD-3-Clause               |
+| Google.Protobuf .NET runtime, prebuilt (Google LLC)         | `libs/protobuf_net/Google.Protobuf.dll`                                          | BSD-3-Clause               |
 
 ## Web UI
 

--- a/installers/installer-NSCP/License.rtf
+++ b/installers/installer-NSCP/License.rtf
@@ -2,7 +2,7 @@
 {\*\generator Msftedit 5.41.15.1507;}\viewkind4\uc1\pard\f0\fs20\b NSClient++\b0\par
 Copyright (C) 2004-2026 Michael Medin\par
 \par
-SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only\par
+SPDX: Apache-2.0 OR GPL-2.0-only\par
 \par
 NSClient++ is dual-licensed. You may use, modify, and distribute it under the terms of EITHER of the following licenses, at your option:\par
 \par


### PR DESCRIPTION
@mickem
One caveat on the new `wixca.dll` annotation: I tagged it `CPL-1.0` for consistency with the WiX UI files already listed in THIRD-PARTY-NOTICES.md, but the DLL was added to the tree in 2014, i.e. the WiX 3.x era, and WiX had switched from CPL-1.0 to MS-RL around 3.5. If you can tell which WiX release it was built from, it may need retagging to `LicenseRef-MS-RL` (and a matching text file), or ideally rebuilding it from a current WiX so the license question goes away.

After this change `reuse lint` has one remaining complaint: `Unused licenses: OFL-1.1, Zlib`. Those two texts only cover binary dependencies (Roboto in the web bundle, TinyXML-2), no tracked file uses them, and the REUSE spec reserves `LICENSES/` for licenses referenced from the tree. I deliberately left that to you; the options I see are:

* keep them where they are and accept the lint flag;
* ship them from another location (e.g. `files/licenses/LICENSE-OFL-1.1.txt` — reuse skips `LICENSE*`-named files — with the matching `files/CMakeLists.txt` and `Product.wxs` tweaks), which makes lint fully green;
* drop them from the repo and point THIRD-PARTY-NOTICES.md at the canonical texts — Zlib does not require shipping the text with binaries, and OFL only matters where the Roboto font is actually distributed (the web bundle, which carries its own license report).