### PR TITLE
feature/improved-unix-checks

### DIFF
--- a/docs/samples/CheckDisk_check_drivesize_desc.md
+++ b/docs/samples/CheckDisk_check_drivesize_desc.md
@@ -1,0 +1,46 @@
+#### Optional mounts (`ignore-missing`)
+
+By default a drive named with `drive=` that does not exist fails the whole
+check:
+
+```
+check_drivesize drive=/data
+Drive /data was not found
+```
+
+That is right when the mount is supposed to be there, and wrong when it is not
+— a removable volume, a filesystem mounted only on some hosts of a group, a
+share that is attached on demand. `ignore-missing=true` drops such drives
+instead:
+
+```
+check_drivesize drive=/data ignore-missing=true
+OK: No drives found
+```
+
+Drives that *do* exist are still checked normally, so mixing the two in one
+call works and the missing one simply contributes nothing:
+
+```
+check_drivesize drive=/ drive=/data ignore-missing=true "warn=used > 90%" "crit=used > 95%"
+OK All 1 drive(s) are ok|'/ used'=43.555GB;906.169;956.511;0;1006.854 '/ used %'=4%;90;95;0;100
+```
+
+**`ignore-missing=true` implies `empty-state=ok`.** Without that, a check whose
+drives are *all* missing would report UNKNOWN — trading a false CRITICAL for a
+false UNKNOWN, which still pages someone. Only the default is changed, so
+asking for something else explicitly still wins:
+
+```
+check_drivesize drive=/data ignore-missing=true empty-state=warning
+WARNING: No drives found
+```
+
+**On Windows, `require=` is unaffected.** Listing a drive there is an explicit
+assertion that it is present, so it stays CRITICAL when absent even under
+`ignore-missing` — which is the whole point of listing it. Use `drive=` +
+`ignore-missing` for optional volumes and `require=` for mandatory ones; they
+compose in one call.
+
+The same option exists on [`check_files`](#check_files) (for scan paths) and
+[`check_single_file`](#check_single_file) (for the file itself).

--- a/docs/samples/CheckDisk_check_drivesize_samples.md
+++ b/docs/samples/CheckDisk_check_drivesize_samples.md
@@ -125,3 +125,17 @@ OK: / inodes 350474/67108864 (1%)
 
 The inode keywords are `inodes_total`, `inodes_free`, `inodes_used`,
 `inodes_free_pct` and `inodes_used_pct`.
+
+**Treat a drive that is not mounted as OK rather than an error (`ignore-missing`):**
+
+```
+check_drivesize drive=/data ignore-missing=true
+OK: No drives found
+```
+
+**Optional and mandatory drives in one call — the real one is still checked:**
+
+```
+check_drivesize drive=/ drive=/data ignore-missing=true "warn=used > 90%" "crit=used > 95%"
+OK All 1 drive(s) are ok|'/ used'=43.555GB;906.169;956.511;0;1006.854 '/ used %'=4%;90;95;0;100
+```

--- a/docs/samples/CheckDisk_check_files_desc.md
+++ b/docs/samples/CheckDisk_check_files_desc.md
@@ -1,0 +1,38 @@
+#### Optional directories (`ignore-missing`)
+
+A top-level `path=` that does not exist fails the check by default, so a
+mistyped or unmounted directory is reported rather than silently scanning
+nothing:
+
+```
+check_files path=/var/spool/exports
+Path was not found: /var/spool/exports
+```
+
+When a directory is legitimately absent some of the time, `ignore-missing=true`
+skips it instead:
+
+```
+check_files path=/var/spool/exports ignore-missing=true
+No files found
+```
+
+Paths that do exist are still scanned, so the missing one simply contributes no
+files rather than wiping out the result:
+
+```
+check_files path=/var/log path=/var/spool/exports ignore-missing=true pattern=*.log
+OK: All 2 files are ok
+```
+
+Two details:
+
+* **It implies `empty-state=ok`**, so a scan whose paths are all missing reports
+  OK rather than UNKNOWN — otherwise the false CRITICAL is merely traded for a
+  false UNKNOWN. Only the default changes; an explicit `empty-state=` wins.
+* **The skipped path is not logged as an error.** Without the option a missing
+  path writes an `Invalid file specified` error to the log; with it the path is
+  expected, so it is logged at debug instead.
+
+The same option exists on [`check_single_file`](#check_single_file) (for the
+file itself) and [`check_drivesize`](#check_drivesize) (for optional mounts).

--- a/docs/samples/CheckDisk_check_files_samples.md
+++ b/docs/samples/CheckDisk_check_files_samples.md
@@ -66,3 +66,10 @@ CRITICAL: largest=250M avg=12M folders=3
 
 These four keywords are meaningful on the `total` object (they aggregate across
 everything `add`-ed into it); on an individual file row they read as 0.
+
+**Skip a scan path that does not exist (`ignore-missing`):**
+
+```
+check_files path=/var/spool/exports ignore-missing=true
+No files found
+```

--- a/docs/samples/CheckDisk_check_single_file_desc.md
+++ b/docs/samples/CheckDisk_check_single_file_desc.md
@@ -15,3 +15,29 @@ Behaviour at a glance:
   decide the status. With no thresholds the result is **OK** confirming
   the file exists.
 
+
+#### Files that are legitimately absent (`ignore-missing`)
+
+By default a missing file fails the check, which is what you want when the file
+is supposed to be there:
+
+```
+check_single_file file=/var/reports/nightly.csv
+File not found: /var/reports/nightly.csv
+```
+
+Some files are only there some of the time — a lock file, a report written
+after a run, a spool entry. `ignore-missing=true` returns OK instead, naming
+the path so the result cannot be mistaken for "the file was inspected and was
+fine":
+
+```
+check_single_file file=/var/reports/nightly.csv ignore-missing=true
+File not found (ignored): /var/reports/nightly.csv
+```
+
+A file that *is* present is checked exactly as before; the option only affects
+the missing case.
+
+The same option exists on [`check_files`](#check_files) (for scan paths) and
+[`check_drivesize`](#check_drivesize) (for optional mounts).

--- a/docs/samples/CheckDisk_check_single_file_samples.md
+++ b/docs/samples/CheckDisk_check_single_file_samples.md
@@ -46,3 +46,10 @@ check_single_file path=C:/Windows/win.ini
 L        cli OK: win.ini (size=92, age=873123)
 ```
 
+
+**Treat a file that is not there yet as OK (`ignore-missing`):**
+
+```
+check_single_file file=/tmp/no-such-report.csv ignore-missing=true
+File not found (ignored): /tmp/no-such-report.csv
+```

--- a/docs/samples/CheckNet_check_ntp_offset_desc.md
+++ b/docs/samples/CheckNet_check_ntp_offset_desc.md
@@ -1,0 +1,65 @@
+#### Is the clock wrong, or is the source unstable?
+
+`offset` answers the first question. A source can answer promptly with a
+believable offset and still be unusable, because that offset will not hold
+still — that is what the remaining keywords are for.
+
+| Keyword           | Description                                                                                      |
+|-------------------|--------------------------------------------------------------------------------------------------|
+| `jitter`          | RMS variation between the sampled offsets, in ms. **`-1` until `samples` is raised to 2 or more.** |
+| `samples`         | How many samples actually answered.                                                               |
+| `root_delay`      | Round-trip delay the server reports to its own reference clock, in ms.                            |
+| `root_dispersion` | Maximum error the server claims for the time it serves, in ms.                                    |
+
+`root_delay` and `root_dispersion` come straight out of the packet header, so
+they need no extra traffic and are available from the default single query.
+They are the server's own statement about its accuracy — useful for spotting a
+source that has lost its upstream and is coasting on a free-running clock,
+which it will happily keep serving:
+
+```
+check_ntp_offset server=ntp.example.com "top-syntax=${list}" "detail-syntax=${server} root_delay=${root_delay}ms root_dispersion=${root_dispersion}ms stratum=${stratum}"
+OK: ntp.example.com root_delay=11ms root_dispersion=33ms stratum=2
+```
+
+#### Measuring jitter (`samples`)
+
+Jitter is the variation *between* measurements, so it needs more than one.
+**`samples` defaults to 1**, which sends a single query exactly as before and
+leaves `jitter` at `-1`:
+
+```
+check_ntp_offset server=ntp.example.com "top-syntax=${list}" "detail-syntax=samples=${samples} jitter=${jitter}"
+OK: samples=1 jitter=-1
+```
+
+Raise it to measure:
+
+```
+check_ntp_offset server=ntp.example.com samples=6 "warn=jitter > 50" "crit=jitter > 100" "top-syntax=${list}" "detail-syntax=${server} jitter=${jitter}ms over ${samples} samples"
+WARNING: ntp.example.com jitter=70ms over 6 samples|'ntp.example.com_jitter'=70ms;50;100
+```
+
+`-1` is a safe "not measured" marker rather than a magic number: jitter is a
+magnitude, so a real reading is never negative and cannot be confused with it.
+Note that a threshold like `jitter > 50` is simply false at `-1`, so leaving
+`samples` at its default silently never alerts — set both together.
+
+Three things worth knowing about how the burst behaves:
+
+* **Sampling stops at the first failure.** An unreachable or slow server costs
+  one timeout, not `samples` of them, so raising `samples` does not multiply
+  the worst-case runtime of the check.
+* **The reported `offset` and `time` come from the quickest exchange.** A
+  delayed packet biases the offset by roughly half its extra delay, so the
+  fastest round trip is the most trustworthy estimate. With the default of one
+  sample this is simply that sample.
+* **A steady offset produces no jitter.** A clock that is consistently five
+  seconds wrong is inaccurate but perfectly stable, so it shows a large
+  `offset` and a near-zero `jitter`. The two conditions are independent and
+  worth alerting on separately:
+
+```
+check_ntp_offset server=ntp.example.com samples=6 "warn=offset > 100 or jitter > 50" "crit=offset > 1000 or jitter > 200 or stratum >= 16" "top-syntax=${list}" "detail-syntax=offset=${offset_signed}ms jitter=${jitter}ms"
+WARNING: offset=35ms jitter=70ms|'ntp.example.com_jitter'=70ms;50;200
+```

--- a/docs/samples/CheckNet_check_ntp_offset_samples.md
+++ b/docs/samples/CheckNet_check_ntp_offset_samples.md
@@ -46,3 +46,24 @@ check_nscp_client --host 192.168.56.103 --command check_ntp_offset --argument "s
 OK: pool.ntp.org offset=1326ms stratum=2| 'pool.ntp.org_offset'=1326;60000;120000 'pool.ntp.org_stratum'=2;16;16
 ```
 
+
+**Measure jitter across a burst of samples (needs `samples` >= 2):**
+
+```
+check_ntp_offset server=ntp.example.com samples=6 "warn=jitter > 50" "crit=jitter > 100" "top-syntax=${list}" "detail-syntax=${server} jitter=${jitter}ms over ${samples} samples"
+WARNING: ntp.example.com jitter=70ms over 6 samples|'ntp.example.com_jitter'=70ms;50;100
+```
+
+**Alert on an inaccurate clock and an unstable source independently:**
+
+```
+check_ntp_offset server=ntp.example.com samples=6 "warn=offset > 100 or jitter > 50" "crit=offset > 1000 or jitter > 200 or stratum >= 16" "top-syntax=${list}" "detail-syntax=offset=${offset_signed}ms jitter=${jitter}ms"
+WARNING: offset=35ms jitter=70ms|'ntp.example.com_jitter'=70ms;50;200
+```
+
+**Report what the server claims about its own accuracy (no extra traffic):**
+
+```
+check_ntp_offset server=ntp.example.com "top-syntax=${list}" "detail-syntax=${server} root_delay=${root_delay}ms root_dispersion=${root_dispersion}ms stratum=${stratum}"
+OK: ntp.example.com root_delay=11ms root_dispersion=33ms stratum=2
+```

--- a/docs/samples/CheckNet_check_ping_desc.md
+++ b/docs/samples/CheckNet_check_ping_desc.md
@@ -1,0 +1,42 @@
+#### Jitter
+
+Beyond "does it answer" (`loss`) and "how fast" (`time`), `check_ping` reports
+how *steady* the latency is:
+
+| Keyword  | Description                                                                                 |
+|----------|---------------------------------------------------------------------------------------------|
+| `jitter` | Mean variation between the round trip times, in ms. **`-1` until `count` is 2 or more.**    |
+
+Jitter is the variation *between* packets, so it needs more than one. **`count`
+defaults to 1**, which leaves `jitter` at `-1`; raise it to measure:
+
+```
+check_ping host=gw.example.com count=10 "warn=jitter > 20" "crit=jitter > 50" "top-syntax=${list}" "detail-syntax=${host} rtt=${time}ms jitter=${jitter}ms"
+```
+
+`-1` is a safe "not measured" marker rather than a magic number: jitter is a
+magnitude, so a real reading is never negative and cannot be confused with it.
+Note that a threshold like `jitter > 20` is simply false at `-1`, so leaving
+`count` at its default silently never alerts — set both together.
+
+**A slow link is not a jittery one.** A host that consistently answers in 250 ms
+has a large `time` and near-zero `jitter`; a host alternating between 10 ms and
+200 ms has a small average `time` and large `jitter`. Latency-sensitive traffic
+(VoIP, RDP, database replication) cares about the second far more than the
+first, which is why they threshold separately:
+
+```
+check_ping host=voip-gw.example.com count=20 "warn=jitter > 30 or loss > 1%" "crit=jitter > 60 or loss > 5%"
+```
+
+**On the `total` row, `jitter` is the worst value across hosts**, not a jitter
+computed over all the hosts' round trip times pooled together — mixing a fast
+host with a slow one would manufacture a large number that describes nothing.
+So a fleet-wide `crit=jitter > 50` fires when *any* host is that unstable:
+
+```
+check_ping hosts=a.example.com,b.example.com,c.example.com count=10 total=true "crit=jitter > 50"
+```
+
+Note that `time` remains the round trip time of the **last** reply, not an
+average over the burst.

--- a/docs/samples/CheckNet_check_ping_desc.md
+++ b/docs/samples/CheckNet_check_ping_desc.md
@@ -40,3 +40,59 @@ check_ping hosts=a.example.com,b.example.com,c.example.com count=10 total=true "
 
 Note that `time` remains the round trip time of the **last** reply, not an
 average over the burst.
+
+#### TTL
+
+`ttl` and the `ttl=` argument are two different numbers that share a name, the
+same way `ping -t` and the `ttl=` in its output do:
+
+| Name              | Meaning                                                                        |
+|-------------------|--------------------------------------------------------------------------------|
+| `ttl=N` (argument)| TTL / hop limit stamped on the packets **we send**. `0` (default) keeps the system default. |
+| `${ttl}` (keyword)| TTL of the **reply we got back** — what is left of the remote host's own outgoing TTL after the return path. |
+
+```
+check_ping host=router.example.com "top-syntax=${list}" "detail-syntax=${host} replied with ttl=${ttl}"
+```
+
+The reply TTL is a rough proxy for path length, so a drop in it means the route
+changed — traffic failing over to a longer path, for instance:
+
+```
+check_ping host=peer.example.com "warn=ttl < 50" "crit=ttl < 20"
+```
+
+Limiting the outgoing TTL is how you check that a host is where you think it is
+on the network: with `ttl=1` only a directly attached neighbour can answer.
+
+```
+check_ping host=gw.example.com ttl=1
+```
+
+`ttl` is **`-1` when unknown** — nothing came back, or the check ran over IPv6,
+where the hop limit is not available without ancillary data the check does not
+request. As with `jitter`, a `ttl < 20` threshold is false at `-1`, so it will
+not fire on an unanswered host; use `loss` for that.
+
+On the `total` row `ttl` is the **lowest** value across hosts (the reply closest
+to running out of hops), and hosts with no TTL are ignored rather than dragging
+the fleet-wide value to "unknown".
+
+#### Packet size
+
+`size=N` sets the ICMP payload to exactly N bytes. The `payload` string is
+repeated and cut to length, so the bytes on the wire stay recognisable rather
+than being a run of zeroes. `size=0` (the default) sends the `payload` string
+as-is, unchanged from previous behaviour.
+
+The 8-byte ICMP header sits on top of the payload, and IPv4 adds 20 more, so
+**1472 bytes is the largest payload that fits an untagged 1500-byte MTU**. That
+makes `size` the tool for finding a path-MTU or fragmentation problem — a link
+that passes small packets and silently drops big ones:
+
+```
+check_ping host=remote.example.com size=1472 count=5 "crit=loss > 0%"
+```
+
+The accepted range is 0–65507 (65535 minus the IPv4 and ICMP headers); anything
+outside it is rejected with a message rather than being silently clamped.

--- a/docs/samples/CheckNet_check_ping_samples.md
+++ b/docs/samples/CheckNet_check_ping_samples.md
@@ -35,3 +35,38 @@ L        cli  Performance data: '1.1.1.1_loss'=0%;5;10 '1.1.1.1'=2ms;60;100 '8.8
 check_nscp_client --host 192.168.56.103 --command check_ping --argument "host=192.168.56.1"
 OK: All 1 hosts are ok|'192.168.56.1_loss'=0%;5;10 '192.168.56.1'=1ms;60;100
 ```
+
+**Report the TTL of the reply (a rough proxy for path length):**
+
+```
+check_ping host=192.168.56.10 "top-syntax=${list}" "detail-syntax=${host} replied with ttl=${ttl}"
+OK: 192.168.56.10 replied with ttl=64
+```
+
+**Alert when the route grows (the reply TTL drops):**
+
+```
+check_ping host=peer.example.com "warn=ttl < 50" "crit=ttl < 20"
+OK: peer.example.com Packet loss = 0%, RTA = 12ms
+```
+
+**Limit the outgoing TTL to check a host is a directly attached neighbour:**
+
+```
+check_ping host=192.168.56.1 ttl=1
+OK: 192.168.56.1 Packet loss = 0%, RTA = 1ms
+```
+
+**Send a full-MTU packet to find a path-MTU or fragmentation problem:**
+
+```
+check_ping host=remote.example.com size=1472 count=5 "crit=loss > 0%"
+OK: remote.example.com Packet loss = 0%, RTA = 24ms
+```
+
+**Sizes outside the ICMP payload range are rejected rather than clamped:**
+
+```
+check_ping host=192.168.56.10 size=99999
+Invalid size: 99999 (expected 0-65507)
+```

--- a/docs/samples/CheckNet_check_ssh_desc.md
+++ b/docs/samples/CheckNet_check_ssh_desc.md
@@ -7,7 +7,7 @@ the server sends on connect, and requires it to start with `SSH-` (e.g.
 a key exchange or authenticate — it is a lightweight "is sshd up and answering"
 probe.
 
-It is a thin preset over [`check_tcp`](#check_tcp) (`service=ssh`), so it shares
+It builds on [`check_tcp`](#check_tcp) (the `service=ssh` preset), so it shares
 `check_tcp`'s keywords and thresholds:
 
 | Keyword     | Description                                             |
@@ -22,3 +22,44 @@ It is a thin preset over [`check_tcp`](#check_tcp) (`service=ssh`), so it shares
 Default thresholds: **warning** `time > 1000`, **critical**
 `time > 5000 or result != 'ok'`. A port that answers but is not SSH yields
 `result = no_match` (CRITICAL); a closed port yields `result = refused`.
+
+#### The parsed identification string
+
+On top of those, `check_ssh` splits the SSH identification string
+(RFC 4253 §4.2) into its parts, so the server's protocol and software version
+can be thresholded directly instead of regex-matching the raw `response`:
+
+```
+SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5
+    │   │             └── comments
+    │   └── version ─────── software "OpenSSH" + software_version "9.6p1"
+    └── protocol
+```
+
+| Keyword            | Type   | Description                                                                 |
+|--------------------|--------|-----------------------------------------------------------------------------|
+| `banner`           | string | The raw identification line, e.g. `SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5` |
+| `protocol`         | string | Protocol version as announced, e.g. `2.0` or `1.99`                         |
+| `protocol_major`   | int    | Major protocol version as a number (`2` for `2.0`)                          |
+| `protocol_minor`   | int    | Minor protocol version as a number (`0` for `2.0`, `99` for `1.99`)         |
+| `version`          | string | The whole software version field, e.g. `OpenSSH_9.6p1`                      |
+| `software`         | string | Software name, e.g. `OpenSSH`, `dropbear`, `OpenSSH_for_Windows`            |
+| `software_version` | string | Version number, e.g. `9.6p1`, `2022.83`                                     |
+| `comments`         | string | Anything after the first space, typically a distribution patch level        |
+
+`software` / `software_version` are split on the last `_` that is followed by a
+digit, which keeps multi-word names intact (`OpenSSH_for_Windows_9.5` →
+`OpenSSH_for_Windows` + `9.5`). A server that publishes an opaque build id
+rather than a version (e.g. `SSH-2.0-GitLab-SSHD`) keeps the whole string as
+`software` and leaves `software_version` empty; `version` always holds the full
+field, so it is the safe one to regex against.
+
+All of these are **empty** (and the numeric ones `0`) when no banner was read —
+a refused or timed-out connection, or a port that is not speaking SSH. Since
+the default critical already covers `result != 'ok'`, that case is caught
+regardless; guard on `result = 'ok'` explicitly if you add your own thresholds
+and want to keep the two failure modes apart.
+
+A note on `protocol`: `1.99` is not "older than 2.0" — it means the server
+speaks 2.0 *and* still accepts the insecure SSHv1, which is exactly what
+`protocol_major < 2` is for.

--- a/docs/samples/CheckNet_check_ssh_samples.md
+++ b/docs/samples/CheckNet_check_ssh_samples.md
@@ -20,6 +20,41 @@ check_ssh host=www.google.com port=443
 CRITICAL: www.google.com:443 no_match in 12ms
 ```
 
+**Report what the server is running:**
+
+```
+check_ssh host=192.168.56.10 "top-syntax=${list}" "detail-syntax=${host} runs ${software} ${software_version} (SSH ${protocol}, ${comments})"
+OK: 192.168.56.10 runs OpenSSH 9.6p1 (SSH 2.0, Ubuntu-3ubuntu13.5)
+```
+
+**Show the raw identification string:**
+
+```
+check_ssh host=gitlab.com "top-syntax=${list}" "detail-syntax=${banner}"
+OK: SSH-2.0-GitLab-SSHD
+```
+
+**Alert when the server still speaks the insecure SSHv1 (`1.99` or `1.x`):**
+
+```
+check_ssh host=192.168.56.10 "crit=protocol_major < 2" "top-syntax=${list}" "detail-syntax=${host} speaks SSH ${protocol}"
+OK: 192.168.56.10 speaks SSH 2.0
+```
+
+**Alert on an outdated sshd:**
+
+```
+check_ssh host=192.168.56.10 "crit=software = 'OpenSSH' and software_version not like '9.'" "top-syntax=${list}" "detail-syntax=${software} ${software_version}"
+OK: OpenSSH 9.6p1
+```
+
+**Check a fleet and list each server's version:**
+
+```
+check_ssh hosts=github.com,gitlab.com,bitbucket.org "top-syntax=${list}" "detail-syntax=${host}: ${version}"
+OK: github.com: 7f27de7, gitlab.com: GitLab-SSHD, bitbucket.org: conker_20260806-85ca5cadcf
+```
+
 **Tighter response-time thresholds:**
 
 ```

--- a/docs/samples/CheckNet_check_tcp_desc.md
+++ b/docs/samples/CheckNet_check_tcp_desc.md
@@ -1,0 +1,45 @@
+#### TLS certificate expiry (`ssl_expiry_days` / `has_certificate`)
+
+When the connection is wrapped in TLS — `ssl=true`, or one of the implicit-TLS
+service presets (`spop`, `simap`, `ssmtp`) — `check_tcp` reads the certificate
+the peer serves and exposes it as two keywords:
+
+| Keyword           | Type | Description                                                                     |
+|-------------------|------|---------------------------------------------------------------------------------|
+| `ssl_expiry_days` | int  | Whole days until the peer's certificate expires; **negative** once it has expired. `-1` when the connection is not TLS or the peer presented no certificate. Emitted as perfdata. |
+| `has_certificate` | int  | `1` when the peer presented a certificate, `0` otherwise.                       |
+
+This makes certificate monitoring work for any TLS service, not just HTTPS —
+LDAPS, IMAPS, SMTPS, RDP, a database listener, or anything else that speaks TLS
+on a port:
+
+```
+check_tcp host=ldap.example.com port=636 ssl=true "warn=ssl_expiry_days < 30" "crit=ssl_expiry_days < 10"
+```
+
+Two details worth knowing.
+
+**The count is truncated, not rounded.** A certificate with 23 hours left reads
+as `0`, not `1` — the remainder is dropped rather than rounded up into a
+reassuring number.
+
+**`-1` is ambiguous on its own, which is what `has_certificate` is for.** An
+expired certificate legitimately reports a negative day count, so
+`ssl_expiry_days = -1` could mean either "no certificate here" or "expired
+yesterday". A bare `crit=ssl_expiry_days < 30` therefore also fires on every
+plain connection. Guard it when that matters:
+
+```
+check_tcp host=mail.example.com port=993 ssl=true "crit=has_certificate = 1 and ssl_expiry_days < 30"
+```
+
+**Reading the certificate does not verify it.** The expiry is a property of what
+the peer served, so it is available at the default `verify=none` — a
+self-signed or otherwise untrusted certificate still reports its real remaining
+lifetime. Use `verify=peer` with a `ca=` bundle when you want the chain checked
+as well; the two are independent.
+
+This complements the other two certificate checks: `check_http`'s
+`ssl_expiry_days` covers HTTPS endpoints specifically, and `check_certificate`
+inspects certificates at rest (files on disk, the Windows certificate store)
+rather than ones served over a connection.

--- a/docs/samples/CheckNet_check_tcp_samples.md
+++ b/docs/samples/CheckNet_check_tcp_samples.md
@@ -65,6 +65,39 @@ check_tcp host=mail.example.com port=25 "crit=response not regexp '^220'"
 OK: mail.example.com:25 ok in 8ms
 ```
 
+**Check how long the peer's TLS certificate is still valid (`ssl_expiry_days`):**
+
+```
+check_tcp host=secure.example.com port=443 ssl=true "warn=ssl_expiry_days < 30" "crit=ssl_expiry_days < 10" "top-syntax=${list}" "detail-syntax=cert expires in ${ssl_expiry_days} days"
+OK: cert expires in 399 days|'secure.example.com_443_ssl_expiry_days'=399;30;10
+```
+
+```
+check_tcp host=expiring.example.com port=443 ssl=true "warn=ssl_expiry_days < 30" "crit=ssl_expiry_days < 10" "top-syntax=${list}" "detail-syntax=cert expires in ${ssl_expiry_days} days"
+WARNING: cert expires in 19 days|'expiring.example.com_443_ssl_expiry_days'=19;30;10
+```
+
+**Guard the threshold with `has_certificate` so a plain connection cannot look like an expired one:**
+
+```
+check_tcp host=expiring.example.com port=443 ssl=true "crit=has_certificate = 1 and ssl_expiry_days < 30" "top-syntax=${list}" "detail-syntax=${host}:${port} expires in ${ssl_expiry_days} days"
+CRITICAL: expiring.example.com:443 expires in 19 days|'expiring.example.com_443_ssl_expiry_days'=19;0;30
+```
+
+**The certificate keywords also work through the implicit-TLS presets:**
+
+```
+check_tcp host=imap.example.com service=simap "top-syntax=${list}" "detail-syntax=${host}:${port} cert=${has_certificate} days=${ssl_expiry_days}"
+OK: imap.example.com:993 cert=1 days=399
+```
+
+**Without TLS there is no certificate at all:**
+
+```
+check_tcp host=mail.example.com port=110 "top-syntax=${list}" "detail-syntax=cert=${has_certificate} days=${ssl_expiry_days}"
+OK: cert=0 days=-1
+```
+
 **Verify the server certificate when using TLS (needs a CA bundle):**
 
 ```

--- a/docs/samples/CheckNet_desc.md
+++ b/docs/samples/CheckNet_desc.md
@@ -1,0 +1,79 @@
+#### Choosing the IP version (`address-family`)
+
+Every network check in this module accepts an `address-family` argument that
+pins which IP version it uses:
+
+| Value  | Aliases              | Meaning                                                     |
+|--------|----------------------|-------------------------------------------------------------|
+| `any`  | `both`, `unspec`, `` | **Default.** Let the resolver choose (the historic behaviour). |
+| `ipv4` | `4`, `v4`, `inet`    | Resolve and connect over IPv4 only.                          |
+| `ipv6` | `6`, `v6`, `inet6`   | Resolve and connect over IPv6 only.                          |
+
+Values are case-insensitive. Anything else is rejected with
+`Invalid address-family: <value>` rather than silently falling back to `any` —
+a typo must not quietly stop testing the family you asked for.
+
+Supported by `check_ping`, `check_tcp`, `check_ssh`, `check_http`, `check_dns`
+and `check_ntp_offset`.
+
+On a dual-stack host the default leaves the choice to the resolver, so a check
+that passes tells you *one* of the two stacks works, not which. Pinning the
+family is what turns that into an assertion:
+
+```
+check_ssh host=srv.example.com address-family=ipv6
+OK: localhost:22 ok in 1ms
+```
+
+```
+check_http url=http://srv.example.com/health address-family=ipv6
+OK: http://srv.example.com/health -> 200 ok (2B in 3ms)
+```
+
+Run the same check twice — once per family — to monitor both paths
+independently. A host with no address in the requested family fails rather than
+falling back:
+
+```
+check_tcp host=v6-only.example.com port=443 address-family=ipv4
+CRITICAL: v6-only.example.com:443 refused in 0ms
+```
+
+For `check_dns` the flag selects how the **DNS server** is reached, which is
+independent of the record `type=` being queried — you can ask an IPv6-reachable
+server for an A record. When no `server=` is given and the type is A/AAAA (the
+system-resolver path), it additionally restricts the answer to that family.
+
+```
+check_dns host=example.com server=2001:db8::53 address-family=ipv6
+OK: example.com -> 10.1.2.3 (1) in 0ms [ok]
+```
+
+`check_dns` and `check_ntp_offset` were previously IPv4-only regardless of the
+server address; they now open the socket in whichever family the server
+resolves to, so an IPv6 DNS or NTP server is reachable at all.
+
+#### IPv6 literals in URLs
+
+`check_http` accepts a bracketed IPv6 literal, as required by RFC 3986:
+
+```
+check_http url=http://[::1]:8080/health
+OK: http://[::1]:8080/health -> 200 ok (2B in 1ms)
+```
+
+The brackets are part of the URL syntax (an unbracketed `::1` is ambiguous with
+the `host:port` separator) and are kept in the `Host:` header, while the `host`
+keyword reports the bare address.
+
+#### A note on `check_ping`
+
+`check_ping` uses ICMP echo, and ICMPv4 and ICMPv6 are separate protocols
+rather than two modes of one: with `address-family=ipv6` the check sends an
+ICMPv6 echo request (type 128) on an ICMPv6 socket. Two consequences:
+
+* The `ttl` field is not populated over IPv6. The IPv6 hop limit is only
+  available through ancillary data the check does not request, so it reports
+  `0` there instead of an invented value.
+* Raw ICMP sockets need privileges (root / `CAP_NET_RAW` on Linux,
+  Administrator on Windows) for both families, exactly as before.

--- a/docs/samples/CheckNet_desc.md
+++ b/docs/samples/CheckNet_desc.md
@@ -36,8 +36,13 @@ falling back:
 
 ```
 check_tcp host=v6-only.example.com port=443 address-family=ipv4
-CRITICAL: v6-only.example.com:443 refused in 0ms
+CRITICAL: v6-only.example.com:443 resolve_failed in 0ms
 ```
+
+The failure is `resolve_failed`, not `refused`: with the family pinned there is
+no address to connect to, so the check never gets as far as a connection
+attempt. "The name exists but has nothing in this family" is the answer being
+asked for here, not an internal error.
 
 For `check_dns` the flag selects how the **DNS server** is reached, which is
 independent of the record `type=` being queried — you can ask an IPv6-reachable
@@ -74,6 +79,8 @@ ICMPv6 echo request (type 128) on an ICMPv6 socket. Two consequences:
 
 * The `ttl` field is not populated over IPv6. The IPv6 hop limit is only
   available through ancillary data the check does not request, so it reports
-  `0` there instead of an invented value.
+  `-1` there instead of an invented value. `-1` is the "not known" marker
+  generally — an unanswered host reports it too, and the `total` row ignores
+  those rather than letting them win its minimum.
 * Raw ICMP sockets need privileges (root / `CAP_NET_RAW` on Linux,
   Administrator on Windows) for both families, exactly as before.

--- a/docs/samples/CheckSystemUnix_check_process_desc.md
+++ b/docs/samples/CheckSystemUnix_check_process_desc.md
@@ -1,0 +1,100 @@
+#### Process owner (`username` / `uid`)
+
+| Keyword    | Type   | Description                                                              |
+|------------|--------|--------------------------------------------------------------------------|
+| `uid`      | int    | Real uid of the process owner, from `/proc/<pid>/status`. `-1` when not known (the synthetic "not found" and `total` rows). |
+| `username` | string | The owner's user name. Empty unless `resolve-owner=true`.                |
+
+`uid` is **always** populated — it is read out of a file the check already
+opens, so it costs nothing — and it is numeric, so it can be thresholded
+directly:
+
+```
+check_process process=* "crit=uid = 0 and working_set > 1G" "detail-syntax=%(exe) uid=%(uid) ws=%(working_set)"
+```
+
+```
+check_process process=* "filter=uid >= 1000" "warn=count > 200" "top-syntax=%(status): %(count) user processes"
+```
+
+**`resolve-owner`** (default `false`) additionally turns each uid into a user
+name. It is opt-in because the lookup goes through NSS, which can block for
+seconds when it is backed by a remote directory (LDAP/SSSD) — the same reason
+the Windows check gates owner resolution. Names are cached per uid for the
+lifetime of the agent, so the cost is one lookup per *distinct* owner, not per
+process.
+
+```
+check_process process=postgres resolve-owner=true "crit=username != 'postgres'" "detail-syntax=%(exe) owner=%(username)"
+```
+
+#### Process state: `state` vs `proc_state`
+
+Two different questions, two keywords.
+
+| Keyword      | Values                                                                                       |
+|--------------|-----------------------------------------------------------------------------------------------|
+| `state`      | `started`, `stopped` — the cross-platform verdict, also available on Windows. `running` is accepted as a synonym for `started` in expressions; the rendered value stays `started`. |
+| `proc_state` | `running`, `sleeping`, `disk_sleep`, `zombie`, `stopped`, `tracing_stop`, `dead`, `idle`, `parked`, `unknown` — the raw Linux scheduler state, i.e. the letter `ps` prints in its `STAT` column. |
+
+`state` answers "is this process there and alive"; a zombie reports `stopped`
+there. `proc_state` answers "what is it *doing*", which is what the two classic
+Linux alerts need:
+
+```
+check_process process=* "crit=proc_state = 'zombie'" "detail-syntax=%(exe) (pid %(pid)) is a zombie"
+```
+
+```
+check_process process=* "warn=proc_state = 'disk_sleep'" "detail-syntax=%(exe) is blocked in uninterruptible I/O"
+```
+
+`disk_sleep` (`D`) is the useful I/O-hang signal: a process stuck there cannot
+be killed and usually means a wedged disk or an unresponsive NFS mount.
+
+For readability the parser also accepts `uninterruptible` for `disk_sleep`,
+`defunct` for `zombie` and `traced` for `tracing_stop`.
+
+Note that `proc_state = 'stopped'` means SIGSTOP'd / job-control stopped (`T`),
+which is **not** the same as `state = 'stopped'` (process not running).
+
+#### `ppid`
+
+The parent process id, so process trees can be expressed:
+
+```
+check_process process=* "filter=ppid = 1" "warn=count < 10" "top-syntax=%(status): %(count) processes reparented to init"
+```
+
+It is also how kernel threads are excluded: on a standard Linux kernel every
+kernel thread is a child of `kthreadd`, which is pid 2, so
+
+```
+check_process process=* "filter=ppid != 2 and pid != 2" "warn=count > 500"
+```
+
+drops them all. (Note that some environments — WSL, and some container
+runtimes — do not run a `kthreadd` at pid 2, so check what pid 2 is on the host
+before relying on this.)
+
+#### `elapsed` and `rss`
+
+| Keyword   | Description                                                                                        |
+|-----------|-----------------------------------------------------------------------------------------------------|
+| `elapsed` | Wall-clock seconds since the process started (`0` when the start time could not be established). Emitted as perfdata with unit `s`. |
+| `rss`     | Resident set size — a straight alias for `working_set`, matching the Windows keyword set so the same expression works on both platforms. |
+
+`elapsed` is the "has this been running long enough / too long" check, which
+`creation` (an absolute timestamp) makes awkward:
+
+```
+check_process process=my-batch-job "crit=elapsed > 3600" "detail-syntax=%(exe) has been running for %(elapsed)s"
+```
+
+```
+check_process process=nginx "crit=elapsed < 300" "top-syntax=%(status): nginx restarted recently"
+```
+
+```
+check_process process=* "crit=rss > 2G" "detail-syntax=%(exe) rss=%(rss)"
+```

--- a/docs/samples/CheckSystemUnix_check_process_samples.md
+++ b/docs/samples/CheckSystemUnix_check_process_samples.md
@@ -1,0 +1,63 @@
+**Show the owner, parent and state of every matching process:**
+
+```
+check_process process=bash "top-syntax=${list}" "detail-syntax=${exe} uid=${uid} ppid=${ppid} proc_state=${proc_state} elapsed=${elapsed}s"
+bash uid=1000 ppid=385 proc_state=sleeping elapsed=961739s, bash uid=1000 ppid=381 proc_state=sleeping elapsed=961715s, bash uid=0 ppid=12728 proc_state=sleeping elapsed=961693s
+```
+
+**Resolve uids to user names (opt-in, `resolve-owner=true`):**
+
+```
+check_process process=bash resolve-owner=true "top-syntax=${list}" "detail-syntax=${exe} uid=${uid} owner=${username}"
+bash uid=1000 owner=mickem, bash uid=1000 owner=mickem, bash uid=0 owner=root
+```
+
+Without the flag `uid` is still populated; only `username` stays empty.
+
+**Count the processes owned by root (`uid` is numeric, so it thresholds
+directly):**
+
+```
+check_process process=* "filter=uid = 0" "warn=count > 1000" "ok-syntax=%(status): %(count) processes owned by root"
+OK: 27 processes owned by root
+L        cli  Performance data: 'count'=27;1000;0 ...
+```
+
+**Alert on zombie processes:**
+
+```
+check_process process=* "crit=proc_state = 'zombie'" "ok-syntax=%(status): no zombie processes (%(count) checked)" "detail-syntax=%(exe) (pid %(pid)) is a zombie"
+OK: no zombie processes (49 checked)
+```
+
+**Alert on processes blocked in uninterruptible I/O (a wedged disk or a hung
+NFS mount):**
+
+```
+check_process process=* "warn=proc_state = 'disk_sleep'" "ok-syntax=%(status): no processes blocked in uninterruptible I/O"
+OK: no processes blocked in uninterruptible I/O
+```
+
+**Select by parent process id:**
+
+```
+check_process process=* "filter=ppid = 1" "ok-syntax=%(status): %(count) processes reparented to init"
+OK: 22 processes reparented to init
+```
+
+**Threshold on how long a process has been running (`elapsed`, in seconds):**
+
+```
+check_process process=bash "crit=elapsed > 31536000" "top-syntax=${list}" "detail-syntax=${exe} up ${elapsed}s"
+bash up 961756s, bash up 961732s, bash up 6183s, bash up 6s
+L        cli  Performance data: 'bash elapsed'=961756s;0;31536000 ...
+```
+
+**`rss` is an alias for `working_set` (same value, portable with the Windows
+check):**
+
+```
+check_process process=bash "crit=rss > 2G" "top-syntax=${list}" "detail-syntax=${exe} rss=${rss} ws=${working_set}"
+bash rss=8.594MB ws=8.594MB, bash rss=9.219MB ws=9.219MB, bash rss=4.688MB ws=4.688MB
+L        cli  Performance data: 'bash rss'=0.00839GB;0;2 ...
+```

--- a/include/net/address_family.hpp
+++ b/include/net/address_family.hpp
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <boost/system/error_code.hpp>
+#include <string>
+
+namespace net {
+
+// Which IP version a network check should use. `any` leaves the choice to the
+// resolver (the historical behaviour), the other two pin it, which is what a
+// dual-stack host needs to assert "this service answers over IPv6" or to keep
+// a check on IPv4 while an IPv6 path is known-broken.
+enum class address_family { any, ipv4, ipv6 };
+
+// Parse the value of an `address-family` argument. Returns false — leaving
+// `out` untouched — for anything unrecognised, so the caller can report the bad
+// value rather than silently falling back to `any`.
+inline bool parse_address_family(const std::string &value, address_family &out) {
+  std::string v;
+  v.reserve(value.size());
+  for (const char c : value) v += static_cast<char>(c >= 'A' && c <= 'Z' ? c - 'A' + 'a' : c);
+
+  if (v.empty() || v == "any" || v == "both" || v == "0" || v == "unspec") {
+    out = address_family::any;
+    return true;
+  }
+  if (v == "ipv4" || v == "v4" || v == "4" || v == "inet") {
+    out = address_family::ipv4;
+    return true;
+  }
+  if (v == "ipv6" || v == "v6" || v == "6" || v == "inet6") {
+    out = address_family::ipv6;
+    return true;
+  }
+  return false;
+}
+
+inline std::string to_string(const address_family af) {
+  switch (af) {
+    case address_family::ipv4:
+      return "ipv4";
+    case address_family::ipv6:
+      return "ipv6";
+    default:
+      return "any";
+  }
+}
+
+// The help text for the `address-family` option, kept in one place so every
+// check documents it identically.
+inline const char *address_family_option_help() {
+  return "IP version to use: any (default, let the resolver choose), ipv4 or ipv6. Accepts 4/v4/inet and 6/v6/inet6 as aliases.";
+}
+
+// Resolve host/service restricted to the requested address family. Templated on
+// the resolver so it serves tcp, udp and icmp alike; `Resolver::protocol_type`
+// supplies the v4()/v6() instances, which keeps this header free of any
+// protocol-specific asio includes.
+template <typename Resolver>
+typename Resolver::results_type resolve_for_family(Resolver &resolver, const address_family af, const std::string &host, const std::string &service,
+                                                   boost::system::error_code &ec) {
+  typedef typename Resolver::protocol_type protocol_type;
+  if (af == address_family::ipv4) return resolver.resolve(protocol_type::v4(), host, service, ec);
+  if (af == address_family::ipv6) return resolver.resolve(protocol_type::v6(), host, service, ec);
+  return resolver.resolve(host, service, ec);
+}
+
+}  // namespace net

--- a/include/net/http/client.hpp
+++ b/include/net/http/client.hpp
@@ -365,12 +365,9 @@ struct ssl_socket final : generic_socket {
   long peer_certificate_expiry_days() const override {
     // native_handle() is non-const; the underlying SSL* is not mutated here.
     SSL *ssl = const_cast<ssl_socket *>(this)->ssl_socket_.native_handle();
-    X509 *cert = SSL_get_peer_certificate(ssl);
-    if (cert == nullptr) return -1;
-    int days = -1, seconds = 0;
-    const int ok = ASN1_TIME_diff(&days, &seconds, nullptr, X509_get0_notAfter(cert));
-    X509_free(cert);
-    return ok == 1 ? static_cast<long>(days) : -1;
+    // -1 for "no certificate" is this interface's historical contract (it is
+    // what check_http's ssl_expiry_days keyword reports for plain http).
+    return socket_helpers::peer_certificate_expiry_days(ssl).get_value_or(-1);
   }
 
   /// Establish an HTTP CONNECT tunnel through proxy_ then perform TLS handshake.

--- a/include/net/http/client.hpp
+++ b/include/net/http/client.hpp
@@ -13,6 +13,7 @@
 #include <bytes/base64.hpp>
 #include <istream>
 #include <memory>
+#include <net/address_family.hpp>
 #include <net/http/http_packet.hpp>
 #include <net/http/proxy_config.hpp>
 #include <net/socket/socket_helpers.hpp>
@@ -146,6 +147,9 @@ struct generic_socket {
   // Applied by the client right after connecting; no-op for transports that
   // are not sockets.
   virtual void set_timeouts(unsigned int seconds) {}
+  // Pins which IP version the connection uses; no-op for transports that do not
+  // resolve host names (named pipes).
+  virtual void set_address_family(net::address_family af) {}
 };
 
 struct tcp_socket final : generic_socket {
@@ -153,6 +157,9 @@ struct tcp_socket final : generic_socket {
   tcp::resolver resolver_;
   boost::asio::io_context &io_;
   unsigned int timeout_ = 0;
+  net::address_family address_family_ = net::address_family::any;
+
+  void set_address_family(const net::address_family af) override { address_family_ = af; }
 
   explicit tcp_socket(boost::asio::io_context &io_service) : socket_(io_service), resolver_(io_service), io_(io_service) {}
   ~tcp_socket() override {
@@ -169,9 +176,10 @@ struct tcp_socket final : generic_socket {
 
   void connect(const std::string &server, const std::string &port) override {
     boost::system::error_code resolve_ec;
-    auto endpoints = resolver_.resolve(server, port, resolve_ec);
-    if (resolve_ec) {
-      throw socket_helpers::socket_exception("Failed to resolve " + server + ":" + port + ": " + resolve_ec.message());
+    auto endpoints = net::resolve_for_family(resolver_, address_family_, server, port, resolve_ec);
+    if (resolve_ec || endpoints.begin() == endpoints.end()) {
+      throw socket_helpers::socket_exception("Failed to resolve " + server + ":" + port + " over " + net::to_string(address_family_) + ": " +
+                                             (resolve_ec ? resolve_ec.message() : std::string("no address in the requested family")));
     }
 
     boost::system::error_code error = boost::asio::error::host_not_found;
@@ -241,6 +249,7 @@ struct ssl_socket final : generic_socket {
   boost::asio::ssl::stream<tcp::socket> ssl_socket_;
   tcp::resolver resolver_;
   boost::asio::ssl::verify_mode verify_;
+  net::address_family address_family_ = net::address_family::any;
   std::string sni_;  // TLS SNI / verification hostname override (empty = use the connected host)
   proxy_config proxy_;
   bool pinned_;  // pinned peer cert: verify against it only, no hostname check
@@ -306,6 +315,8 @@ struct ssl_socket final : generic_socket {
         pinned_(identity.is_pinned()),
         io_(io_service) {}
 
+  void set_address_family(const net::address_family af) override { address_family_ = af; }
+
   ~ssl_socket() override {
     try {
       ssl_socket_.lowest_layer().close();
@@ -370,7 +381,7 @@ struct ssl_socket final : generic_socket {
     auto &tcp_sock = ssl_socket_.next_layer();
 
     boost::system::error_code error = boost::asio::error::host_not_found;
-    auto proxy_endpoints = resolver_.resolve(proxy_.host, proxy_.port, error);
+    auto proxy_endpoints = net::resolve_for_family(resolver_, address_family_, proxy_.host, proxy_.port, error);
     if (error) {
       throw socket_helpers::socket_exception("Failed to resolve proxy " + proxy_.host + ":" + proxy_.port + ": " + error.message());
     }
@@ -459,9 +470,10 @@ struct ssl_socket final : generic_socket {
     }
 
     boost::system::error_code error = boost::asio::error::host_not_found;
-    auto endpoints = resolver_.resolve(server, port, error);
-    if (error) {
-      throw socket_helpers::socket_exception("Failed to resolve " + server + ":" + port + ": " + error.message());
+    auto endpoints = net::resolve_for_family(resolver_, address_family_, server, port, error);
+    if (error || endpoints.begin() == endpoints.end()) {
+      throw socket_helpers::socket_exception("Failed to resolve " + server + ":" + port + " over " + net::to_string(address_family_) + ": " +
+                                             (error ? error.message() : std::string("no address in the requested family")));
     }
     error = boost::asio::error::host_not_found;
     for (auto it = endpoints.begin(); error && it != endpoints.end(); ++it) {
@@ -558,6 +570,9 @@ struct http_client_options {
   // hurts. execute() streams to the caller's ostream instead of buffering, so
   // it is deliberately not covered - that is the path large downloads use.
   std::size_t max_response_bytes_ = 5u * 1024u * 1024u;
+  // Pins the connection (and the proxy connection, when one is used) to one IP
+  // version; `any` leaves the choice to the resolver.
+  net::address_family address_family_ = net::address_family::any;
 
   http_client_options(std::string protocol, std::string tls_version, std::string verify, std::string ca, proxy_config proxy = proxy_config())
       : protocol_(std::move(protocol)), tls_version_(std::move(tls_version)), verify_(std::move(verify)), ca_(std::move(ca)), proxy_(std::move(proxy)) {}
@@ -593,6 +608,7 @@ class simple_client {
     } else {
       socket_ = std::make_unique<tcp_socket>(io_service_);
     }
+    socket_->set_address_family(options.address_family_);
   }
 
   ~simple_client() = default;

--- a/include/net/icmp_header.hpp
+++ b/include/net/icmp_header.hpp
@@ -47,6 +47,13 @@ class icmp_header {
     address_reply = 18
   };
 
+  // ICMPv6 (RFC 4443) reuses this header layout but numbers its messages
+  // differently: echo request/reply are 128/129 rather than 8/0.
+  enum {
+    echo_request_v6 = 128,
+    echo_reply_v6 = 129
+  };
+
   icmp_header() = default;
 
   unsigned char type() const { return rep_[0]; }

--- a/include/net/pinger.hpp
+++ b/include/net/pinger.hpp
@@ -16,7 +16,7 @@
 #include <vector>
 
 struct result_container {
-  result_container() : num_send_(0), num_replies_(0), num_timeouts_(0), length_(0), sequence_number_(0), ttl_(0), time_(0) {}
+  result_container() : num_send_(0), num_replies_(0), num_timeouts_(0), length_(0), sequence_number_(0), ttl_(-1), time_(0) {}
 
   std::string destination_;
   std::string ip_;
@@ -25,7 +25,11 @@ struct result_container {
   std::size_t num_timeouts_;
   std::size_t length_;
   unsigned short sequence_number_;
-  unsigned char ttl_;
+  // TTL (IPv4) of the last reply, or -1 when it is not known: nothing came
+  // back, or the reply was ICMPv6, where the hop limit is only available
+  // through ancillary data we do not request. Signed so "unknown" cannot be
+  // confused with a real TTL of 0.
+  int ttl_;
   std::size_t time_;
   // Round trip time of every packet that came back, in order. time_ above is
   // only the most recent one; the series is what jitter is computed from.
@@ -36,8 +40,10 @@ class pinger {
  public:
   // `af` pins the IP version; with `any` the resolver picks and the socket is
   // opened in whichever family the destination resolved to.
+  // `ttl` sets the TTL / hop limit on outgoing packets; 0 leaves the system
+  // default in place.
   pinger(boost::asio::io_context& io_service, result_container& result, const char* destination, int timeout, unsigned short identifier, std::string payload,
-         const net::address_family af = net::address_family::any)
+         const net::address_family af = net::address_family::any, const int ttl = 0)
       : resolver_(io_service),
         socket_(io_service),
         timer_(io_service),
@@ -59,6 +65,9 @@ class pinger {
     // must be opened in the family the destination actually resolved to.
     is_v6_ = destination_.address().is_v6();
     socket_.open(destination_.protocol());
+    // unicast::hops maps to IP_TTL on v4 and IPV6_UNICAST_HOPS on v6, so one
+    // option covers both families.
+    if (ttl > 0) socket_.set_option(boost::asio::ip::unicast::hops(ttl));
     result.destination_ = destination;
     result.ip_ = destination_.address().to_string();
   }
@@ -145,9 +154,9 @@ class pinger {
       const auto now = std::chrono::steady_clock::now();
       // No IP header was consumed on v6, and the hop limit is only available
       // through IPV6_RECVHOPLIMIT ancillary data, which we do not request — so
-      // ttl stays 0 there rather than reporting a fabricated value.
+      // ttl stays unknown there rather than reporting a fabricated value.
       result_.length_ = is_v6_ ? length : length - ipv4_hdr.header_length();
-      result_.ttl_ = is_v6_ ? 0 : ipv4_hdr.time_to_live();
+      result_.ttl_ = is_v6_ ? -1 : static_cast<int>(ipv4_hdr.time_to_live());
       result_.time_ = std::chrono::duration_cast<std::chrono::milliseconds>(now - time_sent_).count();
       result_.rtts_.push_back(result_.time_);
     }

--- a/include/net/pinger.hpp
+++ b/include/net/pinger.hpp
@@ -13,6 +13,7 @@
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <vector>
 
 struct result_container {
   result_container() : num_send_(0), num_replies_(0), num_timeouts_(0), length_(0), sequence_number_(0), ttl_(0), time_(0) {}
@@ -26,6 +27,9 @@ struct result_container {
   unsigned short sequence_number_;
   unsigned char ttl_;
   std::size_t time_;
+  // Round trip time of every packet that came back, in order. time_ above is
+  // only the most recent one; the series is what jitter is computed from.
+  std::vector<std::size_t> rtts_;
 };
 
 class pinger {
@@ -145,6 +149,7 @@ class pinger {
       result_.length_ = is_v6_ ? length : length - ipv4_hdr.header_length();
       result_.ttl_ = is_v6_ ? 0 : ipv4_hdr.time_to_live();
       result_.time_ = std::chrono::duration_cast<std::chrono::milliseconds>(now - time_sent_).count();
+      result_.rtts_.push_back(result_.time_);
     }
     // start_receive();
   }

--- a/include/net/pinger.hpp
+++ b/include/net/pinger.hpp
@@ -6,9 +6,11 @@
 #include <boost/asio.hpp>
 #include <chrono>
 #include <istream>
+#include <net/address_family.hpp>
 #include <net/icmp_header.hpp>
 #include <net/ipv4_header.hpp>
 #include <ostream>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -28,9 +30,12 @@ struct result_container {
 
 class pinger {
  public:
-  pinger(boost::asio::io_context& io_service, result_container& result, const char* destination, int timeout, unsigned short identifier, std::string payload)
+  // `af` pins the IP version; with `any` the resolver picks and the socket is
+  // opened in whichever family the destination resolved to.
+  pinger(boost::asio::io_context& io_service, result_container& result, const char* destination, int timeout, unsigned short identifier, std::string payload,
+         const net::address_family af = net::address_family::any)
       : resolver_(io_service),
-        socket_(io_service, boost::asio::ip::icmp::v4()),
+        socket_(io_service),
         timer_(io_service),
         sequence_number_(0),
         timeout_(timeout),
@@ -39,7 +44,17 @@ class pinger {
         payload_(std::move(payload))
 
   {
-    destination_ = resolver_.resolve(boost::asio::ip::icmp::v4(), destination, "").begin()->endpoint();
+    boost::system::error_code resolve_ec;
+    const auto results = net::resolve_for_family(resolver_, af, destination, "", resolve_ec);
+    if (resolve_ec) throw std::runtime_error(std::string("Failed to resolve ") + destination + ": " + resolve_ec.message());
+    if (results.begin() == results.end())
+      throw std::runtime_error(std::string("Failed to resolve ") + destination + " over " + net::to_string(af) + ": no address in the requested family");
+
+    destination_ = results.begin()->endpoint();
+    // ICMP and ICMPv6 are different protocols, not two modes of one: the socket
+    // must be opened in the family the destination actually resolved to.
+    is_v6_ = destination_.address().is_v6();
+    socket_.open(destination_.protocol());
     result.destination_ = destination;
     result.ip_ = destination_.address().to_string();
   }
@@ -57,11 +72,16 @@ class pinger {
     std::string body(payload_);
 
     icmp_header echo_request;
-    echo_request.type(icmp_header::echo_request);
+    echo_request.type(is_v6_ ? static_cast<unsigned char>(icmp_header::echo_request_v6) : static_cast<unsigned char>(icmp_header::echo_request));
     echo_request.code(0);
     echo_request.identifier(identifier_);
     echo_request.sequence_number(++sequence_number_);
-    compute_checksum(echo_request, body.begin(), body.end());
+    // The ICMPv6 checksum covers an IPv6 pseudo-header whose source address is
+    // only chosen by the kernel at send time, so the kernel computes and
+    // inserts it for raw IPPROTO_ICMPV6 sockets (RFC 3542 section 3.1) and we
+    // leave the field at zero. IPv4 has no pseudo-header and no such kernel
+    // support, so there we still compute it ourselves.
+    if (!is_v6_) compute_checksum(echo_request, body.begin(), body.end());
 
     boost::asio::streambuf request_buffer;
     std::ostream os(&request_buffer);
@@ -97,11 +117,17 @@ class pinger {
     reply_buffer_.commit(length);
 
     std::istream is(&reply_buffer_);
+    // An IPv4 raw socket hands up the IP header with the payload; an ICMPv6 one
+    // does not (the kernel strips it), so there the ICMP header is at offset 0.
     ipv4_header ipv4_hdr;
     icmp_header icmp_hdr;
-    is >> ipv4_hdr >> icmp_hdr;
+    if (is_v6_)
+      is >> icmp_hdr;
+    else
+      is >> ipv4_hdr >> icmp_hdr;
 
-    if (is && icmp_hdr.type() == icmp_header::echo_reply && icmp_hdr.identifier() == identifier_ && icmp_hdr.sequence_number() == sequence_number_) {
+    const unsigned char expected_reply = is_v6_ ? static_cast<unsigned char>(icmp_header::echo_reply_v6) : static_cast<unsigned char>(icmp_header::echo_reply);
+    if (is && icmp_hdr.type() == expected_reply && icmp_hdr.identifier() == identifier_ && icmp_hdr.sequence_number() == sequence_number_) {
       // cancel() can throw (the non-throwing cancel(ec) overload is removed
       // under BOOST_ASIO_NO_DEPRECATED). Swallow it so it can't escape this
       // handler and propagate out of the caller's io_service.run(); the reply
@@ -113,8 +139,11 @@ class pinger {
       result_.num_replies_++;
 
       const auto now = std::chrono::steady_clock::now();
-      result_.length_ = length - ipv4_hdr.header_length();
-      result_.ttl_ = ipv4_hdr.time_to_live();
+      // No IP header was consumed on v6, and the hop limit is only available
+      // through IPV6_RECVHOPLIMIT ancillary data, which we do not request — so
+      // ttl stays 0 there rather than reporting a fabricated value.
+      result_.length_ = is_v6_ ? length : length - ipv4_hdr.header_length();
+      result_.ttl_ = is_v6_ ? 0 : ipv4_hdr.time_to_live();
       result_.time_ = std::chrono::duration_cast<std::chrono::milliseconds>(now - time_sent_).count();
     }
     // start_receive();
@@ -131,4 +160,5 @@ class pinger {
   result_container& result_;
   unsigned short identifier_;
   std::string payload_;
+  bool is_v6_ = false;
 };

--- a/include/net/pinger_test.cpp
+++ b/include/net/pinger_test.cpp
@@ -21,7 +21,7 @@ TEST(ResultContainer, DefaultConstruction) {
   EXPECT_EQ(0u, r.num_timeouts_);
   EXPECT_EQ(0u, r.length_);
   EXPECT_EQ(0, r.sequence_number_);
-  EXPECT_EQ(0, r.ttl_);
+  EXPECT_EQ(-1, r.ttl_);  // unknown until a reply carries one
   EXPECT_EQ(0u, r.time_);
   EXPECT_TRUE(r.destination_.empty());
   EXPECT_TRUE(r.ip_.empty());

--- a/include/net/pinger_test.cpp
+++ b/include/net/pinger_test.cpp
@@ -137,6 +137,16 @@ TEST(IcmpHeader, TypeConstants) {
   EXPECT_EQ(18, icmp_header::address_reply);
 }
 
+TEST(IcmpHeader, IcmpV6TypeConstants) {
+  // ICMPv6 (RFC 4443) reuses the header layout but renumbers echo: 128/129
+  // rather than 8/0. Sending an ICMPv4 type 8 over an ICMPv6 socket gets no
+  // reply, so these must not be confused.
+  EXPECT_EQ(128, icmp_header::echo_request_v6);
+  EXPECT_EQ(129, icmp_header::echo_reply_v6);
+  EXPECT_NE(static_cast<int>(icmp_header::echo_request), static_cast<int>(icmp_header::echo_request_v6));
+  EXPECT_NE(static_cast<int>(icmp_header::echo_reply), static_cast<int>(icmp_header::echo_reply_v6));
+}
+
 // ============================================================================
 // icmp_header serialization round-trip
 // ============================================================================
@@ -608,6 +618,30 @@ TEST(Ipv4Header, ParseBroadcastAddress) {
 // ============================================================================
 // pinger construction (requires no actual network)
 // ============================================================================
+
+TEST(Pinger, RejectsADestinationWithNoAddressInTheRequestedFamily) {
+  // Resolution happens before the (privileged) raw socket is opened, so this
+  // case is reachable without any capability: an IPv4 literal simply has no
+  // IPv6 address, and the pinger must say so rather than silently pinging over
+  // the other family.
+  boost::asio::io_context io_service;
+  result_container result;
+  EXPECT_THROW(pinger(io_service, result, "127.0.0.1", 1000, 42, "payload", net::address_family::ipv6), std::exception);
+  EXPECT_THROW(pinger(io_service, result, "::1", 1000, 42, "payload", net::address_family::ipv4), std::exception);
+}
+
+TEST(Pinger, PingerSendsToResolvedEndpointOverIpv6) {
+  boost::asio::io_context io_service;
+  result_container result;
+  try {
+    pinger p(io_service, result, "::1", 1000, 42, "payload", net::address_family::ipv6);
+  } catch (const std::exception &e) {
+    GTEST_SKIP() << "Skipping: unable to create ICMPv6 socket or resolve address: " << e.what();
+  }
+  EXPECT_EQ("::1", result.destination_);
+  EXPECT_EQ("::1", result.ip_);
+  EXPECT_EQ(0u, result.num_send_);
+}
 
 TEST(Pinger, PingerSendsToResolvedEndpoint) {
   // Construct a pinger targeting localhost — constructor resolves the name

--- a/include/net/socket/socket_helpers.cpp
+++ b/include/net/socket/socket_helpers.cpp
@@ -529,14 +529,25 @@ boost::optional<long> socket_helpers::peer_certificate_expiry_days(SSL *ssl) {
   X509 *cert = SSL_get_peer_certificate(ssl);
   if (cert == nullptr) return boost::none;
 
-  // ASN1_TIME_diff splits the interval into whole days plus leftover seconds;
-  // we report the days and drop the remainder, so a certificate with 23 hours
-  // left reads as 0 rather than rounding up to a reassuring 1.
+  // ASN1_TIME_diff splits the interval into whole days plus leftover seconds,
+  // both carrying the sign of the interval. We report whole days and drop the
+  // remainder, so a certificate with 23 hours left reads as 0 rather than
+  // rounding up to a reassuring 1.
+  //
+  // Dropping the remainder has to round DOWN, not toward zero. A certificate
+  // that expired three hours ago comes back as days=0, seconds=-10800: taking
+  // days as-is reports 0, which is indistinguishable from "23 hours left" and
+  // leaves an already-expired certificate looking merely urgent. Any threshold
+  // written the obvious way ("critical when < 0") would never fire during the
+  // first day of expiry. Flooring keeps the useful invariant that the value is
+  // negative if and only if the certificate has expired, and never reports more
+  // time than actually remains.
   int days = 0;
   int seconds = 0;
   const int ok = ASN1_TIME_diff(&days, &seconds, nullptr, X509_get0_notAfter(cert));
   X509_free(cert);
   if (ok != 1) return boost::none;
+  if (seconds < 0) days -= 1;
   return static_cast<long>(days);
 }
 

--- a/include/net/socket/socket_helpers.cpp
+++ b/include/net/socket/socket_helpers.cpp
@@ -524,4 +524,20 @@ boost::asio::ssl::verify_mode socket_helpers::verify_mode_parser(const std::stri
   return mode;
 }
 
+boost::optional<long> socket_helpers::peer_certificate_expiry_days(SSL *ssl) {
+  if (ssl == nullptr) return boost::none;
+  X509 *cert = SSL_get_peer_certificate(ssl);
+  if (cert == nullptr) return boost::none;
+
+  // ASN1_TIME_diff splits the interval into whole days plus leftover seconds;
+  // we report the days and drop the remainder, so a certificate with 23 hours
+  // left reads as 0 rather than rounding up to a reassuring 1.
+  int days = 0;
+  int seconds = 0;
+  const int ok = ASN1_TIME_diff(&days, &seconds, nullptr, X509_get0_notAfter(cert));
+  X509_free(cert);
+  if (ok != 1) return boost::none;
+  return static_cast<long>(days);
+}
+
 #endif

--- a/include/net/socket/socket_helpers.hpp
+++ b/include/net/socket/socket_helpers.hpp
@@ -224,6 +224,12 @@ struct connection_info {
 #ifdef USE_SSL
 boost::asio::ssl::context_base::method tls_method_parser(const std::string& tls_version);
 boost::asio::ssl::verify_mode verify_mode_parser(const std::string& verify_mode);
+
+// Whole days until the peer's certificate expires, negative once it already
+// has. Returns none when the peer presented no certificate at all, so a caller
+// can tell that apart from "expired a day ago" - collapsing both to -1 loses a
+// distinction that matters when the number drives an alert.
+boost::optional<long> peer_certificate_expiry_days(SSL* ssl);
 #endif
 
 namespace io {

--- a/libs/onboarding/sync_test.cpp
+++ b/libs/onboarding/sync_test.cpp
@@ -79,14 +79,15 @@ std::string sign_bundle(EVP_PKEY *key, const std::string &payload) {
   return bytes::base64_encode(signature);
 }
 
-// A minimal self-signed certificate expiring `days` from now.
-std::string make_cert_expiring_in(const long days) {
+// A minimal self-signed certificate expiring `seconds` from now (negative for
+// one that has already expired).
+std::string make_cert_expiring_in_seconds(const long seconds) {
   const pkey_ptr key = generate_ed25519();
   const std::unique_ptr<X509, x509_deleter> cert(X509_new());
   X509_set_version(cert.get(), 2);
   ASN1_INTEGER_set(X509_get_serialNumber(cert.get()), 1);
-  X509_gmtime_adj(X509_getm_notBefore(cert.get()), -3600);
-  X509_gmtime_adj(X509_getm_notAfter(cert.get()), days * 24 * 3600);
+  X509_gmtime_adj(X509_getm_notBefore(cert.get()), seconds < 0 ? seconds - 3600 : -3600);
+  X509_gmtime_adj(X509_getm_notAfter(cert.get()), seconds);
   X509_set_pubkey(cert.get(), key.get());
   X509_NAME *name = X509_get_subject_name(cert.get());
   X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char *>("test"), -1, -1, 0);
@@ -98,6 +99,9 @@ std::string make_cert_expiring_in(const long days) {
   const long len = BIO_get_mem_data(bio.get(), &data);
   return std::string(data, static_cast<std::size_t>(len));
 }
+
+// A minimal self-signed certificate expiring `days` from now.
+std::string make_cert_expiring_in(const long days) { return make_cert_expiring_in_seconds(days * 24 * 3600); }
 
 // A 64 character hex digest made of one repeated character - shape-valid
 // without pretending to be a real digest.
@@ -895,6 +899,21 @@ TEST(SyncCert, DaysUntilExpiry) {
 }
 
 TEST(SyncCert, ExpiredCertIsNegative) { EXPECT_LT(onboarding::days_until_expiry(make_cert_expiring_in(-10)), 0); }
+
+TEST(SyncCert, ACertExpiredLessThanADayAgoIsStillNegative) {
+  // ASN1_TIME_diff reports this as days=0 with negative seconds. Returning the
+  // day count as-is made it 0 - the same answer as "expires later today" - so
+  // an already-expired certificate read as merely urgent, and any "< 0" test
+  // stayed false for the whole first day of expiry.
+  EXPECT_LT(onboarding::days_until_expiry(make_cert_expiring_in_seconds(-3600)), 0) << "expired an hour ago";
+  EXPECT_LT(onboarding::days_until_expiry(make_cert_expiring_in_seconds(-60)), 0) << "expired a minute ago";
+}
+
+TEST(SyncCert, ACertValidForLessThanADayIsNotNegative) {
+  // The other side of the same rounding: still valid must never read as expired.
+  EXPECT_EQ(onboarding::days_until_expiry(make_cert_expiring_in_seconds(23 * 3600)), 0);
+  EXPECT_EQ(onboarding::days_until_expiry(make_cert_expiring_in_seconds(60)), 0);
+}
 
 TEST(SyncCert, GarbagePemThrows) { EXPECT_THROW(onboarding::days_until_expiry("not a pem"), onboarding::onboarding_error); }
 

--- a/libs/onboarding/verify.cpp
+++ b/libs/onboarding/verify.cpp
@@ -135,5 +135,12 @@ long onboarding::days_until_expiry(const std::string &cert_pem) {
   if (ASN1_TIME_diff(&days, &seconds, nullptr, X509_get0_notAfter(cert.get())) != 1) {
     throw onboarding_error("Failed to compute certificate expiry", false);
   }
+  // Round down rather than toward zero. ASN1_TIME_diff gives days and seconds
+  // with a common sign, so a certificate that expired an hour ago is days=0,
+  // seconds=-3600 - returning days as-is would report 0, the same value as
+  // "still valid, expires within the day". Flooring keeps negative meaning
+  // expired. (Renewal here triggers on `< renew_threshold_days`, so 0 already
+  // renewed; the sign still has to be right for anything else reading this.)
+  if (seconds < 0) days -= 1;
   return days;
 }

--- a/modules/CheckDisk/check_drive_unix.cpp
+++ b/modules/CheckDisk/check_drive_unix.cpp
@@ -449,6 +449,7 @@ void do_check(const PB::Commands::QueryRequestMessage::Request &request, PB::Com
   modern_filter::cli_helper<filter_type> filter_helper(request, response, data);
   std::vector<std::string> drives, excludes;
   bool total = false;
+  bool ignore_missing = false;
 
   // clang-format off
   filter_type filter;
@@ -459,11 +460,20 @@ void do_check(const PB::Commands::QueryRequestMessage::Request &request, PB::Com
       "The drives to check.\nMultiple options can be used to check more than one mount or wildcards can be used to indicate multiple drives to check. Examples: drive=/, drive=/home, drive=*, drive=all-drives")
     ("exclude", po::value<std::vector<std::string>>(&excludes), "A list of drives (mount points) not to check")
     ("total", po::value<bool>(&total)->implicit_value(true)->default_value(false), "Include the total of all matching drives")
+    ("ignore-missing", po::value<bool>(&ignore_missing)->implicit_value(true)->default_value(false),
+      "Silently skip drives named with drive= that do not exist, instead of failing the whole check. Intended for optional mounts. "
+      "Implies empty-state=ok, so a check whose drives are all missing reports OK rather than UNKNOWN (pass empty-state= to choose a different one).")
     ;
   // clang-format on
 
   if (!filter_helper.parse_options()) return;
   if (!filter_helper.build_filter(filter)) return;
+
+  // "Ignore missing" only makes sense if a check whose drives are ALL missing
+  // is OK too - otherwise the false CRITICAL is merely traded for a false
+  // UNKNOWN. Only the default is overridden, so an explicit empty-state= still
+  // wins.
+  if (ignore_missing && data.empty_state == "unknown") data.empty_state = "ok";
 
   if (drives.empty()) drives.emplace_back("*");
   if (!total) {
@@ -480,7 +490,7 @@ void do_check(const PB::Commands::QueryRequestMessage::Request &request, PB::Com
 
   std::vector<std::string> not_found;
   const std::list<drive_container> resolved = find_drives(drives, not_found);
-  if (!not_found.empty()) {
+  if (!not_found.empty() && !ignore_missing) {
     std::string msg = "Drive";
     msg += not_found.size() == 1 ? " " : "s ";
     bool first = true;

--- a/modules/CheckDisk/check_drive_win.cpp
+++ b/modules/CheckDisk/check_drive_win.cpp
@@ -792,7 +792,7 @@ void check_drive::check(const PB::Commands::QueryRequestMessage::Request &reques
   modern_filter::data_container data;
   modern_filter::cli_helper<filter_type> filter_helper(request, response, data);
   std::vector<std::string> drives, excludes, require;
-  bool ignore_unreadable = false, total = false, only_mounted = false;
+  bool ignore_unreadable = false, total = false, only_mounted = false, ignore_missing = false;
   ;
   double magic;
 
@@ -813,11 +813,21 @@ void check_drive::check(const PB::Commands::QueryRequestMessage::Request &reques
 			"Drives that MUST be present: the check goes CRITICAL if any listed drive is not found, even when scanning wildcards. Alias: mandatory-drives.")
 		("mandatory-drives", po::value<std::vector<std::string>>(&require), "Alias for require.")
 		("total", po::value<bool>(&total)->implicit_value(true)->default_value(false), "Include the total of all matching drives")
+		("ignore-missing", po::value<bool>(&ignore_missing)->implicit_value(true)->default_value(false),
+			"Silently skip drives named with drive= that do not exist, instead of failing the whole check. Intended for optional mounts. "
+			"Implies empty-state=ok, so a check whose drives are all missing reports OK rather than UNKNOWN (pass empty-state= to choose a different one). "
+			"Drives listed in require= are unaffected: those are still CRITICAL when absent, which is the point of listing them.")
 		;
 	add_custom_options(filter_helper.get_desc());
   // clang-format on
 
   if (!filter_helper.parse_options()) return;
+
+  // "Ignore missing" only makes sense if a check whose drives are ALL missing
+  // is OK too - otherwise the false CRITICAL is merely traded for a false
+  // UNKNOWN. Only the default is overridden, so an explicit empty-state= still
+  // wins.
+  if (ignore_missing && data.empty_state == "unknown") data.empty_state = "ok";
 
   if (only_mounted) {
     filter_helper.append_all_filters("and", "( mounted = 1  or media_type = 0 )");
@@ -852,7 +862,7 @@ void check_drive::check(const PB::Commands::QueryRequestMessage::Request &reques
 
   std::vector<std::string> not_found;
   const std::list<drive_container> resolved = find_drives(drives, not_found);
-  if (!not_found.empty()) {
+  if (!not_found.empty() && !ignore_missing) {
     std::string msg = "Drive";
     msg += not_found.size() == 1 ? " " : "s ";
     bool first = true;

--- a/modules/CheckDisk/check_files.cpp
+++ b/modules/CheckDisk/check_files.cpp
@@ -27,6 +27,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   file_finder::scanner_context context;
   context.max_depth = -1;
   std::string total;
+  bool ignore_missing = false;
 
   file_filter::filter filter;
   filter_helper.add_options("", "", "", filter.get_filter_syntax(), "unknown");
@@ -41,6 +42,10 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
     ("pattern", po::value<std::string>(&context.pattern)->default_value("*.*"), "The pattern of files to search for (works like a filter but is faster and can be combined with a filter).")
     ("max-depth", po::value<int>(&context.max_depth), "Maximum depth to recurse")
     ("total", po::value(&total)->implicit_value("filter"), "Include the total of either (filter) all files matching the filter or (all) all files regardless of the filter")
+    ("ignore-missing", po::value<bool>(&ignore_missing)->implicit_value(true)->default_value(false),
+        "Silently skip top-level paths that do not exist, instead of failing the whole check. Intended for directories that are legitimately absent "
+        "some of the time. Implies empty-state=ok, so a scan whose paths are all missing reports OK rather than UNKNOWN (pass empty-state= to choose "
+        "a different one).")
   ;
   // clang-format on
 
@@ -51,6 +56,12 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   context.now = parsers::where::constants::get_now();
 
   if (!filter_helper.parse_options()) return;
+
+  // See check_drivesize: ignoring missing paths only helps if an entirely
+  // empty result is OK too, otherwise the false CRITICAL becomes a false
+  // UNKNOWN. An explicit empty-state= still wins.
+  if (ignore_missing && data.empty_state == "unknown") data.empty_state = "ok";
+  context.ignore_missing = ignore_missing;
 
   if (!files_string.empty()) boost::split(file_list, files_string, boost::is_any_of(","));
 
@@ -64,7 +75,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   for (const std::string &path : file_list) {
     file_finder::recursive_scan(filter, context, path, total_obj, total == "all");
   }
-  if (!context.missing_paths.empty()) {
+  if (!context.missing_paths.empty() && !ignore_missing) {
     // One or more user-supplied top-level paths could not be opened. Surface
     // this as UNKNOWN with the offending path(s) so operators see a clear
     // error instead of a misleading OK / "No files found" (issue #613).

--- a/modules/CheckDisk/check_single_file.cpp
+++ b/modules/CheckDisk/check_single_file.cpp
@@ -5,6 +5,7 @@
 
 #include <memory>
 #include <nscapi/nscapi_program_options.hpp>
+#include <nscapi/protobuf/functions_query.hpp>
 #include <parsers/filter/cli_helper.hpp>
 #include <parsers/filter/modern_filter.hpp>
 #include <parsers/helpers.hpp>
@@ -20,6 +21,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   modern_filter::data_container data;
   modern_filter::cli_helper<file_filter::filter> filter_helper(request, response, data);
   std::string file_path;
+  bool ignore_missing = false;
 
   file_filter::filter filter;
   // No "empty" state: a single-file check either has the file (and runs the
@@ -45,6 +47,9 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   filter_helper.get_desc().add_options()
     ("file", po::value<std::string>(&file_path), "The file to check.")
     ("path", po::value<std::string>(&file_path), "Alias for file.")
+    ("ignore-missing", po::value<bool>(&ignore_missing)->implicit_value(true)->default_value(false),
+        "Return OK instead of failing when the file does not exist. Intended for files that are legitimately absent some of the time, such as a "
+        "lock file or a report that is only written after a run.")
     ;
   // clang-format on
 
@@ -60,6 +65,14 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   const long long now = parsers::where::constants::get_now();
   const std::shared_ptr<file_filter::filter_obj> info = file_finder::stat_single_file(file_path, now);
   if (!info) {
+    if (ignore_missing) {
+      // Deliberately not routed through the filter: there is no object to
+      // match, and saying so plainly beats an empty-syntax line that reads
+      // like the file was inspected and found fine.
+      nscapi::protobuf::functions::append_simple_query_response_payload(response, "check_single_file", NSCAPI::query_return_codes::returnOK,
+                                                                       "File not found (ignored): " + file_path, "");
+      return;
+    }
     return nscapi::protobuf::functions::set_response_bad(*response, "File not found: " + file_path);
   }
 

--- a/modules/CheckDisk/file_finder.hpp
+++ b/modules/CheckDisk/file_finder.hpp
@@ -24,6 +24,11 @@ struct scanner_context {
   // UNKNOWN with a useful message instead of silently returning OK / "No
   // files found" when the operator has misconfigured the path. See #613.
   std::vector<std::string> missing_paths;
+  // When the caller passed ignore-missing, a missing top-level path is an
+  // expected condition rather than a misconfiguration, so it is logged at
+  // debug instead of error. It is still recorded above; the caller decides
+  // what to do with it.
+  bool ignore_missing = false;
   bool is_valid_level(int current_level) const;
   static void report_error(const std::string &str);
   void report_debug(const std::string &str) const;

--- a/modules/CheckDisk/file_finder_unix.cpp
+++ b/modules/CheckDisk/file_finder_unix.cpp
@@ -48,7 +48,10 @@ void file_finder::recursive_scan(file_filter::filter &filter, scanner_context &c
       // Top-level path supplied by the user does not exist / is inaccessible.
       // Record it so the caller surfaces UNKNOWN rather than "No files found".
       context.missing_paths.push_back(dir.string());
-      context.report_error("Invalid file specified: " + dir.string());
+      if (context.ignore_missing)
+        context.report_debug("Ignoring missing path: " + dir.string());
+      else
+        context.report_error("Invalid file specified: " + dir.string());
     } else {
       context.report_warning("Invalid file specified: " + dir.string());
     }

--- a/modules/CheckDisk/file_finder_win.cpp
+++ b/modules/CheckDisk/file_finder_win.cpp
@@ -52,7 +52,10 @@ void file_finder::recursive_scan(file_filter::filter &filter, scanner_context &c
     // accessible). Record it so the caller can surface this as an UNKNOWN
     // result instead of silently returning "No files found" (issue #613).
     context.missing_paths.push_back(dir.string());
-    context.report_error("Invalid file specified: " + dir.string());
+    if (context.ignore_missing)
+      context.report_debug("Ignoring missing path: " + dir.string());
+    else
+      context.report_error("Invalid file specified: " + dir.string());
     return;
   } else if (fileAttr == INVALID_FILE_ATTRIBUTES) {
     context.report_warning("Invalid file specified: " + dir.string());

--- a/modules/CheckNet/CheckNet.cpp
+++ b/modules/CheckNet/CheckNet.cpp
@@ -5,6 +5,7 @@
 
 #include <boost/atomic.hpp>
 #include <memory>
+#include <net/address_family.hpp>
 #include <net/pinger.hpp>
 #include <nscapi/nscapi_program_options.hpp>
 #include <nscapi/protobuf/functions_convert.hpp>
@@ -44,6 +45,7 @@ void CheckNet::check_ping(const PB::Commands::QueryRequestMessage::Request &requ
   bool total = false;
   int count = 0;
   int timeout = 0;
+  std::string address_family_arg;
 
   ping_filter::filter filter;
   filter_helper.add_options("time > 60 or loss > 5%", "time > 100 or loss > 10%", "", filter.get_filter_syntax(), "unknown");
@@ -57,10 +59,15 @@ void CheckNet::check_ping(const PB::Commands::QueryRequestMessage::Request &requ
     ("count", po::value<int>(&count)->default_value(1), "Number of packets to send.")
     ("timeout", po::value<int>(&timeout)->default_value(500), "Timeout in milliseconds.")
     ("payload", po::value<std::string>(&payload)->default_value("Hello from NSClient++."), "The payload to send in the ping request (default: 'Hello from NSClient++')")
+    ("address-family", po::value<std::string>(&address_family_arg), net::address_family_option_help())
     ;
   // clang-format on
 
   if (!filter_helper.parse_options()) return;
+
+  net::address_family af = net::address_family::any;
+  if (!net::parse_address_family(address_family_arg, af))
+    return nscapi::protobuf::functions::set_response_bad(*response, "Invalid address-family: " + address_family_arg + " (expected any, ipv4 or ipv6)");
 
   if (!hosts_string.empty()) boost::split(hosts, hosts_string, boost::is_any_of(","));
 
@@ -77,7 +84,10 @@ void CheckNet::check_ping(const PB::Commands::QueryRequestMessage::Request &requ
     for (int i = 0; i < count; i++) {
       boost::asio::io_context io_service;
       auto id = identifier.fetch_add(1, boost::memory_order_relaxed);
-      pinger ping(io_service, result, host.c_str(), timeout, id, payload);
+      // A destination with no address in the requested family throws out of the
+      // pinger constructor and, as before for any resolve failure, surfaces as
+      // an error response for the whole check.
+      pinger ping(io_service, result, host.c_str(), timeout, id, payload, af);
       ping.ping();
       io_service.run();
     }

--- a/modules/CheckNet/CheckNet.cpp
+++ b/modules/CheckNet/CheckNet.cpp
@@ -88,6 +88,25 @@ void CheckNet::check_ping(const PB::Commands::QueryRequestMessage::Request &requ
 
   payload = check_net::check_ping_internal::build_ping_payload(payload, size);
 
+  // `size` is new and caller-controlled up to 64 KB; `count` has never been
+  // bounded. Together they decide how many bytes this agent throws at an
+  // arbitrary `host`, and whoever can run a check picks all three - over REST
+  // that is any caller holding `queries.execute`, which the stock `monitoring`
+  // and `client` roles both have. Before this option the payload was a fixed
+  // ~22 byte string, so count was the only lever; a 64 KB payload multiplies
+  // the traffic a single check can generate by about three thousand.
+  //
+  // Bound the volume rather than `count` itself: an existing high-count check
+  // with the default payload is unaffected, and only the combination that turns
+  // the agent into a packet cannon is refused.
+  constexpr long long kMaxPingBytesPerHost = 10LL * 1024 * 1024;
+  const long long packets = count > 0 ? count : 0;
+  const long long total_bytes = packets * static_cast<long long>(payload.size());
+  if (total_bytes > kMaxPingBytesPerHost)
+    return nscapi::protobuf::functions::set_response_bad(
+        *response, "Refusing to send " + str::xtos(total_bytes) + " bytes to each host (count=" + str::xtos(count) + " x payload=" +
+                       str::xtos(payload.size()) + " bytes); the limit is " + str::xtos(kMaxPingBytesPerHost) + " bytes per host.");
+
   if (!hosts_string.empty()) boost::split(hosts, hosts_string, boost::is_any_of(","));
 
   if (hosts.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No host specified");

--- a/modules/CheckNet/CheckNet.cpp
+++ b/modules/CheckNet/CheckNet.cpp
@@ -13,11 +13,13 @@
 #include <nscapi/settings/helper.hpp>
 #include <parsers/filter/cli_helper.hpp>
 #include <parsers/filter/modern_filter.hpp>
+#include <str/xtos.hpp>
 
 #include "check_connections.h"
 #include "check_dns.h"
 #include "check_http.h"
 #include "check_nsclient_web_online.h"
+#include "check_ping_internal.hpp"
 #include "check_ntp_offset.h"
 #include "check_tcp.h"
 #include "filter.hpp"
@@ -45,6 +47,8 @@ void CheckNet::check_ping(const PB::Commands::QueryRequestMessage::Request &requ
   bool total = false;
   int count = 0;
   int timeout = 0;
+  int size = 0;
+  int ttl = 0;
   std::string address_family_arg;
 
   ping_filter::filter filter;
@@ -60,6 +64,12 @@ void CheckNet::check_ping(const PB::Commands::QueryRequestMessage::Request &requ
     ("timeout", po::value<int>(&timeout)->default_value(500), "Timeout in milliseconds.")
     ("payload", po::value<std::string>(&payload)->default_value("Hello from NSClient++."), "The payload to send in the ping request (default: 'Hello from NSClient++')")
     ("address-family", po::value<std::string>(&address_family_arg), net::address_family_option_help())
+    ("size", po::value<int>(&size)->default_value(0),
+        "Size of the ICMP payload in bytes (0 keeps the --payload string as-is). The payload is repeated or truncated to reach exactly this many bytes; "
+        "the 8 byte ICMP header is on top, so a 1472 byte payload is the largest that fits an untagged 1500 byte MTU over IPv4.")
+    ("ttl", po::value<int>(&ttl)->default_value(0),
+        "TTL / hop limit to set on outgoing packets (0 keeps the system default). Note the ttl keyword reports the TTL of the reply, which is a different "
+        "number: it is what is left of the remote host's own outgoing TTL after the return path.")
     ;
   // clang-format on
 
@@ -68,6 +78,15 @@ void CheckNet::check_ping(const PB::Commands::QueryRequestMessage::Request &requ
   net::address_family af = net::address_family::any;
   if (!net::parse_address_family(address_family_arg, af))
     return nscapi::protobuf::functions::set_response_bad(*response, "Invalid address-family: " + address_family_arg + " (expected any, ipv4 or ipv6)");
+
+  using check_net::check_ping_internal::kMaxPingPayload;
+  if (size < 0 || size > kMaxPingPayload)
+    return nscapi::protobuf::functions::set_response_bad(
+        *response, "Invalid size: " + str::xtos(size) + " (expected 0-" + str::xtos(kMaxPingPayload) + ")");
+  if (ttl < 0 || ttl > 255)
+    return nscapi::protobuf::functions::set_response_bad(*response, "Invalid ttl: " + str::xtos(ttl) + " (expected 0-255)");
+
+  payload = check_net::check_ping_internal::build_ping_payload(payload, size);
 
   if (!hosts_string.empty()) boost::split(hosts, hosts_string, boost::is_any_of(","));
 
@@ -87,7 +106,7 @@ void CheckNet::check_ping(const PB::Commands::QueryRequestMessage::Request &requ
       // A destination with no address in the requested family throws out of the
       // pinger constructor and, as before for any resolve failure, surfaces as
       // an error response for the whole check.
-      pinger ping(io_service, result, host.c_str(), timeout, id, payload, af);
+      pinger ping(io_service, result, host.c_str(), timeout, id, payload, af, ttl);
       ping.ping();
       io_service.run();
     }

--- a/modules/CheckNet/check_dns.cpp
+++ b/modules/CheckNet/check_dns.cpp
@@ -7,6 +7,7 @@
 #include <boost/asio.hpp>
 #include <boost/chrono.hpp>
 #include <boost/program_options.hpp>
+#include <net/address_family.hpp>
 #include <chrono>
 #include <memory>
 #include <nscapi/nscapi_program_options.hpp>
@@ -40,7 +41,8 @@ namespace {
 
 // Resolve "host" using the system resolver.
 // Optionally checks that all "expected" addresses appear in the answer.
-void run_dns_check(const std::string &host, int timeout_ms, const std::vector<std::string> &expected, check_dns_filter::filter_obj &out) {
+void run_dns_check(const std::string &host, int timeout_ms, net::address_family af, const std::vector<std::string> &expected,
+                   check_dns_filter::filter_obj &out) {
   using boost::asio::ip::tcp;
 
   out.host = host;
@@ -67,7 +69,10 @@ void run_dns_check(const std::string &host, int timeout_ms, const std::vector<st
   });
 
   try {
-    resolver.async_resolve(host, "", [&](const boost::system::error_code &ec, const tcp::resolver::results_type &results) {
+    // With a family pinned the resolver is asked for that family only, so the
+    // answer contains just those records (a dual-stack name otherwise returns
+    // both).
+    const auto collect = [&](const boost::system::error_code &ec, const tcp::resolver::results_type &results) {
       resolve_done = true;
       resolve_ec = ec;
       std::set<std::string> seen;
@@ -82,7 +87,13 @@ void run_dns_check(const std::string &host, int timeout_ms, const std::vector<st
         timer.cancel();
       } catch (...) {
       }
-    });
+    };
+    if (af == net::address_family::ipv4)
+      resolver.async_resolve(tcp::v4(), host, "", collect);
+    else if (af == net::address_family::ipv6)
+      resolver.async_resolve(tcp::v6(), host, "", collect);
+    else
+      resolver.async_resolve(host, "", collect);
 
     io_service.run();
   } catch (const std::exception &e) {
@@ -143,7 +154,7 @@ std::string default_nameserver() {
 // Query `server` over UDP for `host`/`qtype` and fill the result. Used for
 // non-A/AAAA record types and for an explicitly chosen server.
 void run_dns_udp_check(const std::string &host, int qtype, const std::string &server, unsigned short port, int timeout_ms, bool recursion,
-                       const std::vector<std::string> &expected, check_dns_filter::filter_obj &out) {
+                       net::address_family af, const std::vector<std::string> &expected, check_dns_filter::filter_obj &out) {
   using boost::asio::ip::udp;
   namespace dns = check_dns_internal;
 
@@ -166,13 +177,15 @@ void run_dns_udp_check(const std::string &host, int qtype, const std::string &se
   try {
     udp::resolver resolver(io);
     boost::system::error_code rec;
-    auto endpoints = resolver.resolve(udp::v4(), server, std::to_string(port), rec);
+    auto endpoints = net::resolve_for_family(resolver, af, server, std::to_string(port), rec);
     if (rec || endpoints.empty()) {
       out.result = "server_unresolved";
       return;
     }
     const udp::endpoint dest = *endpoints.begin();
-    socket.open(udp::v4());
+    // Open the socket in whatever family the server resolved to. This used to
+    // be hardcoded to v4, which made an IPv6 DNS server unreachable.
+    socket.open(dest.protocol());
     socket.send_to(boost::asio::buffer(query), dest);
 
     std::array<char, 4096> buf{};
@@ -264,6 +277,7 @@ void check_dns(const PB::Commands::QueryRequestMessage::Request &request, PB::Co
   std::string server;
   unsigned short port = 53;
   bool norec = false;
+  std::string address_family_arg;
 
   filter f;
   filter_helper.add_options("time > 1000", "result != 'ok'", "", f.get_filter_syntax(), "ignored");
@@ -282,10 +296,17 @@ void check_dns(const PB::Commands::QueryRequestMessage::Request &request, PB::Co
         "Record that must be present in the answer (may be given multiple times).")
     ("expected", po::value<std::string>(&expected_string),
         "Comma separated list of records that must all be present in the answer.")
+    ("address-family", po::value<std::string>(&address_family_arg),
+        "IP version to use: any (default), ipv4 or ipv6. Selects which address of the DNS server to query; with the system resolver "
+        "(A/AAAA and no server=) it also restricts the answer to that family. Accepts 4/v4/inet and 6/v6/inet6 as aliases.")
     ;
   // clang-format on
 
   if (!filter_helper.parse_options()) return;
+
+  net::address_family af = net::address_family::any;
+  if (!net::parse_address_family(address_family_arg, af))
+    return nscapi::protobuf::functions::set_response_bad(*response, "Invalid address-family: " + address_family_arg + " (expected any, ipv4 or ipv6)");
 
   if (host.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No host specified");
 
@@ -308,7 +329,7 @@ void check_dns(const PB::Commands::QueryRequestMessage::Request &request, PB::Co
   if (server.empty() && a_or_aaaa) {
     // A/AAAA without an explicit server: the system resolver (honours
     // /etc/hosts and nsswitch; may return both families).
-    run_dns_check(host, timeout_ms, expected, *obj);
+    run_dns_check(host, timeout_ms, af, expected, *obj);
     obj->type = type;
   } else {
     std::string dns_server = server;
@@ -316,7 +337,7 @@ void check_dns(const PB::Commands::QueryRequestMessage::Request &request, PB::Co
     if (dns_server.empty()) {
       return nscapi::protobuf::functions::set_response_bad(*response, "No DNS server configured; specify one with server=<ip>");
     }
-    run_dns_udp_check(host, qtype, dns_server, port, timeout_ms, !norec, expected, *obj);
+    run_dns_udp_check(host, qtype, dns_server, port, timeout_ms, !norec, af, expected, *obj);
   }
   f.match(obj);
 

--- a/modules/CheckNet/check_http.cpp
+++ b/modules/CheckNet/check_http.cpp
@@ -8,6 +8,7 @@
 #include <boost/program_options.hpp>
 #include <bytes/base64.hpp>
 #include <memory>
+#include <net/address_family.hpp>
 #include <net/http/client.hpp>
 #include <net/http/http_packet.hpp>
 #include <nscapi/nscapi_program_options.hpp>
@@ -48,6 +49,7 @@ filter_obj_handler::filter_obj_handler() {
 
 namespace {
 
+using check_http_internal::host_header_value;
 using check_http_internal::parse_url;
 using check_http_internal::parsed_url;
 using check_http_internal::resolve_redirect;
@@ -69,6 +71,7 @@ struct http_check_options {
   std::string sni;
   bool follow_redirects = false;
   int max_redirs = 15;
+  net::address_family address_family = net::address_family::any;
   std::vector<std::pair<std::string, std::string>> json_paths;  // (alias, dotted path)
 };
 
@@ -97,9 +100,10 @@ void run_http_check(const std::string &url_in, const http_check_options &opt, ch
 
       http::http_client_options options(u.protocol, opt.tls_version, opt.verify_mode, opt.ca_file);
       if (!opt.sni.empty()) options.sni_ = opt.sni;
+      options.address_family_ = opt.address_family;
       http::simple_client client(options);
 
-      http::request rq(opt.method, u.host, u.path);
+      http::request rq(opt.method, host_header_value(u.host), u.path);
       if (!opt.user_agent.empty()) rq.add_header("User-Agent", opt.user_agent);
       if (!opt.username.empty() || !opt.password.empty())
         rq.add_header("Authorization", "Basic " + bytes::base64_encode(opt.username + ":" + opt.password));
@@ -185,6 +189,7 @@ void check_http(const std::string &default_ca_file, const PB::Commands::QueryReq
   bool use_ssl = false;
   std::string onredirect = "ok";
   std::string ca_file;
+  std::string address_family_arg;
   std::vector<std::string> json_paths_raw;
 
   http_check_options opt;
@@ -227,10 +232,14 @@ void check_http(const std::string &default_ca_file, const PB::Commands::QueryReq
         "Extract a value from the JSON response body as a filter keyword: 'alias:dotted.path' (repeatable). "
         "Numeric segments index arrays; single-quote a segment containing a dot. "
         "Example: --json-path qlen:data.queue.length \"crit=qlen > 100\".")
+    ("address-family", po::value<std::string>(&address_family_arg), net::address_family_option_help())
     ;
   // clang-format on
 
   if (!filter_helper.parse_options()) return;
+
+  if (!net::parse_address_family(address_family_arg, opt.address_family))
+    return nscapi::protobuf::functions::set_response_bad(*response, "Invalid address-family: " + address_family_arg + " (expected any, ipv4 or ipv6)");
 
   for (const std::string &jp : json_paths_raw) {
     const auto pos = jp.find(':');

--- a/modules/CheckNet/check_http_internal.hpp
+++ b/modules/CheckNet/check_http_internal.hpp
@@ -34,6 +34,25 @@ inline bool parse_url(const std::string &url, parsed_url &out) {
     host_port = s.substr(0, slash);
     out.path = s.substr(slash);
   }
+  // An IPv6 literal is bracketed (RFC 3986) precisely because it is full of
+  // colons: "[::1]:8080". Strip the brackets and only look for a port
+  // separator after them, otherwise the first colon of the address is mistaken
+  // for the port separator.
+  if (!host_port.empty() && host_port[0] == '[') {
+    const auto close = host_port.find(']');
+    if (close == std::string::npos) return false;
+    out.host = host_port.substr(1, close - 1);
+    const std::string rest = host_port.substr(close + 1);
+    if (rest.empty()) {
+      out.port = (out.protocol == "https") ? "443" : "80";
+    } else if (rest[0] == ':') {
+      out.port = rest.substr(1);
+    } else {
+      return false;
+    }
+    return !out.host.empty() && !out.port.empty();
+  }
+
   const auto colon = host_port.find(':');
   if (colon == std::string::npos) {
     out.host = host_port;
@@ -43,6 +62,14 @@ inline bool parse_url(const std::string &url, parsed_url &out) {
     out.port = host_port.substr(colon + 1);
   }
   return !out.host.empty();
+}
+
+// The value to put in the Host header for a parsed host. parse_url strips the
+// brackets from an IPv6 literal (the resolver wants it bare), but RFC 7230
+// requires them back in the header, so "::1" has to be sent as "[::1]".
+inline std::string host_header_value(const std::string &host) {
+  if (host.find(':') == std::string::npos) return host;
+  return "[" + host + "]";
 }
 
 // Resolve a redirect target (a Location header value) against the URL that

--- a/modules/CheckNet/check_net_test.cpp
+++ b/modules/CheckNet/check_net_test.cpp
@@ -267,6 +267,155 @@ TEST(CheckTcp, TlsServicePresets) {
 }
 
 // ============================================================================
+// check_ssh - SSH identification string (RFC 4253 4.2) parsing
+// ============================================================================
+
+namespace {
+check_net::check_ssh_internal::ssh_banner parse_banner(const std::string &raw) {
+  check_net::check_ssh_internal::ssh_banner b;
+  EXPECT_TRUE(check_net::check_ssh_internal::parse_ssh_banner(raw, b)) << "failed to parse: " << raw;
+  return b;
+}
+}  // namespace
+
+TEST(CheckSsh, ParsesOpenSshBannerWithComments) {
+  const auto b = parse_banner("SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5\r\n");
+  EXPECT_EQ("SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5", b.banner);
+  EXPECT_EQ("2.0", b.protocol);
+  EXPECT_EQ(2, b.protocol_major);
+  EXPECT_EQ(0, b.protocol_minor);
+  EXPECT_EQ("OpenSSH_9.6p1", b.version);
+  EXPECT_EQ("OpenSSH", b.software);
+  EXPECT_EQ("9.6p1", b.software_version);
+  EXPECT_EQ("Ubuntu-3ubuntu13.5", b.comments);
+}
+
+TEST(CheckSsh, ParsesBannerWithoutComments) {
+  const auto b = parse_banner("SSH-2.0-dropbear_2022.83\r\n");
+  EXPECT_EQ("dropbear", b.software);
+  EXPECT_EQ("2022.83", b.software_version);
+  EXPECT_EQ("", b.comments);
+}
+
+TEST(CheckSsh, ProtocolOneNineNineIsMajorOne) {
+  // "1.99" advertises 2.0 with 1.x backwards compatibility, i.e. the server
+  // still speaks the insecure SSHv1 — protocol_major < 2 must catch it.
+  const auto b = parse_banner("SSH-1.99-OpenSSH_3.9p1\r\n");
+  EXPECT_EQ("1.99", b.protocol);
+  EXPECT_EQ(1, b.protocol_major);
+  EXPECT_EQ(99, b.protocol_minor);
+}
+
+TEST(CheckSsh, ProtocolOneFiveIsSshV1Only) {
+  const auto b = parse_banner("SSH-1.5-OpenSSH_2.9\r\n");
+  EXPECT_EQ(1, b.protocol_major);
+  EXPECT_EQ(5, b.protocol_minor);
+}
+
+TEST(CheckSsh, SoftwareSplitsOnTheLastUnderscoreBeforeADigit) {
+  // A first-underscore split would cut these in the wrong place.
+  const auto win = parse_banner("SSH-2.0-OpenSSH_for_Windows_9.5\r\n");
+  EXPECT_EQ("OpenSSH_for_Windows", win.software);
+  EXPECT_EQ("9.5", win.software_version);
+
+  const auto sun = parse_banner("SSH-2.0-Sun_SSH_1.1\r\n");
+  EXPECT_EQ("Sun_SSH", sun.software);
+  EXPECT_EQ("1.1", sun.software_version);
+}
+
+TEST(CheckSsh, SoftwareWithoutAVersionKeepsTheWholeName) {
+  // Some servers publish an opaque build id rather than a version.
+  const auto b = parse_banner("SSH-2.0-GitLab-SSHD\r\n");
+  EXPECT_EQ("GitLab-SSHD", b.software);
+  EXPECT_EQ("", b.software_version);
+  // The full version string is still there for regex matching.
+  EXPECT_EQ("GitLab-SSHD", b.version);
+}
+
+TEST(CheckSsh, UnderscoreNotFollowedByADigitIsNotAVersionSeparator) {
+  const auto b = parse_banner("SSH-2.0-Foo_Bar\r\n");
+  EXPECT_EQ("Foo_Bar", b.software);
+  EXPECT_EQ("", b.software_version);
+}
+
+TEST(CheckSsh, SkipsPreambleLinesBeforeTheIdentificationString) {
+  // RFC 4253 lets a server send other lines before the identification string.
+  const auto b = parse_banner("You are being watched\r\nAuthorized use only\r\nSSH-2.0-OpenSSH_8.9p1\r\n");
+  EXPECT_EQ("SSH-2.0-OpenSSH_8.9p1", b.banner);
+  EXPECT_EQ("OpenSSH", b.software);
+  EXPECT_EQ("8.9p1", b.software_version);
+}
+
+TEST(CheckSsh, HandlesBareNewlineAndNoTrailingNewline) {
+  const auto lf = parse_banner("SSH-2.0-OpenSSH_9.6p1\n");
+  EXPECT_EQ("OpenSSH", lf.software);
+  const auto none = parse_banner("SSH-2.0-OpenSSH_9.6p1");
+  EXPECT_EQ("OpenSSH", none.software);
+  EXPECT_EQ("9.6p1", none.software_version);
+}
+
+TEST(CheckSsh, NonSshAndMalformedInputIsRejected) {
+  check_net::check_ssh_internal::ssh_banner b;
+  EXPECT_FALSE(check_net::check_ssh_internal::parse_ssh_banner("", b));
+  EXPECT_FALSE(check_net::check_ssh_internal::parse_ssh_banner("HELLO not ssh\r\n", b));
+  EXPECT_FALSE(check_net::check_ssh_internal::parse_ssh_banner("220 mail.example.com ESMTP\r\n", b));
+  // "SSH-" prefixed but not a usable identification string.
+  EXPECT_FALSE(check_net::check_ssh_internal::parse_ssh_banner("SSH-2.0\r\n", b));    // no software part
+  EXPECT_FALSE(check_net::check_ssh_internal::parse_ssh_banner("SSH-2.0-\r\n", b));   // empty software part
+  EXPECT_FALSE(check_net::check_ssh_internal::parse_ssh_banner("SSH--OpenSSH\r\n", b));  // empty protocol
+  // A rejected parse must leave the output untouched rather than half-filled.
+  EXPECT_EQ("", b.banner);
+  EXPECT_EQ("", b.protocol);
+  EXPECT_EQ(0, b.protocol_major);
+}
+
+TEST(CheckSsh, NonNumericProtocolLeavesTheNumbersAtZero) {
+  const auto b = parse_banner("SSH-x.y-OpenSSH_9.6p1\r\n");
+  EXPECT_EQ("x.y", b.protocol);
+  EXPECT_EQ(0, b.protocol_major);
+  EXPECT_EQ(0, b.protocol_minor);
+}
+
+TEST(CheckSsh, FilterObjExposesTheParsedBannerAndKeepsTcpFields) {
+  check_net::check_ssh_filter::filter_obj o;
+  o.host = "srv";
+  o.port = 22;
+  o.result = "ok";
+  o.response = "SSH-2.0-OpenSSH_9.6p1 Debian-2";
+  o.post_read();
+
+  // TCP fields still behave as they do for check_tcp.
+  EXPECT_EQ("srv", o.get_host());
+  EXPECT_EQ(22, o.get_port());
+  EXPECT_EQ("srv:22 (ok)", o.show());
+  // ...plus the parsed identification string.
+  EXPECT_EQ("SSH-2.0-OpenSSH_9.6p1 Debian-2", o.get_banner());
+  EXPECT_EQ("2.0", o.get_protocol());
+  EXPECT_EQ(2, o.get_protocol_major());
+  EXPECT_EQ(0, o.get_protocol_minor());
+  EXPECT_EQ("OpenSSH_9.6p1", o.get_version());
+  EXPECT_EQ("OpenSSH", o.get_software());
+  EXPECT_EQ("9.6p1", o.get_software_version());
+  EXPECT_EQ("Debian-2", o.get_comments());
+}
+
+TEST(CheckSsh, FilterObjFieldsStayEmptyWhenNoBannerWasRead) {
+  // A refused/timed-out connection reads nothing; the banner keywords must be
+  // empty (and the numbers 0) rather than carrying stale or invented data.
+  check_net::check_ssh_filter::filter_obj o;
+  o.host = "srv";
+  o.port = 22;
+  o.result = "refused";
+  o.post_read();
+
+  EXPECT_EQ("", o.get_banner());
+  EXPECT_EQ("", o.get_protocol());
+  EXPECT_EQ("", o.get_version());
+  EXPECT_EQ("", o.get_software());
+  EXPECT_EQ(0, o.get_protocol_major());
+}
+
+// ============================================================================
 // check_nsclient_web_online - REST result JSON parsing
 // ============================================================================
 

--- a/modules/CheckNet/check_net_test.cpp
+++ b/modules/CheckNet/check_net_test.cpp
@@ -79,6 +79,44 @@ TEST(CheckTcp, filter_obj_defaults) {
   EXPECT_EQ(o.get_connected(), 0);
 }
 
+TEST(CheckTcp, filter_obj_certificate_defaults_to_absent) {
+  // A plain (or failed) connection has no certificate. -1 is the "unknown"
+  // day count, and has_certificate is what distinguishes it from a real
+  // negative value.
+  check_net::check_tcp_filter::filter_obj o;
+  EXPECT_EQ(o.get_has_certificate(), 0);
+  EXPECT_EQ(o.get_ssl_expiry_days(), -1);
+}
+
+TEST(CheckTcp, filter_obj_certificate_getters) {
+  check_net::check_tcp_filter::filter_obj o;
+  o.has_certificate = true;
+  o.ssl_expiry_days = 42;
+  EXPECT_EQ(o.get_has_certificate(), 1);
+  EXPECT_EQ(o.get_ssl_expiry_days(), 42);
+}
+
+TEST(CheckTcp, filter_obj_expired_certificate_is_negative_but_present) {
+  // The case has_certificate exists for: an expired certificate reports a
+  // negative day count, which must not read as "there was no certificate".
+  check_net::check_tcp_filter::filter_obj o;
+  o.has_certificate = true;
+  o.ssl_expiry_days = -7;
+  EXPECT_EQ(o.get_has_certificate(), 1);
+  EXPECT_EQ(o.get_ssl_expiry_days(), -7);
+}
+
+TEST(CheckSsh, filter_obj_inherits_the_certificate_fields_unset) {
+  // check_ssh shares the TCP object but never negotiates TLS, so the fields
+  // exist and stay at their "no certificate" defaults.
+  check_net::check_ssh_filter::filter_obj o;
+  o.response = "SSH-2.0-OpenSSH_9.6p1";
+  o.post_read();
+  EXPECT_EQ(o.get_has_certificate(), 0);
+  EXPECT_EQ(o.get_ssl_expiry_days(), -1);
+  EXPECT_EQ(o.get_software(), "OpenSSH");
+}
+
 TEST(CheckTcp, filter_obj_show_and_getters) {
   check_net::check_tcp_filter::filter_obj o;
   o.host = "host.example";

--- a/modules/CheckNet/check_net_test.cpp
+++ b/modules/CheckNet/check_net_test.cpp
@@ -4,6 +4,7 @@
 #include <gtest/gtest.h>
 
 #include <memory>
+#include <net/address_family.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 
 #include "check_connections.h"
@@ -267,6 +268,62 @@ TEST(CheckTcp, TlsServicePresets) {
 }
 
 // ============================================================================
+// address-family selection (shared by every CheckNet check)
+// ============================================================================
+
+TEST(AddressFamily, ParsesTheCanonicalNames) {
+  net::address_family af = net::address_family::ipv6;
+  ASSERT_TRUE(net::parse_address_family("any", af));
+  EXPECT_EQ(net::address_family::any, af);
+  ASSERT_TRUE(net::parse_address_family("ipv4", af));
+  EXPECT_EQ(net::address_family::ipv4, af);
+  ASSERT_TRUE(net::parse_address_family("ipv6", af));
+  EXPECT_EQ(net::address_family::ipv6, af);
+}
+
+TEST(AddressFamily, ParsesAliasesAndIsCaseInsensitive) {
+  net::address_family af = net::address_family::any;
+  for (const char *v : {"4", "v4", "inet", "IPv4", "IPV4", "V4"}) {
+    ASSERT_TRUE(net::parse_address_family(v, af)) << v;
+    EXPECT_EQ(net::address_family::ipv4, af) << v;
+  }
+  for (const char *v : {"6", "v6", "inet6", "IPv6", "INET6"}) {
+    ASSERT_TRUE(net::parse_address_family(v, af)) << v;
+    EXPECT_EQ(net::address_family::ipv6, af) << v;
+  }
+  for (const char *v : {"any", "ANY", "both", "unspec"}) {
+    ASSERT_TRUE(net::parse_address_family(v, af)) << v;
+    EXPECT_EQ(net::address_family::any, af) << v;
+  }
+}
+
+TEST(AddressFamily, EmptyMeansAnySoAnOmittedArgumentKeepsTheOldBehaviour) {
+  net::address_family af = net::address_family::ipv6;
+  ASSERT_TRUE(net::parse_address_family("", af));
+  EXPECT_EQ(net::address_family::any, af);
+}
+
+TEST(AddressFamily, UnknownValueIsRejectedAndLeavesTheTargetUntouched) {
+  // Rejecting rather than falling back to `any` is the point: a typo like
+  // "ipv64" must be reported, not silently ignored, or the check would quietly
+  // stop testing the family the user asked for.
+  net::address_family af = net::address_family::ipv4;
+  EXPECT_FALSE(net::parse_address_family("ipv64", af));
+  EXPECT_FALSE(net::parse_address_family("v5", af));
+  EXPECT_FALSE(net::parse_address_family("yes", af));
+  EXPECT_FALSE(net::parse_address_family("46", af));
+  EXPECT_EQ(net::address_family::ipv4, af);
+}
+
+TEST(AddressFamily, ToStringRoundTrips) {
+  for (const auto af : {net::address_family::any, net::address_family::ipv4, net::address_family::ipv6}) {
+    net::address_family parsed = net::address_family::any;
+    ASSERT_TRUE(net::parse_address_family(net::to_string(af), parsed));
+    EXPECT_EQ(af, parsed);
+  }
+}
+
+// ============================================================================
 // check_ssh - SSH identification string (RFC 4253 4.2) parsing
 // ============================================================================
 
@@ -484,6 +541,43 @@ TEST(CheckHttp, parse_url_http_default_port) {
   EXPECT_EQ(u.host, "example.com");
   EXPECT_EQ(u.port, "80");
   EXPECT_EQ(u.path, "/path");
+}
+
+TEST(CheckHttp, parse_url_ipv6_literal) {
+  // An IPv6 literal is bracketed exactly because it is full of colons; a naive
+  // find(':') would take "::1" apart at the first one and leave a port of ":1".
+  check_net::check_http_internal::parsed_url u;
+  ASSERT_TRUE(check_net::check_http_internal::parse_url("http://[::1]:8080/api", u));
+  EXPECT_EQ(u.host, "::1");
+  EXPECT_EQ(u.port, "8080");
+  EXPECT_EQ(u.path, "/api");
+
+  ASSERT_TRUE(check_net::check_http_internal::parse_url("http://[2001:db8::1]/", u));
+  EXPECT_EQ(u.host, "2001:db8::1");
+  EXPECT_EQ(u.port, "80");  // default applies to a bracketed host too
+  EXPECT_EQ(u.path, "/");
+
+  ASSERT_TRUE(check_net::check_http_internal::parse_url("https://[2001:db8::1]", u));
+  EXPECT_EQ(u.host, "2001:db8::1");
+  EXPECT_EQ(u.port, "443");
+  EXPECT_EQ(u.path, "/");
+}
+
+TEST(CheckHttp, parse_url_malformed_ipv6_literal_is_rejected) {
+  check_net::check_http_internal::parsed_url u;
+  EXPECT_FALSE(check_net::check_http_internal::parse_url("http://[::1/", u));      // unterminated bracket
+  EXPECT_FALSE(check_net::check_http_internal::parse_url("http://[]/", u));        // empty host
+  EXPECT_FALSE(check_net::check_http_internal::parse_url("http://[::1]x8080/", u));  // junk after the bracket
+  EXPECT_FALSE(check_net::check_http_internal::parse_url("http://[::1]:/", u));    // empty port
+}
+
+TEST(CheckHttp, host_header_value_brackets_only_ipv6) {
+  // RFC 7230 wants the brackets back in the Host header, but a name or an IPv4
+  // literal must be sent unchanged.
+  EXPECT_EQ("[::1]", check_net::check_http_internal::host_header_value("::1"));
+  EXPECT_EQ("[2001:db8::1]", check_net::check_http_internal::host_header_value("2001:db8::1"));
+  EXPECT_EQ("example.com", check_net::check_http_internal::host_header_value("example.com"));
+  EXPECT_EQ("192.0.2.1", check_net::check_http_internal::host_header_value("192.0.2.1"));
 }
 
 TEST(CheckHttp, parse_url_https_default_port) {

--- a/modules/CheckNet/check_net_test.cpp
+++ b/modules/CheckNet/check_net_test.cpp
@@ -14,6 +14,7 @@
 #include "check_http.h"
 #include "check_http_internal.hpp"
 #include "check_nsclient_web_online.h"
+#include "check_ping_internal.hpp"
 #include "check_ntp_internal.hpp"
 #include "check_ntp_offset.h"
 #include "check_tcp.h"
@@ -66,6 +67,105 @@ TEST(CheckPing, filter_obj_aggregates_counters) {
   EXPECT_EQ(total->get_recv(), 6);
   EXPECT_EQ(total->get_timeout(), 2);
   EXPECT_EQ(total->get_time(), 62);
+}
+
+// ============================================================================
+// check_ping - payload sizing and reply TTL
+// ============================================================================
+
+TEST(CheckPingPayload, SizeZeroLeavesThePayloadAlone) {
+  using check_net::check_ping_internal::build_ping_payload;
+  EXPECT_EQ("Hello from NSClient++.", build_ping_payload("Hello from NSClient++.", 0));
+  // Negative is treated the same rather than doing something surprising; the
+  // caller rejects it before reaching here.
+  EXPECT_EQ("abc", build_ping_payload("abc", -5));
+}
+
+TEST(CheckPingPayload, RepeatsThePatternToReachTheRequestedSize) {
+  using check_net::check_ping_internal::build_ping_payload;
+  EXPECT_EQ("abcabcabca", build_ping_payload("abc", 10));
+  const std::string big = build_ping_payload("abc", 1472);
+  EXPECT_EQ(1472u, big.size());
+  EXPECT_EQ('a', big[0]);
+  EXPECT_EQ("abc", big.substr(0, 3));
+}
+
+TEST(CheckPingPayload, TruncatesAPayloadLongerThanTheRequestedSize) {
+  using check_net::check_ping_internal::build_ping_payload;
+  EXPECT_EQ("Hel", build_ping_payload("Hello from NSClient++.", 3));
+  EXPECT_EQ(1u, build_ping_payload("Hello", 1).size());
+}
+
+TEST(CheckPingPayload, EmptyPayloadStillFillsRatherThanSpinning) {
+  // The fill loop would never terminate on an empty pattern; it substitutes a
+  // single character instead.
+  using check_net::check_ping_internal::build_ping_payload;
+  const std::string filled = build_ping_payload("", 64);
+  EXPECT_EQ(64u, filled.size());
+  EXPECT_EQ(std::string(64, 'x'), filled);
+}
+
+TEST(CheckPingPayload, ProducesExactlyTheRequestedSizeAtTheCeiling) {
+  using check_net::check_ping_internal::build_ping_payload;
+  using check_net::check_ping_internal::kMaxPingPayload;
+  // 65535 total - 20 byte IP header - 8 byte ICMP header.
+  EXPECT_EQ(65507, kMaxPingPayload);
+  EXPECT_EQ(static_cast<std::size_t>(kMaxPingPayload), build_ping_payload("ab", kMaxPingPayload).size());
+}
+
+TEST(CheckPingTtl, DefaultsToUnknown) {
+  // -1, not 0: a TTL of 0 is a real (if doomed) value, so "no reply yet" needs
+  // a value outside the range.
+  const result_container r;
+  EXPECT_EQ(-1, r.ttl_);
+  ping_filter::filter_obj o(r);
+  EXPECT_EQ(-1, o.get_ttl());
+}
+
+TEST(CheckPingTtl, ReportsTheReplyTtl) {
+  result_container r;
+  r.ttl_ = 57;
+  ping_filter::filter_obj o(r);
+  EXPECT_EQ(57, o.get_ttl());
+}
+
+TEST(CheckPingTtl, TotalCarriesTheLowestTtlAcrossHosts) {
+  // A low TTL is the interesting end - a reply nearly out of hops, or a route
+  // that has grown - so the total reports the minimum rather than the maximum.
+  result_container near;
+  near.ttl_ = 64;
+  result_container far;
+  far.ttl_ = 6;
+
+  auto a = std::make_shared<ping_filter::filter_obj>(near);
+  auto b = std::make_shared<ping_filter::filter_obj>(far);
+  auto total = ping_filter::filter_obj::get_total();
+  total->add(a);
+  total->add(b);
+  EXPECT_EQ(6, total->get_ttl());
+}
+
+TEST(CheckPingTtl, TotalIgnoresHostsWithNoTtl) {
+  // An unanswered host (or an IPv6 one) contributes -1, which must not win the
+  // minimum and report "unknown" for the whole fleet.
+  result_container answered;
+  answered.ttl_ = 42;
+  result_container unknown;  // ttl_ stays -1
+
+  auto a = std::make_shared<ping_filter::filter_obj>(answered);
+  auto b = std::make_shared<ping_filter::filter_obj>(unknown);
+  auto total = ping_filter::filter_obj::get_total();
+  total->add(b);
+  total->add(a);
+  EXPECT_EQ(42, total->get_ttl());
+}
+
+TEST(CheckPingTtl, TotalStaysUnknownWhenNoHostAnswered) {
+  result_container unknown;
+  auto a = std::make_shared<ping_filter::filter_obj>(unknown);
+  auto total = ping_filter::filter_obj::get_total();
+  total->add(a);
+  EXPECT_EQ(-1, total->get_ttl());
 }
 
 // ============================================================================

--- a/modules/CheckNet/check_net_test.cpp
+++ b/modules/CheckNet/check_net_test.cpp
@@ -69,6 +69,77 @@ TEST(CheckPing, filter_obj_aggregates_counters) {
 }
 
 // ============================================================================
+// check_ping - jitter (mean absolute difference between round trip times)
+// ============================================================================
+
+TEST(CheckPingJitter, MeanAbsoluteDifferenceOfRoundTripTimes) {
+  // Deltas 5, 5, 10 -> mean 6 (integer division of 20/3).
+  EXPECT_EQ(6, ping_filter::mean_abs_delta_ms({10, 15, 20, 30}));
+  // Direction does not matter: it is the magnitude of the change.
+  EXPECT_EQ(5, ping_filter::mean_abs_delta_ms({20, 15}));
+  EXPECT_EQ(5, ping_filter::mean_abs_delta_ms({15, 20}));
+}
+
+TEST(CheckPingJitter, SteadyLatencyHasNoJitter) {
+  // A high but perfectly stable round trip time is not jitter - that is the
+  // whole point of reporting it separately from `time`.
+  EXPECT_EQ(0, ping_filter::mean_abs_delta_ms({250, 250, 250, 250}));
+}
+
+TEST(CheckPingJitter, UndefinedForFewerThanTwoReplies) {
+  EXPECT_EQ(-1, ping_filter::mean_abs_delta_ms({}));
+  EXPECT_EQ(-1, ping_filter::mean_abs_delta_ms({42}));
+}
+
+TEST(CheckPingJitter, FilterObjExposesItPerHost) {
+  result_container r;
+  r.destination_ = "a.example";
+  r.num_send_ = 4;
+  r.num_replies_ = 4;
+  r.rtts_ = {10, 20, 10, 20};  // deltas 10,10,10
+  ping_filter::filter_obj o(r);
+  EXPECT_EQ(10, o.get_jitter());
+}
+
+TEST(CheckPingJitter, FilterObjIsMinusOneWithASingleReply) {
+  result_container r;
+  r.num_send_ = 1;
+  r.num_replies_ = 1;
+  r.rtts_ = {12};
+  ping_filter::filter_obj o(r);
+  EXPECT_EQ(-1, o.get_jitter());
+}
+
+TEST(CheckPingJitter, TotalReportsTheWorstHostRatherThanPoolingRoundTrips) {
+  // Pooling the two hosts' round trip times would manufacture a huge "jitter"
+  // out of the difference between a fast host and a slow one, which is not
+  // jitter at all. The total carries the worst per-host value instead.
+  result_container fast;
+  fast.rtts_ = {10, 12, 10};  // jitter 2
+  result_container slow;
+  slow.rtts_ = {200, 260, 200};  // jitter 60
+
+  auto a = std::make_shared<ping_filter::filter_obj>(fast);
+  auto b = std::make_shared<ping_filter::filter_obj>(slow);
+  auto total = ping_filter::filter_obj::get_total();
+  total->add(a);
+  total->add(b);
+
+  EXPECT_EQ(2, a->get_jitter());
+  EXPECT_EQ(60, b->get_jitter());
+  EXPECT_EQ(60, total->get_jitter());
+}
+
+TEST(CheckPingJitter, TotalIsMinusOneWhenNoHostHadEnoughReplies) {
+  result_container one;
+  one.rtts_ = {10};
+  auto a = std::make_shared<ping_filter::filter_obj>(one);
+  auto total = ping_filter::filter_obj::get_total();
+  total->add(a);
+  EXPECT_EQ(-1, total->get_jitter());
+}
+
+// ============================================================================
 // check_tcp - filter_obj
 // ============================================================================
 
@@ -695,6 +766,62 @@ TEST(CheckNtp, filter_obj_offset_is_absolute_value) {
   o.offset_ms = 1234;
   EXPECT_EQ(o.get_offset(), 1234);
   EXPECT_EQ(o.get_offset_signed(), 1234);
+}
+
+TEST(CheckNtp, filter_obj_jitter_defaults_to_unmeasured) {
+  // A default (single-sample) query has no jitter to report; -1 says so, and a
+  // real jitter can never be negative so the two cannot be confused.
+  check_net::check_ntp_filter::filter_obj o;
+  EXPECT_EQ(o.get_jitter(), -1);
+  EXPECT_EQ(o.get_samples(), 0);
+  EXPECT_EQ(o.get_root_delay(), 0);
+  EXPECT_EQ(o.get_root_dispersion(), 0);
+}
+
+TEST(CheckNtp, rms_jitter_needs_two_samples) {
+  using check_net::check_ntp_internal::rms_jitter_ms;
+  EXPECT_EQ(-1, rms_jitter_ms({}));
+  EXPECT_EQ(-1, rms_jitter_ms({7}));
+}
+
+TEST(CheckNtp, rms_jitter_of_a_steady_offset_is_zero) {
+  // A large but perfectly steady offset is a clock that is wrong, not one that
+  // is unstable: jitter must stay 0 so the two alert independently.
+  using check_net::check_ntp_internal::rms_jitter_ms;
+  EXPECT_EQ(0, rms_jitter_ms({5000, 5000, 5000, 5000}));
+}
+
+TEST(CheckNtp, rms_jitter_uses_differences_between_successive_samples) {
+  using check_net::check_ntp_internal::rms_jitter_ms;
+  // Deltas of 10 each: RMS is 10.
+  EXPECT_EQ(10, rms_jitter_ms({0, 10, 20, 30}));
+  // Deltas 30 and -30: RMS is 30 (sign does not cancel, unlike a plain mean).
+  EXPECT_EQ(30, rms_jitter_ms({0, 30, 0}));
+  // RMS weights the large excursion more than a mean would: deltas 0 and 10
+  // give sqrt((0+100)/2) = 7.07 -> 7, where the mean would be 5.
+  EXPECT_EQ(7, rms_jitter_ms({0, 0, 10}));
+}
+
+TEST(CheckNtp, rms_jitter_is_symmetric_in_sign) {
+  using check_net::check_ntp_internal::rms_jitter_ms;
+  EXPECT_EQ(rms_jitter_ms({0, 20, 40}), rms_jitter_ms({0, -20, -40}));
+}
+
+TEST(CheckNtp, ntp_short_to_ms_converts_fixed_point_seconds) {
+  using check_net::check_ntp_internal::ntp_short_to_ms;
+  // "NTP short" is 16 bits of seconds and 16 of fraction.
+  EXPECT_EQ(0, ntp_short_to_ms(0));
+  EXPECT_EQ(1000, ntp_short_to_ms(1u << 16));           // exactly one second
+  EXPECT_EQ(500, ntp_short_to_ms(1u << 15));            // half a second
+  EXPECT_EQ(1500, ntp_short_to_ms((1u << 16) + (1u << 15)));
+  // Sub-millisecond values truncate toward zero rather than rounding up.
+  EXPECT_EQ(0, ntp_short_to_ms(1));
+}
+
+TEST(CheckNtp, ntp_short_to_ms_handles_the_full_range) {
+  using check_net::check_ntp_internal::ntp_short_to_ms;
+  // The field is unsigned: the top value must not come back negative.
+  EXPECT_EQ(65535999, ntp_short_to_ms(0xffffffffu));
 }
 
 TEST(CheckNtp, ntp_to_unix_ms_zero_is_sentinel) { EXPECT_EQ(check_net::check_ntp_internal::ntp_to_unix_ms(0, 0), 0); }

--- a/modules/CheckNet/check_net_test.cpp
+++ b/modules/CheckNet/check_net_test.cpp
@@ -132,13 +132,16 @@ TEST(CheckPingTtl, ReportsTheReplyTtl) {
 TEST(CheckPingTtl, TotalCarriesTheLowestTtlAcrossHosts) {
   // A low TTL is the interesting end - a reply nearly out of hops, or a route
   // that has grown - so the total reports the minimum rather than the maximum.
-  result_container near;
-  near.ttl_ = 64;
-  result_container far;
-  far.ttl_ = 6;
+  // Not `near`/`far`: <minwindef.h> still defines both as empty macros for
+  // 16-bit source compatibility, so `near.ttl_` preprocesses to `.ttl_` and the
+  // Windows build fails with "syntax error: '.'".
+  result_container nearby;
+  nearby.ttl_ = 64;
+  result_container distant;
+  distant.ttl_ = 6;
 
-  auto a = std::make_shared<ping_filter::filter_obj>(near);
-  auto b = std::make_shared<ping_filter::filter_obj>(far);
+  auto a = std::make_shared<ping_filter::filter_obj>(nearby);
+  auto b = std::make_shared<ping_filter::filter_obj>(distant);
   auto total = ping_filter::filter_obj::get_total();
   total->add(a);
   total->add(b);

--- a/modules/CheckNet/check_ntp_internal.hpp
+++ b/modules/CheckNet/check_ntp_internal.hpp
@@ -3,7 +3,9 @@
 
 #pragma once
 
+#include <cmath>
 #include <cstdint>
+#include <vector>
 
 namespace check_net {
 namespace check_ntp_internal {
@@ -27,6 +29,30 @@ inline long long ntp_to_unix_ms(std::uint32_t secs, std::uint32_t frac) {
 // Compute the standard NTP offset (server - local) in milliseconds.
 // t1 = local send time, t2 = server receive time, t3 = server transmit time, t4 = local receive time.
 inline long long ntp_offset_ms(long long t1, long long t2, long long t3, long long t4) { return ((t2 - t1) + (t3 - t4)) / 2; }
+
+// Convert an "NTP short" fixed-point value (16 bits of seconds, 16 bits of
+// fraction) to milliseconds. This is the encoding of the root delay and root
+// dispersion fields of the packet header.
+inline long long ntp_short_to_ms(std::uint32_t value) { return (static_cast<long long>(value) * 1000LL) >> 16; }
+
+// RMS jitter over a series of offset measurements, in milliseconds: the root
+// mean square of the differences between successive samples. This is the
+// definition NTP tooling reports, so the number is directly comparable with
+// what `ntpq -p` shows for the same server.
+//
+// Returns -1 for fewer than two samples: jitter is a property of the variation
+// between measurements and is simply not defined for a single one, and -1 can
+// never be confused with a real value (jitter is a magnitude, so never
+// negative).
+inline long long rms_jitter_ms(const std::vector<long long> &offsets) {
+  if (offsets.size() < 2) return -1;
+  double sum_sq = 0.0;
+  for (std::size_t i = 1; i < offsets.size(); ++i) {
+    const double delta = static_cast<double>(offsets[i] - offsets[i - 1]);
+    sum_sq += delta * delta;
+  }
+  return static_cast<long long>(std::sqrt(sum_sq / static_cast<double>(offsets.size() - 1)) + 0.5);
+}
 
 }  // namespace check_ntp_internal
 }  // namespace check_net

--- a/modules/CheckNet/check_ntp_offset.cpp
+++ b/modules/CheckNet/check_ntp_offset.cpp
@@ -6,6 +6,7 @@
 #include <boost/asio.hpp>
 #include <boost/chrono.hpp>
 #include <boost/program_options.hpp>
+#include <vector>
 #include <net/address_family.hpp>
 #include <chrono>
 #include <cstdint>
@@ -32,6 +33,23 @@ filter_obj_handler::filter_obj_handler() {
                         "Signed clock offset (positive = local clock is ahead of server), in milliseconds");
   registry_.add_int_var("stratum", parsers::where::type_int, &filter_obj::get_stratum, "Stratum reported by the server (0..16)").add_int_perf("");
   registry_.add_int_var("time", parsers::where::type_int, &filter_obj::get_time, "Round trip time of the NTP query in milliseconds").add_int_perf("ms");
+
+  // How steady the server's time is, rather than how far off it is: a source
+  // can answer promptly with an accurate-looking offset and still be unusable
+  // because that offset will not hold still.
+  registry_
+      .add_int_var("jitter", parsers::where::type_int, &filter_obj::get_jitter,
+                   "RMS variation between the sampled offsets, in milliseconds; -1 when fewer than 2 samples were taken (raise samples= to measure it)")
+      .add_int_perf("ms", "", "_jitter");
+  registry_.add_int_var("samples", parsers::where::type_int, &filter_obj::get_samples, "Number of samples that answered").no_perf();
+  registry_
+      .add_int_var("root_delay", parsers::where::type_int, &filter_obj::get_root_delay,
+                   "Round trip delay the server reports to its own reference clock, in milliseconds")
+      .add_int_perf("ms", "", "_root_delay");
+  registry_
+      .add_int_var("root_dispersion", parsers::where::type_int, &filter_obj::get_root_dispersion,
+                   "Maximum error the server claims for the time it is serving, in milliseconds")
+      .add_int_perf("ms", "", "_root_dispersion");
 }
 
 }  // namespace check_ntp_filter
@@ -41,7 +59,10 @@ namespace {
 using check_ntp_internal::ntp_offset_ms;
 using check_ntp_internal::ntp_to_unix_ms;
 
-void run_ntp_check(const std::string &server, unsigned short port, int timeout_ms, net::address_family af, check_ntp_filter::filter_obj &out) {
+// One request/response exchange. Fills `out` with the result of that single
+// sample; run_ntp_check below repeats it when more than one sample is asked
+// for.
+void run_ntp_query(const std::string &server, unsigned short port, int timeout_ms, net::address_family af, check_ntp_filter::filter_obj &out) {
   using boost::asio::ip::udp;
 
   out.server = server;
@@ -50,6 +71,8 @@ void run_ntp_check(const std::string &server, unsigned short port, int timeout_m
   out.offset_ms = 0;
   out.stratum = 0;
   out.time = 0;
+  out.root_delay = 0;
+  out.root_dispersion = 0;
 
   boost::asio::io_context io_service;
   udp::resolver resolver(io_service);
@@ -142,6 +165,12 @@ void run_ntp_check(const std::string &server, unsigned short port, int timeout_m
              (static_cast<std::uint32_t>(resp_buf[offset + 2]) << 8) | (static_cast<std::uint32_t>(resp_buf[offset + 3]));
     };
 
+    // Root delay (byte 4) and root dispersion (byte 8) are "NTP short"
+    // fixed-point seconds: what the server itself claims about the quality of
+    // the time it is serving, independent of our own measurement.
+    out.root_delay = check_ntp_internal::ntp_short_to_ms(read_be32(4));
+    out.root_dispersion = check_ntp_internal::ntp_short_to_ms(read_be32(8));
+
     // Receive timestamp T2 at byte 32, transmit timestamp T3 at byte 40.
     const std::uint32_t t2_secs = read_be32(32);
     const std::uint32_t t2_frac = read_be32(36);
@@ -174,6 +203,45 @@ void run_ntp_check(const std::string &server, unsigned short port, int timeout_m
   socket.close(ignore);
 }
 
+// Query the server `samples` times and summarise. With the default of one
+// sample this is exactly one exchange and behaves as it always has.
+//
+// Sampling stops at the first failure, so an unreachable or slow server costs
+// one timeout rather than `samples` of them.
+void run_ntp_check(const std::string &server, unsigned short port, int timeout_ms, net::address_family af, int samples,
+                   check_ntp_filter::filter_obj &out) {
+  if (samples < 1) samples = 1;
+
+  std::vector<long long> offsets;
+  offsets.reserve(static_cast<std::size_t>(samples));
+  bool have_best = false;
+
+  for (int i = 0; i < samples; ++i) {
+    check_ntp_filter::filter_obj sample;
+    run_ntp_query(server, port, timeout_ms, af, sample);
+
+    if (sample.result != "ok") {
+      // Report the failure, but keep any good samples already collected so the
+      // jitter of a partially-answered burst is not thrown away.
+      if (!have_best) out = sample;
+      out.result = sample.result;
+      break;
+    }
+
+    offsets.push_back(sample.offset_ms);
+    // Keep the sample with the shortest round trip: a delayed packet biases the
+    // offset by roughly half the extra delay, so the quickest exchange is the
+    // most trustworthy estimate of the real offset.
+    if (!have_best || sample.time < out.time) {
+      out = sample;
+      have_best = true;
+    }
+  }
+
+  out.samples = static_cast<long long>(offsets.size());
+  out.jitter = check_ntp_internal::rms_jitter_ms(offsets);
+}
+
 }  // namespace
 
 void check_ntp_offset(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
@@ -187,6 +255,7 @@ void check_ntp_offset(const PB::Commands::QueryRequestMessage::Request &request,
   std::string servers_string;
   unsigned short port = 123;
   int timeout_ms = 5000;
+  int samples = 1;
   std::string address_family_arg;
 
   filter f;
@@ -202,6 +271,9 @@ void check_ntp_offset(const PB::Commands::QueryRequestMessage::Request &request,
     ("port", po::value<unsigned short>(&port)->default_value(123), "UDP port to use (default: 123).")
     ("timeout", po::value<int>(&timeout_ms)->default_value(5000), "Timeout in milliseconds.")
     ("address-family", po::value<std::string>(&address_family_arg), net::address_family_option_help())
+    ("samples", po::value<int>(&samples)->default_value(1),
+        "Number of queries to send to each server (default: 1). At least 2 are needed for the jitter keyword, which is the variation between samples; "
+        "sampling stops at the first failure so an unreachable server still costs only one timeout.")
     ;
   // clang-format on
 
@@ -226,7 +298,7 @@ void check_ntp_offset(const PB::Commands::QueryRequestMessage::Request &request,
 
   for (const auto &server : servers) {
     auto obj = std::make_shared<filter_obj>();
-    run_ntp_check(server, port, timeout_ms, af, *obj);
+    run_ntp_check(server, port, timeout_ms, af, samples, *obj);
     f.match(obj);
   }
 

--- a/modules/CheckNet/check_ntp_offset.cpp
+++ b/modules/CheckNet/check_ntp_offset.cpp
@@ -6,6 +6,7 @@
 #include <boost/asio.hpp>
 #include <boost/chrono.hpp>
 #include <boost/program_options.hpp>
+#include <net/address_family.hpp>
 #include <chrono>
 #include <cstdint>
 #include <memory>
@@ -40,7 +41,7 @@ namespace {
 using check_ntp_internal::ntp_offset_ms;
 using check_ntp_internal::ntp_to_unix_ms;
 
-void run_ntp_check(const std::string &server, unsigned short port, int timeout_ms, check_ntp_filter::filter_obj &out) {
+void run_ntp_check(const std::string &server, unsigned short port, int timeout_ms, net::address_family af, check_ntp_filter::filter_obj &out) {
   using boost::asio::ip::udp;
 
   out.server = server;
@@ -57,14 +58,16 @@ void run_ntp_check(const std::string &server, unsigned short port, int timeout_m
 
   try {
     boost::system::error_code resolve_ec;
-    auto results = resolver.resolve(udp::v4(), server, std::to_string(port), resolve_ec);
+    auto results = net::resolve_for_family(resolver, af, server, std::to_string(port), resolve_ec);
     if (resolve_ec || results.empty()) {
       out.result = "resolve_failed";
       return;
     }
-    udp::endpoint endpoint = results.begin()->endpoint();
+    const udp::endpoint endpoint = results.begin()->endpoint();
 
-    socket.open(udp::v4());
+    // Open the socket in whatever family the server actually resolved to. This
+    // used to be hardcoded to v4, which made an IPv6 NTP server unreachable.
+    socket.open(endpoint.protocol());
 
     // Build the NTP request packet (NTPv3 client mode, widely accepted by NTPv4 servers).
     // Byte 0 layout: LI (2 bits) | VN (3 bits) | Mode (3 bits)
@@ -184,6 +187,7 @@ void check_ntp_offset(const PB::Commands::QueryRequestMessage::Request &request,
   std::string servers_string;
   unsigned short port = 123;
   int timeout_ms = 5000;
+  std::string address_family_arg;
 
   filter f;
   filter_helper.add_options("offset > 50 or stratum >= 16", "offset > 100 or stratum >= 16 or result != 'ok'", "", f.get_filter_syntax(), "ignored");
@@ -197,10 +201,15 @@ void check_ntp_offset(const PB::Commands::QueryRequestMessage::Request &request,
         "Comma separated list of NTP servers to query.")
     ("port", po::value<unsigned short>(&port)->default_value(123), "UDP port to use (default: 123).")
     ("timeout", po::value<int>(&timeout_ms)->default_value(5000), "Timeout in milliseconds.")
+    ("address-family", po::value<std::string>(&address_family_arg), net::address_family_option_help())
     ;
   // clang-format on
 
   if (!filter_helper.parse_options()) return;
+
+  net::address_family af = net::address_family::any;
+  if (!net::parse_address_family(address_family_arg, af))
+    return nscapi::protobuf::functions::set_response_bad(*response, "Invalid address-family: " + address_family_arg + " (expected any, ipv4 or ipv6)");
 
   if (!servers_string.empty()) {
     std::vector<std::string> tmp;
@@ -217,7 +226,7 @@ void check_ntp_offset(const PB::Commands::QueryRequestMessage::Request &request,
 
   for (const auto &server : servers) {
     auto obj = std::make_shared<filter_obj>();
-    run_ntp_check(server, port, timeout_ms, *obj);
+    run_ntp_check(server, port, timeout_ms, af, *obj);
     f.match(obj);
   }
 

--- a/modules/CheckNet/check_ntp_offset.h
+++ b/modules/CheckNet/check_ntp_offset.h
@@ -21,6 +21,18 @@ struct filter_obj {
   long long time;  // round trip time, ms
   std::string result;
 
+  // Number of samples actually collected, and the RMS variation between their
+  // offsets. jitter is -1 when fewer than two samples were taken (the default),
+  // since the variation between measurements needs at least two of them.
+  long long samples = 0;
+  long long jitter = -1;
+
+  // The server's own advertised time quality, straight out of the packet
+  // header: root_delay is the round-trip to its reference clock, and
+  // root_dispersion the error bound it claims. Both in milliseconds.
+  long long root_delay = 0;
+  long long root_dispersion = 0;
+
   filter_obj() : port(0), offset_ms(0), stratum(0), time(0) {}
 
   std::string show() const { return server + " offset=" + std::to_string(offset_ms) + "ms stratum=" + std::to_string(stratum) + " (" + result + ")"; }
@@ -32,6 +44,10 @@ struct filter_obj {
   long long get_offset_signed() const { return offset_ms; }
   long long get_stratum() const { return stratum; }
   long long get_time() const { return time; }
+  long long get_samples() const { return samples; }
+  long long get_jitter() const { return jitter; }
+  long long get_root_delay() const { return root_delay; }
+  long long get_root_dispersion() const { return root_dispersion; }
   std::string get_result() const { return result; }
 };
 

--- a/modules/CheckNet/check_ping_internal.hpp
+++ b/modules/CheckNet/check_ping_internal.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <string>
+
+namespace check_net {
+namespace check_ping_internal {
+
+// Largest ICMP payload that still fits an IPv4 datagram: 65535 total, minus the
+// 20 byte IP header and the 8 byte ICMP header.
+constexpr int kMaxPingPayload = 65507;
+
+// Build the ICMP payload for a requested size.
+//
+// `size` of 0 means "no size was asked for" and hands back the payload
+// unchanged, so the default behaviour is untouched. Otherwise the payload is
+// repeated and then cut to exactly `size` bytes, the way ping fills its packets
+// with a repeating pattern - which keeps the bytes on the wire recognisable
+// instead of a run of zeroes.
+//
+// An empty payload would make the fill loop spin forever, so it is substituted
+// with a single character first.
+inline std::string build_ping_payload(const std::string &payload, const int size) {
+  if (size <= 0) return payload;
+
+  const std::string pattern = payload.empty() ? std::string("x") : payload;
+  std::string filled;
+  filled.reserve(static_cast<std::size_t>(size));
+  while (filled.size() < static_cast<std::size_t>(size)) filled += pattern;
+  filled.resize(static_cast<std::size_t>(size));
+  return filled;
+}
+
+}  // namespace check_ping_internal
+}  // namespace check_net

--- a/modules/CheckNet/check_ssh_internal.hpp
+++ b/modules/CheckNet/check_ssh_internal.hpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <cctype>
+#include <string>
+
+namespace check_net {
+namespace check_ssh_internal {
+
+// The pieces of an SSH identification string (RFC 4253 section 4.2):
+//
+//   SSH-<protoversion>-<softwareversion>[ <comments>]
+//
+// e.g. "SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5" yields
+//   protocol         = "2.0"   (major 2, minor 0)
+//   version          = "OpenSSH_9.6p1"
+//   software         = "OpenSSH"
+//   software_version = "9.6p1"
+//   comments         = "Ubuntu-3ubuntu13.5"
+struct ssh_banner {
+  std::string banner;
+  std::string protocol;
+  long long protocol_major = 0;
+  long long protocol_minor = 0;
+  std::string version;
+  std::string software;
+  std::string software_version;
+  std::string comments;
+};
+
+namespace detail {
+
+// Parse a leading run of digits. Returns the value and advances `pos` past it;
+// returns false when there is no digit at `pos` (so a non-numeric protocol
+// version leaves the numeric keywords at 0 rather than guessing).
+inline bool parse_uint(const std::string &s, std::size_t &pos, long long &out) {
+  const std::size_t start = pos;
+  long long value = 0;
+  while (pos < s.size() && std::isdigit(static_cast<unsigned char>(s[pos]))) {
+    // Saturate rather than overflow on absurd input; the exact value of a
+    // 19-digit protocol version does not matter, only that it is huge.
+    if (value < 1000000000LL) value = value * 10 + (s[pos] - '0');
+    ++pos;
+  }
+  if (pos == start) return false;
+  out = value;
+  return true;
+}
+
+// Split "<software>_<version>" on the LAST underscore that is followed by a
+// digit. That handles the plain "OpenSSH_9.6p1" and "dropbear_2022.83" forms as
+// well as the multi-word "OpenSSH_for_Windows_9.5" and "Sun_SSH_1.1" ones,
+// which a first-underscore split would cut in the wrong place. Software with no
+// underscore at all (e.g. "Go") keeps the whole string as the name.
+inline void split_software(const std::string &version, std::string &software, std::string &software_version) {
+  software = version;
+  software_version.clear();
+  for (std::size_t i = version.size(); i-- > 0;) {
+    if (version[i] != '_') continue;
+    if (i + 1 < version.size() && std::isdigit(static_cast<unsigned char>(version[i + 1]))) {
+      software = version.substr(0, i);
+      software_version = version.substr(i + 1);
+      return;
+    }
+  }
+}
+
+}  // namespace detail
+
+// Extract the SSH identification string from whatever the server sent and split
+// it into its parts. A server may emit other lines before the identification
+// string (RFC 4253 allows it), so the first line starting with "SSH-" wins.
+// Returns false — leaving `out` untouched — when no usable identification
+// string is present.
+inline bool parse_ssh_banner(const std::string &raw, ssh_banner &out) {
+  std::size_t line_start = 0;
+  while (line_start <= raw.size()) {
+    std::size_t line_end = raw.find('\n', line_start);
+    if (line_end == std::string::npos) line_end = raw.size();
+
+    std::string line = raw.substr(line_start, line_end - line_start);
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    line_start = line_end + 1;
+
+    if (line.compare(0, 4, "SSH-") != 0) {
+      if (line_end == raw.size()) break;
+      continue;
+    }
+
+    // "<protoversion>-<softwareversion>[ <comments>]"
+    const std::string rest = line.substr(4);
+    const std::size_t dash = rest.find('-');
+    if (dash == std::string::npos) return false;
+
+    const std::string protocol = rest.substr(0, dash);
+    std::string version = rest.substr(dash + 1);
+    if (protocol.empty()) return false;
+
+    std::string comments;
+    const std::size_t space = version.find(' ');
+    if (space != std::string::npos) {
+      comments = version.substr(space + 1);
+      version = version.substr(0, space);
+    }
+    if (version.empty()) return false;
+
+    out.banner = line;
+    out.protocol = protocol;
+    out.version = version;
+    out.comments = comments;
+
+    // "1.99" means "2.0 speaking, 1.x compatible"; both numbers are exposed so
+    // `protocol_major < 2` catches an SSHv1-only server.
+    out.protocol_major = 0;
+    out.protocol_minor = 0;
+    std::size_t pos = 0;
+    if (detail::parse_uint(protocol, pos, out.protocol_major) && pos < protocol.size() && protocol[pos] == '.') {
+      ++pos;
+      detail::parse_uint(protocol, pos, out.protocol_minor);
+    }
+
+    detail::split_software(version, out.software, out.software_version);
+    return true;
+  }
+  return false;
+}
+
+}  // namespace check_ssh_internal
+}  // namespace check_net

--- a/modules/CheckNet/check_tcp.cpp
+++ b/modules/CheckNet/check_tcp.cpp
@@ -13,6 +13,7 @@
 #include <boost/regex.hpp>
 #include <chrono>
 #include <memory>
+#include <net/address_family.hpp>
 #include <net/socket/socket_helpers.hpp>
 #include <nscapi/nscapi_program_options.hpp>
 #include <nscapi/protobuf/functions_response.hpp>
@@ -138,8 +139,8 @@ void tcp_converse(Stream &stream, tcp::socket &lowest, boost::asio::io_context &
 // "no_match" when the response fails either. "result" gets a short status word
 // (ok/timeout/refused/no_match/tls_handshake_failed/error).
 void run_tcp_check(const std::string &host, unsigned short port, int timeout_ms, const std::string &send_data, const std::string &expect,
-                   const std::string &expect_regex, bool use_tls, const std::string &tls_version, const std::string &verify_mode,
-                   const std::string &ca_file, check_tcp_filter::filter_obj &out) {
+                   const std::string &expect_regex, bool use_tls, const std::string &tls_version, const std::string &verify_mode, const std::string &ca_file,
+                   net::address_family af, check_tcp_filter::filter_obj &out) {
   out.host = host;
   out.port = port;
   out.connected = false;
@@ -157,8 +158,11 @@ void run_tcp_check(const std::string &host, unsigned short port, int timeout_ms,
   try {
     bool connect_done = false;
     boost::system::error_code resolve_ec;
-    auto endpoints = resolver.resolve(host, std::to_string(port), resolve_ec);
-    if (resolve_ec) {
+    auto endpoints = net::resolve_for_family(resolver, af, host, std::to_string(port), resolve_ec);
+    if (resolve_ec || endpoints.empty()) {
+      // With address-family pinned this also covers "the name exists but has no
+      // address in the requested family", which is the answer the check is
+      // being asked for rather than an internal error.
       out.result = "resolve_failed";
       return;
     }
@@ -291,6 +295,7 @@ void check_tcp_impl(const PB::Commands::QueryRequestMessage::Request &request, P
   std::string tls_version = "tlsv1.2+";
   std::string verify_mode = "none";
   std::string ca_file;
+  std::string address_family_arg;
 
   filter f;
   filter_helper.add_options("time > 1000", "time > 5000 or result != 'ok'", "", f.get_filter_syntax(), "ignored");
@@ -309,6 +314,7 @@ void check_tcp_impl(const PB::Commands::QueryRequestMessage::Request &request, P
     ("verify", po::value<std::string>(&verify_mode)->default_value("none"),
         "Certificate verify mode when --ssl is used: none (default), peer, ... (peer requires --ca).")
     ("ca", po::value<std::string>(&ca_file), "CA bundle used to verify the server certificate when --ssl --verify peer is used.")
+    ("address-family", po::value<std::string>(&address_family_arg), net::address_family_option_help())
     ;
   if (forced == nullptr) {
     filter_helper.get_desc().add_options()
@@ -320,6 +326,10 @@ void check_tcp_impl(const PB::Commands::QueryRequestMessage::Request &request, P
   // clang-format on
 
   if (!filter_helper.parse_options()) return;
+
+  net::address_family af = net::address_family::any;
+  if (!net::parse_address_family(address_family_arg, af))
+    return nscapi::protobuf::functions::set_response_bad(*response, "Invalid address-family: " + address_family_arg + " (expected any, ipv4 or ipv6)");
 
   // Resolve the preset: forced (check_ssh) or from the `service` argument.
   const service_preset *preset = forced;
@@ -352,7 +362,7 @@ void check_tcp_impl(const PB::Commands::QueryRequestMessage::Request &request, P
 
   for (const auto &host : hosts) {
     auto obj = std::make_shared<filter_obj>();
-    run_tcp_check(host, port, timeout_ms, send_data, expect, expect_regex, use_ssl, tls_version, verify_mode, ca_file, *obj);
+    run_tcp_check(host, port, timeout_ms, send_data, expect, expect_regex, use_ssl, tls_version, verify_mode, ca_file, af, *obj);
     obj->post_read();
     f.match(obj);
   }

--- a/modules/CheckNet/check_tcp.cpp
+++ b/modules/CheckNet/check_tcp.cpp
@@ -25,16 +25,33 @@ namespace po = boost::program_options;
 namespace check_net {
 namespace check_tcp_filter {
 
-filter_obj_handler::filter_obj_handler() {
-  registry_.add_string_var("host", &filter_obj::get_host, "Host the check connected to");
-  registry_.add_string_var("result", &filter_obj::get_result, "Textual result of the check (ok, refused, timeout, no_match, ...)");
-  registry_.add_string_var("response", &filter_obj::get_response, "The data received from the peer (use with 'like'/'regexp' for custom matching)");
-  registry_.add_int_var("port", parsers::where::type_int, &filter_obj::get_port, "TCP port the check connected to");
-  registry_.add_int_var("time", parsers::where::type_int, &filter_obj::get_time, "Connection time in milliseconds").add_int_perf("ms");
-  registry_.add_int_var("connected", parsers::where::type_int, &filter_obj::get_connected, "1 when the connection succeeded, 0 otherwise");
-}
+filter_obj_handler::filter_obj_handler() { register_common_keywords(registry_); }
 
 }  // namespace check_tcp_filter
+
+namespace check_ssh_filter {
+
+filter_obj_handler::filter_obj_handler() {
+  check_tcp_filter::register_common_keywords(registry_);
+
+  // Fields parsed out of the SSH identification string. They are empty (and the
+  // numeric ones 0) whenever no banner was read — a refused/timed-out
+  // connection, or a port that is not speaking SSH — so guard on `result` when
+  // that distinction matters.
+  registry_.add_string_var("banner", &filter_obj::get_banner, "The raw SSH identification string, e.g. SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5");
+  registry_.add_string_var("protocol", &filter_obj::get_protocol, "SSH protocol version the server announced, e.g. 2.0 or 1.99");
+  registry_.add_string_var("version", &filter_obj::get_version, "Software version the server announced, e.g. OpenSSH_9.6p1");
+  registry_.add_string_var("software", &filter_obj::get_software, "Software name from the version string, e.g. OpenSSH or dropbear");
+  registry_.add_string_var("software_version", &filter_obj::get_software_version, "Software version number from the version string, e.g. 9.6p1");
+  registry_.add_string_var("comments", &filter_obj::get_comments, "Trailing comments of the identification string, e.g. the distribution patch level");
+  registry_.add_int_var("protocol_major", parsers::where::type_int, &filter_obj::get_protocol_major,
+                        "Major SSH protocol version as a number (2 for 2.0); use protocol_major < 2 to catch an SSHv1-only server")
+      .no_perf();
+  registry_.add_int_var("protocol_minor", parsers::where::type_int, &filter_obj::get_protocol_minor, "Minor SSH protocol version as a number (0 for 2.0)")
+      .no_perf();
+}
+
+}  // namespace check_ssh_filter
 
 namespace {
 
@@ -252,11 +269,13 @@ void run_tcp_check(const std::string &host, unsigned short port, int timeout_ms,
 namespace {
 // Shared core for check_tcp and check_ssh. When `forced` is non-null (check_ssh)
 // its preset is always applied; otherwise the preset is chosen from a `service`
-// argument.
+// argument. FilterT/ObjT let check_ssh plug in its own object, which adds the
+// parsed identification string on top of the TCP fields.
+template <typename FilterT, typename ObjT>
 void check_tcp_impl(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
                     const service_preset *forced) {
-  using check_tcp_filter::filter;
-  using check_tcp_filter::filter_obj;
+  typedef FilterT filter;
+  typedef ObjT filter_obj;
 
   modern_filter::data_container data;
   modern_filter::cli_helper<filter> filter_helper(request, response, data);
@@ -334,6 +353,7 @@ void check_tcp_impl(const PB::Commands::QueryRequestMessage::Request &request, P
   for (const auto &host : hosts) {
     auto obj = std::make_shared<filter_obj>();
     run_tcp_check(host, port, timeout_ms, send_data, expect, expect_regex, use_ssl, tls_version, verify_mode, ca_file, *obj);
+    obj->post_read();
     f.match(obj);
   }
 
@@ -342,11 +362,11 @@ void check_tcp_impl(const PB::Commands::QueryRequestMessage::Request &request, P
 }  // namespace
 
 void check_tcp(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
-  check_tcp_impl(request, response, nullptr);
+  check_tcp_impl<check_tcp_filter::filter, check_tcp_filter::filter_obj>(request, response, nullptr);
 }
 
 void check_ssh(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
-  check_tcp_impl(request, response, find_service_preset("SSH"));
+  check_tcp_impl<check_ssh_filter::filter, check_ssh_filter::filter_obj>(request, response, find_service_preset("SSH"));
 }
 
 }  // namespace check_net

--- a/modules/CheckNet/check_tcp.cpp
+++ b/modules/CheckNet/check_tcp.cpp
@@ -26,7 +26,22 @@ namespace po = boost::program_options;
 namespace check_net {
 namespace check_tcp_filter {
 
-filter_obj_handler::filter_obj_handler() { register_common_keywords(registry_); }
+filter_obj_handler::filter_obj_handler() {
+  register_common_keywords(registry_);
+
+  // TLS certificate of the connected peer. Registered here rather than in the
+  // common set because check_ssh is never TLS and would only advertise a
+  // keyword that can never be populated.
+  registry_
+      .add_int_var("ssl_expiry_days", parsers::where::type_int, &filter_obj::get_ssl_expiry_days,
+                   "Days until the peer's TLS certificate expires; negative once it has expired, and -1 when the connection is not TLS or the peer presented "
+                   "no certificate (guard with has_certificate to tell those apart)")
+      .add_int_perf("", "", "_ssl_expiry_days");
+  registry_
+      .add_int_var("has_certificate", parsers::where::type_int, &filter_obj::get_has_certificate,
+                   "1 when the peer presented a TLS certificate, 0 otherwise")
+      .no_perf();
+}
 
 }  // namespace check_tcp_filter
 
@@ -252,6 +267,13 @@ void run_tcp_check(const std::string &host, unsigned short port, int timeout_ms,
       if (hs_ec) {
         out.result = "tls_handshake_failed";
         return;
+      }
+
+      // Read the peer certificate straight after the handshake: it is available
+      // regardless of `verify`, so an expiry check needs no trust decision.
+      if (const auto expiry = socket_helpers::peer_certificate_expiry_days(ssl_stream.native_handle())) {
+        out.has_certificate = true;
+        out.ssl_expiry_days = *expiry;
       }
 
       tcp_converse(ssl_stream, socket, io_service, timeout_ms, send_data, expect, expect_regex, out);

--- a/modules/CheckNet/check_tcp.h
+++ b/modules/CheckNet/check_tcp.h
@@ -52,6 +52,13 @@ struct filter_obj {
   std::string response;
   bool connected;
 
+  // TLS peer certificate, populated only when the connection was wrapped in
+  // TLS and the peer actually presented one. `has_certificate` is the guard:
+  // ssl_expiry_days is legitimately negative for an expired certificate, so the
+  // -1 it carries otherwise cannot be told apart from "expired yesterday".
+  bool has_certificate = false;
+  long long ssl_expiry_days = -1;
+
   filter_obj() : port(0), time(0), connected(false) {}
   virtual ~filter_obj() = default;
 
@@ -63,6 +70,8 @@ struct filter_obj {
   std::string get_result() const { return result; }
   std::string get_response() const { return response; }
   long long get_connected() const { return connected ? 1 : 0; }
+  long long get_has_certificate() const { return has_certificate ? 1 : 0; }
+  long long get_ssl_expiry_days() const { return ssl_expiry_days; }
 
   // Called once the peer's response has been read, so a specialised check can
   // derive extra fields from it (check_ssh parses the identification string).

--- a/modules/CheckNet/check_tcp.h
+++ b/modules/CheckNet/check_tcp.h
@@ -9,6 +9,8 @@
 #include <parsers/where/filter_handler_impl.hpp>
 #include <string>
 
+#include "check_ssh_internal.hpp"
+
 namespace check_net {
 
 // A named service preset: default port, an optional payload to send, a regular
@@ -51,6 +53,7 @@ struct filter_obj {
   bool connected;
 
   filter_obj() : port(0), time(0), connected(false) {}
+  virtual ~filter_obj() = default;
 
   std::string show() const { return host + ":" + std::to_string(port) + " (" + result + ")"; }
 
@@ -60,7 +63,24 @@ struct filter_obj {
   std::string get_result() const { return result; }
   std::string get_response() const { return response; }
   long long get_connected() const { return connected ? 1 : 0; }
+
+  // Called once the peer's response has been read, so a specialised check can
+  // derive extra fields from it (check_ssh parses the identification string).
+  virtual void post_read() {}
 };
+
+// The keywords every TCP-style check shares. Templated on the registry so
+// check_ssh can register the same set for its own (derived) filter_obj instead
+// of duplicating them.
+template <typename Registry>
+void register_common_keywords(Registry &registry) {
+  registry.add_string_var("host", &filter_obj::get_host, "Host the check connected to");
+  registry.add_string_var("result", &filter_obj::get_result, "Textual result of the check (ok, refused, timeout, no_match, ...)");
+  registry.add_string_var("response", &filter_obj::get_response, "The data received from the peer (use with 'like'/'regexp' for custom matching)");
+  registry.add_int_var("port", parsers::where::type_int, &filter_obj::get_port, "TCP port the check connected to");
+  registry.add_int_var("time", parsers::where::type_int, &filter_obj::get_time, "Connection time in milliseconds").add_int_perf("ms");
+  registry.add_int_var("connected", parsers::where::type_int, &filter_obj::get_connected, "1 when the connection succeeded, 0 otherwise");
+}
 
 typedef parsers::where::filter_handler_impl<std::shared_ptr<filter_obj> > native_context;
 struct filter_obj_handler : public native_context {
@@ -69,6 +89,33 @@ struct filter_obj_handler : public native_context {
 typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;
 
 }  // namespace check_tcp_filter
+
+namespace check_ssh_filter {
+
+// check_ssh is check_tcp against the SSH preset plus the parsed identification
+// string, so its object is the TCP one with the banner fields added.
+struct filter_obj : public check_tcp_filter::filter_obj {
+  check_ssh_internal::ssh_banner banner;
+
+  std::string get_banner() const { return banner.banner; }
+  std::string get_protocol() const { return banner.protocol; }
+  long long get_protocol_major() const { return banner.protocol_major; }
+  long long get_protocol_minor() const { return banner.protocol_minor; }
+  std::string get_version() const { return banner.version; }
+  std::string get_software() const { return banner.software; }
+  std::string get_software_version() const { return banner.software_version; }
+  std::string get_comments() const { return banner.comments; }
+
+  void post_read() override { check_ssh_internal::parse_ssh_banner(response, banner); }
+};
+
+typedef parsers::where::filter_handler_impl<std::shared_ptr<filter_obj> > native_context;
+struct filter_obj_handler : public native_context {
+  filter_obj_handler();
+};
+typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;
+
+}  // namespace check_ssh_filter
 
 void check_tcp(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
 void check_ssh(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);

--- a/modules/CheckNet/filter.cpp
+++ b/modules/CheckNet/filter.cpp
@@ -33,7 +33,10 @@ ping_filter::filter_obj_handler::filter_obj_handler() {
       .add_int_perf("ms")
       .add_int_var("sent", type_int, &filter_obj::get_sent, "Number of packets sent to the host")
       .add_int_var("recv", type_int, &filter_obj::get_recv, "Number of packets received from the host")
-      .add_int_var("timeout", type_int, &filter_obj::get_timeout, "Number of packets which timed out from the host");
+      .add_int_var("timeout", type_int, &filter_obj::get_timeout, "Number of packets which timed out from the host")
+      .add_int_var("jitter", type_int, &filter_obj::get_jitter,
+                   "Mean variation between the round trip times, in ms; -1 when fewer than 2 packets came back (raise count= to measure it)")
+      .add_int_perf("ms", "", "_jitter");
   registry_.add_converter(type_custom_pct, &get_percentage);
 }
 
@@ -43,6 +46,10 @@ void ping_filter::filter_obj::add(std::shared_ptr<ping_filter::filter_obj> other
   result.num_replies_ += other->result.num_replies_;
   result.num_timeouts_ += other->result.num_timeouts_;
   result.time_ += other->result.time_;
+  // Worst jitter across the hosts, not a jitter over the pooled round trip
+  // times: those come from different hosts and their spread is not jitter.
+  const long long other_jitter = other->get_jitter();
+  if (other_jitter > total_jitter_) total_jitter_ = other_jitter;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/modules/CheckNet/filter.cpp
+++ b/modules/CheckNet/filter.cpp
@@ -36,7 +36,10 @@ ping_filter::filter_obj_handler::filter_obj_handler() {
       .add_int_var("timeout", type_int, &filter_obj::get_timeout, "Number of packets which timed out from the host")
       .add_int_var("jitter", type_int, &filter_obj::get_jitter,
                    "Mean variation between the round trip times, in ms; -1 when fewer than 2 packets came back (raise count= to measure it)")
-      .add_int_perf("ms", "", "_jitter");
+      .add_int_perf("ms", "", "_jitter")
+      .add_int_var("ttl", type_int, &filter_obj::get_ttl,
+                   "TTL of the last reply; -1 when unknown (no reply, or IPv6, where the hop limit is not available)")
+      .add_int_perf("", "", "_ttl");
   registry_.add_converter(type_custom_pct, &get_percentage);
 }
 
@@ -50,6 +53,9 @@ void ping_filter::filter_obj::add(std::shared_ptr<ping_filter::filter_obj> other
   // times: those come from different hosts and their spread is not jitter.
   const long long other_jitter = other->get_jitter();
   if (other_jitter > total_jitter_) total_jitter_ = other_jitter;
+  // Lowest TTL wins: that is the reply closest to running out of hops.
+  const long long other_ttl = other->get_ttl();
+  if (other_ttl >= 0 && (total_ttl_ < 0 || other_ttl < total_ttl_)) total_ttl_ = other_ttl;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/modules/CheckNet/filter.hpp
+++ b/modules/CheckNet/filter.hpp
@@ -92,8 +92,16 @@ struct filter_obj {
   // worst per-host jitter instead, which is what a fleet-wide alert wants.
   long long get_jitter() const { return is_total_ ? total_jitter_ : mean_abs_delta_ms(result.rtts_); }
 
+  // TTL of the last reply, or -1 when unknown (nothing came back, or IPv6).
+  //
+  // The total row carries the LOWEST TTL across the hosts: a low TTL is the
+  // interesting end (a reply nearly out of hops, or a route that grew), so the
+  // minimum is what a fleet-wide threshold wants.
+  long long get_ttl() const { return is_total_ ? total_ttl_ : result.ttl_; }
+
   bool is_total_;
   long long total_jitter_ = -1;
+  long long total_ttl_ = -1;
   result_container result;
 };
 

--- a/modules/CheckNet/filter.hpp
+++ b/modules/CheckNet/filter.hpp
@@ -19,6 +19,25 @@
 #include <string>
 
 namespace ping_filter {
+
+// Mean absolute difference between consecutive round trip times, in
+// milliseconds. This is the definition ping and VoIP tooling reports as
+// "jitter", so the number is directly comparable with those tools.
+//
+// Returns -1 for fewer than two replies: jitter describes the variation
+// between packets and is undefined for one of them. -1 can never collide with
+// a real reading, since a mean of absolute values is never negative.
+inline long long mean_abs_delta_ms(const std::vector<std::size_t>& rtts) {
+  if (rtts.size() < 2) return -1;
+  long long total = 0;
+  for (std::size_t i = 1; i < rtts.size(); ++i) {
+    const long long a = static_cast<long long>(rtts[i]);
+    const long long b = static_cast<long long>(rtts[i - 1]);
+    total += a > b ? a - b : b - a;
+  }
+  return total / static_cast<long long>(rtts.size() - 1);
+}
+
 struct filter_obj {
   filter_obj(result_container result) : is_total_(false), result(result) {}
   filter_obj() : is_total_(true) {}
@@ -65,7 +84,16 @@ struct filter_obj {
   }
   long long get_time() { return result.time_; }
 
+  // Variation between the round trip times of the packets sent to this host.
+  // Needs count >= 2 to mean anything; -1 until then.
+  //
+  // The total row cannot pool round trip times across hosts - the spread
+  // between two different hosts' latencies is not jitter - so it carries the
+  // worst per-host jitter instead, which is what a fleet-wide alert wants.
+  long long get_jitter() const { return is_total_ ? total_jitter_ : mean_abs_delta_ms(result.rtts_); }
+
   bool is_total_;
+  long long total_jitter_ = -1;
   result_container result;
 };
 

--- a/modules/CheckSystemUnix/check_process.cpp
+++ b/modules/CheckSystemUnix/check_process.cpp
@@ -4,12 +4,15 @@
 #include "check_process.h"
 
 #include <dirent.h>
+#include <pwd.h>
 #include <unistd.h>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
+#include <ctime>
 #include <fstream>
 #include <map>
+#include <mutex>
 #include <nscapi/protobuf/functions_convert.hpp>
 #include <nscapi/protobuf/functions_exec.hpp>
 #include <nscapi/protobuf/functions_query.hpp>
@@ -36,20 +39,31 @@ node_type parse_state(std::shared_ptr<filter_obj> object, evaluation_context con
   return factory::create_int(filter_obj::parse_state(subject->get_string_value(context)));
 }
 
+node_type parse_proc_state(std::shared_ptr<filter_obj> object, evaluation_context context, node_type subject) {
+  return factory::create_int(filter_obj::parse_proc_state(subject->get_string_value(context)));
+}
+
 filter_obj_handler::filter_obj_handler() {
   static const value_type type_custom_state = type_custom_int_1;
+  static const value_type type_custom_proc_state = type_custom_int_2;
 
   registry_.add_string_var("filename", &filter_obj::get_filename, "Name of process (with path)")
       .add_string_var("exe", &filter_obj::get_exe, "The name of the executable")
       .add_string_var("error", &filter_obj::get_error, "Any error messages associated with fetching info")
-      .add_string_var("command_line", &filter_obj::get_command_line, "Command line of process");
+      .add_string_var("command_line", &filter_obj::get_command_line, "Command line of process")
+      .add_string_var("username", &filter_obj::get_username, "Process owner user name (empty unless resolve-owner=true)");
 
   registry_.add_int_var("pid", &filter_obj::get_pid, "Process id")
+      .add_int_var("ppid", &filter_obj::get_ppid, "Parent process id")
+      .add_int_var("uid", &filter_obj::get_uid, "Process owner uid (-1 when not known)")
       .add_int_var("started", &filter_obj::get_started, "Process is started")
       .add_int_var("stopped", &filter_obj::get_stopped, "Process is stopped")
-      .add_int_var("state", type_custom_state, &filter_obj::get_state_i, "The current state (started, stopped, hung)");
+      .add_int_var("state", type_custom_state, &filter_obj::get_state_i, "The current state (started, stopped, hung)")
+      .add_int_var("proc_state", type_custom_proc_state, &filter_obj::get_proc_state_i,
+                   "Raw Linux process state: running, sleeping, disk_sleep, zombie, stopped, tracing_stop, dead, idle, parked");
 
   registry_.add_human_string("state", &filter_obj::get_state_s, "The current state (started, stopped, hung)");
+  registry_.add_human_string("proc_state", &filter_obj::get_proc_state_s, "The raw Linux process state");
 
   // Memory counters. Perfdata mirrors the Windows check_process: working set and
   // virtual size are emitted as scaled bytes, page faults as a plain counter.
@@ -68,7 +82,14 @@ filter_obj_handler::filter_obj_handler() {
       .add_scaled_byte(std::string(""), " pws_size")("page_fault", [](auto obj, auto context) { return obj->get_page_faults(); }, "Page fault count")
       .add_perf("", "", " pf_count");
 
+  // `rss` is a straight alias for `working_set`, matching the Windows
+  // check_process keyword set so the same expression works on both platforms.
+  registry_.add_int_legacy()("rss", parsers::where::type_size, [](auto obj, auto context) { return obj->get_working_set(); },
+                             "Resident set size; alias for working_set (g,m,k,b)")
+      .add_scaled_byte(std::string(""), " rss");
+
   registry_.add_human_string("virtual", &filter_obj::get_virtual_size_human, "").add_human_string("working_set", &filter_obj::get_working_set_human, "");
+  registry_.add_human_string("rss", &filter_obj::get_working_set_human, "");
   registry_.add_human_string("peak_virtual", &filter_obj::get_peak_virtual_size_human, "")
       .add_human_string("peak_working_set", &filter_obj::get_peak_working_set_human, "");
 
@@ -79,9 +100,12 @@ filter_obj_handler::filter_obj_handler() {
       .add_perf("", "", " creation")("user", [](auto obj, auto context) { return obj->get_user_time(); }, "User time in seconds")
       .add_perf("", "", " user")("kernel", [](auto obj, auto context) { return obj->get_kernel_time(); }, "Kernel time in seconds")
       .add_perf("", "", " kernel")("time", [](auto obj, auto context) { return obj->get_total_time(); }, "User-kernel time in seconds")
-      .add_perf("", "", " total");
+      .add_perf("", "", " total")("elapsed", [](auto obj, auto context) { return obj->get_elapsed(); },
+                                  "Wall-clock seconds since the process started (0 when not known)")
+      .add_perf("s", "", " elapsed");
 
   registry_.add_converter(type_custom_state, &parse_state);
+  registry_.add_converter(type_custom_proc_state, &parse_proc_state);
 }
 
 bool parse_proc_pid_stat(const std::string &line, proc_stat_data &data) {
@@ -106,6 +130,7 @@ bool parse_proc_pid_stat(const std::string &line, proc_stat_data &data) {
   if (iss.fail()) return false;
 
   data.state = state;
+  data.ppid = ppid;
   data.major_faults = majflt;
   data.utime_jiffies = utime;
   data.stime_jiffies = stime;
@@ -128,6 +153,55 @@ bool parse_proc_status_bytes(const std::string &content, const std::string &key,
     }
   }
   return false;
+}
+
+bool parse_proc_status_uid(const std::string &content, long long &uid) {
+  std::istringstream iss(content);
+  std::string line;
+  while (std::getline(iss, line)) {
+    if (line.compare(0, 4, "Uid:") == 0) {
+      // "Uid:\t<real>\t<effective>\t<saved>\t<filesystem>" — the real uid is
+      // the process owner.
+      std::istringstream value(line.substr(4));
+      long long real_uid = -1;
+      value >> real_uid;
+      if (value.fail() || real_uid < 0) return false;
+      uid = real_uid;
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string lookup_username(const long long uid) {
+  if (uid < 0) return "";
+
+  // Memoised: a host has a handful of distinct uids but can have thousands of
+  // processes, and each miss is an NSS lookup. Negative results are cached too
+  // so a deleted uid is not retried once per process. The cache lives for the
+  // lifetime of the agent, so a uid renamed underneath us stays stale until
+  // restart — an acceptable trade for not hammering NSS.
+  static std::mutex cache_mutex;
+  static std::map<long long, std::string> cache;
+  {
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    const auto it = cache.find(uid);
+    if (it != cache.end()) return it->second;
+  }
+
+  std::string name;
+  long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+  if (bufsize <= 0) bufsize = 16384;
+  std::vector<char> buffer(static_cast<std::size_t>(bufsize));
+  struct passwd pwd;
+  struct passwd *result = nullptr;
+  if (getpwuid_r(static_cast<uid_t>(uid), &pwd, buffer.data(), buffer.size(), &result) == 0 && result != nullptr && result->pw_name != nullptr) {
+    name = result->pw_name;
+  }
+
+  std::lock_guard<std::mutex> lock(cache_mutex);
+  cache[uid] = name;
+  return name;
 }
 
 bool parse_proc_stat_cpu_total(const std::string &content, unsigned long long &total_jiffies) {
@@ -193,7 +267,7 @@ unsigned long long get_boot_time() {
 }  // namespace
 
 // Read process information from /proc
-filter_obj read_process_info(int pid) {
+filter_obj read_process_info(int pid, bool resolve_owner = false) {
   filter_obj info;
   info.pid = pid;
   info.started = true;
@@ -273,6 +347,8 @@ filter_obj read_process_info(int pid) {
       if (parse_proc_pid_stat(line, stat_data)) {
         // State: R=running, S=sleeping, D=disk sleep, Z=zombie, T=stopped, t=tracing stop, X=dead
         info.started = (stat_data.state == 'R' || stat_data.state == 'S' || stat_data.state == 'D');
+        info.proc_state = stat_data.state;
+        info.ppid = stat_data.ppid;
 
         info.user_time_raw = stat_data.utime_jiffies;
         info.kernel_time_raw = stat_data.stime_jiffies;
@@ -280,10 +356,18 @@ filter_obj read_process_info(int pid) {
 
         // Convert jiffies to seconds (typically 100 Hz = USER_HZ)
         long ticks_per_sec = sysconf(_SC_CLK_TCK);
+        const unsigned long long boot_time = get_boot_time();
         if (ticks_per_sec > 0) {
           info.user_time = stat_data.utime_jiffies / ticks_per_sec;
           info.kernel_time = stat_data.stime_jiffies / ticks_per_sec;
-          info.creation_time = get_boot_time() + stat_data.starttime_jiffies / ticks_per_sec;
+          info.creation_time = boot_time + stat_data.starttime_jiffies / ticks_per_sec;
+          // Only meaningful once the boot time is known; without it
+          // creation_time is an offset from the epoch and the elapsed seconds
+          // would be nonsense rather than merely imprecise.
+          if (boot_time != 0) {
+            const unsigned long long now = static_cast<unsigned long long>(::time(nullptr));
+            info.elapsed = now > info.creation_time ? now - info.creation_time : 0;
+          }
         }
         info.total_time = info.user_time + info.kernel_time;
 
@@ -294,8 +378,8 @@ filter_obj read_process_info(int pid) {
     info.error = "Cannot read stat";
   }
 
-  // Read /proc/[pid]/status for the peak memory counters. Kernel threads have
-  // no Vm* entries; the peaks then stay 0.
+  // Read /proc/[pid]/status for the peak memory counters and the owner uid.
+  // Kernel threads have no Vm* entries; the peaks then stay 0.
   try {
     std::ifstream status_file(proc_path + "/status");
     if (status_file.is_open()) {
@@ -304,6 +388,10 @@ filter_obj read_process_info(int pid) {
       const std::string content = ss.str();
       parse_proc_status_bytes(content, "VmPeak", info.peak_virtual_size);
       parse_proc_status_bytes(content, "VmHWM", info.peak_working_set);
+      // The uid itself is free (it is in the file we just read); turning it
+      // into a name is what costs, so that stays behind resolve-owner.
+      parse_proc_status_uid(content, info.uid);
+      if (resolve_owner) info.username = lookup_username(info.uid);
     }
   } catch (...) {
     info.error = "Cannot read status";
@@ -330,7 +418,7 @@ filter_obj read_process_info(int pid) {
 }
 
 // Enumerate all processes from /proc
-std::vector<filter_obj> enumerate_processes() {
+std::vector<filter_obj> enumerate_processes(bool resolve_owner) {
   std::vector<filter_obj> result;
 
   DIR *proc_dir = opendir("/proc");
@@ -347,7 +435,7 @@ std::vector<filter_obj> enumerate_processes() {
     if (is_pid) {
       int pid = std::stoi(name);
       try {
-        filter_obj info = read_process_info(pid);
+        filter_obj info = read_process_info(pid, resolve_owner);
         if (!info.exe.empty() || !info.command_line.empty()) {
           result.push_back(info);
         }
@@ -367,13 +455,15 @@ std::vector<filter_obj> enumerate_processes() {
 // two /proc/stat reads bracket both process snapshots so the numerator
 // (per-process jiffies) and denominator (system jiffies) cover the same
 // wall-clock window.
-std::vector<filter_obj> enumerate_processes_delta() {
+std::vector<filter_obj> enumerate_processes_delta(bool resolve_owner) {
   unsigned long long capacity_start = 0;
   const bool have_start = parse_proc_stat_cpu_total(read_file("/proc/stat"), capacity_start);
 
+  // Only the second (reported) snapshot needs owner names; the first is used
+  // purely for the CPU counters it carries.
   const std::vector<filter_obj> first = enumerate_processes();
   usleep(1000 * 1000);
-  std::vector<filter_obj> second = enumerate_processes();
+  std::vector<filter_obj> second = enumerate_processes(resolve_owner);
 
   unsigned long long capacity_end = 0;
   const bool have_end = parse_proc_stat_cpu_total(read_file("/proc/stat"), capacity_end);
@@ -432,6 +522,7 @@ void check_process(const PB::Commands::QueryRequestMessage::Request &request, PB
   std::vector<std::string> processes;
   bool delta_scan = false;
   bool total = false;
+  bool resolve_owner = false;
 
   filter_type filter;
   filter_helper.add_filter_option("state != 'unreadable'");
@@ -446,6 +537,8 @@ void check_process(const PB::Commands::QueryRequestMessage::Request &request, PB
     ("process", po::value<std::vector<std::string>>(&processes), "The process to check, set this to * to check all processes")
     ("delta", po::value<bool>(&delta_scan), "Measure CPU usage as a delta over a one second interval.\nThe check samples process and system CPU times, sleeps for one second, then samples again. With delta=true the 'time' (and 'kernel'/'user') fields report the process CPU usage during that second as a whole percentage of total CPU, instead of cumulative CPU seconds.")
     ("total", po::value<bool>(&total)->implicit_value(true)->default_value(false), "Include the total of all matching processes")
+    ("resolve-owner", po::value<bool>(&resolve_owner)->implicit_value(true)->default_value(false),
+        "Populate the username keyword with the process owner's user name. Off by default: the lookup goes through NSS and can block for seconds when it is backed by a remote directory (LDAP/SSSD). The numeric uid keyword is always populated and needs no flag.")
     ;
   // clang-format on
 
@@ -474,7 +567,7 @@ void check_process(const PB::Commands::QueryRequestMessage::Request &request, PB
 
   std::vector<std::string> matched;
   std::vector<check_proc_filter::filter_obj> process_list =
-      delta_scan ? check_proc_filter::enumerate_processes_delta() : check_proc_filter::enumerate_processes();
+      delta_scan ? check_proc_filter::enumerate_processes_delta(resolve_owner) : check_proc_filter::enumerate_processes(resolve_owner);
 
   for (const check_proc_filter::filter_obj &info : process_list) {
     bool wanted = procs.count(info.exe) > 0;

--- a/modules/CheckSystemUnix/check_process.h
+++ b/modules/CheckSystemUnix/check_process.h
@@ -20,8 +20,23 @@ struct filter_obj {
   std::string exe;
   std::string command_line;
   int pid = 0;
+  // Parent pid from /proc/[pid]/stat. 0 for the synthetic "not found" and
+  // "total" rows, and genuinely 0 for the init process itself.
+  int ppid = 0;
   bool started = false;
   std::string error;
+
+  // Process owner. `uid` is the real uid from /proc/[pid]/status and is always
+  // populated (it is a plain read); `username` is resolved through NSS and is
+  // therefore only populated with resolve-owner=true. -1 means "not known"
+  // (the synthetic not-found / total rows).
+  long long uid = -1;
+  std::string username;
+
+  // Raw process state character from /proc/[pid]/stat (R, S, D, Z, T, ...).
+  // This is the Linux state, exposed as the `proc_state` keyword; the
+  // cross-platform `state` keyword keeps its started/stopped meaning.
+  char proc_state = '?';
 
   // Memory counters
   unsigned long long virtual_size = 0;
@@ -47,6 +62,9 @@ struct filter_obj {
   // timestamp exposed as the `creation` keyword.
   unsigned long long start_time_jiffies = 0;
   unsigned long long creation_time = 0;
+  // Wall-clock seconds since the process started, derived from creation_time
+  // when it could be established. 0 when unknown.
+  unsigned long long elapsed = 0;
 
   filter_obj() {}
 
@@ -61,6 +79,9 @@ struct filter_obj {
   std::string get_command_line() const { return command_line; }
   std::string get_error() const { return error; }
   long long get_pid() const { return pid; }
+  long long get_ppid() const { return ppid; }
+  long long get_uid() const { return uid; }
+  std::string get_username() const { return username; }
 
   bool get_started() const { return started; }
   bool get_stopped() const { return !started; }
@@ -82,9 +103,95 @@ struct filter_obj {
   }
 
   static long long parse_state(const std::string &s) {
-    if (s == "started") return state_started;
+    // "running" is accepted as a synonym for "started" (as on Windows).
+    // The rendered state string stays "started" for backward compatibility.
+    if (s == "started" || s == "running") return state_started;
     if (s == "stopped") return state_stopped;
     return state_unknown;
+  }
+
+  // The raw Linux process state, exposed as `proc_state`. This is deliberately
+  // a separate keyword from `state`: `state` is the cross-platform
+  // started/stopped verdict (and a zombie counts as stopped there), whereas
+  // `proc_state` is the scheduler state `ps` prints in its STAT column, which
+  // is what "alert on a zombie" or "alert on uninterruptible sleep" needs.
+  static constexpr long long proc_state_unknown = 0;
+  static constexpr long long proc_state_running = 1;       // R
+  static constexpr long long proc_state_sleeping = 2;      // S
+  static constexpr long long proc_state_disk_sleep = 3;    // D
+  static constexpr long long proc_state_zombie = 4;        // Z
+  static constexpr long long proc_state_stopped = 5;       // T
+  static constexpr long long proc_state_tracing_stop = 6;  // t
+  static constexpr long long proc_state_dead = 7;          // X / x
+  static constexpr long long proc_state_idle = 8;          // I
+  static constexpr long long proc_state_parked = 9;        // P
+
+  static long long proc_state_from_char(const char state) {
+    switch (state) {
+      case 'R':
+        return proc_state_running;
+      case 'S':
+        return proc_state_sleeping;
+      case 'D':
+        return proc_state_disk_sleep;
+      case 'Z':
+        return proc_state_zombie;
+      case 'T':
+        return proc_state_stopped;
+      case 't':
+        return proc_state_tracing_stop;
+      case 'X':
+      case 'x':
+        return proc_state_dead;
+      case 'I':
+        return proc_state_idle;
+      case 'P':
+        return proc_state_parked;
+      default:
+        return proc_state_unknown;
+    }
+  }
+
+  long long get_proc_state_i() const { return proc_state_from_char(proc_state); }
+
+  std::string get_proc_state_s() const {
+    switch (get_proc_state_i()) {
+      case proc_state_running:
+        return "running";
+      case proc_state_sleeping:
+        return "sleeping";
+      case proc_state_disk_sleep:
+        return "disk_sleep";
+      case proc_state_zombie:
+        return "zombie";
+      case proc_state_stopped:
+        return "stopped";
+      case proc_state_tracing_stop:
+        return "tracing_stop";
+      case proc_state_dead:
+        return "dead";
+      case proc_state_idle:
+        return "idle";
+      case proc_state_parked:
+        return "parked";
+      default:
+        return "unknown";
+    }
+  }
+
+  static long long parse_proc_state(const std::string &s) {
+    if (s == "running") return proc_state_running;
+    if (s == "sleeping") return proc_state_sleeping;
+    // "uninterruptible" is accepted for D since that is how the state is
+    // usually described when people go looking for an I/O hang.
+    if (s == "disk_sleep" || s == "uninterruptible") return proc_state_disk_sleep;
+    if (s == "zombie" || s == "defunct") return proc_state_zombie;
+    if (s == "stopped") return proc_state_stopped;
+    if (s == "tracing_stop" || s == "traced") return proc_state_tracing_stop;
+    if (s == "dead") return proc_state_dead;
+    if (s == "idle") return proc_state_idle;
+    if (s == "parked") return proc_state_parked;
+    return proc_state_unknown;
   }
 
   // Memory getters
@@ -104,6 +211,7 @@ struct filter_obj {
   long long get_kernel_time() const { return kernel_time; }
   long long get_total_time() const { return total_time; }
   long long get_creation_time() const { return creation_time; }
+  long long get_elapsed() const { return elapsed; }
 
   // Compute `part * 100 / whole` rounded to the nearest whole percent rather
   // than truncated, so small-but-real usage stays visible (same rounding as
@@ -163,6 +271,7 @@ struct filter_obj {
 struct proc_stat_data {
   std::string comm;
   char state = '?';
+  int ppid = 0;
   unsigned long long major_faults = 0;
   unsigned long long utime_jiffies = 0;
   unsigned long long stime_jiffies = 0;
@@ -180,6 +289,18 @@ bool parse_proc_pid_stat(const std::string &line, proc_stat_data &data);
 // (kernel threads have no Vm* entries).
 bool parse_proc_status_bytes(const std::string &content, const std::string &key, unsigned long long &bytes);
 
+// Extract the real uid from the "Uid:" line of /proc/[pid]/status content.
+// The line holds four values (real, effective, saved, filesystem); the real
+// uid is the one reported as the process owner. Returns false when the line is
+// missing or unparsable.
+bool parse_proc_status_uid(const std::string &content, long long &uid);
+
+// Resolve a uid to a user name through NSS (getpwuid_r), memoised per uid.
+// Returns an empty string for unknown / unresolvable uids. Only called with
+// resolve-owner=true: NSS can block for seconds when it is backed by a remote
+// directory (LDAP/SSSD).
+std::string lookup_username(long long uid);
+
 // Total CPU jiffies (all cores, including idle) from the aggregate "cpu "
 // line of /proc/stat. guest/guest_nice are already folded into user/nice by
 // the kernel and are NOT summed again.
@@ -195,12 +316,13 @@ struct filter_obj_handler : native_context {
 typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;
 
 // Enumerate every process from /proc (used by check_process and the real-time
-// process filter).
-std::vector<filter_obj> enumerate_processes();
+// process filter). `resolve_owner` additionally resolves each uid to a user
+// name; it is off by default because that goes through NSS.
+std::vector<filter_obj> enumerate_processes(bool resolve_owner = false);
 
 // Enumerate processes twice, one second apart, and report user/kernel/time as
 // whole-percent CPU usage over that window (delta=true mode).
-std::vector<filter_obj> enumerate_processes_delta();
+std::vector<filter_obj> enumerate_processes_delta(bool resolve_owner = false);
 
 }  // namespace check_proc_filter
 

--- a/modules/CheckSystemUnix/check_process_test.cpp
+++ b/modules/CheckSystemUnix/check_process_test.cpp
@@ -6,10 +6,12 @@
 #include <gtest/gtest.h>
 
 using check_proc::check_proc_filter::filter_obj;
+using check_proc::check_proc_filter::lookup_username;
 using check_proc::check_proc_filter::parse_proc_pid_stat;
 using check_proc::check_proc_filter::parse_proc_stat_btime;
 using check_proc::check_proc_filter::parse_proc_stat_cpu_total;
 using check_proc::check_proc_filter::parse_proc_status_bytes;
+using check_proc::check_proc_filter::parse_proc_status_uid;
 using check_proc::check_proc_filter::proc_stat_data;
 
 // ============================================================================
@@ -28,6 +30,7 @@ TEST(ParseProcPidStat, TypicalLine) {
       "1234 (bash) S 1000 1234 1234 34816 1234 4194304 1500 0 7 0 250 125 3 2 20 0 1 0 9876 8192000 500 18446744073709551615", data));
   EXPECT_EQ("bash", data.comm);
   EXPECT_EQ('S', data.state);
+  EXPECT_EQ(1000, data.ppid);
   EXPECT_EQ(7ull, data.major_faults);
   EXPECT_EQ(250ull, data.utime_jiffies);
   EXPECT_EQ(125ull, data.stime_jiffies);
@@ -39,6 +42,16 @@ TEST(ParseProcPidStat, CommWithSpaces) {
   ASSERT_TRUE(parse_proc_pid_stat("42 (Web Content) R 1 42 42 0 -1 4194560 100 0 5 0 60 40 0 0 20 0 1 0 12345 0 0", data));
   EXPECT_EQ("Web Content", data.comm);
   EXPECT_EQ('R', data.state);
+  EXPECT_EQ(1, data.ppid);
+}
+
+TEST(ParseProcPidStat, PpidIsReadFromTheFieldAfterState) {
+  // ppid is field 4, immediately after the state character. Kernel threads are
+  // children of kthreadd (pid 2), which is how they can be filtered out.
+  proc_stat_data data;
+  ASSERT_TRUE(parse_proc_pid_stat("15 (kworker/0:1) I 2 0 0 0 -1 69238880 0 0 0 0 0 3 0 0 20 0 1 0 22 0 0", data));
+  EXPECT_EQ(2, data.ppid);
+  EXPECT_EQ('I', data.state);
 }
 
 TEST(ParseProcPidStat, CommWithCloseOpenParenSequence) {
@@ -79,6 +92,8 @@ namespace {
 const std::string status_content =
     "Name:\tbash\n"
     "State:\tS (sleeping)\n"
+    "Uid:\t1000\t1000\t1000\t1000\n"
+    "Gid:\t1000\t1000\t1000\t1000\n"
     "VmPeak:\t   10240 kB\n"
     "VmSize:\t    8192 kB\n"
     "VmHWM:\t      512 kB\n"
@@ -106,6 +121,138 @@ TEST(ParseProcStatusBytes, KeyMustMatchWholeLabel) {
   unsigned long long bytes = 0;
   EXPECT_FALSE(parse_proc_status_bytes(status_content, "VmP", bytes));
   EXPECT_FALSE(parse_proc_status_bytes(status_content, "VmSwap", bytes));
+}
+
+// ============================================================================
+// /proc/[pid]/status Uid: parsing and uid -> name resolution
+// ============================================================================
+
+TEST(ParseProcStatusUid, ExtractsTheRealUid) {
+  // The line holds real, effective, saved and filesystem uid; the owner is the
+  // first (real) one.
+  long long uid = -1;
+  ASSERT_TRUE(parse_proc_status_uid(status_content, uid));
+  EXPECT_EQ(1000, uid);
+}
+
+TEST(ParseProcStatusUid, RootIsZeroNotMissing) {
+  long long uid = -1;
+  ASSERT_TRUE(parse_proc_status_uid("Name:\tsystemd\nUid:\t0\t0\t0\t0\n", uid));
+  EXPECT_EQ(0, uid);
+}
+
+TEST(ParseProcStatusUid, EffectiveUidDiffersFromRealUid) {
+  // A setuid binary: real 1000, effective 0. We report the real uid (the owner
+  // who started it), which is what `ps -o uid` shows.
+  long long uid = -1;
+  ASSERT_TRUE(parse_proc_status_uid("Uid:\t1000\t0\t0\t0\n", uid));
+  EXPECT_EQ(1000, uid);
+}
+
+TEST(ParseProcStatusUid, MissingOrMalformedLineLeavesValueUntouched) {
+  long long uid = -1;
+  EXPECT_FALSE(parse_proc_status_uid("Name:\tkthreadd\nState:\tS (sleeping)\n", uid));
+  EXPECT_EQ(-1, uid);
+  EXPECT_FALSE(parse_proc_status_uid("Uid:\tnotanumber\n", uid));
+  EXPECT_EQ(-1, uid);
+  // "Uid:" must match the whole label, not a prefix of another key.
+  EXPECT_FALSE(parse_proc_status_uid("NStgid:\t42\n", uid));
+  EXPECT_EQ(-1, uid);
+}
+
+TEST(LookupUsername, NegativeUidResolvesToEmpty) {
+  // -1 is the "not known" sentinel used by the synthetic not-found/total rows;
+  // it must never reach getpwuid_r.
+  EXPECT_EQ("", lookup_username(-1));
+}
+
+TEST(LookupUsername, ResolvesRootAndIsStableAcrossCalls) {
+  // uid 0 exists on every Unix; the second call must come from the cache and
+  // return exactly the same answer.
+  const std::string first = lookup_username(0);
+  EXPECT_EQ("root", first);
+  EXPECT_EQ(first, lookup_username(0));
+}
+
+TEST(LookupUsername, UnknownUidResolvesToEmptyRatherThanFailing) {
+  // A uid with no passwd entry (e.g. a deleted user still owning processes in
+  // a container) must degrade to an empty name, not an error.
+  EXPECT_EQ("", lookup_username(4294967000LL));
+}
+
+// ============================================================================
+// Raw Linux process state (`proc_state`)
+// ============================================================================
+
+TEST(ProcState, StateCharactersMapToNames) {
+  filter_obj p;
+  const struct {
+    char c;
+    const char *name;
+  } cases[] = {{'R', "running"},      {'S', "sleeping"}, {'D', "disk_sleep"}, {'Z', "zombie"}, {'T', "stopped"},
+               {'t', "tracing_stop"}, {'X', "dead"},     {'I', "idle"},       {'P', "parked"}};
+  for (const auto &c : cases) {
+    p.proc_state = c.c;
+    EXPECT_EQ(c.name, p.get_proc_state_s()) << "state char " << c.c;
+  }
+}
+
+TEST(ProcState, UnsetOrUnrecognisedStateIsUnknown) {
+  filter_obj p;  // default '?'
+  EXPECT_EQ("unknown", p.get_proc_state_s());
+  EXPECT_EQ(filter_obj::proc_state_unknown, p.get_proc_state_i());
+  p.proc_state = 'W';  // obsolete "paging"/"wakekill"
+  EXPECT_EQ("unknown", p.get_proc_state_s());
+}
+
+TEST(ProcState, ParseRoundTripsEveryRenderedName) {
+  // Whatever get_proc_state_s() renders must be usable verbatim in an
+  // expression such as `proc_state = 'zombie'`.
+  filter_obj p;
+  for (const char c : std::string("RSDZTtXIP")) {
+    p.proc_state = c;
+    EXPECT_EQ(p.get_proc_state_i(), filter_obj::parse_proc_state(p.get_proc_state_s())) << "state char " << c;
+  }
+}
+
+TEST(ProcState, ParseAcceptsCommonSynonyms) {
+  EXPECT_EQ(filter_obj::proc_state_disk_sleep, filter_obj::parse_proc_state("uninterruptible"));
+  EXPECT_EQ(filter_obj::proc_state_zombie, filter_obj::parse_proc_state("defunct"));
+  EXPECT_EQ(filter_obj::proc_state_tracing_stop, filter_obj::parse_proc_state("traced"));
+}
+
+TEST(ProcState, UnknownNameParsesToUnknownRatherThanMatchingSomething) {
+  EXPECT_EQ(filter_obj::proc_state_unknown, filter_obj::parse_proc_state("nonsense"));
+  EXPECT_EQ(filter_obj::proc_state_unknown, filter_obj::parse_proc_state(""));
+}
+
+TEST(ProcState, IsIndependentOfTheCrossPlatformStateKeyword) {
+  // `state` keeps its started/stopped meaning: a zombie is not "started", but
+  // it is precisely distinguishable through `proc_state`. This separation is
+  // why proc_state exists as its own keyword.
+  filter_obj zombie;
+  zombie.proc_state = 'Z';
+  zombie.started = false;
+  EXPECT_EQ("stopped", zombie.get_state_s());
+  EXPECT_EQ("zombie", zombie.get_proc_state_s());
+
+  filter_obj blocked;
+  blocked.proc_state = 'D';
+  blocked.started = true;  // D counts as started for `state`
+  EXPECT_EQ("started", blocked.get_state_s());
+  EXPECT_EQ("disk_sleep", blocked.get_proc_state_s());
+}
+
+TEST(ParseState, AcceptsRunningAsSynonymForStarted) {
+  // Matches the Windows check; the rendered value stays "started".
+  EXPECT_EQ(filter_obj::state_started, filter_obj::parse_state("running"));
+  EXPECT_EQ(filter_obj::state_started, filter_obj::parse_state("started"));
+  EXPECT_EQ(filter_obj::state_stopped, filter_obj::parse_state("stopped"));
+  EXPECT_EQ(filter_obj::state_unknown, filter_obj::parse_state("zombie"));
+
+  filter_obj p;
+  p.started = true;
+  EXPECT_EQ("started", p.get_state_s());
 }
 
 // ============================================================================

--- a/tests/checkdisk-unix.test.ts
+++ b/tests/checkdisk-unix.test.ts
@@ -24,10 +24,20 @@ onLinux("CheckDisk (Unix)", () => {
 
   /** Run a CheckDisk query and return the combined output. */
   async function query(command: string, args: string[] = []): Promise<string> {
+    return (await queryWithCode(command, args)).out;
+  }
+
+  /**
+   * As query(), but also returns the process exit code, which is the Nagios
+   * status (0 OK / 1 WARNING / 2 CRITICAL / 3 UNKNOWN). The client-query path
+   * prints the raw message with no status word, so for checks whose syntax
+   * does not embed %(status) this is the only way to assert the verdict.
+   */
+  async function queryWithCode(command: string, args: string[] = []): Promise<{ out: string; code: number }> {
     const r = await nscp.run(["client", "--module", "CheckDisk", "--boot", "--query", command, ...args], {
       allowFailure: true,
     });
-    return r.all ?? `${r.stdout}\n${r.stderr}`;
+    return { out: r.all ?? `${r.stdout}\n${r.stderr}`, code: r.exitCode };
   }
 
   beforeAll(() => {
@@ -72,6 +82,45 @@ onLinux("CheckDisk (Unix)", () => {
   it("rejects a non-existent drive", async () => {
     const out = await query("check_drivesize", ["drive=/no/such/mount/point"]);
     expect(out).toMatch(/not be found|not found|was not found/i);
+  });
+
+  it("ignore-missing turns a non-existent drive into OK", async () => {
+    const out = await query("check_drivesize", ["drive=/no/such/mount/point", "ignore-missing=true"]);
+    expect(out).not.toMatch(/not found/i);
+    expect(out).toMatch(/^OK/m);
+  });
+
+  it("ignore-missing still checks the drives that do exist", async () => {
+    // The missing one is dropped; the real one is checked normally, so this
+    // must not silently degrade into "nothing was checked".
+    const out = await query("check_drivesize", [
+      "drive=/",
+      "drive=/no/such/mount/point",
+      "ignore-missing=true",
+      "warning=used>99%",
+      "critical=used>99%",
+    ]);
+    expect(out).toMatch(/^OK/m);
+    expect(out).toMatch(/'\/ used'=/);
+  });
+
+  it("ignore-missing does not override an explicit empty-state", async () => {
+    // ignore-missing implies empty-state=ok, but only as a default: asking for
+    // something else must still win.
+    const out = await query("check_drivesize", [
+      "drive=/no/such/mount/point",
+      "ignore-missing=true",
+      "empty-state=warning",
+    ]);
+    expect(out).toMatch(/WARNING/);
+  });
+
+  it("require= is Windows-only, so its interaction with ignore-missing is not reachable here", async () => {
+    // On Windows require= asserts a drive IS present and stays CRITICAL when
+    // it is not, even under ignore-missing. Linux has no such option at all,
+    // which is pinned here so this is revisited if it is ever added.
+    const out = await query("check_drivesize", ["drive=/", "ignore-missing=true", "require=/no/such/mount/point"]);
+    expect(out).toMatch(/unrecognised option 'require/i);
   });
 
   // Regression: `total` is a boolean option passed as the token `total=true`
@@ -189,6 +238,44 @@ onLinux("CheckDisk (Unix)", () => {
     expect(out).not.toContain("<small.log>");
   });
 
+  it("check_files fails on a missing path by default", async () => {
+    const out = await query("check_files", [`path=${path.join(scratch, "no-such-dir")}`]);
+    expect(out).toMatch(/Path was not found/i);
+  });
+
+  it("check_files ignore-missing turns a missing path into OK", async () => {
+    const missing = path.join(scratch, "no-such-dir");
+    const bad = await queryWithCode("check_files", [`path=${missing}`]);
+    expect(bad.code).toBe(3); // UNKNOWN
+
+    const ok = await queryWithCode("check_files", [`path=${missing}`, "ignore-missing=true"]);
+    expect(ok.code).toBe(0); // OK
+    expect(ok.out).not.toMatch(/Path was not found/i);
+  });
+
+  it("check_files ignore-missing still scans the paths that do exist", async () => {
+    const out = await query("check_files", [
+      `path=${scratch}`,
+      `path=${path.join(scratch, "no-such-dir")}`,
+      "ignore-missing=true",
+      "pattern=*.log",
+      "top-syntax=%(status): %(count) files",
+    ]);
+    // small.log + big.log are there; the missing directory contributes nothing
+    // rather than wiping out the result.
+    expect(out).toMatch(/All 2 files are ok/);
+  });
+
+  it("check_files ignore-missing does not log the skipped path as an error", async () => {
+    // An intentionally-absent path is an expected condition, so it must not
+    // show up as an ERROR line in the log.
+    const out = await query("check_files", [
+      `path=${path.join(scratch, "no-such-dir")}`,
+      "ignore-missing=true",
+    ]);
+    expect(out).not.toMatch(/Invalid file specified/i);
+  });
+
   // --- check_single_file ---------------------------------------------------
 
   it("inspects a single file", async () => {
@@ -200,6 +287,25 @@ onLinux("CheckDisk (Unix)", () => {
   it("fails clearly on a missing single file", async () => {
     const out = await query("check_single_file", [`file=${path.join(scratch, "missing.log")}`]);
     expect(out).toMatch(/File not found/i);
+  });
+
+  it("ignore-missing makes a missing single file OK", async () => {
+    const out = await query("check_single_file", [
+      `file=${path.join(scratch, "missing.log")}`,
+      "ignore-missing=true",
+    ]);
+    expect(out).toMatch(/ignored/i);
+    // The path is named so the result is not mistaken for "the file was fine".
+    expect(out).toMatch(/missing\.log/);
+  });
+
+  it("ignore-missing does not change a file that is present", async () => {
+    const out = await query("check_single_file", [
+      `file=${path.join(scratch, "big.log")}`,
+      "ignore-missing=true",
+    ]);
+    expect(out).toMatch(/size=5000/);
+    expect(out).not.toMatch(/ignored/i);
   });
 
   // --- check_disk_write ------------------------------------------------------

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -271,6 +271,105 @@ describe("CheckNet commands", () => {
     expect(q.result).toBe(OK);
   });
 
+  it("check_tcp exposes the peer certificate expiry via ssl_expiry_days", async () => {
+    const s = await startTlsGreeter("220 secure service\r\n", serverCert);
+    const q = await executeQuery(key, "check_tcp", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      ssl: "true",
+      verify: "none",
+      "top-syntax": "${list}",
+      "detail-syntax": "cert=${has_certificate} days=${ssl_expiry_days}",
+    });
+    expect(q.result).toBe(OK);
+    const m = messageOf(q).match(/cert=(\d+) days=(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m?.[1])).toBe(1); // a certificate was presented
+    // The shared fixture cert is valid for 365 days.
+    expect(Number(m?.[2])).toBeGreaterThan(300);
+  });
+
+  it("check_tcp reads the certificate without verifying it", async () => {
+    // verify=none is the default: the expiry is a property of the certificate
+    // the peer served, so it must be readable without a trust decision (the
+    // fixture cert is signed by a CA nscp does not trust).
+    const s = await startTlsGreeter("220 secure service\r\n", serverCert);
+    const q = await executeQuery(key, "check_tcp", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      ssl: "true",
+      critical: "has_certificate = 0",
+    });
+    expect(q.result).toBe(OK);
+  });
+
+  it("check_tcp alerts on a certificate that expires soon", async () => {
+    // A 20-day cert against a 30-day threshold: this is the check the keyword
+    // exists for, and it must fire on the real remaining lifetime.
+    const shortLived = generateCertChain({
+      outDir: nscp.scratch("checknet_shortlived"),
+      signed: { server: { commonName: "localhost", isServer: true } },
+      days: 20,
+    }).signed.server;
+    const s = await startTlsGreeter("220 secure service\r\n", shortLived);
+    const q = await executeQuery(key, "check_tcp", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      ssl: "true",
+      critical: "has_certificate = 1 and ssl_expiry_days < 30",
+      "top-syntax": "${list}",
+      "detail-syntax": "expires in ${ssl_expiry_days} days",
+    });
+    expect(q.result).toBe(CRITICAL);
+    // Whole days, with the sub-day remainder dropped, so a cert issued for 20
+    // days reads as 20 or 19 depending on where in the second the check lands.
+    const days = Number(messageOf(q).match(/expires in (\d+) days/)?.[1]);
+    expect(days).toBeGreaterThanOrEqual(19);
+    expect(days).toBeLessThanOrEqual(20);
+  });
+
+  it("check_tcp emits ssl_expiry_days as perfdata when thresholded", async () => {
+    const s = await startTlsGreeter("220 secure service\r\n", serverCert);
+    const q = await executeQuery(key, "check_tcp", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      ssl: "true",
+      warning: "ssl_expiry_days < 30",
+    });
+    expect(q.result).toBe(OK);
+    expect(perfValue(q, "127.0.0.1_" + s.port + "_ssl_expiry_days")).toBeGreaterThan(300);
+  });
+
+  it("check_tcp reports no certificate on a plain connection", async () => {
+    // Without ssl=true there is no certificate at all: has_certificate must be
+    // 0 so a threshold can tell that apart from an expired one (both of which
+    // would otherwise look like a negative ssl_expiry_days).
+    const s = await startTcpGreeter("220 service ready\r\n");
+    const q = await executeQuery(key, "check_tcp", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      "top-syntax": "${list}",
+      "detail-syntax": "cert=${has_certificate} days=${ssl_expiry_days}",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toBe("cert=0 days=-1");
+  });
+
+  it("check_tcp certificate keywords work through a service preset", async () => {
+    // The s-prefixed presets (spop/simap/ssmtp) imply TLS, so they get the
+    // certificate keywords without ssl=true being passed explicitly.
+    const s = await startTlsGreeter("+OK ready\r\n", serverCert);
+    const q = await executeQuery(key, "check_tcp", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      service: "spop",
+      "top-syntax": "${list}",
+      "detail-syntax": "cert=${has_certificate}",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toBe("cert=1");
+  });
+
   // --- check_ssh ------------------------------------------------------------
 
   it("check_ssh accepts a valid SSH banner", async () => {

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -166,21 +166,49 @@ function startDnsResponder(
   });
 }
 
+interface NtpOptions {
+  stratum?: number;
+  bind?: string;
+  /**
+   * Milliseconds added to the served time, cycled per request. A varying series
+   * produces jitter; a constant one produces a steady offset with no jitter.
+   */
+  skewSequenceMs?: number[];
+  /** Root delay / root dispersion to advertise, in milliseconds. */
+  rootDelayMs?: number;
+  rootDispersionMs?: number;
+}
+
 /**
  * A minimal UDP NTP responder: answers every request with a server-mode packet
  * carrying the current time at the given stratum. Enough to exercise
  * check_ntp_offset's client end to end without touching a real time server.
  */
-function startNtpResponder(stratum = 2, bind = "127.0.0.1"): Promise<Listener> {
+function startNtpResponder(opts: NtpOptions = {}): Promise<Listener> {
+  const stratum = opts.stratum ?? 2;
+  const bind = opts.bind ?? "127.0.0.1";
+  const skews = opts.skewSequenceMs ?? [0];
+  let call = 0;
   return new Promise((resolve) => {
     const sock = dgram.createSocket(bind.includes(":") ? "udp6" : "udp4");
     sock.on("message", (_msg, rinfo) => {
       const pkt = Buffer.alloc(48);
       pkt[0] = 0x1c; // LI=0, VN=3, mode=4 (server)
       pkt[1] = stratum;
-      // NTP timestamps are seconds since 1900; the fraction is left at 0.
-      const secs = Math.floor(Date.now() / 1000) + 2208988800;
-      for (const off of [16, 24, 32, 40]) pkt.writeUInt32BE(secs, off);
+      // Root delay (byte 4) and dispersion (byte 8) are 16.16 fixed-point secs.
+      const toShort = (ms: number) => Math.round((ms / 1000) * 65536);
+      pkt.writeUInt32BE(toShort(opts.rootDelayMs ?? 0), 4);
+      pkt.writeUInt32BE(toShort(opts.rootDispersionMs ?? 0), 8);
+      // NTP timestamps are seconds since 1900 plus a 32-bit fraction.
+      const skew = skews[call % skews.length];
+      call += 1;
+      const nowMs = Date.now() + skew;
+      const secs = Math.floor(nowMs / 1000) + 2208988800;
+      const frac = Math.floor(((nowMs % 1000) / 1000) * 4294967296);
+      for (const off of [16, 24, 32, 40]) {
+        pkt.writeUInt32BE(secs, off);
+        pkt.writeUInt32BE(frac, off + 4);
+      }
       sock.send(pkt, rinfo.port, rinfo.address);
     });
     sock.bind(0, bind, () =>
@@ -689,6 +717,111 @@ describe("CheckNet commands", () => {
     expect(q.result).toBe(OK);
   });
 
+  // --- check_ntp_offset -----------------------------------------------------
+
+  it("check_ntp_offset reports the server's advertised root delay and dispersion", async () => {
+    // These come straight out of the packet header, so they are available from
+    // a single sample and say what the server claims about its own accuracy.
+    const s = await startNtpResponder({ rootDelayMs: 12, rootDispersionMs: 34 });
+    const q = await executeQuery(key, "check_ntp_offset", {
+      server: "127.0.0.1",
+      port: String(s.port),
+      "top-syntax": "${list}",
+      "detail-syntax": "delay=${root_delay} disp=${root_dispersion}",
+    });
+    expect(q.result).toBe(OK);
+    // The wire format is 16.16 fixed point, so the millisecond value is
+    // truncated on the way back out.
+    expect(messageOf(q)).toBe("delay=11 disp=33");
+  });
+
+  it("check_ntp_offset reports jitter as unmeasured with a single sample", async () => {
+    const s = await startNtpResponder();
+    const q = await executeQuery(key, "check_ntp_offset", {
+      server: "127.0.0.1",
+      port: String(s.port),
+      "top-syntax": "${list}",
+      "detail-syntax": "samples=${samples} jitter=${jitter}",
+    });
+    expect(q.result).toBe(OK);
+    // One sample is the default, and jitter needs two to mean anything.
+    expect(messageOf(q)).toBe("samples=1 jitter=-1");
+  });
+
+  it("check_ntp_offset measures jitter across samples", async () => {
+    // The server alternates its served time by +/-100ms, so successive offsets
+    // differ by ~200ms regardless of how fast loopback is.
+    const s = await startNtpResponder({ skewSequenceMs: [100, -100] });
+    const q = await executeQuery(key, "check_ntp_offset", {
+      server: "127.0.0.1",
+      port: String(s.port),
+      samples: "6",
+      // The swing also moves the offset past its default threshold; this test
+      // is about the jitter measurement, so neutralise those.
+      warning: "none",
+      critical: "none",
+      "top-syntax": "${list}",
+      "detail-syntax": "samples=${samples} jitter=${jitter}",
+    });
+    const m = messageOf(q).match(/samples=(\d+) jitter=(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m?.[1])).toBe(6);
+    // ~200ms of swing, allowing for loopback scheduling noise.
+    expect(Number(m?.[2])).toBeGreaterThan(150);
+    expect(Number(m?.[2])).toBeLessThan(250);
+  });
+
+  it("check_ntp_offset separates a steady offset from jitter", async () => {
+    // A clock that is consistently 5s wrong is inaccurate but perfectly
+    // stable: the offset must be large and the jitter near zero, so the two
+    // conditions can be alerted on independently.
+    const s = await startNtpResponder({ skewSequenceMs: [5000] });
+    const q = await executeQuery(key, "check_ntp_offset", {
+      server: "127.0.0.1",
+      port: String(s.port),
+      samples: "5",
+      warning: "none",
+      critical: "none",
+      "top-syntax": "${list}",
+      "detail-syntax": "offset=${offset} jitter=${jitter}",
+    });
+    const m = messageOf(q).match(/offset=(\d+) jitter=(\d+)/);
+    expect(m).not.toBeNull();
+    expect(Number(m?.[1])).toBeGreaterThan(4000);
+    expect(Number(m?.[2])).toBeLessThan(50);
+  });
+
+  it("check_ntp_offset alerts on jitter alone", async () => {
+    const s = await startNtpResponder({ skewSequenceMs: [80, -80] });
+    const q = await executeQuery(key, "check_ntp_offset", {
+      server: "127.0.0.1",
+      port: String(s.port),
+      samples: "6",
+      warning: "none",
+      critical: "jitter > 50",
+      "top-syntax": "${list}",
+      "detail-syntax": "jitter=${jitter}",
+    });
+    expect(q.result).toBe(CRITICAL);
+  });
+
+  it("check_ntp_offset stops sampling at the first failure", async () => {
+    // Nothing is listening: a burst must still cost a single timeout, not one
+    // per sample, so a dead server does not multiply the check's runtime.
+    const port = await closedPort();
+    const started = Date.now();
+    const q = await executeQuery(key, "check_ntp_offset", {
+      server: "127.0.0.1",
+      port: String(port),
+      samples: "5",
+      timeout: "700",
+    });
+    const elapsed = Date.now() - started;
+    expect(q.result).toBe(CRITICAL);
+    // One timeout (~700ms), not five (~3500ms).
+    expect(elapsed).toBeLessThan(2000);
+  });
+
   // --- address-family (ipv4 / ipv6) -----------------------------------------
   //
   // Each case binds the target to ONE loopback family and then asks the check
@@ -824,7 +957,7 @@ describe("CheckNet commands", () => {
   });
 
   it("check_ntp_offset queries an IPv6 NTP server", async () => {
-    const s = await startNtpResponder(2, "::1");
+    const s = await startNtpResponder({ bind: "::1" });
     const q = await executeQuery(key, "check_ntp_offset", {
       server: "::1",
       port: String(s.port),

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -56,16 +56,19 @@ function closeNetServer(srv: net.Server): () => Promise<void> {
   return () => new Promise<void>((res) => srv.close(() => res()));
 }
 
-/** A plain-TCP server that greets each client and closes (FTP/SMTP style). */
-function startTcpGreeter(greeting: string): Promise<Listener> {
+/**
+ * A plain-TCP server that greets each client and closes (FTP/SMTP style).
+ * `bind` selects the loopback address, so passing "::1" gives a listener that
+ * only an IPv6 connection can reach - which is how the address-family tests
+ * prove the flag actually changed the transport.
+ */
+function startTcpGreeter(greeting: string, bind = "127.0.0.1"): Promise<Listener> {
   return new Promise((resolve) => {
     const srv = net.createServer((sock) => {
       sock.on("error", () => {});
       sock.end(greeting); // write banner then FIN → the check sees a clean EOF
     });
-    srv.listen(0, "127.0.0.1", () =>
-      resolve(track({ port: portOf(srv), close: closeNetServer(srv) })),
-    );
+    srv.listen(0, bind, () => resolve(track({ port: portOf(srv), close: closeNetServer(srv) })));
   });
 }
 
@@ -88,12 +91,16 @@ function startTlsGreeter(greeting: string, cert: CertPair): Promise<Listener> {
 }
 
 /** An http or https server driven by the supplied request handler. */
-function startHttp(handler: http.RequestListener, cert?: CertPair): Promise<Listener> {
+function startHttp(
+  handler: http.RequestListener,
+  cert?: CertPair,
+  bind = "127.0.0.1",
+): Promise<Listener> {
   return new Promise((resolve) => {
     const srv = cert
       ? https.createServer({ key: cert.keyPem, cert: cert.certPem }, handler)
       : http.createServer(handler);
-    srv.listen(0, "127.0.0.1", () =>
+    srv.listen(0, bind, () =>
       resolve(
         track({
           port: portOf(srv as unknown as net.Server),
@@ -111,9 +118,10 @@ function startHttp(handler: http.RequestListener, cert?: CertPair): Promise<List
  */
 function startDnsResponder(
   ip: [number, number, number, number] = [93, 184, 216, 34],
+  bind = "127.0.0.1",
 ): Promise<Listener> {
   return new Promise((resolve) => {
-    const sock = dgram.createSocket("udp4");
+    const sock = dgram.createSocket(bind.includes(":") ? "udp6" : "udp4");
     sock.on("message", (msg, rinfo) => {
       // Question starts at offset 12; walk the length-prefixed labels to the 0.
       let p = 12;
@@ -147,7 +155,35 @@ function startDnsResponder(
       ]);
       sock.send(Buffer.concat([header, question, answer]), rinfo.port, rinfo.address);
     });
-    sock.bind(0, "127.0.0.1", () =>
+    sock.bind(0, bind, () =>
+      resolve(
+        track({
+          port: (sock.address() as AddressInfo).port,
+          close: () => new Promise<void>((r) => sock.close(() => r())),
+        }),
+      ),
+    );
+  });
+}
+
+/**
+ * A minimal UDP NTP responder: answers every request with a server-mode packet
+ * carrying the current time at the given stratum. Enough to exercise
+ * check_ntp_offset's client end to end without touching a real time server.
+ */
+function startNtpResponder(stratum = 2, bind = "127.0.0.1"): Promise<Listener> {
+  return new Promise((resolve) => {
+    const sock = dgram.createSocket(bind.includes(":") ? "udp6" : "udp4");
+    sock.on("message", (_msg, rinfo) => {
+      const pkt = Buffer.alloc(48);
+      pkt[0] = 0x1c; // LI=0, VN=3, mode=4 (server)
+      pkt[1] = stratum;
+      // NTP timestamps are seconds since 1900; the fraction is left at 0.
+      const secs = Math.floor(Date.now() / 1000) + 2208988800;
+      for (const off of [16, 24, 32, 40]) pkt.writeUInt32BE(secs, off);
+      sock.send(pkt, rinfo.port, rinfo.address);
+    });
+    sock.bind(0, bind, () =>
       resolve(
         track({
           port: (sock.address() as AddressInfo).port,
@@ -552,6 +588,155 @@ describe("CheckNet commands", () => {
     });
     expect(messageOf(q)).not.toMatch(/does not take any arguments/);
     expect(q.result).toBe(OK);
+  });
+
+  // --- address-family (ipv4 / ipv6) -----------------------------------------
+  //
+  // Each case binds the target to ONE loopback family and then asks the check
+  // for that family and the other one. A check that ignored the flag would pass
+  // both halves (the resolver would just pick the family that works), so the
+  // negative half is what actually proves the transport changed.
+
+  it("check_tcp address-family=ipv6 connects over IPv6", async () => {
+    const s = await startTcpGreeter("220 service ready\r\n", "::1");
+    const ok = await executeQuery(key, "check_tcp", {
+      host: "localhost",
+      port: String(s.port),
+      "address-family": "ipv6",
+      expect: "220",
+    });
+    expect(ok.result).toBe(OK);
+
+    // Same name and port over IPv4: nothing is listening there.
+    const bad = await executeQuery(key, "check_tcp", {
+      host: "localhost",
+      port: String(s.port),
+      "address-family": "ipv4",
+    });
+    expect(bad.result).toBe(CRITICAL);
+  });
+
+  it("check_tcp address-family=ipv4 connects over IPv4", async () => {
+    const s = await startTcpGreeter("220 service ready\r\n", "127.0.0.1");
+    const ok = await executeQuery(key, "check_tcp", {
+      host: "localhost",
+      port: String(s.port),
+      "address-family": "ipv4",
+      expect: "220",
+    });
+    expect(ok.result).toBe(OK);
+
+    const bad = await executeQuery(key, "check_tcp", {
+      host: "localhost",
+      port: String(s.port),
+      "address-family": "ipv6",
+    });
+    expect(bad.result).toBe(CRITICAL);
+  });
+
+  it("check_tcp accepts the short address-family aliases", async () => {
+    const s = await startTcpGreeter("220 service ready\r\n", "::1");
+    for (const alias of ["6", "v6", "inet6", "IPv6"]) {
+      const q = await executeQuery(key, "check_tcp", {
+        host: "localhost",
+        port: String(s.port),
+        "address-family": alias,
+        expect: "220",
+      });
+      expect(q.result).toBe(OK);
+    }
+  });
+
+  it("check_tcp rejects an unknown address-family", async () => {
+    const s = await startTcpGreeter("220 service ready\r\n");
+    const q = await executeQuery(key, "check_tcp", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      "address-family": "ipv64",
+    });
+    expect(messageOf(q)).toMatch(/Invalid address-family: ipv64/);
+  });
+
+  it("check_ssh honours address-family", async () => {
+    const s = await startTcpGreeter("SSH-2.0-OpenSSH_9.6p1\r\n", "::1");
+    const q = await executeQuery(key, "check_ssh", {
+      host: "localhost",
+      port: String(s.port),
+      "address-family": "ipv6",
+      "top-syntax": "${list}",
+      "detail-syntax": "${software} ${software_version}",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toBe("OpenSSH 9.6p1");
+  });
+
+  it("check_http address-family=ipv6 fetches over IPv6", async () => {
+    const s = await startHttp((_req, res) => {
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok");
+    }, undefined, "::1");
+    const ok = await executeQuery(key, "check_http", {
+      url: `http://localhost:${s.port}/`,
+      "address-family": "ipv6",
+    });
+    expect(ok.result).toBe(OK);
+
+    const bad = await executeQuery(key, "check_http", {
+      url: `http://localhost:${s.port}/`,
+      "address-family": "ipv4",
+    });
+    expect(bad.result).toBe(CRITICAL);
+  });
+
+  it("check_http accepts a bracketed IPv6 literal URL", async () => {
+    // The host is echoed back so the Host header can be asserted: RFC 7230
+    // wants the brackets kept there even though the resolver needs them gone.
+    const s = await startHttp((req, res) => {
+      const body = `host=${req.headers.host}`;
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end(body);
+    }, undefined, "::1");
+    const q = await executeQuery(key, "check_http", {
+      url: `http://[::1]:${s.port}/`,
+      "top-syntax": "${list}",
+      "detail-syntax": "${host}|${port}|${code}|${body}",
+    });
+    expect(q.result).toBe(OK);
+    // Brackets are kept in the Host header. (The port is not sent there for any
+    // address family - a separate, pre-existing gap, not an IPv6 one.)
+    expect(messageOf(q)).toBe(`::1|${s.port}|200|host=[::1]`);
+  });
+
+  it("check_dns queries an IPv6 DNS server", async () => {
+    // The DNS server itself is reached over IPv6; the record it returns is an
+    // ordinary A record, which keeps the two concepts (transport vs record
+    // type) visibly separate.
+    const s = await startDnsResponder([10, 1, 2, 3], "::1");
+    const q = await executeQuery(key, "check_dns", {
+      host: "example.com",
+      server: "::1",
+      port: String(s.port),
+      "address-family": "ipv6",
+      "top-syntax": "${list}",
+      "detail-syntax": "${addresses}",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toBe("10.1.2.3");
+  });
+
+  it("check_ntp_offset queries an IPv6 NTP server", async () => {
+    const s = await startNtpResponder(2, "::1");
+    const q = await executeQuery(key, "check_ntp_offset", {
+      server: "::1",
+      port: String(s.port),
+      "address-family": "ipv6",
+      warning: "stratum >= 16",
+      critical: "result != 'ok'",
+      "top-syntax": "${list}",
+      "detail-syntax": "${result} stratum=${stratum}",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toBe("ok stratum=2");
   });
 
   // --- check_nsclient_web_online -------------------------------------------

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -904,13 +904,22 @@ describe("CheckNet commands", () => {
   });
 
   it("check_ping still accepts an ordinary size and count", async () => {
-    // The guard bounds bytes, not count: a high count with the default payload
-    // must keep working, so existing checks are unaffected.
+    // The guard bounds bytes, not count: the same count that is refused with a
+    // 64KB payload above must pass with the default ~22 byte one, so existing
+    // high-count checks are unaffected.
+    //
+    // No host is given on purpose. The volume guard runs before the host list
+    // is examined, so "No host specified" means execution got past it - and
+    // this stays a check that opens no socket, like its sibling above. Actually
+    // pinging would need raw-socket privileges, and 5000 sequential pings (each
+    // one waiting out its own timeout when loopback ICMP is not answered, as on
+    // Windows) take far longer than the suite's timeout, blocking every test
+    // that follows on the shared nscp instance.
     const q = await executeQuery(key, "check_ping", {
-      host: "127.0.0.1",
       count: "5000",
     });
     expect(messageOf(q)).not.toMatch(/Refusing to send/);
+    expect(messageOf(q)).toMatch(/No host specified/);
   });
 
   it("check_ssh honours address-family", async () => {

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -249,6 +249,99 @@ describe("CheckNet commands", () => {
     expect(q.result).toBe(CRITICAL);
   });
 
+  it("check_ssh splits the identification string into keywords", async () => {
+    const s = await startTcpGreeter("SSH-2.0-OpenSSH_9.6p1 Ubuntu-3ubuntu13.5\r\n");
+    const q = await executeQuery(key, "check_ssh", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      "top-syntax": "${list}",
+      "detail-syntax":
+        "proto=${protocol} major=${protocol_major} minor=${protocol_minor} version=${version} sw=${software} swver=${software_version} comments=[${comments}]",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toBe(
+      "proto=2.0 major=2 minor=0 version=OpenSSH_9.6p1 sw=OpenSSH swver=9.6p1 comments=[Ubuntu-3ubuntu13.5]",
+    );
+  });
+
+  it("check_ssh banner keyword carries the raw identification string", async () => {
+    const s = await startTcpGreeter("SSH-2.0-OpenSSH_9.6p1\r\n");
+    const q = await executeQuery(key, "check_ssh", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      "top-syntax": "${list}",
+      "detail-syntax": "${banner}",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toBe("SSH-2.0-OpenSSH_9.6p1");
+  });
+
+  it("check_ssh can alert on an outdated software version", async () => {
+    // The point of the software/version keywords: express "not this build"
+    // without hand-writing a regex over the raw banner.
+    const s = await startTcpGreeter("SSH-2.0-OpenSSH_7.4\r\n");
+    const q = await executeQuery(key, "check_ssh", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      critical: "software = 'OpenSSH' and software_version not like '9.'",
+      "top-syntax": "${list}",
+      "detail-syntax": "${software} ${software_version} is outdated",
+    });
+    expect(q.result).toBe(CRITICAL);
+    expect(messageOf(q)).toBe("OpenSSH 7.4 is outdated");
+  });
+
+  it("check_ssh protocol_major flags an SSHv1-capable server", async () => {
+    // "1.99" means the server still speaks the insecure SSHv1.
+    const legacy = await startTcpGreeter("SSH-1.99-OpenSSH_3.9p1\r\n");
+    const q = await executeQuery(key, "check_ssh", {
+      host: "127.0.0.1",
+      port: String(legacy.port),
+      critical: "protocol_major < 2",
+      "top-syntax": "${list}",
+      "detail-syntax": "${host} speaks SSH ${protocol}",
+    });
+    expect(q.result).toBe(CRITICAL);
+    expect(messageOf(q)).toBe("127.0.0.1 speaks SSH 1.99");
+
+    // ...and a 2.0-only server passes the same threshold.
+    const modern = await startTcpGreeter("SSH-2.0-OpenSSH_9.6p1\r\n");
+    const ok = await executeQuery(key, "check_ssh", {
+      host: "127.0.0.1",
+      port: String(modern.port),
+      critical: "protocol_major < 2",
+    });
+    expect(ok.result).toBe(OK);
+  });
+
+  it("check_ssh leaves the banner keywords empty when nothing was read", async () => {
+    // Nothing is listening: the check fails on `result`, and the banner
+    // keywords must be empty rather than stale.
+    const dead = await startTcpGreeter("SSH-2.0-OpenSSH_9.6p1\r\n");
+    const port = dead.port;
+    await dead.close();
+    const q = await executeQuery(key, "check_ssh", {
+      host: "127.0.0.1",
+      port: String(port),
+      "top-syntax": "${list}",
+      "detail-syntax": "result=${result} sw=[${software}] major=${protocol_major}",
+    });
+    expect(q.result).toBe(CRITICAL);
+    expect(messageOf(q)).toBe("result=refused sw=[] major=0");
+  });
+
+  it("check_ssh still supports the check_tcp keywords", async () => {
+    const s = await startTcpGreeter("SSH-2.0-OpenSSH_9.6p1\r\n");
+    const q = await executeQuery(key, "check_ssh", {
+      host: "127.0.0.1",
+      port: String(s.port),
+      "top-syntax": "${list}",
+      "detail-syntax": "${host}:${port} ${result} connected=${connected}",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toBe(`127.0.0.1:${s.port} ok connected=1`);
+  });
+
   // --- check_http -----------------------------------------------------------
 
   it("check_http reports OK for a 200 response", async () => {

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -889,6 +889,30 @@ describe("CheckNet commands", () => {
     expect(messageOf(q)).toMatch(/Invalid address-family: ipv64/);
   });
 
+  it("check_ping rejects a size/count combination that would flood the target", async () => {
+    // size= is caller-controlled up to 64KB and count= is unbounded, so the
+    // product decides how many bytes the agent throws at an arbitrary host.
+    // The guard runs before any socket is opened, so this case does not need
+    // the raw-socket privileges check_ping normally requires.
+    const q = await executeQuery(key, "check_ping", {
+      host: "127.0.0.1",
+      size: "65507",
+      count: "5000",
+    });
+    expect(messageOf(q)).toMatch(/Refusing to send/);
+    expect(messageOf(q)).toMatch(/limit is/);
+  });
+
+  it("check_ping still accepts an ordinary size and count", async () => {
+    // The guard bounds bytes, not count: a high count with the default payload
+    // must keep working, so existing checks are unaffected.
+    const q = await executeQuery(key, "check_ping", {
+      host: "127.0.0.1",
+      count: "5000",
+    });
+    expect(messageOf(q)).not.toMatch(/Refusing to send/);
+  });
+
   it("check_ssh honours address-family", async () => {
     const s = await startTcpGreeter("SSH-2.0-OpenSSH_9.6p1\r\n", "::1");
     const q = await executeQuery(key, "check_ssh", {

--- a/tests/checksystem-commands.test.ts
+++ b/tests/checksystem-commands.test.ts
@@ -148,8 +148,7 @@ describe("CheckSystem commands", () => {
     expect(time).toBe(user + kernel);
   });
 
-  it("check_process rss is an alias for working_set (Windows)", async () => {
-    if (!onWindows) return; // rss/working_set keywords are the Windows process check.
+  it("check_process rss is an alias for working_set", async () => {
     const q = await executeQuery(key, "check_process", {
       process: SELF_EXE,
       "top-syntax": "${list}",
@@ -163,8 +162,7 @@ describe("CheckSystem commands", () => {
     expect(m![1]).toBe(m![2]);
   });
 
-  it("check_process accepts 'running' as a synonym for 'started' (Windows)", async () => {
-    if (!onWindows) return;
+  it("check_process accepts 'running' as a synonym for 'started'", async () => {
     const q = await executeQuery(key, "check_process", {
       process: SELF_EXE,
       warning: "state != 'running'",
@@ -203,6 +201,112 @@ describe("CheckSystem commands", () => {
     });
     expect(q.result).toBe(OK);
     expect(messageOf(q)).toMatch(/user=\[\]/); // owner not resolved by default
+  });
+
+  it("check_process resolve-owner=true populates username (Linux)", async () => {
+    if (onWindows) return; // Windows resolves a SID; covered by its own test above.
+    // uid needs no flag (it is read straight out of /proc/<pid>/status), the
+    // name does because it goes through NSS.
+    const q = await executeQuery(key, "check_process", {
+      process: SELF_EXE,
+      "resolve-owner": "true",
+      "top-syntax": "${list}",
+      "detail-syntax": "user=[${username}] uid=[${uid}]",
+    });
+    expect(q.result).toBe(OK);
+    const msg = messageOf(q);
+    expect(msg).toMatch(/user=\[[^\]]+\]/);
+    expect(msg).toMatch(/uid=\[\d+\]/); // a numeric uid, not a SID
+  });
+
+  it("check_process reports a numeric uid without resolve-owner (Linux)", async () => {
+    if (onWindows) return;
+    const q = await executeQuery(key, "check_process", {
+      process: SELF_EXE,
+      "top-syntax": "${list}",
+      "detail-syntax": "user=[${username}] uid=[${uid}]",
+    });
+    expect(q.result).toBe(OK);
+    const msg = messageOf(q);
+    expect(msg).toMatch(/user=\[\]/); // name not resolved by default
+    expect(msg).toMatch(/uid=\[\d+\]/); // ...but the uid is always there
+  });
+
+  it("check_process uid is numerically thresholdable (Linux)", async () => {
+    if (onWindows) return;
+    // The point of uid being an int rather than a string: `uid < 1000` selects
+    // system accounts. Our own process is owned by whoever runs the suite, so
+    // assert on the expression evaluating rather than on a specific verdict.
+    const q = await executeQuery(key, "check_process", {
+      process: SELF_EXE,
+      warning: "none",
+      critical: "uid < 0", // never true: uid is always known for a live process
+      "top-syntax": "${list}",
+      "detail-syntax": "${exe} uid=${uid}",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toMatch(/uid=\d+/);
+  });
+
+  it("check_process exposes ppid (Linux)", async () => {
+    if (onWindows) return;
+    const q = await executeQuery(key, "check_process", {
+      process: SELF_EXE,
+      "top-syntax": "${list}",
+      "detail-syntax": "pid=${pid} ppid=${ppid}",
+    });
+    expect(q.result).toBe(OK);
+    const m = /pid=(\d+) ppid=(\d+)/.exec(messageOf(q));
+    expect(m).not.toBeNull();
+    const [, pid, ppid] = m!.map(Number);
+    expect(pid).toBeGreaterThan(0);
+    // We were started by the test harness, so we have a real parent that is
+    // not ourselves.
+    expect(ppid).toBeGreaterThan(0);
+    expect(ppid).not.toBe(pid);
+  });
+
+  it("check_process proc_state reports the raw Linux state (Linux)", async () => {
+    if (onWindows) return;
+    // A live process is in one of the running states; `state` stays "started".
+    const q = await executeQuery(key, "check_process", {
+      process: SELF_EXE,
+      "top-syntax": "${list}",
+      "detail-syntax": "state=${state} proc_state=${proc_state}",
+    });
+    expect(q.result).toBe(OK);
+    const msg = messageOf(q);
+    expect(msg).toMatch(/state=started/);
+    expect(msg).toMatch(/proc_state=(running|sleeping|disk_sleep|idle)/);
+  });
+
+  it("check_process proc_state is usable in threshold expressions (Linux)", async () => {
+    if (onWindows) return;
+    // The canonical use: alert on zombies. We are not a zombie, so this must
+    // come back OK — and it must parse, which is the real assertion (an
+    // unknown state name would evaluate to `unknown` and never match).
+    const q = await executeQuery(key, "check_process", {
+      process: "*",
+      warning: "none",
+      critical: "proc_state = 'zombie' and exe = 'definitely-not-a-real-process'",
+      "top-syntax": "${status}: ${count} processes",
+    });
+    expect(q.result).toBe(OK);
+  });
+
+  it("check_process exposes elapsed seconds since start (Linux)", async () => {
+    if (onWindows) return;
+    const q = await executeQuery(key, "check_process", {
+      process: SELF_EXE,
+      "top-syntax": "${list}",
+      "detail-syntax": "elapsed=${elapsed}",
+    });
+    expect(q.result).toBe(OK);
+    const elapsed = Number(/elapsed=(\d+)/.exec(messageOf(q))?.[1]);
+    // The instance has been up since beforeAll; a sane age is seconds to
+    // minutes, and certainly less than a day.
+    expect(elapsed).toBeGreaterThanOrEqual(0);
+    expect(elapsed).toBeLessThan(86_400);
   });
 
   it("check_process delta=true reports CPU as a percentage (Linux)", async () => {


### PR DESCRIPTION
Expands Unix process inspection and network-check capabilities, adding new keywords/options (owner/uid, raw proc state, elapsed time; TLS cert expiry; SSH banner parsing; NTP jitter/root metrics) and makes multiple checks more robust/controllable (address-family pinning, ignore-missing paths/drives).

**Changes:**
- CheckSystemUnix `check_process`: add `uid/username/ppid/proc_state/elapsed` keywords, `resolve-owner` option, and `rss` alias; add corresponding unit tests and samples/docs.
- CheckNet: add `address-family` option across checks, TLS cert expiry keywords for `check_tcp`, SSH banner parsing keywords for `check_ssh`, NTP jitter/root metrics and sampling in `check_ntp_offset`, and ping enhancements (payload sizing, TTL, jitter); add tests and docs.
- CheckDisk: add `ignore-missing` behavior for optional drives/paths/files with test coverage and docs.