### PR TITLE
feature/fixed_more_issues

### DIFF
--- a/docs/docs/concepts/settings.md
+++ b/docs/docs/concepts/settings.md
@@ -152,8 +152,11 @@ be configured in the `boot.ini` file.
 This is a special file which is used to load configuration before the configuration is loaded.
 For instance, it defines which settings store to use but you can also configure TLS options.
 
-> It is advised to set `verify mode` to `peer` and use a CA certificate to verify the server certificate.
-> This will become the default in the future.
+> **Changed in 0.14:** the settings download now verifies the server certificate by default
+> (`verify mode = peer` against `${ca-path}`, the platform CA bundle). Earlier versions defaulted to
+> `verify mode = none`, which meant anyone who could answer for the settings host controlled the
+> agent's entire configuration - including `[/settings/external scripts]`, which is command
+> execution by design. See [Upgrading to verified settings downloads](#upgrading-to-verified-settings-downloads).
 
 ```ini
 [tls]
@@ -165,8 +168,34 @@ ca = c:\program files\NSClient++\security\ca.pem
 | Key         | Default Value | Values          | Description                                                                |
 |-------------|---------------|-----------------|----------------------------------------------------------------------------|
 | version     | 1.3           | 1.0, 1.1, 1.3   | The TLS version to use.                                                    |
-| verify mode | none          | none, peer      | The verify mode to use (Set this to none to use self signed certificates). |
-| ca          |               | Path to CA file | The path to the CA certificate to use.                                     |
+| verify mode | peer          | none, peer      | The verify mode to use (Set this to none to use self signed certificates). |
+| ca          | `${ca-path}`  | Path to CA file | The path to the CA certificate to use. Defaults to the platform CA bundle: the auto-exported Windows ROOT store on Windows, the distribution bundle on Linux. |
+
+##### Upgrading to verified settings downloads
+
+If your settings server presents a certificate issued by a public CA, the new defaults work with no
+configuration change.
+
+If it presents a self-signed certificate, or one issued by a private/internal CA, the download will
+now fail with a certificate verification error where it previously succeeded silently. Either point
+`ca` at the issuing CA (recommended):
+
+```ini
+[tls]
+verify mode = peer
+ca = c:\program files\NSClient++\security\my-internal-ca.pem
+```
+
+or restore the previous behaviour explicitly, accepting that the configuration channel is
+unauthenticated:
+
+```ini
+[tls]
+verify mode = none
+```
+
+`verify mode = none` is still honoured, but it is now logged as an error on every fetch - it can only
+be reached by writing it out, never by omission.
 
 #### Using a proxy
 

--- a/docs/docs/concepts/settings.md
+++ b/docs/docs/concepts/settings.md
@@ -194,8 +194,14 @@ unauthenticated:
 verify mode = none
 ```
 
-`verify mode = none` is still honoured, but it is now logged as an error on every fetch - it can only
-be reached by writing it out, never by omission.
+`verify mode = none` is still honoured, but it is now logged as a warning naming the risk on every
+fetch - it can only be reached by writing it out, never by omission.
+
+The Windows installer applies the same defaults when it downloads a settings source given as
+`CONFIGURATION_TYPE=https://...`, and verifies against a temporary export of the Windows ROOT store
+(`${ca-path}` belongs to the service and is not written until it first starts). Use the `TLS_CA` and
+`TLS_VERIFY_MODE` properties to make the same two choices at install time - see
+[Installing](../setup/installing.md#verifying-the-settings-server).
 
 #### Using a proxy
 

--- a/docs/docs/setup/installing.md
+++ b/docs/docs/setup/installing.md
@@ -239,8 +239,8 @@ A list of all the MSI options can be found below.
 | OP5_CONTACTGROUP    | Additional contactgroups to add to the host.                                                                            |
 | NO_SERVICE          | Set to 1 to disable installing the service (then you can manually create and activate the service when needed)          |
 | TLS_VERSION         | The TLS version to use (1.0, 1.1, 1.2, *1.3*)                                                                           |
-| TLS_VERIFY_MODE     | The TLS verify mode to use (*none*, peer, fail_if_no_peer_cert)                                                         |
-| TLS_CA              | The CA file to use for TLS connections (if not using the system default)                                                |
+| TLS_VERIFY_MODE     | The TLS verify mode to use (none, *peer*, fail_if_no_peer_cert)                                                         |
+| TLS_CA              | The CA file to use for TLS connections (defaults to the Windows ROOT store)                                             |
 | CONF_SET            | Set a configuration value in the form of section1;key1;value1;section2;key2;value2...                                   |
 | IMPORT_CONFIG       | URL or file path to a configuration file to copy during install and use as the configuration for NSClient++             |
 
@@ -334,3 +334,33 @@ Any changes you make to the configuration file on the server will automatically 
 ```
 msiexec /i NSClient++.msi CONFIGURATION_TYPE=http://myserver.com/nsclient.ini
 ```
+
+### Verifying the settings server
+
+Over `https` the installer verifies the server certificate before it uses what
+it downloaded - that file becomes the whole configuration of the agent,
+including its external script definitions, so whoever can answer for the
+settings host would otherwise own the machine.
+
+The certificate is checked against the Windows ROOT certificate store, which the
+installer exports to a temporary bundle for the duration of the install (the
+service maintains its own copy at `${ca-path}`, but that file does not exist yet
+while the installer is running). Nothing needs to be configured for a settings
+server whose certificate was issued by a public CA, or by an internal CA that
+has been rolled out to the machine's trust store.
+
+For a private CA that is *not* in the Windows store, point `TLS_CA` at the
+issuing CA instead:
+
+```
+msiexec /i NSClient++.msi CONFIGURATION_TYPE=https://myserver.com/nsclient.ini TLS_CA=c:\certs\my-ca.pem
+```
+
+`TLS_CA` is used verbatim and replaces the exported store, so it also works for
+pinning a single issuer. It is written to `boot.ini`, so the service keeps using
+it for later fetches.
+
+As a last resort verification can be turned off with `TLS_VERIFY_MODE=none`,
+which makes the download trust whatever answers. Do this only on a network you
+control; it is the one setting that turns a compromised or spoofed settings
+server into remote code execution on every agent that boots against it.

--- a/include/onboarding/onboarding.hpp
+++ b/include/onboarding/onboarding.hpp
@@ -53,10 +53,14 @@ struct enrollment_request {
   std::string hostname;         // optional; defaults to the local host name
   std::string os;               // optional; defaults to windows/macos/linux
 
-  // TLS settings for the public HTTPS enrollment call.
+  // TLS settings for the public HTTPS enrollment call. This is the exchange
+  // that decides who the fleet server is, so it verifies by default: an
+  // unverified enrollment lets an on-path attacker substitute both trust
+  // anchors (the mTLS pin and the bundle signing key) for the life of the
+  // agent. Pass verify_mode = "none" explicitly to opt out.
   std::string tls_version = "tlsv1.2+";
-  std::string verify_mode;  // empty: "certificate" when a ca is given, else "none"
-  std::string ca;           // optional CA bundle used to verify the server
+  std::string verify_mode;  // empty: "certificate"
+  std::string ca;           // CA bundle used to verify the server
 
   unsigned int max_attempts = 3;  // attempts for retryable failures (429/5xx/network)
 };

--- a/include/process/execute_process_unix.cpp
+++ b/include/process/execute_process_unix.cpp
@@ -82,6 +82,31 @@ NSCAPI::nagiosReturn map_exit_status(int status) {
 // Run an argv vector via fork + execvp. No shell is involved, so attacker-
 // controlled argv elements cannot become metacharacters.
 int execute_argv(const process::exec_arguments& args, std::string& output) {
+  if (args.argv.empty()) {
+    output = "Refusing to execute an empty command";
+    return NSCAPI::query_return_codes::returnUNKNOWN;
+  }
+
+  // Build the execvp argv BEFORE forking. Only async-signal-safe calls are
+  // legal between fork() and exec() in a multithreaded process, and this one is
+  // emphatically multithreaded - each socket server runs a 10-thread io pool by
+  // default, plus the scheduler pool and the collectors. Allocating in the
+  // child (this vector used to be built there, and reserve() is a malloc) can
+  // deadlock against an allocator lock that some other thread held at the
+  // moment of the fork, and whose owner does not exist in the child. The parent
+  // then blocks in drain_with_timeout until the command timeout expires and
+  // reports a bogus "didn't terminate" - an intermittent, load-dependent check
+  // failure that is close to undiagnosable from the logs.
+  //
+  // The backing std::strings in args.argv stay alive across the fork, so the
+  // child only indexes an array that already exists.
+  std::vector<char*> cargs;
+  cargs.reserve(args.argv.size() + 1);
+  for (const auto& a : args.argv) {
+    cargs.push_back(const_cast<char*>(a.c_str()));
+  }
+  cargs.push_back(nullptr);
+
   int pipefd[2];
   if (pipe(pipefd) != 0) {
     output = "Failed to create pipe: ";
@@ -98,18 +123,12 @@ int execute_argv(const process::exec_arguments& args, std::string& output) {
     return NSCAPI::query_return_codes::returnUNKNOWN;
   }
   if (pid == 0) {
-    // Child. Wire stdout / stderr to the parent's pipe and execvp.
+    // Child. Everything from here to execvp must be async-signal-safe: no
+    // allocation, no locking, no libstdc++ calls that might do either.
     close(pipefd[0]);
     if (dup2(pipefd[1], STDOUT_FILENO) < 0) _exit(127);
     if (dup2(pipefd[1], STDERR_FILENO) < 0) _exit(127);
     close(pipefd[1]);
-    // Build an argv compatible with execvp.
-    std::vector<char*> cargs;
-    cargs.reserve(args.argv.size() + 1);
-    for (const auto& a : args.argv) {
-      cargs.push_back(const_cast<char*>(a.c_str()));
-    }
-    cargs.push_back(nullptr);
     execvp(cargs[0], cargs.data());
     // execvp only returns on error.
     _exit(127);

--- a/include/settings/impl/settings_http.hpp
+++ b/include/settings/impl/settings_http.hpp
@@ -136,7 +136,31 @@ class settings_http : public settings::settings_interface_impl {
 
       auto tls_version = get_core()->get_tls_version();
       auto verify_mode = get_core()->get_tls_verify_mode();
-      auto ca = get_core()->get_tls_ca();
+      // The CA may be written as a path macro (it defaults to ${ca-path}), so
+      // it has to be expanded before OpenSSL sees it.
+      auto ca = get_core()->expand_path(get_core()->get_tls_ca());
+
+      // This download becomes the agent's configuration. An unverified fetch
+      // hands whoever answers for `url.host` full control of the host, so it
+      // must never be the quiet path: complain on every attempt, and say what
+      // to set. Proceeding rather than refusing is deliberate - `none` can now
+      // only come from an operator explicitly writing it into boot.ini, and
+      // silently bricking such an install on upgrade would be worse than a
+      // loud log line.
+      if (url.protocol == "https") {
+        if (verify_mode.empty() || verify_mode == "none") {
+          get_logger()->error("settings", __FILE__, __LINE__,
+                              "INSECURE: fetching settings from " + url.to_string() +
+                                  " without verifying the server certificate ([tls] verify mode = none in boot.ini). Anyone who can answer for this host "
+                                  "controls this agent's entire configuration, including external script definitions. Set 'verify mode = peer' and point "
+                                  "'ca' at the issuing CA.");
+        } else if (!ca.empty() && ca != "none" && !boost::filesystem::is_regular_file(ca)) {
+          get_logger()->error("settings", __FILE__, __LINE__,
+                              "CA bundle '" + ca + "' not found; the settings download from " + url.to_string() +
+                                  " will fail certificate verification. Point [tls] ca in boot.ini at the CA that issued the settings server's "
+                                  "certificate. (On Windows the default bundle is exported at startup, so it is absent during the very first boot.)");
+        }
+      }
 
       http::proxy_config proxy = http::parse_proxy_url(get_core()->get_proxy_url());
       const std::string no_proxy_str = get_core()->get_no_proxy();

--- a/include/settings/impl/settings_http.hpp
+++ b/include/settings/impl/settings_http.hpp
@@ -147,6 +147,16 @@ class settings_http : public settings::settings_interface_impl {
       // only come from an operator explicitly writing it into boot.ini, and
       // silently bricking such an install on upgrade would be worse than a
       // loud log line.
+      //
+      // Both of these are advisories about a fetch that is still going to be
+      // attempted, so they are logged as warnings rather than errors. Error
+      // level means "this operation failed" to whoever is listening: the MSI
+      // custom action reads back the existing configuration through this very
+      // code path and treats any error-level message as a failed settings
+      // read, discarding the CONFIGURATION_TYPE the operator asked for and
+      // falling back to a local ini - i.e. an advisory logged as an error
+      // silently broke every https:// install. The real failure, when there is
+      // one, is still logged as an error by the download below.
       if (url.protocol == "https") {
         if (verify_mode.empty() || verify_mode == "none") {
           // Both spellings disable verification (an empty mode parses to
@@ -155,15 +165,15 @@ class settings_http : public settings::settings_interface_impl {
           // reads "verify mode =" sends them looking for the wrong line.
           const std::string how = verify_mode.empty() ? "[tls] verify mode is set but empty in boot.ini, which disables verification just as 'none' does"
                                                       : "[tls] verify mode = none in boot.ini";
-          get_logger()->error("settings", __FILE__, __LINE__,
-                              "INSECURE: fetching settings from " + url.to_string() + " without verifying the server certificate (" + how +
-                                  "). Anyone who can answer for this host controls this agent's entire configuration, including external script "
-                                  "definitions. Set 'verify mode = peer' and point 'ca' at the issuing CA.");
+          get_logger()->warning("settings", __FILE__, __LINE__,
+                                "INSECURE: fetching settings from " + url.to_string() + " without verifying the server certificate (" + how +
+                                    "). Anyone who can answer for this host controls this agent's entire configuration, including external script "
+                                    "definitions. Set 'verify mode = peer' and point 'ca' at the issuing CA.");
         } else if (!ca.empty() && ca != "none" && !boost::filesystem::is_regular_file(ca)) {
-          get_logger()->error("settings", __FILE__, __LINE__,
-                              "CA bundle '" + ca + "' not found; the settings download from " + url.to_string() +
-                                  " will fail certificate verification. Point [tls] ca in boot.ini at the CA that issued the settings server's "
-                                  "certificate. (On Windows the default bundle is exported at startup, so it is absent during the very first boot.)");
+          get_logger()->warning("settings", __FILE__, __LINE__,
+                                "CA bundle '" + ca + "' not found; the settings download from " + url.to_string() +
+                                    " will fail certificate verification. Point [tls] ca in boot.ini at the CA that issued the settings server's "
+                                    "certificate. (On Windows the default bundle is exported at startup, so it is absent during the very first boot.)");
         }
       }
 

--- a/include/settings/impl/settings_http.hpp
+++ b/include/settings/impl/settings_http.hpp
@@ -149,11 +149,16 @@ class settings_http : public settings::settings_interface_impl {
       // loud log line.
       if (url.protocol == "https") {
         if (verify_mode.empty() || verify_mode == "none") {
+          // Both spellings disable verification (an empty mode parses to
+          // verify_none), but say which one is actually in the file - telling
+          // an operator their boot.ini reads "verify mode = none" when it
+          // reads "verify mode =" sends them looking for the wrong line.
+          const std::string how = verify_mode.empty() ? "[tls] verify mode is set but empty in boot.ini, which disables verification just as 'none' does"
+                                                      : "[tls] verify mode = none in boot.ini";
           get_logger()->error("settings", __FILE__, __LINE__,
-                              "INSECURE: fetching settings from " + url.to_string() +
-                                  " without verifying the server certificate ([tls] verify mode = none in boot.ini). Anyone who can answer for this host "
-                                  "controls this agent's entire configuration, including external script definitions. Set 'verify mode = peer' and point "
-                                  "'ca' at the issuing CA.");
+                              "INSECURE: fetching settings from " + url.to_string() + " without verifying the server certificate (" + how +
+                                  "). Anyone who can answer for this host controls this agent's entire configuration, including external script "
+                                  "definitions. Set 'verify mode = peer' and point 'ca' at the issuing CA.");
         } else if (!ca.empty() && ca != "none" && !boost::filesystem::is_regular_file(ca)) {
           get_logger()->error("settings", __FILE__, __LINE__,
                               "CA bundle '" + ca + "' not found; the settings download from " + url.to_string() +

--- a/installer_lib/CMakeLists.txt
+++ b/installer_lib/CMakeLists.txt
@@ -222,6 +222,11 @@ set(SRCS
     ${NSCP_INCLUDEDIR}/bytes/base64.c
     ../libs/settings_manager/settings_manager_impl.cpp
     ../libs/settings_manager/settings_handler_impl.cpp
+    # Shared with the service (which exports the same bundle at boot): the
+    # installer needs a trust anchor of its own to verify an https:// settings
+    # source, since it runs before any file is installed.
+    ../service/windows_ca_store.cpp
+    ../service/windows_ca_store.hpp
     # Fleet onboarding (enrollment) shared with the core client, see
     # libs/onboarding and include/onboarding/onboarding.hpp.
     ../libs/onboarding/identity.cpp

--- a/installer_lib/installer_lib.cpp
+++ b/installer_lib/installer_lib.cpp
@@ -27,6 +27,9 @@
 #include <string>
 
 #include "../libs/settings_manager/settings_manager_impl.h"
+// The Windows ROOT store exporter the service uses to produce ${ca-path}; the
+// installer needs its own copy of that bundle, see prepare_trust_store() below.
+#include "../service/windows_ca_store.hpp"
 #include "installer_helper.hpp"
 #include "keys.hpp"
 
@@ -129,11 +132,77 @@ struct installer_settings_provider : public settings_manager::provider_interface
   std::string old_settings_map;
   std::shared_ptr<msi_logger> logger;
   std::map<std::string, std::string> path_overrides_;
+  // The CA bundle ${ca-path} resolves to for this custom action, and whether we
+  // are the ones who put it there (and so have to clean it up). See
+  // prepare_trust_store().
+  std::string ca_bundle_;
+  bool ca_bundle_is_ours_ = false;
+  bool trust_store_ready_ = false;
+  bool user_ca_ = false;
 
   installer_settings_provider(msi_helper *h, std::wstring basepath, std::wstring old_settings_map)
       : h(h), basepath(utf8::cvt<std::string>(basepath)), old_settings_map(utf8::cvt<std::string>(old_settings_map)), logger(new msi_logger(h)) {}
   installer_settings_provider(msi_helper *h, std::wstring basepath)
       : h(h), basepath(utf8::cvt<std::string>(basepath)), old_settings_map(utf8::cvt<std::string>(old_settings_map)), logger(new msi_logger(h)) {}
+
+  ~installer_settings_provider() {
+    if (!ca_bundle_is_ours_ || ca_bundle_.empty()) return;
+    boost::system::error_code ec;
+    boost::filesystem::remove(ca_bundle_, ec);
+  }
+
+  // The operator brought their own trust anchor (the TLS_CA property). It is
+  // handed to the settings transport verbatim, so there is nothing for us to
+  // export - and overwriting ${ca-path} with a store dump would be actively
+  // wrong for someone who deliberately pinned a single issuing CA.
+  void use_user_ca() { user_ca_ = true; }
+
+  // Materialise the trust anchor an https:// settings source is verified
+  // against, before the settings store is opened (and thus before that source
+  // is downloaded).
+  //
+  // The service exports the Windows ROOT store to ${ca-path}
+  // (${certificate-path}/windows-ca.pem) at boot, but nothing has done so by
+  // the time the installer runs: ImportConfig is sequenced before InstallFiles,
+  // so the install folder - let alone its security/ subfolder - does not exist
+  // yet, and on a fresh install the service has never started. So the installer
+  // exports its own copy to a temp file and points ${ca-path} at that for the
+  // duration of the custom action, then removes it again. Without this there is
+  // no anchor on disk at all and the fetch that delivers the agent's entire
+  // configuration would have to run unverified.
+  //
+  // A failure here is not fatal on its own: it leaves ${ca-path} unexpanded,
+  // and the download that follows fails with its own error. Note the level -
+  // these are warnings, never errors: ImportConfig treats any error-level
+  // message from this provider as "the settings context is broken" and throws
+  // the operator's CONFIGURATION_TYPE away.
+  void prepare_trust_store() override {
+    if (trust_store_ready_ || user_ca_) return;
+    trust_store_ready_ = true;
+    try {
+      const boost::filesystem::path bundle = boost::filesystem::temp_directory_path() / boost::filesystem::unique_path("nscp-install-ca-%%%%%%%%.pem");
+      std::list<std::string> ca_errors;
+      const unsigned int count = nsclient::windows_ca::export_root_store(bundle.string(), ca_errors);
+      for (const std::string &e : ca_errors) {
+        logger->warning("settings", __FILE__, __LINE__, "windows-ca: " + e);
+      }
+      if (count == 0) {
+        boost::system::error_code ec;
+        boost::filesystem::remove(bundle, ec);
+        logger->warning("settings", __FILE__, __LINE__,
+                        "No certificates were exported from the Windows ROOT store; an https:// settings source cannot be verified. Pass TLS_CA=<file> to "
+                        "use your own CA bundle, or TLS_VERIFY_MODE=none to fetch it unverified.");
+        return;
+      }
+      ca_bundle_ = bundle.string();
+      ca_bundle_is_ours_ = true;
+      logger->debug("settings", __FILE__, __LINE__, "Exported " + str::xtos(count) + " Windows ROOT certificates to " + ca_bundle_);
+    } catch (const std::exception &e) {
+      logger->warning("settings", __FILE__, __LINE__, std::string("Failed to export the Windows ROOT store: ") + e.what());
+    } catch (...) {
+      logger->warning("settings", __FILE__, __LINE__, "Failed to export the Windows ROOT store: <unknown exception>");
+    }
+  }
 
   virtual std::string expand_path(std::string file) {
     // Overrides win over the hardcoded fallbacks. We apply them first so a
@@ -148,6 +217,14 @@ struct installer_settings_provider : public settings_manager::provider_interface
     // boot.ini until the installer grows a full path resolver.
     for (const auto &kv : path_overrides_) {
       str::utils::replace(file, "${" + kv.first + "}", kv.second);
+    }
+    // ${ca-path} means the same thing here as it does to the service - "the
+    // platform trust store as a PEM bundle" - but it resolves to the temp copy
+    // prepare_trust_store() exported, since the service's own copy does not
+    // exist during an install. Left alone if the export never ran or failed, so
+    // the transport reports a missing CA rather than reading some other file.
+    if (!ca_bundle_.empty()) {
+      str::utils::replace(file, "${ca-path}", ca_bundle_);
     }
     str::utils::replace(file, "${base-path}", basepath);
     str::utils::replace(file, "${exe-path}", basepath);
@@ -344,14 +421,20 @@ extern "C" UINT __stdcall ImportConfig(MSIHANDLE hInstall) {
     std::string tls_version = utf8::cvt<std::string>(h.getMsiPropery(L"TLS_VERSION"));
     std::string tls_verify_mode = utf8::cvt<std::string>(h.getMsiPropery(L"TLS_VERIFY_MODE"));
     std::string tls_ca = utf8::cvt<std::string>(h.getMsiPropery(L"TLS_CA"));
+    // The unset defaults are the service's, not laxer ones: this transport
+    // fetches the file that becomes the agent's whole configuration, and the
+    // installer is the very first time it runs. TLS_CA, when given, is used
+    // verbatim (bring your own); otherwise ${ca-path} resolves to the ROOT
+    // store copy the provider exports below.
+    const bool user_ca = !tls_ca.empty();
     if (tls_version.empty()) {
       tls_version = "1.3";
     }
     if (tls_verify_mode.empty()) {
-      tls_verify_mode = "none";
+      tls_verify_mode = settings_manager::NSCSettingsImpl::kDefaultTlsVerifyMode;
     }
-    if (tls_ca.empty()) {
-      tls_ca = "";
+    if (!user_ca) {
+      tls_ca = settings_manager::NSCSettingsImpl::kDefaultTlsCa;
     }
 
     std::wstring map_data = read_map_data(h);
@@ -378,6 +461,7 @@ extern "C" UINT __stdcall ImportConfig(MSIHANDLE hInstall) {
                  utf8::cvt<std::wstring>(tls_verify_mode) + L", tls_ca=" + utf8::cvt<std::wstring>(tls_ca));
 
     installer_settings_provider provider(&h, target, map_data);
+    if (user_ca) provider.use_user_ca();
     if (!settings_manager::init_installer_settings(&provider, utf8::cvt<std::string>(context), tls_version, tls_verify_mode, tls_ca)) {
       h.setError(L"ImportConfig::init_installer_settings", L"Settings context had fatal errors");
       h.setConfHasErrors(L"Failed to load existing configuration");
@@ -827,10 +911,16 @@ extern "C" UINT __stdcall ExecWriteConfig(MSIHANDLE hInstall) {
     }
 
     installer_settings_provider provider(&h, target);
+    if (!tls_ca.empty()) provider.use_user_ca();
 
-    auto use_tls_version = tls_version.empty() ? "1.3" : utf8::cvt<std::string>(tls_version);
-    auto use_tls_verify_mode = tls_verify_mode.empty() ? "none" : utf8::cvt<std::string>(tls_verify_mode);
-    auto use_tls_ca = tls_ca.empty() ? "" : utf8::cvt<std::string>(tls_ca);
+    // Same defaults as ImportConfig - see the note there. Only the properties
+    // the operator actually set are written to boot.ini further down, so an
+    // unset TLS_VERIFY_MODE/TLS_CA leaves the [tls] section alone and the
+    // service applies its own (identical) defaults at boot.
+    auto use_tls_version = tls_version.empty() ? std::string("1.3") : utf8::cvt<std::string>(tls_version);
+    auto use_tls_verify_mode =
+        tls_verify_mode.empty() ? std::string(settings_manager::NSCSettingsImpl::kDefaultTlsVerifyMode) : utf8::cvt<std::string>(tls_verify_mode);
+    auto use_tls_ca = tls_ca.empty() ? std::string(settings_manager::NSCSettingsImpl::kDefaultTlsCa) : utf8::cvt<std::string>(tls_ca);
 
     h.logMessage(L"Writing existing config TLS options: tls version=" + utf8::cvt<std::wstring>(use_tls_version) + L", tls_verify=" +
                  utf8::cvt<std::wstring>(use_tls_verify_mode) + L", tls_ca=" + utf8::cvt<std::wstring>(use_tls_ca));

--- a/libs/mongoose-cpp/ServerBeastImpl.cpp
+++ b/libs/mongoose-cpp/ServerBeastImpl.cpp
@@ -120,9 +120,14 @@ Mongoose::Request beast_to_request(const http::request<http::string_body>& req, 
     headers[name] = value;
   }
 
-  const auto override = headers.find("X-HTTP-Method-Override");
-  if (override != headers.end() && !override->second.empty()) {
-    method = override->second;
+  // Case-insensitive full-name match, matching ServerMongooseImpl. headers_type
+  // is an ordinary case-sensitive map (see L13 in the security review for the
+  // general problem), so this one lookup scans rather than relying on find().
+  for (const auto &kv : headers) {
+    if (!kv.second.empty() && boost::algorithm::iequals(kv.first, "X-HTTP-Method-Override")) {
+      method = kv.second;
+      break;
+    }
   }
 
   return {remote_ip, is_ssl, std::move(method), std::move(url), std::move(query), std::move(headers), req.body()};

--- a/libs/mongoose-cpp/ServerBeastImpl.cpp
+++ b/libs/mongoose-cpp/ServerBeastImpl.cpp
@@ -122,12 +122,25 @@ Mongoose::Request beast_to_request(const http::request<http::string_body>& req, 
 
   // Case-insensitive full-name match, matching ServerMongooseImpl. headers_type
   // is an ordinary case-sensitive map (see L13 in the security review for the
-  // general problem), so this one lookup scans rather than relying on find().
-  for (const auto &kv : headers) {
-    if (!kv.second.empty() && boost::algorithm::iequals(kv.first, "X-HTTP-Method-Override")) {
-      method = kv.second;
-      break;
-    }
+  // general problem), so this scans rather than relying on find().
+  //
+  // Scanned over `req` rather than `headers`: the map above collapses repeated
+  // fields to the last value and folds nothing by case, so it cannot tell a
+  // single override from several. A repeated override is ambiguous and is
+  // dropped, not resolved - if this backend picked "first wins" while the
+  // mongoose backend picked "last wins", a proxy ACL that classifies by method
+  // could be bypassed by sending both.
+  std::string override_value;
+  std::size_t override_count = 0;
+  for (const auto& field : req) {
+    if (!boost::algorithm::iequals(std::string(field.name_string()), "X-HTTP-Method-Override")) continue;
+    std::string value(field.value());
+    if (value.empty()) continue;
+    override_value = std::move(value);
+    override_count++;
+  }
+  if (override_count == 1) {
+    method = override_value;
   }
 
   return {remote_ip, is_ssl, std::move(method), std::move(url), std::move(query), std::move(headers), req.body()};

--- a/libs/mongoose-cpp/ServerMongooseImpl.cpp
+++ b/libs/mongoose-cpp/ServerMongooseImpl.cpp
@@ -165,9 +165,18 @@ void ServerMongooseImpl::onHttpRequest(mg_connection *connection, mg_http_messag
   auto url = std::string(message->uri.buf, message->uri.len);
   auto method = std::string(message->method.buf, message->method.len);
 
-  size_t max = std::size(message->headers);
+  // Match the override header on its full name. The comparison used to be
+  // bounded by the *incoming* header's length, so strncmp succeeded for any
+  // name that is a prefix of it - "X:", "X-H:" and "X-HTTP:" all silently
+  // changed the request method, which defeats any upstream proxy or WAF ACL
+  // that classifies requests by method. Compare the whole thing, and
+  // case-insensitively, since RFC 7230 §3.2 makes field names case-insensitive
+  // (the Beast backend does an exact map lookup for the same header).
+  static const std::string kMethodOverride = "X-HTTP-Method-Override";
+  const size_t max = std::size(message->headers);
   for (size_t i = 0; i < max && message->headers[i].name.len > 0; i++) {
-    if (message->headers[i].value.len > 0 && strncmp(message->headers[i].name.buf, "X-HTTP-Method-Override", message->headers[i].name.len) == 0) {
+    const std::string name(message->headers[i].name.buf, message->headers[i].name.len);
+    if (message->headers[i].value.len > 0 && boost::algorithm::iequals(name, kMethodOverride)) {
       method = std::string(message->headers[i].value.buf, message->headers[i].value.len);
     }
   }

--- a/libs/mongoose-cpp/ServerMongooseImpl.cpp
+++ b/libs/mongoose-cpp/ServerMongooseImpl.cpp
@@ -170,15 +170,28 @@ void ServerMongooseImpl::onHttpRequest(mg_connection *connection, mg_http_messag
   // name that is a prefix of it - "X:", "X-H:" and "X-HTTP:" all silently
   // changed the request method, which defeats any upstream proxy or WAF ACL
   // that classifies requests by method. Compare the whole thing, and
-  // case-insensitively, since RFC 7230 §3.2 makes field names case-insensitive
-  // (the Beast backend does an exact map lookup for the same header).
+  // case-insensitively, since RFC 7230 §3.2 makes field names case-insensitive.
+  //
+  // A repeated override is ambiguous, so it is ignored rather than resolved:
+  // an upstream proxy or WAF that classifies by method has to agree with us on
+  // which copy counts, and "first wins" here vs "last wins" there is exactly
+  // the disagreement that makes the ACL bypassable. Both backends drop the
+  // request's override entirely in that case - see ServerBeastImpl.
   static const std::string kMethodOverride = "X-HTTP-Method-Override";
   const size_t max = std::size(message->headers);
+  std::string override_value;
+  size_t override_count = 0;
   for (size_t i = 0; i < max && message->headers[i].name.len > 0; i++) {
     const std::string name(message->headers[i].name.buf, message->headers[i].name.len);
     if (message->headers[i].value.len > 0 && boost::algorithm::iequals(name, kMethodOverride)) {
-      method = std::string(message->headers[i].value.buf, message->headers[i].value.len);
+      override_value.assign(message->headers[i].value.buf, message->headers[i].value.len);
+      override_count++;
     }
+  }
+  if (override_count == 1) {
+    method = override_value;
+  } else if (override_count > 1) {
+    logger_->log_error("Ignoring " + std::to_string(override_count) + " conflicting X-HTTP-Method-Override headers");
   }
 
   for (Controller *ctrl : controllers) {

--- a/libs/onboarding/enroll.cpp
+++ b/libs/onboarding/enroll.cpp
@@ -105,7 +105,16 @@ std::string error_snippet(const std::string &payload) {
 
 http::response default_post(const onboarding::enrollment_request &request, const std::string &url, const std::string &payload) {
   const http::parsed_url parsed = http::parse_url(url);
-  const std::string verify = request.verify_mode.empty() ? (request.ca.empty() ? "none" : "certificate") : request.verify_mode;
+  // Verify by default. Enrollment is the one exchange that establishes who the
+  // fleet server is: the response supplies mtls_server_cert_pem (the pin every
+  // later call validates against) and bundle_signing_pub_pem (the key that
+  // authorises executable bundles), and the request carries the bootstrap
+  // token. Falling back to "none" whenever no CA happened to be supplied meant
+  // an on-path attacker could hand over both trust anchors and keep the agent
+  // permanently - after which pinning and bundle signature checks still pass,
+  // against the attacker's material. Callers that genuinely want an unverified
+  // enrollment now have to ask for it explicitly (nscp enroll --insecure).
+  const std::string verify = request.verify_mode.empty() ? "certificate" : request.verify_mode;
   const http::http_client_options options(parsed.protocol, request.tls_version, verify, request.ca);
   http::request rq("POST", parsed.host, parsed.path);
   rq.add_post_payload("application/json", payload);

--- a/libs/settings_manager/settings_manager_impl.cpp
+++ b/libs/settings_manager/settings_manager_impl.cpp
@@ -167,6 +167,12 @@ void NSCSettingsImpl::boot(std::string key) {
       provider_->apply_path_overrides(std::move(path_overrides));
     }
   }
+  // Everything below opens the master settings store, and for an http(s)://
+  // source that means an immediate network fetch. Give the provider its chance
+  // to lay down the trust material that fetch verifies against first - after
+  // the [paths] overrides above, so it lands where the operator asked.
+  provider_->prepare_trust_store();
+
   if (order.size() == 0) {
     get_logger()->debug("settings", __FILE__, __LINE__, "No entries found looking in (adding default): " + boot_.string());
 #ifdef WIN32

--- a/libs/settings_manager/settings_manager_impl.h
+++ b/libs/settings_manager/settings_manager_impl.h
@@ -21,6 +21,15 @@ struct provider_interface {
   // opened, so that overrides take effect for every subsequent path lookup
   // (including the main INI's own location).
   virtual void apply_path_overrides(std::map<std::string, std::string> overrides) = 0;
+  // Materialise anything the settings transport needs to verify a peer, before
+  // the main settings store is opened. A remote (https://) settings source is
+  // fetched as part of opening that store, and on Windows the CA bundle it
+  // verifies against (${ca-path}) is a file this service exports itself - so it
+  // has to exist by now, not merely by the end of startup. Called from boot()
+  // after boot.ini's [paths] overrides have been applied, so ${ca-path}
+  // resolves against the operator's final paths. Implementations must be
+  // idempotent; the default is a no-op for providers with nothing to prepare.
+  virtual void prepare_trust_store() {}
 };
 
 class NSCSettingsImpl : public settings::settings_handler_impl {

--- a/libs/settings_manager/settings_manager_impl.h
+++ b/libs/settings_manager/settings_manager_impl.h
@@ -34,8 +34,26 @@ class NSCSettingsImpl : public settings::settings_handler_impl {
   std::string no_proxy_;
 
  public:
+  // Defaults for [tls] in boot.ini. These govern the transport used to fetch a
+  // remote (http[s]://) settings source, i.e. the channel that delivers this
+  // agent's entire configuration - including [/settings/external scripts],
+  // which is arbitrary command execution by design. Verifying the peer is
+  // therefore not optional-by-default: `verify mode = none` used to mean any
+  // attacker who could answer for the settings host owned every agent that
+  // booted against it, with no certificate error and nothing in the log.
+  //
+  // `ca-path` is the same trust anchor CheckNet and CheckNSCP already default
+  // to: the auto-exported Windows ROOT bundle on Windows, the distribution CA
+  // bundle on Linux.
+  static constexpr const char *kDefaultTlsVerifyMode = "peer";
+  static constexpr const char *kDefaultTlsCa = "${ca-path}";
+
   explicit NSCSettingsImpl(provider_interface *provider)
-      : settings::settings_handler_impl(provider->get_logger()), provider_(provider), tls_version_("1.3"), tls_verify_mode_("none"), tls_ca_("") {}
+      : settings::settings_handler_impl(provider->get_logger()),
+        provider_(provider),
+        tls_version_("1.3"),
+        tls_verify_mode_(kDefaultTlsVerifyMode),
+        tls_ca_(kDefaultTlsCa) {}
   NSCSettingsImpl(provider_interface *provider, std::string tls_version, std::string tls_verify_mode, std::string tls_ca)
       : settings::settings_handler_impl(provider->get_logger()),
         provider_(provider),

--- a/libs/settings_manager/settings_manager_impl_test.cpp
+++ b/libs/settings_manager/settings_manager_impl_test.cpp
@@ -211,16 +211,32 @@ TEST_F(SettingsManagerBootTest, TlsSectionPopulatesAccessors) {
 }
 
 TEST_F(SettingsManagerBootTest, TlsSectionDefaultsWhenAbsent) {
-  // Constructor defaults are "1.3" / "none" / "". A boot.ini with no [tls]
-  // section must leave them intact.
+  // A boot.ini with no [tls] section must leave the constructor defaults
+  // intact. Those defaults verify the peer against the platform CA bundle:
+  // the transport they govern delivers this agent's whole configuration, so
+  // "don't check who we are talking to" is not an acceptable default.
   write_boot_ini("");
 
   settings_manager::NSCSettingsImpl impl(provider_.get());
   impl.boot("");
 
   EXPECT_EQ(impl.get_tls_version(), "1.3");
+  EXPECT_EQ(impl.get_tls_verify_mode(), "peer");
+  EXPECT_EQ(impl.get_tls_ca(), "${ca-path}");
+}
+
+TEST_F(SettingsManagerBootTest, TlsVerificationCanStillBeDisabledExplicitly) {
+  // The insecure mode remains reachable, but only by writing it out - which is
+  // the point: `none` can no longer be arrived at by omission.
+  write_boot_ini(
+      "[tls]\n"
+      "verify mode=none\n"
+      "ca=\n");
+
+  settings_manager::NSCSettingsImpl impl(provider_.get());
+  impl.boot("");
+
   EXPECT_EQ(impl.get_tls_verify_mode(), "none");
-  EXPECT_EQ(impl.get_tls_ca(), "");
 }
 
 // ---------------------------------------------------------------------------

--- a/modules/CheckDocker/CMakeLists.txt
+++ b/modules/CheckDocker/CMakeLists.txt
@@ -38,6 +38,7 @@ if(WIN32)
         ${SRCS}
         "${TARGET}.h"
         check_docker.hpp
+        docker_endpoint.hpp
         ${NSCP_DEF_PLUGIN_HPP}
         ${NSCP_FILTER_HPP}
     )
@@ -54,4 +55,12 @@ target_link_libraries(
     expression_parser
     ${EXTRA_LIBS}
 )
+NSCP_CREATE_TEST(
+    docker_endpoint_test
+    SOURCES
+        docker_endpoint_test.cpp
+    LIBRARIES
+        GTest::gtest_main
+)
+
 include(${BUILD_CMAKE_FOLDER}/module.cmake)

--- a/modules/CheckDocker/check_docker.cpp
+++ b/modules/CheckDocker/check_docker.cpp
@@ -3,6 +3,8 @@
 
 #include "check_docker.hpp"
 
+#include "docker_endpoint.hpp"
+
 #include <boost/json.hpp>
 #include <net/http/client.hpp>
 #include <nscapi/nscapi_plugin_wrapper.hpp>
@@ -93,16 +95,29 @@ void check(const PB::Commands::QueryRequestMessage::Request& request, PB::Comman
   typedef check_docker_filter::filter filter_type;
   modern_filter::data_container data;
   modern_filter::cli_helper<filter_type> filter_helper(request, response, data);
-  std::string host = "\\\\.\\pipe\\docker_engine";
+  std::string host = default_docker_endpoint();
 
   filter_type filter;
   filter_helper.add_options("container_state != 'running'", "container_state != 'running'", "", filter.get_filter_syntax(), "warning");
   filter_helper.add_syntax("${status}: ${list}", "${names}=${container_state}", "${id}", "", "");
-  filter_helper.get_desc().add_options()("host", po::value<std::string>(&host), "The host or socket of the docker daemon");
+  filter_helper.get_desc().add_options()("host", po::value<std::string>(&host), "The local docker daemon socket (named pipe on Windows, unix socket elsewhere)");
 
   if (!filter_helper.parse_options()) return;
 
   if (!filter_helper.build_filter(filter)) return;
+
+  // `host` is a check argument, so it arrives from whoever can run this check -
+  // over REST that is anyone holding `queries.execute`, which the stock
+  // `monitoring` and `client` roles both have. It is handed to the "pipe"
+  // transport, which on Windows calls CreateFileA on it: a UNC target such as
+  // \\attacker\pipe\x makes Windows open an SMB session to an arbitrary host
+  // using the service account's credentials, exposing them for capture or
+  // relay (NSClient++ commonly runs as LocalSystem). Constrain it to a local
+  // endpoint before it gets that far.
+  std::string endpoint_error;
+  if (!is_local_docker_endpoint(host, endpoint_error)) {
+    return nscapi::protobuf::functions::set_response_bad(*response, endpoint_error);
+  }
 
   try {
     http::request rq("GET", "", "/v1.40/containers/json");

--- a/modules/CheckDocker/check_docker.hpp
+++ b/modules/CheckDocker/check_docker.hpp
@@ -5,7 +5,11 @@
 
 #include <nscapi/protobuf/command.hpp>
 
+// default_docker_endpoint / is_local_docker_endpoint live in
+// docker_endpoint.hpp so they can be unit-tested without this module's
+// protobuf and filter dependencies.
+
 namespace docker_checks {
 
 void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
-}
+}  // namespace docker_checks

--- a/modules/CheckDocker/docker_endpoint.hpp
+++ b/modules/CheckDocker/docker_endpoint.hpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <string>
+
+namespace docker_checks {
+
+// The docker daemon endpoint this platform uses when `--host` is not given.
+inline std::string default_docker_endpoint() {
+#ifdef WIN32
+  return "\\\\.\\pipe\\docker_engine";
+#else
+  return "/var/run/docker.sock";
+#endif
+}
+
+// True when `host` names a docker endpoint on this machine.
+//
+// `--host` is a check argument, so it arrives from whoever can run the check -
+// over REST that is any caller holding `queries.execute`, which the stock
+// `monitoring` and `client` roles both have. It is handed to the "pipe"
+// transport, which on Windows calls CreateFileA on it. A UNC target such as
+// \\attacker\pipe\x makes Windows open an SMB session to an arbitrary host
+// using the service account's credentials, exposing them for capture or relay
+// (NSClient++ commonly runs as LocalSystem). SECURITY_SQOS_PRESENT |
+// SECURITY_IDENTIFICATION on that call limits what a hostile pipe server can
+// impersonate, but does nothing to prevent the outbound authentication - so
+// the endpoint has to be constrained here, before the connect.
+//
+// On failure `error` explains what was rejected.
+//
+// Header-only so it can be unit-tested without the module's protobuf/filter
+// dependencies; the platform branch is compile-time, so a given build only
+// ever exercises one of them.
+inline bool is_local_docker_endpoint(const std::string &host, std::string &error) {
+  if (host.empty()) {
+    error = "No docker endpoint given";
+    return false;
+  }
+#ifdef WIN32
+  // Accept only the local-device pipe namespace: \\.\pipe\<name> or the
+  // equivalent \\?\pipe\<name>. A UNC server name in that slot (\\host\pipe\x)
+  // is what turns this into an outbound SMB authentication, so the third
+  // character has to be a literal '.' or '?', and <name> must not contain
+  // further separators that could walk back out of the pipe namespace.
+  const std::string prefix_dot = "\\\\.\\pipe\\";
+  const std::string prefix_q = "\\\\?\\pipe\\";
+  const bool dotted = host.compare(0, prefix_dot.size(), prefix_dot) == 0;
+  const bool questioned = host.compare(0, prefix_q.size(), prefix_q) == 0;
+  if (!dotted && !questioned) {
+    error = "Refusing docker endpoint '" + host +
+            "': only a local named pipe (\\\\.\\pipe\\<name>) is allowed. A UNC path would make this host authenticate to a remote server over SMB.";
+    return false;
+  }
+  const std::string name = host.substr(prefix_dot.size());
+  if (name.empty() || name.find('\\') != std::string::npos || name.find('/') != std::string::npos) {
+    error = "Refusing docker endpoint '" + host + "': the pipe name must be a single path-separator-free component.";
+    return false;
+  }
+  return true;
+#else
+  // Unix domain socket path. The "pipe" transport is Windows-only, so this
+  // never reaches CreateFileA - but keep the endpoint local and unambiguous
+  // rather than letting a relative or traversing path through.
+  if (host[0] != '/') {
+    error = "Refusing docker endpoint '" + host + "': expected an absolute path to the docker socket.";
+    return false;
+  }
+  if (host.find("/../") != std::string::npos || (host.size() >= 3 && host.compare(host.size() - 3, 3, "/..") == 0)) {
+    error = "Refusing docker endpoint '" + host + "': path traversal is not allowed.";
+    return false;
+  }
+  return true;
+#endif
+}
+
+}  // namespace docker_checks

--- a/modules/CheckDocker/docker_endpoint.hpp
+++ b/modules/CheckDocker/docker_endpoint.hpp
@@ -3,9 +3,26 @@
 
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 namespace docker_checks {
+
+// ASCII case-insensitive prefix test. Deliberately hand-rolled rather than
+// boost::algorithm::istarts_with: this header is kept dependency-free so it can
+// be unit-tested without the module's protobuf and filter dependencies, and
+// pipe path prefixes are pure ASCII.
+inline bool starts_with_ci(const std::string &value, const std::string &prefix) {
+  if (value.size() < prefix.size()) return false;
+  for (std::size_t i = 0; i < prefix.size(); i++) {
+    char a = value[i];
+    char b = prefix[i];
+    if (a >= 'A' && a <= 'Z') a = static_cast<char>(a - 'A' + 'a');
+    if (b >= 'A' && b <= 'Z') b = static_cast<char>(b - 'A' + 'a');
+    if (a != b) return false;
+  }
+  return true;
+}
 
 // The docker daemon endpoint this platform uses when `--host` is not given.
 inline std::string default_docker_endpoint() {
@@ -45,16 +62,28 @@ inline bool is_local_docker_endpoint(const std::string &host, std::string &error
   // is what turns this into an outbound SMB authentication, so the third
   // character has to be a literal '.' or '?', and <name> must not contain
   // further separators that could walk back out of the pipe namespace.
+  //
+  // Matched case-insensitively because Win32 path and pipe names are:
+  // \\.\Pipe\docker_engine names the same object as \\.\pipe\docker_engine and
+  // is a perfectly ordinary thing for an operator to type. This only ever
+  // widens what is accepted into the local namespace - anything that does not
+  // match one of these two prefixes is still refused outright.
   const std::string prefix_dot = "\\\\.\\pipe\\";
   const std::string prefix_q = "\\\\?\\pipe\\";
-  const bool dotted = host.compare(0, prefix_dot.size(), prefix_dot) == 0;
-  const bool questioned = host.compare(0, prefix_q.size(), prefix_q) == 0;
-  if (!dotted && !questioned) {
+  // Length of the prefix that actually matched, so this stays correct if the
+  // two ever stop being the same length.
+  std::size_t prefix_len = 0;
+  if (starts_with_ci(host, prefix_dot)) {
+    prefix_len = prefix_dot.size();
+  } else if (starts_with_ci(host, prefix_q)) {
+    prefix_len = prefix_q.size();
+  } else {
     error = "Refusing docker endpoint '" + host +
-            "': only a local named pipe (\\\\.\\pipe\\<name>) is allowed. A UNC path would make this host authenticate to a remote server over SMB.";
+            "': only a local named pipe (\\\\.\\pipe\\<name> or \\\\?\\pipe\\<name>) is allowed. A UNC path would make this host authenticate to a "
+            "remote server over SMB.";
     return false;
   }
-  const std::string name = host.substr(prefix_dot.size());
+  const std::string name = host.substr(prefix_len);
   if (name.empty() || name.find('\\') != std::string::npos || name.find('/') != std::string::npos) {
     error = "Refusing docker endpoint '" + host + "': the pipe name must be a single path-separator-free component.";
     return false;

--- a/modules/CheckDocker/docker_endpoint_test.cpp
+++ b/modules/CheckDocker/docker_endpoint_test.cpp
@@ -1,0 +1,87 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "docker_endpoint.hpp"
+
+using docker_checks::default_docker_endpoint;
+using docker_checks::is_local_docker_endpoint;
+
+namespace {
+bool accepted(const std::string &host) {
+  std::string error;
+  return is_local_docker_endpoint(host, error);
+}
+std::string rejection(const std::string &host) {
+  std::string error;
+  EXPECT_FALSE(is_local_docker_endpoint(host, error)) << "expected '" << host << "' to be rejected";
+  return error;
+}
+}  // namespace
+
+TEST(docker_endpoint, the_platform_default_is_accepted) { EXPECT_TRUE(accepted(default_docker_endpoint())); }
+
+TEST(docker_endpoint, empty_is_rejected) { EXPECT_FALSE(rejection("").empty()); }
+
+#ifdef WIN32
+
+// --- Windows: only the local device pipe namespace ---
+
+TEST(docker_endpoint, local_pipe_is_accepted) {
+  EXPECT_TRUE(accepted("\\\\.\\pipe\\docker_engine"));
+  EXPECT_TRUE(accepted("\\\\?\\pipe\\docker_engine"));
+  EXPECT_TRUE(accepted("\\\\.\\pipe\\some-other-name"));
+}
+
+TEST(docker_endpoint, unc_host_is_rejected) {
+  // The finding: a UNC target makes Windows authenticate outbound over SMB as
+  // the service account.
+  EXPECT_FALSE(rejection("\\\\attacker\\pipe\\docker_engine").empty());
+  EXPECT_FALSE(rejection("\\\\10.0.0.5\\pipe\\x").empty());
+  EXPECT_FALSE(rejection("\\\\evil.example.com\\pipe\\docker_engine").empty());
+}
+
+TEST(docker_endpoint, unc_rejection_explains_why) {
+  const std::string error = rejection("\\\\attacker\\pipe\\docker_engine");
+  EXPECT_NE(error.find("SMB"), std::string::npos) << error;
+}
+
+TEST(docker_endpoint, non_pipe_paths_are_rejected) {
+  EXPECT_FALSE(rejection("C:\\windows\\system32\\config\\sam").empty());
+  EXPECT_FALSE(rejection("\\\\.\\C:").empty());
+  EXPECT_FALSE(rejection("docker_engine").empty());
+  EXPECT_FALSE(rejection("http://attacker/").empty());
+}
+
+TEST(docker_endpoint, pipe_name_may_not_contain_separators) {
+  // No walking back out of the pipe namespace.
+  EXPECT_FALSE(rejection("\\\\.\\pipe\\..\\..\\x").empty());
+  EXPECT_FALSE(rejection("\\\\.\\pipe\\a\\b").empty());
+  EXPECT_FALSE(rejection("\\\\.\\pipe\\a/b").empty());
+  EXPECT_FALSE(rejection("\\\\.\\pipe\\").empty());
+}
+
+#else
+
+// --- POSIX: an absolute, non-traversing socket path ---
+
+TEST(docker_endpoint, absolute_socket_path_is_accepted) {
+  EXPECT_TRUE(accepted("/var/run/docker.sock"));
+  EXPECT_TRUE(accepted("/run/docker.sock"));
+}
+
+TEST(docker_endpoint, relative_paths_are_rejected) {
+  EXPECT_FALSE(rejection("docker.sock").empty());
+  EXPECT_FALSE(rejection("../docker.sock").empty());
+  EXPECT_FALSE(rejection("attacker.example.com").empty());
+}
+
+TEST(docker_endpoint, traversal_is_rejected) {
+  EXPECT_FALSE(rejection("/var/run/../../etc/passwd").empty());
+  EXPECT_FALSE(rejection("/var/run/..").empty());
+}
+
+#endif

--- a/modules/CheckDocker/docker_endpoint_test.cpp
+++ b/modules/CheckDocker/docker_endpoint_test.cpp
@@ -49,6 +49,28 @@ TEST(docker_endpoint, unc_rejection_explains_why) {
   EXPECT_NE(error.find("SMB"), std::string::npos) << error;
 }
 
+TEST(docker_endpoint, rejection_names_both_accepted_forms) {
+  // The message has to describe what is actually allowed, or an operator using
+  // the \\?\ form is told their working endpoint is the only illegal one.
+  const std::string error = rejection("\\\\attacker\\pipe\\docker_engine");
+  EXPECT_NE(error.find("\\\\.\\pipe\\"), std::string::npos) << error;
+  EXPECT_NE(error.find("\\\\?\\pipe\\"), std::string::npos) << error;
+}
+
+TEST(docker_endpoint, the_prefix_is_matched_case_insensitively) {
+  // Win32 path and pipe names are case-insensitive, so these all name the same
+  // object as the canonical spelling and must not be refused.
+  EXPECT_TRUE(accepted("\\\\.\\Pipe\\docker_engine"));
+  EXPECT_TRUE(accepted("\\\\.\\PIPE\\docker_engine"));
+  EXPECT_TRUE(accepted("\\\\?\\Pipe\\docker_engine"));
+}
+
+TEST(docker_endpoint, case_insensitivity_does_not_widen_past_the_local_namespace) {
+  // Folding case must not turn a UNC host into an accepted endpoint.
+  EXPECT_FALSE(rejection("\\\\ATTACKER\\pipe\\docker_engine").empty());
+  EXPECT_FALSE(rejection("\\\\Attacker\\PIPE\\x").empty());
+}
+
 TEST(docker_endpoint, non_pipe_paths_are_rejected) {
   EXPECT_FALSE(rejection("C:\\windows\\system32\\config\\sam").empty());
   EXPECT_FALSE(rejection("\\\\.\\C:").empty());

--- a/modules/WEBServer/legacy_controller.cpp
+++ b/modules/WEBServer/legacy_controller.cpp
@@ -125,15 +125,27 @@ void legacy_controller::auth_token(Mongoose::Request &request, Mongoose::StreamR
     response.setCodeForbidden("403 You're not allowed");
     return;
   }
-  if (session->validate_user("admin", request.get("password"))) {
-    const std::string token = session->generate_token("admin");
-    response.setHeader("__TOKEN", token);
-    response.get_headers()["Content-Type"] = "application/json";
-    response.append("{ \"status\" : \"ok\", \"auth token\": \"" + token + "\" }");
-    NSC_DEBUG_MSG("Issued legacy /auth/token for allowlisted User-Agent: " + user_agent);
-  } else {
-    response.setCodeForbidden("403 Invalid password");
+  // Delegate to the shared password-header path rather than calling
+  // validate_user directly. That is the only place that applies the per-IP
+  // failure backoff, the credential size cap and a single generic 403 for
+  // every failure mode; going around it turned this endpoint into an
+  // unthrottled guessing oracle against the admin account, with a distinct
+  // "403 Invalid password" reply confirming when a guess was right. The
+  // User-Agent allowlist above is not a control here - the client picks its
+  // own User-Agent.
+  //
+  // Same contract as the header form: the password alone, the user implied to
+  // be "admin". On success it generates the session token and stores it in the
+  // response cookie, which is where the legacy body/header below read it from.
+  if (!session->process_password_header("login.get", request, response, request.get("password"))) {
+    return;
   }
+  std::string user, token;
+  session_manager_interface::get_user_from_response(response, user, token);
+  response.setHeader("__TOKEN", token);
+  response.get_headers()["Content-Type"] = "application/json";
+  response.append("{ \"status\" : \"ok\", \"auth token\": \"" + token + "\" }");
+  NSC_DEBUG_MSG("Issued legacy /auth/token for allowlisted User-Agent: " + user_agent);
 }
 void legacy_controller::auth_logout(Mongoose::Request &request, Mongoose::StreamResponse &response) {
   // Same per-branch Content-Type pattern as auth_token above.

--- a/modules/WEBServer/legacy_controller.cpp
+++ b/modules/WEBServer/legacy_controller.cpp
@@ -142,6 +142,17 @@ void legacy_controller::auth_token(Mongoose::Request &request, Mongoose::StreamR
   }
   std::string user, token;
   session_manager_interface::get_user_from_response(response, user, token);
+  if (token.empty()) {
+    // Not reachable today: process_password_header stores a freshly generated
+    // token in the response cookie on every success, and getCookie reads that
+    // same map back. Guarded anyway because the entire purpose of this
+    // endpoint is to hand back a usable token - answering "ok" with an empty
+    // one would leave the caller with a 200 it cannot authenticate with, and
+    // nothing in the type system ties the two halves together.
+    NSC_LOG_ERROR("Authenticated a legacy /auth/token call but no session token was issued");
+    response.setCodeServerError("500 Failed to issue token");
+    return;
+  }
   response.setHeader("__TOKEN", token);
   response.get_headers()["Content-Type"] = "application/json";
   response.append("{ \"status\" : \"ok\", \"auth token\": \"" + token + "\" }");

--- a/service/NSClient++.cpp
+++ b/service/NSClient++.cpp
@@ -91,6 +91,41 @@ struct nscp_settings_provider : public settings_manager::provider_interface {
   virtual std::string expand_path(std::string file) { return path_->expand_path(file); }
   nsclient::logging::logger_instance get_logger() const { return log_instance_; }
   void apply_path_overrides(std::map<std::string, std::string> overrides) override { path_->set_overrides(std::move(overrides)); }
+
+  // Export the Windows ROOT certificate store to the file ${ca-path} points at,
+  // so every SSL setup site has a sensible default for `ca`.
+  //
+  // This has to run before the settings store is opened, not merely during
+  // startup: a boot.ini settings source of https://... is downloaded while that
+  // store is opened, and [tls] now verifies the peer by default against this
+  // very bundle. Exporting afterwards meant the file was missing on the first
+  // boot of a fresh install - load_verify_file() then throws, the settings
+  // download fails, and the agent comes up with no configuration at all. It
+  // "worked" from the second boot onwards, because by then the previous boot
+  // had written the file.
+  //
+  // Idempotent: called from settings boot and again from load_configuration_2
+  // (which still covers any startup path that does not boot the settings
+  // subsystem), but the store is only enumerated once per process.
+  void prepare_trust_store() override {
+#ifdef WIN32
+    if (trust_store_ready_) return;
+    trust_store_ready_ = true;
+    try {
+      const std::string bundle_path = path_->expand_path("${ca-path}");
+      boost::filesystem::create_directories(boost::filesystem::path(bundle_path).parent_path());
+      std::list<std::string> ca_errors;
+      const unsigned int n = nsclient::windows_ca::export_root_store(bundle_path, ca_errors);
+      for (const std::string &e : ca_errors) LOG_WARN_CORE("windows-ca: " + e);
+      if (n > 0) LOG_DEBUG_CORE("Exported " + std::to_string(n) + " Windows ROOT certificates to " + bundle_path);
+    } catch (const std::exception &e) {
+      LOG_WARN_CORE(std::string("Failed to export Windows ROOT store: ") + e.what());
+    }
+#endif
+  }
+
+ private:
+  bool trust_store_ready_ = false;
 };
 
 nscp_settings_provider *provider_ = NULL;
@@ -233,17 +268,10 @@ bool NSClientT::load_configuration_2(const bool override_log) {
 
   // Export the Windows ROOT certificate store to the file pointed at by the
   // ${ca-path} setting so SSL setup sites have a sensible default for `ca`.
-  // The bundle is regenerated on every boot.
-  try {
-    const std::string bundle_path = path_->expand_path("${ca-path}");
-    boost::filesystem::create_directories(boost::filesystem::path(bundle_path).parent_path());
-    std::list<std::string> ca_errors;
-    const unsigned int n = nsclient::windows_ca::export_root_store(bundle_path, ca_errors);
-    for (const std::string &e : ca_errors) LOG_WARN_CORE("windows-ca: " + e);
-    if (n > 0) LOG_DEBUG_CORE("Exported " + std::to_string(n) + " Windows ROOT certificates to " + bundle_path);
-  } catch (const std::exception &e) {
-    LOG_WARN_CORE(std::string("Failed to export Windows ROOT store: ") + e.what());
-  }
+  // Normally already done from the settings boot (a remote settings source is
+  // verified against this bundle, so it cannot wait until here); this call
+  // covers any startup path that skipped that, and is a no-op otherwise.
+  if (provider_ != NULL) provider_->prepare_trust_store();
 #endif
 
   boost::filesystem::path pluginPath = path_->expand_path("${module-path}");

--- a/service/NSClient++.cpp
+++ b/service/NSClient++.cpp
@@ -124,8 +124,12 @@ struct nscp_settings_provider : public settings_manager::provider_interface {
 #endif
   }
 
+#ifdef WIN32
  private:
+  // Only the Windows body has anything to remember; declaring it unconditionally
+  // leaves an unused private field everywhere else (-Wunused-private-field).
   bool trust_store_ready_ = false;
+#endif
 };
 
 nscp_settings_provider *provider_ = NULL;

--- a/service/cli_parser.cpp
+++ b/service/cli_parser.cpp
@@ -747,13 +747,13 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       ("token", po::value<std::string>(&request.bootstrap_token), "One-time bootstrap token from the install command")
       ("hostname", po::value<std::string>(&request.hostname), "Hostname to report to the fleet server (default: this machine's hostname)")
       ("os", po::value<std::string>(&request.os), "Operating system to report to the fleet server (default: detected)")
-      ("ca", po::value<std::string>(&request.ca), "CA bundle used to verify the fleet server certificate")
+      ("ca", po::value<std::string>(&request.ca), "CA bundle used to verify the fleet server certificate (default: the platform CA bundle, ${ca-path})")
       ("tls-version", po::value<std::string>(&request.tls_version)->default_value("tlsv1.2+"), "TLS version for the enrollment call")
-      ("verify", po::value<std::string>(&request.verify_mode), "TLS verify mode (default: certificate when --ca is given, none otherwise)")
+      ("verify", po::value<std::string>(&request.verify_mode), "TLS verify mode (default: certificate). 'none' disables server verification and requires --insecure")
       ("retries", po::value<unsigned int>(&request.max_attempts)->default_value(3), "Attempts for transient failures (rate limiting, server errors)")
       ("state-file", po::value<std::string>(&state_file), "Where to store the enrolled identity (default: ${certificate-path}/agent-state.json)")
       ("force", po::bool_switch(&force), "Overwrite an existing enrollment state file")
-      ("insecure", po::bool_switch(&insecure), "Allow enrollment over plain HTTP (the bootstrap token is sent in cleartext) - only on a trusted network or for testing")
+      ("insecure", po::bool_switch(&insecure), "Allow an unauthenticated enrollment: plain HTTP, or HTTPS with --verify none. Either way the fleet server is not authenticated, so an on-path attacker can read the bootstrap token and supply the trust anchors this agent will use from then on - only on a trusted network or for testing")
     ;
     // clang-format on
 
@@ -795,6 +795,33 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     }
     if (state_file.empty()) state_file = "${certificate-path}/agent-state.json";
     state_file = core_->get_path()->expand_path(state_file);
+
+    // Enrollment is where this agent decides who the fleet server is: the
+    // response carries the certificate every later call pins against and the
+    // key that authorises executable bundles. Getting that over an
+    // unauthenticated channel means an on-path attacker can substitute both
+    // and keep the host indefinitely - after which pinning and bundle
+    // signature verification keep succeeding, against the attacker's material.
+    // So an unverified enrollment has to be asked for, exactly like plain HTTP
+    // above.
+    if (boost::iequals(scheme, "https")) {
+      if (request.ca.empty()) {
+        // Same trust anchor the check modules default to: the exported Windows
+        // ROOT bundle, or the distribution CA bundle on Linux.
+        request.ca = core_->get_path()->expand_path("${ca-path}");
+      }
+      if (boost::iequals(request.verify_mode, "none")) {
+        if (!insecure) {
+          std::cerr << "Refusing to enroll without verifying the fleet server certificate (--verify none)." << std::endl;
+          std::cerr << "The enrollment response supplies the certificate this agent will pin for every later call and the key it will trust for "
+                       "executable bundles, so an unverified enrollment hands both to whoever answers." << std::endl;
+          std::cerr << "Point --ca at the issuing CA (recommended), or pass --insecure to accept an unauthenticated enrollment anyway." << std::endl;
+          return 1;
+        }
+        std::cerr << "WARNING: enrolling without verifying the fleet server certificate. The trust anchors stored by this enrollment are only as "
+                     "trustworthy as the network path you ran it over." << std::endl;
+      }
+    }
 
     boost::system::error_code fs_error;
     if (boost::filesystem::exists(state_file, fs_error) && !force) {

--- a/service/plugins/plugin_list.hpp
+++ b/service/plugins/plugin_list.hpp
@@ -213,14 +213,19 @@ struct plugins_list_listeners_impl {
 
   void remove_all() { listeners_.clear(); }
 
+  // Unsubscribe one plugin from every channel it registered for. Only that
+  // plugin's id is removed; a channel entry is dropped only once it has no
+  // subscribers left. Erasing the whole entry (which this used to do as soon
+  // as any one subscriber matched) silently unsubscribed every *other* plugin
+  // from that channel, and left this plugin's id behind in the channels it
+  // did not erase.
   void remove_plugin(const unsigned long id) {
     auto it = listeners_.begin();
     while (it != listeners_.end()) {
-      if (it->second.count(id) > 0) {
-        auto to_erase = it;
-        ++it;
-        listeners_.erase(to_erase);
-      } else
+      it->second.erase(id);
+      if (it->second.empty())
+        it = listeners_.erase(it);
+      else
         ++it;
     }
   }
@@ -264,6 +269,8 @@ struct plugins_list_with_listener : plugins_list<plugins_list_listeners_impl> {
     }
   }
 
+  // Collect the subscribers for `channel`. Runs under a SHARED lock, so
+  // nothing in here may modify plugins_ - see append_subscribers.
   std::list<plugin_type> get(const std::string &channel) {
     boost::shared_lock<boost::shared_mutex> readLock(mutex_, boost::get_system_time() + boost::posix_time::seconds(5));
     has_valid_lock_throw(readLock, "plugins_list::get:" + channel);
@@ -271,20 +278,12 @@ struct plugins_list_with_listener : plugins_list<plugins_list_listeners_impl> {
     std::set<unsigned long> seen;
     const std::string lower_case = make_key(channel);
     const auto cit = listeners_.find(lower_case);
-    if (cit != listeners_.end()) {
-      for (unsigned long id : cit->second) {
-        if (seen.insert(id).second) ret.push_back(plugins_[id]);
-      }
-    }
+    if (cit != listeners_.end()) append_subscribers(cit->second, seen, ret);
     // Wildcard "*" subscribers receive every channel. Used by sinks that
     // want to capture everything (e.g. the WEB server's event drain) without
     // the operator having to enumerate every emitted event name.
     const auto wit = listeners_.find("*");
-    if (wit != listeners_.end()) {
-      for (unsigned long id : wit->second) {
-        if (seen.insert(id).second) ret.push_back(plugins_[id]);
-      }
-    }
+    if (wit != listeners_.end()) append_subscribers(wit->second, seen, ret);
     return ret;
   }
 
@@ -292,6 +291,25 @@ struct plugins_list_with_listener : plugins_list<plugins_list_listeners_impl> {
     boost::shared_lock<boost::shared_mutex> readLock(mutex_, boost::get_system_time() + boost::posix_time::seconds(5));
     has_valid_lock_throw(readLock, "plugins_list::get_listeners");
     return listeners_;
+  }
+
+ private:
+  // Resolve subscriber ids to plugins, skipping any that are no longer loaded.
+  //
+  // This used to be `ret.push_back(plugins_[id])`. std::map::operator[]
+  // default-INSERTS when the key is absent, so that was a write to plugins_
+  // performed while holding only a shared lock - a data race against every
+  // concurrent reader of the same mutex, on a red-black tree. It also pushed
+  // the default-constructed null plugin_type into the result for callers to
+  // dereference. find() cannot insert and lets a missing id be skipped.
+  //
+  // Callers must hold the lock (shared is enough).
+  void append_subscribers(const plugin_id_type &ids, std::set<unsigned long> &seen, std::list<plugin_type> &ret) const {
+    for (const unsigned long id : ids) {
+      const auto pit = plugins_.find(id);
+      if (pit == plugins_.end() || !pit->second) continue;
+      if (seen.insert(id).second) ret.push_back(pit->second);
+    }
   }
 };
 }  // namespace nsclient

--- a/service/plugins/plugin_list_test.cpp
+++ b/service/plugins/plugin_list_test.cpp
@@ -280,10 +280,46 @@ TEST_F(PluginsListWithListenerTest, RemovePluginRemovesFromListeners) {
 
   list_->remove_plugin(1);
 
-  // Channel should still exist but without the plugin
-  // Note: The current implementation removes the entire channel entry
+  // Sole subscriber gone, so the channel entry goes with it.
   const auto listeners = list_->get("channel");
   EXPECT_TRUE(listeners.empty());
+}
+
+TEST_F(PluginsListWithListenerTest, RemovePluginKeepsOtherSubscribersOnSameChannel) {
+  // Unloading one module must not silently unsubscribe every other module from
+  // the channels it happened to share.
+  const auto plugin1 = std::make_shared<MockListPlugin>(1, "alias1", "Module1");
+  const auto plugin2 = std::make_shared<MockListPlugin>(2, "alias2", "Module2");
+  list_->add_plugin(plugin1);
+  list_->add_plugin(plugin2);
+  list_->register_listener(1, "shared_channel");
+  list_->register_listener(2, "shared_channel");
+
+  list_->remove_plugin(1);
+
+  const auto listeners = list_->get("shared_channel");
+  ASSERT_EQ(listeners.size(), 1u);
+  EXPECT_EQ(listeners.front()->get_id(), 2u);
+}
+
+TEST_F(PluginsListWithListenerTest, GetSkipsSubscriberIdsWithNoLoadedPlugin) {
+  // A listener id with no matching plugin must be skipped. This used to be
+  // `plugins_[id]`, whose default-insert both wrote to the map under a shared
+  // lock and handed the caller a null plugin to dereference.
+  const auto plugin = std::make_shared<MockListPlugin>(1, "alias", "Module");
+  list_->add_plugin(plugin);
+  list_->register_listener(1, "channel");
+  list_->listeners_["channel"].insert(999);
+
+  const std::size_t before = list_->plugins_.size();
+  const auto listeners = list_->get("channel");
+
+  ASSERT_EQ(listeners.size(), 1u);
+  EXPECT_EQ(listeners.front()->get_id(), 1u);
+  EXPECT_NE(listeners.front(), nullptr);
+  // The lookup must not have grown the plugin map.
+  EXPECT_EQ(list_->plugins_.size(), before);
+  EXPECT_TRUE(list_->plugins_.find(999) == list_->plugins_.end());
 }
 
 TEST_F(PluginsListWithListenerTest, RemoveAllClearsListeners) {
@@ -356,9 +392,44 @@ TEST(PluginsListListenersImplTest, RemovePluginRemovesFromAllChannels) {
 
   impl.remove_plugin(1);
 
-  // Channel with only plugin 1 should be removed
+  // channel2 had only plugin 1, so the entry goes.
   EXPECT_TRUE(impl.listeners_.find("channel2") == impl.listeners_.end());
-  // Channel1 should still have plugin 2... but the current implementation removes entire channel
+  // channel1 keeps plugin 2 - removing one subscriber must not unsubscribe the
+  // others, which is what erasing the whole entry used to do.
+  const auto ch1 = impl.listeners_.find("channel1");
+  ASSERT_TRUE(ch1 != impl.listeners_.end());
+  EXPECT_EQ(ch1->second.size(), 1u);
+  EXPECT_TRUE(ch1->second.count(2) > 0);
+  EXPECT_TRUE(ch1->second.count(1) == 0);
+}
+
+TEST(PluginsListListenersImplTest, RemovePluginLeavesNoStaleId) {
+  // The id must be gone from every channel, not just from the ones whose entry
+  // happened to be erased.
+  nsclient::plugins_list_listeners_impl impl;
+
+  impl.listeners_["a"].insert(1);
+  impl.listeners_["a"].insert(2);
+  impl.listeners_["b"].insert(1);
+  impl.listeners_["b"].insert(2);
+
+  impl.remove_plugin(1);
+
+  for (const auto &entry : impl.listeners_) {
+    EXPECT_TRUE(entry.second.count(1) == 0) << "stale id left in channel " << entry.first;
+  }
+}
+
+TEST(PluginsListListenersImplTest, RemoveUnknownPluginIsANoOp) {
+  nsclient::plugins_list_listeners_impl impl;
+
+  impl.listeners_["channel"].insert(1);
+
+  impl.remove_plugin(999);
+
+  const auto it = impl.listeners_.find("channel");
+  ASSERT_TRUE(it != impl.listeners_.end());
+  EXPECT_EQ(it->second.size(), 1u);
 }
 
 TEST(PluginsListListenersImplTest, ListReturnsAllChannels) {

--- a/tests/enroll-cli.test.ts
+++ b/tests/enroll-cli.test.ts
@@ -230,6 +230,37 @@ describe("nscp enroll (fleet onboarding CLI)", () => {
     expect(r.all).not.toMatch(/plain http/i);
   });
 
+  it("refuses --verify none over https unless --insecure is given", async () => {
+    // Enrollment is where the agent learns which certificate to pin and which
+    // key signs its bundles. Taking that over an unverified channel lets an
+    // on-path attacker supply both, so it has to be asked for explicitly - and
+    // the gate must fire before any network call.
+    const stateFile = path.join(nscp.scratch("enroll_verify_none"), "agent-state.json");
+    fs.rmSync(stateFile, { force: true });
+    const r = await enroll(
+      ["--state-file", stateFile, "--verify", "none"],
+      ["--server", baseUrl.replace("http://", "https://"), "--token", "tok-1"],
+    );
+    expect(r.exitCode).not.toBe(0);
+    expect(r.all).toMatch(/without verifying the fleet server certificate/i);
+    expect(r.all).toMatch(/--insecure|--ca/i);
+    expect(requests).toHaveLength(0);
+    expect(fs.existsSync(stateFile)).toBe(false);
+  });
+
+  it("allows --verify none over https with --insecure, but warns", async () => {
+    // Against this http-only server the call still fails at the TLS layer; what
+    // matters is that it got past the gate and said so.
+    const stateFile = path.join(nscp.scratch("enroll_verify_none_ok"), "agent-state.json");
+    fs.rmSync(stateFile, { force: true });
+    const r = await enroll(
+      ["--state-file", stateFile, "--verify", "none", "--retries", "1"],
+      ["--server", baseUrl.replace("http://", "https://"), "--token", "tok-1", "--insecure"],
+    );
+    expect(r.all).not.toMatch(/Refusing to enroll without verifying/i);
+    expect(r.all).toMatch(/WARNING: enrolling without verifying/i);
+  });
+
   it("rejects a server url that is not a url, without contacting anything", async () => {
     for (const url of ["fleet.example.com", "not a url", "/enroll"]) {
       const stateFile = path.join(nscp.scratch("enroll_badurl"), "agent-state.json");

--- a/tests/msi/tests/boot.ini-rest-config-verified.yaml
+++ b/tests/msi/tests/boot.ini-rest-config-verified.yaml
@@ -1,0 +1,19 @@
+# The default https:// settings source, with no TLS_* properties at all.
+#
+# The other rest-config cases all pass TLS_VERIFY_MODE=none, so they never
+# exercise the verified path. Here the certificate is checked against the
+# Windows ROOT store, which the installer has to export to a temp bundle of its
+# own: ${ca-path} points into the install folder, which does not exist yet when
+# ImportConfig runs (it is sequenced before InstallFiles) and is only written by
+# the service at boot.
+#
+# If that export is missing, or the fetch fails or is reported as an error, the
+# installer falls back to a local ini and boot.ini does not carry the URL - so
+# asserting on the URL here is what makes the whole chain testable.
+command_line: ["msiexec.exe", "/i", "$MSI-FILE", "/qn", "/l*", "log.txt", "ADDLOCAL=ALL", "CONFIGURATION_TYPE=https://raw.githubusercontent.com/mickem/nscp/refs/heads/main/tests/msi/nsclient.ini" ]
+replace_password: true
+boot.ini: |
+  [settings]
+  1 = https://raw.githubusercontent.com/mickem/nscp/refs/heads/main/tests/msi/nsclient.ini
+
+nsclient.ini: ""

--- a/tests/rest-legacy-auth-throttle.test.ts
+++ b/tests/rest-legacy-auth-throttle.test.ts
@@ -1,0 +1,98 @@
+/**
+ * The legacy /auth/token endpoint must be subject to the same per-IP failed
+ * authentication backoff as every other credential entry point.
+ *
+ * It used to call validate_user() directly, bypassing auth_rate_limiter
+ * entirely, which made it an unthrottled password-guessing oracle against the
+ * admin account - and it answered "403 Invalid password" only for a wrong
+ * password, confirming when a guess was right. The User-Agent allowlist in
+ * front of it is not a control: the client chooses its own User-Agent.
+ *
+ * This suite runs in its own NscpInstance because it deliberately gets the
+ * source IP blocked, which would leak into any other scenario sharing the
+ * server.
+ */
+import request from "supertest";
+import { NscpInstance, REST_URL, setupRestNscp } from "@fixtures/index";
+
+jest.setTimeout(900_000);
+
+const ICINGA_UA = "Icinga/check_nscp_api/2.14.0";
+const MAX_FAILURES = 3;
+const BLOCK_SECONDS = 3;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe("REST legacy /auth/token — failed-auth throttling", () => {
+  let nscp: NscpInstance;
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    await setupRestNscp(nscp);
+    await nscp.stop();
+    // Tighten the limiter so the test does not need ten round trips and a
+    // 60 second wait. The defaults (10 failures / 60s) are what ships.
+    await nscp.configure({
+      "/settings/WEB/server": {
+        "auth rate limit max failures": String(MAX_FAILURES),
+        "auth rate limit block seconds": String(BLOCK_SECONDS),
+      },
+    });
+    nscp.start();
+    await nscp.waitForPort(8443, { timeoutMs: 30_000 });
+  });
+
+  afterAll(async () => {
+    await nscp?.stop();
+  });
+
+  it("blocks the caller after repeated wrong passwords, even with the right one", async () => {
+    for (let i = 0; i < MAX_FAILURES; i++) {
+      await request(REST_URL)
+        .get("/auth/token")
+        .set("User-Agent", ICINGA_UA)
+        .query({ password: `wrong-password-${i}` })
+        .trustLocalhost(true)
+        .expect(403);
+    }
+
+    // The block is what proves the limiter is engaged: the correct password
+    // is now refused too. Before the fix this returned 200 and a token.
+    await request(REST_URL)
+      .get("/auth/token")
+      .set("User-Agent", ICINGA_UA)
+      .query({ password: "default-password" })
+      .trustLocalhost(true)
+      .expect(403);
+  });
+
+  it("recovers once the block expires", async () => {
+    await sleep((BLOCK_SECONDS + 1) * 1000);
+
+    await request(REST_URL)
+      .get("/auth/token")
+      .set("User-Agent", ICINGA_UA)
+      .query({ password: "default-password" })
+      .trustLocalhost(true)
+      .expect(200)
+      .expect("Content-Type", /application\/json/)
+      .then((response) => {
+        expect(response.body.status).toEqual("ok");
+        expect(response.body["auth token"]).toBeDefined();
+      });
+  });
+
+  it("does not distinguish a wrong password from an unknown outcome", async () => {
+    // A single generic 403 for every failure mode. The old endpoint replied
+    // "403 Invalid password" specifically for a bad password, which is a clean
+    // password-correctness oracle.
+    const failure = await request(REST_URL)
+      .get("/auth/token")
+      .set("User-Agent", ICINGA_UA)
+      .query({ password: "definitely-not-the-password" })
+      .trustLocalhost(true)
+      .expect(403);
+
+    expect(failure.text).not.toMatch(/invalid password/i);
+  });
+});

--- a/tests/rest-legacy-auth-throttle.test.ts
+++ b/tests/rest-legacy-auth-throttle.test.ts
@@ -23,6 +23,14 @@ const BLOCK_SECONDS = 3;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
+/** One /auth/token attempt with the correct password, without asserting a status. */
+const attemptWithCorrectPassword = () =>
+  request(REST_URL)
+    .get("/auth/token")
+    .set("User-Agent", ICINGA_UA)
+    .query({ password: "default-password" })
+    .trustLocalhost(true);
+
 describe("REST legacy /auth/token — failed-auth throttling", () => {
   let nscp: NscpInstance;
 
@@ -67,19 +75,27 @@ describe("REST legacy /auth/token — failed-auth throttling", () => {
   });
 
   it("recovers once the block expires", async () => {
-    await sleep((BLOCK_SECONDS + 1) * 1000);
+    // Poll rather than sleeping exactly one second past the block: a fixed
+    // margin turns scheduler delays and timer granularity on a loaded CI box
+    // into a spurious failure. Give it several times the block duration to
+    // recover, but stop the moment it does.
+    const deadline = Date.now() + (BLOCK_SECONDS + 10) * 1000;
+    let response = await attemptWithCorrectPassword();
+    while (response.status === 403 && Date.now() < deadline) {
+      await sleep(250);
+      response = await attemptWithCorrectPassword();
+    }
 
-    await request(REST_URL)
-      .get("/auth/token")
-      .set("User-Agent", ICINGA_UA)
-      .query({ password: "default-password" })
-      .trustLocalhost(true)
-      .expect(200)
-      .expect("Content-Type", /application\/json/)
-      .then((response) => {
-        expect(response.body.status).toEqual("ok");
-        expect(response.body["auth token"]).toBeDefined();
-      });
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toMatch(/application\/json/);
+    expect(response.body.status).toEqual("ok");
+    // Not toBeDefined(): an empty string is "defined" and would sail through,
+    // which is exactly the regression worth catching - the endpoint returns
+    // "ok" plus a token it read back out of the response, so a token that
+    // never got stored shows up here as "".
+    expect(typeof response.body["auth token"]).toBe("string");
+    expect(response.body["auth token"].length).toBeGreaterThan(0);
+    expect(response.headers.__token).toEqual(response.body["auth token"]);
   });
 
   it("does not distinguish a wrong password from an unknown outcome", async () => {

--- a/tests/rest-method-override.test.ts
+++ b/tests/rest-method-override.test.ts
@@ -11,8 +11,30 @@
  * revokes the token. So "did the method change" is answerable by asking
  * whether the token survived.
  */
+import https from "node:https";
 import request from "supertest";
 import { NscpInstance, REST_URL, setupRestNscp } from "@fixtures/index";
+
+/**
+ * Issue a GET with raw headers, so a field can be sent more than once.
+ * supertest's .set() replaces rather than appends, so it cannot express a
+ * repeated header at all; Node emits one header line per array element.
+ * Returns the status code.
+ */
+function rawGet(path: string, headers: Record<string, string | string[]>): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      { host: "127.0.0.1", port: 8443, path, method: "GET", headers, rejectUnauthorized: false },
+      (res) => {
+        res.resume();
+        res.on("end", () => resolve(res.statusCode ?? 0));
+        res.on("error", reject);
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
 
 jest.setTimeout(900_000);
 
@@ -81,6 +103,19 @@ describe("REST X-HTTP-Method-Override", () => {
         .expect(200);
       expect(await tokenStillValid(token)).toBe(true);
     }
+  });
+
+  it("ignores the override entirely when it is sent more than once", async () => {
+    // Ambiguous: an upstream proxy or WAF that classifies by method has to
+    // agree with the backend on which copy counts. Rather than pick a winner
+    // (and pick a different one on each backend), both drop it.
+    const token = await login();
+    const status = await rawGet("/api/v2/login", {
+      "X-Auth-Token": token,
+      "X-HTTP-Method-Override": ["DELETE", "GET"],
+    });
+    expect(status).toBe(200);
+    expect(await tokenStillValid(token)).toBe(true);
   });
 
   it("ignores a header name that merely starts with it", async () => {

--- a/tests/rest-method-override.test.ts
+++ b/tests/rest-method-override.test.ts
@@ -1,0 +1,96 @@
+/**
+ * X-HTTP-Method-Override handling.
+ *
+ * The mongoose backend matched the header with
+ * `strncmp(name, "X-HTTP-Method-Override", name.len)` — bounded by the
+ * *incoming* header's length, so any name that is a prefix of it ("X",
+ * "X-H", "X-HTTP", ...) silently changed the request method. That defeats
+ * any upstream proxy or WAF ACL that classifies requests by method.
+ *
+ * /api/v2/login is the observable pair: GET reports the session, DELETE
+ * revokes the token. So "did the method change" is answerable by asking
+ * whether the token survived.
+ */
+import request from "supertest";
+import { NscpInstance, REST_URL, setupRestNscp } from "@fixtures/index";
+
+jest.setTimeout(900_000);
+
+describe("REST X-HTTP-Method-Override", () => {
+  let nscp: NscpInstance;
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    await setupRestNscp(nscp);
+  });
+
+  afterAll(async () => {
+    await nscp?.stop();
+  });
+
+  /** Log in with Basic auth and return a fresh session token. */
+  async function login(): Promise<string> {
+    const response = await request(REST_URL)
+      .get("/api/v2/login")
+      .auth("admin", "default-password")
+      .trustLocalhost(true)
+      .expect(200);
+    expect(response.body.key).toBeDefined();
+    return response.body.key as string;
+  }
+
+  /** True when the token still authenticates. */
+  async function tokenStillValid(token: string): Promise<boolean> {
+    const response = await request(REST_URL).get("/api/v2/info").set("X-Auth-Token", token).trustLocalhost(true);
+    return response.status === 200;
+  }
+
+  it("honours the full header name", async () => {
+    const token = await login();
+    await request(REST_URL)
+      .get("/api/v2/login")
+      .set("X-Auth-Token", token)
+      .set("X-HTTP-Method-Override", "DELETE")
+      .trustLocalhost(true)
+      .expect(200);
+    // The GET was dispatched as a DELETE, so the token is revoked.
+    expect(await tokenStillValid(token)).toBe(false);
+  });
+
+  it("matches the header name case-insensitively", async () => {
+    // RFC 7230 §3.2: field names are case-insensitive.
+    const token = await login();
+    await request(REST_URL)
+      .get("/api/v2/login")
+      .set("X-Auth-Token", token)
+      .set("x-http-method-override", "DELETE")
+      .trustLocalhost(true)
+      .expect(200);
+    expect(await tokenStillValid(token)).toBe(false);
+  });
+
+  it("ignores header names that are merely a prefix of it", async () => {
+    // The regression: "X", "X-H" and "X-HTTP" all used to override the method.
+    for (const header of ["X", "X-H", "X-HTTP", "X-HTTP-Method"]) {
+      const token = await login();
+      await request(REST_URL)
+        .get("/api/v2/login")
+        .set("X-Auth-Token", token)
+        .set(header, "DELETE")
+        .trustLocalhost(true)
+        .expect(200);
+      expect(await tokenStillValid(token)).toBe(true);
+    }
+  });
+
+  it("ignores a header name that merely starts with it", async () => {
+    const token = await login();
+    await request(REST_URL)
+      .get("/api/v2/login")
+      .set("X-Auth-Token", token)
+      .set("X-HTTP-Method-Override-Extra", "DELETE")
+      .trustLocalhost(true)
+      .expect(200);
+    expect(await tokenStillValid(token)).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR addresses multiple security and correctness issues across REST handling, enrollment TLS defaults, legacy auth throttling, Docker endpoint validation, plugin listener bookkeeping, and Unix process execution safety, backed by new regression/unit tests.

Changes:

Adds regression tests for REST method override handling and legacy /auth/token throttling/oracle behavior.
Hardens enrollment and settings TLS verification defaults and CLI gating for insecure modes.
Fixes plugin listener removal correctness + a shared-lock map mutation bug; adds tests.
Restricts Docker daemon endpoint inputs (prevents UNC/remote auth on Windows) and adds unit tests.
Makes Unix fork/execvp path safer by avoiding allocations in the child.