### PR TITLE
Add CheckMySQL module for MySQL, MariaDB and Percona servers

### DIFF
--- a/.github/actions/mariadb/action.yaml
+++ b/.github/actions/mariadb/action.yaml
@@ -59,10 +59,20 @@ runs:
     # extra file. auth_gssapi_client is dropped: it is the only plugin that
     # would drag in an external dependency, and CheckMySQL does not offer
     # Kerberos auth.
+    #
+    # CMAKE_SYSTEM_VERSION=10.0 selects the newest installed Windows 10 SDK.
+    # Without it CMake reports "Selecting Windows SDK version 8.1 to target
+    # Windows 6.2.9200" (the runner has the Windows 8.1 SDK installed for the
+    # legacy XP/cryptopp build path, and the runner reports itself as 6.2) and
+    # the connector's Schannel backend then fails to compile: schannel.c needs
+    # SCH_CREDENTIALS / TLS_PARAMETERS and both it and ma_schannel.c need
+    # SP_PROT_TLS1_3_CLIENT, none of which exist in the 8.1 SDK headers.
+    # Only the SDK is bumped, the toolset stays as the caller asked.
     - name: Build
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         cmake -S . -B build -G "Visual Studio 17" -A ${{ steps.setup.outputs.platform }} -T ${{ inputs.toolset }} `
+          -DCMAKE_SYSTEM_VERSION=10.0 `
           -DCMAKE_INSTALL_PREFIX="$pwd/install" `
           -DWITH_UNIT_TESTS=OFF `
           -DWITH_SSL=SCHANNEL `

--- a/.github/actions/mariadb/action.yaml
+++ b/.github/actions/mariadb/action.yaml
@@ -1,0 +1,98 @@
+---
+name: Build MariaDB Connector/C
+description: Build and cache MariaDB Connector/C (the client library CheckMySQL links against)
+inputs:
+  version:
+    description: The MariaDB Connector/C version to build
+    required: true
+  architecture:
+    description: The architecture to build
+    required: true
+  toolset:
+    description: The toolset to use for building
+    required: true
+outputs:
+  path:
+    description: The path to the install tree (windows \ format)
+    value: ${{ steps.path.outputs.path }}
+  path_unix:
+    description: The path to the install tree (unix / format)
+    value: ${{ steps.path.outputs.path_unix }}
+runs:
+  using: composite
+  steps:
+    - id: cache
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-mariadb-${{ inputs.version }}-${{ inputs.architecture }}-${{ inputs.toolset }}
+        path: |
+          tmp/mariadb-connector-c
+
+    - id: setup
+      run: |
+        switch ("${{ inputs.architecture }}") {
+          "x86"   { echo "platform=Win32" >> $env:GITHUB_OUTPUT }
+          "arm64" { echo "platform=ARM64" >> $env:GITHUB_OUTPUT }
+          default { echo "platform=x64"   >> $env:GITHUB_OUTPUT }
+        }
+      shell: pwsh
+
+    - name: Download
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        curl -sSfL https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v${{ inputs.version }}.tar.gz --output connector-c.tar.gz
+        mkdir -p mariadb-connector-c
+        tar xzf connector-c.tar.gz -C mariadb-connector-c --strip-components=1
+        rm connector-c.tar.gz
+      working-directory: tmp
+      shell: bash
+
+    # WITH_SSL=SCHANNEL keeps the connector on the platform TLS stack instead of
+    # pulling in a second OpenSSL next to the one NSClient++ links statically.
+    #
+    # The auth plugins are built STATIC on purpose. By default the connector
+    # loads them as separate DLLs out of a plugin directory baked in at compile
+    # time - a path that does not exist on a target machine - and MySQL 8
+    # accounts default to caching_sha2_password, so a stock MySQL 8 server would
+    # be unreachable unless the operator also passed plugin-dir=. Linking them
+    # in makes libmariadb.dll self-contained and leaves the MSI with exactly one
+    # extra file. auth_gssapi_client is dropped: it is the only plugin that
+    # would drag in an external dependency, and CheckMySQL does not offer
+    # Kerberos auth.
+    - name: Build
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        cmake -S . -B build -G "Visual Studio 17" -A ${{ steps.setup.outputs.platform }} -T ${{ inputs.toolset }} `
+          -DCMAKE_INSTALL_PREFIX="$pwd/install" `
+          -DWITH_UNIT_TESTS=OFF `
+          -DWITH_SSL=SCHANNEL `
+          -DWITH_EXTERNAL_ZLIB=OFF `
+          -DCLIENT_PLUGIN_CACHING_SHA2_PASSWORD=STATIC `
+          -DCLIENT_PLUGIN_SHA256_PASSWORD=STATIC `
+          -DCLIENT_PLUGIN_DIALOG=STATIC `
+          -DCLIENT_PLUGIN_CLIENT_ED25519=STATIC `
+          -DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=STATIC `
+          -DCLIENT_PLUGIN_AUTH_GSSAPI_CLIENT=OFF
+        cmake --build build --config Release
+        cmake --install build --config Release
+      working-directory: tmp/mariadb-connector-c
+      shell: pwsh
+
+    # Fail loudly here rather than letting FindMariaDB quietly skip the module
+    # and the installer fail later on a missing CheckMySQL.dll.
+    - name: Verify
+      run: |
+        foreach ($f in @("install/include/mariadb/mysql.h", "install/lib/mariadb/libmariadb.lib", "install/lib/mariadb/libmariadb.dll")) {
+          if (-not (Test-Path $f)) { Write-Error "MariaDB Connector/C build is missing $f"; exit 1 }
+        }
+      working-directory: tmp/mariadb-connector-c
+      shell: pwsh
+
+    - id: path
+      run: |
+        $path=$pwd.path
+        $path_unix=$pwd.path.replace('\','/')
+        echo "path=$path" >> $env:GITHUB_OUTPUT
+        echo "path_unix=$path_unix" >> $env:GITHUB_OUTPUT
+      shell: pwsh
+      working-directory: tmp/mariadb-connector-c/install

--- a/.github/actions/mariadb/action.yaml
+++ b/.github/actions/mariadb/action.yaml
@@ -68,11 +68,18 @@ runs:
     # SCH_CREDENTIALS / TLS_PARAMETERS and both it and ma_schannel.c need
     # SP_PROT_TLS1_3_CLIENT, none of which exist in the 8.1 SDK headers.
     # Only the SDK is bumped, the toolset stays as the caller asked.
+    #
+    # The quotes around that argument are load-bearing: unquoted, PowerShell
+    # splits "-DCMAKE_SYSTEM_VERSION=10.0" into "-DCMAKE_SYSTEM_VERSION=10"
+    # plus a stray ".0" positional, CMake shrugs ("Ignoring extra path from
+    # command line: .0") and falls straight back to the 8.1 SDK. The assert
+    # below turns that class of silent fallback into one clear line instead of
+    # forty compiler errors.
     - name: Build
       if: steps.cache.outputs.cache-hit != 'true'
       run: |
         cmake -S . -B build -G "Visual Studio 17" -A ${{ steps.setup.outputs.platform }} -T ${{ inputs.toolset }} `
-          -DCMAKE_SYSTEM_VERSION=10.0 `
+          "-DCMAKE_SYSTEM_VERSION=10.0" `
           -DCMAKE_INSTALL_PREFIX="$pwd/install" `
           -DWITH_UNIT_TESTS=OFF `
           -DWITH_SSL=SCHANNEL `
@@ -83,6 +90,16 @@ runs:
           -DCLIENT_PLUGIN_CLIENT_ED25519=STATIC `
           -DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=STATIC `
           -DCLIENT_PLUGIN_AUTH_GSSAPI_CLIENT=OFF
+
+        $match = Select-String -Path "build/libmariadb/*.vcxproj" `
+          -Pattern "<WindowsTargetPlatformVersion>([^<]+)<" | Select-Object -First 1
+        $sdk = if ($match) { $match.Matches[0].Groups[1].Value } else { "" }
+        Write-Host "* Connector configured against Windows SDK '$sdk'"
+        if ($sdk -notlike "10.*") {
+          Write-Error "Expected a Windows 10 SDK, got '$sdk': the connector's Schannel backend needs SCH_CREDENTIALS / SP_PROT_TLS1_3_*, which the 8.1 SDK does not have."
+          exit 1
+        }
+
         cmake --build build --config Release
         cmake --install build --config Release
       working-directory: tmp/mariadb-connector-c

--- a/.github/workflows/build-debian.yml
+++ b/.github/workflows/build-debian.yml
@@ -55,7 +55,7 @@ jobs:
           done
         }
         retry apt-get update
-        retry env DEBIAN_FRONTEND=noninteractive apt-get install -y git curl unzip libboost-all-dev libgtest-dev protobuf-compiler libprotobuf-dev openssl libssl-dev libgmock-dev libcrypto++-dev ${{ matrix.lua_package }} cmake build-essential python3-pip libdbus-1-dev libzip-dev libtinyxml2-dev pkg-config
+        retry env DEBIAN_FRONTEND=noninteractive apt-get install -y git curl unzip libboost-all-dev libgtest-dev protobuf-compiler libprotobuf-dev openssl libssl-dev libgmock-dev libcrypto++-dev ${{ matrix.lua_package }} cmake build-essential python3-pip libdbus-1-dev libzip-dev libtinyxml2-dev libmariadb-dev pkg-config
 
     - uses: actions/checkout@v6
 

--- a/.github/workflows/build-redhat.yml
+++ b/.github/workflows/build-redhat.yml
@@ -80,7 +80,7 @@ jobs:
         retry dnf update -y
         # Node.js / npm are no longer needed here: the web bundle ships
         # separately and is installed at runtime via `nscp web install-ui`.
-        retry dnf install -y --allowerasing coreutils bash file findutils git boost-devel gtest-devel protobuf-compiler protobuf-devel openssl openssl-devel gmock-devel cryptopp-devel lua-devel cmake gcc-c++ python3-pip rpm-build python3-devel dbus-devel bash libzip-devel tinyxml2-devel pkgconf-pkg-config
+        retry dnf install -y --allowerasing coreutils bash file findutils git boost-devel gtest-devel protobuf-compiler protobuf-devel openssl openssl-devel gmock-devel cryptopp-devel lua-devel cmake gcc-c++ python3-pip rpm-build python3-devel dbus-devel bash libzip-devel tinyxml2-devel mariadb-connector-c-devel pkgconf-pkg-config
     - uses: actions/checkout@v6
 
     - name: make dirs

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,6 +37,7 @@ env:
   GOOGLE_TEST_VERSION: 1.12.1
   MONGOOSE_VERSION: "7.20"
   MINIZ_VERSION: "3.1.1"
+  MARIADB_CONNECTOR_VERSION: 3.4.9
 
 jobs:
   build:
@@ -185,6 +186,13 @@ jobs:
       with:
         version: ${{ ENV.MINIZ_VERSION }}
 
+    - id: mariadb
+      uses: ./.github/actions/mariadb
+      with:
+        version: ${{ ENV.MARIADB_CONNECTOR_VERSION }}
+        architecture: ${{ inputs.architecture }}
+        toolset: ${{ steps.setup.outputs.toolset }}
+
     - name: Build Boost (static)
       id: static_boost
       uses: mickem/build-boost@v1
@@ -242,6 +250,7 @@ jobs:
             set(GTEST_ROOT "${{ steps.google-test.outputs.path_unix }}")
             set(MONGOOSE_SOURCE_DIR "${{ steps.mongoose.outputs.path_unix }}")
             set(MINIZ_INCLUDE_DIR "${{ steps.miniz.outputs.path_unix }}")
+            set(MARIADB_ROOT_DIR "${{ steps.mariadb.outputs.path_unix }}")
             set(CHECK_NSCLIENT_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/tmp")
 
     - name: Make python dist

--- a/.github/workflows/integration-tests-windows.yml
+++ b/.github/workflows/integration-tests-windows.yml
@@ -90,7 +90,6 @@ jobs:
         shell: bash
         env:
           NSCP_BIN: ${{ github.workspace }}/tmp/nscp/nscp.exe
-          NSCP_SKIP_DOCKER: "1"
         run: npm test
 
       # TODO: Disabled for now due to issues with docker on windows runners

--- a/.github/workflows/integration-tests-windows.yml
+++ b/.github/workflows/integration-tests-windows.yml
@@ -90,6 +90,7 @@ jobs:
         shell: bash
         env:
           NSCP_BIN: ${{ github.workspace }}/tmp/nscp/nscp.exe
+          NSCP_SKIP_DOCKER: "1"
         run: npm test
 
       # TODO: Disabled for now due to issues with docker on windows runners

--- a/.github/workflows/tests-sanitizers.yml
+++ b/.github/workflows/tests-sanitizers.yml
@@ -44,7 +44,7 @@ jobs:
           protobuf-compiler libprotobuf-dev \
           openssl libssl-dev libcrypto++-dev \
           liblua5.4-dev libdbus-1-dev \
-          libzip-dev libtinyxml2-dev
+          libzip-dev libtinyxml2-dev libmariadb-dev
 
     - uses: actions/checkout@v6
 

--- a/build.md
+++ b/build.md
@@ -71,6 +71,7 @@ set is pinned in `build/python/requirements.txt`.
 | Python 3 dev libs + Boost.Python       | embedding CPython                                         | `python3.12-dev` (+ Boost built `--with-python`) | `PythonScript` module                                                                        |
 | Google Test                            | unit tests                                                | bundled via FetchContent (or `libgmock-dev`)     | unit tests (also toggled by `NSCP_BUILD_TESTS`)                                              |
 | Mongoose                               | web / REST server (mongoose backend)                      | vendored source (`MONGOOSE_SOURCE_DIR`)          | only needed when `NSCP_WEB_BACKEND=mongoose` (the default); not needed with `beast`          |
+| MariaDB Connector/C                    | MySQL / MariaDB / Percona checks                          | `libmariadb-dev` (RHEL: `mariadb-connector-c-devel`) | `CheckMySQL` module                                                                      |
 | Rust toolchain                         | builds the bundled `check_nsclient` plugin                | [`rustup`](https://rust-lang.org/tools/install/) | bundled `check_nsclient` (skip with `-DCHECK_NSCLIENT_MISSING=TRUE`)                         |
 
 A few additional Linux packages are pulled in for packaging and supporting
@@ -117,6 +118,7 @@ path); on Linux the system packages are found automatically.
 | `TINY_XML2_SOURCE_DIR`                         | unpacked TinyXML2 source                          |
 | `MONGOOSE_SOURCE_DIR`                          | unpacked Mongoose source (mongoose backend)       |
 | `MINIZ_INCLUDE_DIR`                            | unpacked miniz source (Windows ZIP backend)       |
+| `MARIADB_ROOT_DIR`                             | MariaDB Connector/C install tree (`CheckMySQL`)   |
 | `DEPENDENCIES_FOLDER`                          | base folder several of the above are derived from |
 
 ### Selecting individual modules
@@ -296,6 +298,64 @@ mkdir miniz-%MINIZ_VERSION%
 del miniz.zip
 ```
 
+
+#### Build MariaDB Connector/C
+
+The client library the `CheckMySQL` module links against. It is optional: without
+it the module is skipped (with a reason) at configure time and everything else
+builds as usual.
+
+There are prebuilt Windows installers on mariadb.com, but building from source is
+what CI does and what these instructions cover - it is the only way to get an
+ARM64 build, and it lets us fold the authentication plugins into the library:
+
+```commandline
+SET MARIADB_CONNECTOR_VERSION=3.4.9
+cd %BUILD_FOLDER%
+curl -L https://github.com/mariadb-corporation/mariadb-connector-c/archive/refs/tags/v%MARIADB_CONNECTOR_VERSION%.tar.gz --output connector-c.tar.gz
+7z x connector-c.tar.gz
+7z x connector-c.tar
+del connector-c.tar connector-c.tar.gz
+
+cd %BUILD_FOLDER%\mariadb-connector-c-%MARIADB_CONNECTOR_VERSION%
+cmake -S . -B build -G "Visual Studio 17" -A x64 -T v141 ^
+  -DCMAKE_INSTALL_PREFIX=%BUILD_FOLDER%\mariadb-connector-c-%MARIADB_CONNECTOR_VERSION%\install ^
+  -DWITH_UNIT_TESTS=OFF -DWITH_SSL=SCHANNEL -DWITH_EXTERNAL_ZLIB=OFF ^
+  -DCLIENT_PLUGIN_CACHING_SHA2_PASSWORD=STATIC -DCLIENT_PLUGIN_SHA256_PASSWORD=STATIC ^
+  -DCLIENT_PLUGIN_DIALOG=STATIC -DCLIENT_PLUGIN_CLIENT_ED25519=STATIC ^
+  -DCLIENT_PLUGIN_MYSQL_CLEAR_PASSWORD=STATIC -DCLIENT_PLUGIN_AUTH_GSSAPI_CLIENT=OFF
+cmake --build build --config Release
+cmake --install build --config Release
+```
+
+`MARIADB_ROOT_DIR` then points at the `install` folder, which holds
+`include/mariadb`, `lib/mariadb/libmariadb.lib` and `lib/mariadb/libmariadb.dll`.
+
+Two of those options matter more than they look:
+
+- **`WITH_SSL=SCHANNEL`** puts the connector on the platform TLS stack. The
+  alternative (`OPENSSL`) links a second OpenSSL beside the one NSClient++
+  already links statically.
+- **The `..._STATIC` plugin options** compile the authentication plugins into
+  `libmariadb.dll`. By default they are separate DLLs loaded from a plugin
+  directory baked in at compile time - a path that does not exist on a target
+  machine. MySQL 8 accounts default to `caching_sha2_password`, which is one of
+  those plugins, so a stock MySQL 8 server would be unreachable without either
+  this or an explicit `plugin-dir=` on every check.
+
+`libmariadb.dll` is a runtime dependency of `CheckMySQL.dll`, and the build copies
+it next to `nscp.exe` for you. It has to live there rather than in `modules\`:
+the plugin loader calls `LoadLibrary` with a full path, and Windows resolves that
+module's own imports against the *application* directory - never against the
+folder the module itself was loaded from.
+
+In the MSI the two travel together as their own feature, `MySQLPlugin` ("MySQL
+Support"), installed by default and removable with `REMOVE=MySQLPlugin` on a
+silent install. It is separate from `CheckPlugins` because it is the one check
+module that pulls in a third-party runtime library. The feature only exists in
+the dynamic-runtime builds; the static XP installer below has no connector and
+leaves `CheckMySQL` out entirely.
+
 ### Build installer library
 
 ```commandline
@@ -335,7 +395,12 @@ SET(CRYPTOPP_ROOT "BUILD_FOLDER/CRYPTOPP_VERSION")
 SET(TINY_XML2_SOURCE_DIR "BUILD_FOLDER/tinyxml2-VERSION")
 SET(MONGOOSE_SOURCE_DIR "BUILD_FOLDER/mongoose-VERSION")
 SET(MINIZ_INCLUDE_DIR "BUILD_FOLDER/miniz-VERSION")
+SET(MARIADB_ROOT_DIR "BUILD_FOLDER/mariadb-connector-c-VERSION/install")
 ```
+
+> `FindMariaDB` caches what it resolves, so pointing `MARIADB_ROOT_DIR` at a
+> different tree later has no effect until the stale entries are dropped:
+> `cmake <build-dir> -U MARIADB_INCLUDE_DIR -U MARIADB_LIBRARY -U MARIADB_DLL`.
 
 ### Build NSClient++
 
@@ -529,8 +594,13 @@ msbuild nscp.sln /p:Configuration=Release /p:Platform=Win32
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y build-essential cmake libssl-dev libboost-all-dev libprotobuf-dev protobuf-compiler liblua5.4-dev libtinyxml2-dev libzip-dev libffi-dev python3.12-dev python3-protobuf python3-jinja2 libdbus-1-dev pkg-config rpm libgmock-dev
+sudo apt-get install -y build-essential cmake libssl-dev libboost-all-dev libprotobuf-dev protobuf-compiler liblua5.4-dev libtinyxml2-dev libzip-dev libmariadb-dev libffi-dev python3.12-dev python3-protobuf python3-jinja2 libdbus-1-dev pkg-config rpm libgmock-dev
 ```
+
+`libmariadb-dev` (RHEL/Fedora: `mariadb-connector-c-devel`) is what the
+`CheckMySQL` module builds against; it is found through the system prefixes, so
+no `MARIADB_ROOT_DIR` is needed. Leave it out and the module is skipped with a
+reason at configure time.
 
 The build generates each module's glue code at build time with a Python script
 that uses **Jinja2** (`python3-jinja2` above). The full set of Python build

--- a/build/cmake/FindMariaDB.cmake
+++ b/build/cmake/FindMariaDB.cmake
@@ -11,6 +11,10 @@
 # MARIADB_FOUND       - the connector's headers and library have been found
 # MARIADB_INCLUDE_DIR - the directory where mysql.h is found
 # MARIADB_LIBRARY     - the client library to link (libmariadb)
+# MARIADB_DLL         - Windows only: the runtime DLL matching MARIADB_LIBRARY,
+#                       which has to be shipped next to nscp.exe (see the note
+#                       in modules/CheckMySQL/CMakeLists.txt). Empty when only a
+#                       static library was found.
 find_path(
     MARIADB_INCLUDE_DIR
     NAMES
@@ -42,6 +46,29 @@ find_library(
         "C:/Program Files (x86)/MariaDB/MariaDB Connector C/lib"
 )
 
+if(WIN32)
+    # libmariadb.lib is an import library, so the DLL has to travel with us.
+    # A Connector/C install tree puts it in bin/ (the CMake default layout) or
+    # beside the import library in lib/mariadb/, depending on the version - look
+    # in both, plus next to whatever we actually resolved above.
+    get_filename_component(_mariadb_lib_dir "${MARIADB_LIBRARY}" DIRECTORY)
+    find_file(
+        MARIADB_DLL
+        NAMES
+            libmariadb.dll
+        PATHS
+            ${_mariadb_lib_dir}
+            ${MARIADB_ROOT_DIR}/bin
+            ${MARIADB_ROOT_DIR}/lib
+            "C:/Program Files/MariaDB/MariaDB Connector C 64-bit/lib"
+            "C:/Program Files (x86)/MariaDB/MariaDB Connector C/lib"
+        PATH_SUFFIXES
+            mariadb
+        NO_DEFAULT_PATH
+    )
+    unset(_mariadb_lib_dir)
+endif()
+
 if(MARIADB_INCLUDE_DIR AND MARIADB_LIBRARY)
     set(MARIADB_FOUND TRUE)
 else()
@@ -50,4 +77,5 @@ endif()
 mark_as_advanced(
     MARIADB_INCLUDE_DIR
     MARIADB_LIBRARY
+    MARIADB_DLL
 )

--- a/build/cmake/FindMariaDB.cmake
+++ b/build/cmake/FindMariaDB.cmake
@@ -1,0 +1,53 @@
+# * Find MariaDB Connector/C (libmariadb), the client library used by the
+#   CheckMySQL module to talk to MySQL, MariaDB, Percona and other
+#   MySQL-compatible servers. The following variables are optionally searched
+#   for defaults:
+#
+# MARIADB_ROOT_DIR - root of a Connector/C installation (system prefix or the
+#                    unpacked Windows "MariaDB Connector C 64-bit" folder)
+#
+# This code sets the following variables:
+#
+# MARIADB_FOUND       - the connector's headers and library have been found
+# MARIADB_INCLUDE_DIR - the directory where mysql.h is found
+# MARIADB_LIBRARY     - the client library to link (libmariadb)
+find_path(
+    MARIADB_INCLUDE_DIR
+    NAMES
+        mysql.h
+    PATH_SUFFIXES
+        mariadb
+        mysql
+    PATHS
+        ${MARIADB_ROOT_DIR}/include
+        ${MARIADB_ROOT_DIR}/usr/include
+        "C:/Program Files/MariaDB/MariaDB Connector C 64-bit/include"
+        "C:/Program Files (x86)/MariaDB/MariaDB Connector C/include"
+)
+
+find_library(
+    MARIADB_LIBRARY
+    NAMES
+        mariadb
+        libmariadb
+        mariadbclient
+    PATH_SUFFIXES
+        mariadb
+    PATHS
+        ${MARIADB_ROOT_DIR}/lib
+        ${MARIADB_ROOT_DIR}/lib/x86_64-linux-gnu
+        ${MARIADB_ROOT_DIR}/usr/lib
+        ${MARIADB_ROOT_DIR}/usr/lib/x86_64-linux-gnu
+        "C:/Program Files/MariaDB/MariaDB Connector C 64-bit/lib"
+        "C:/Program Files (x86)/MariaDB/MariaDB Connector C/lib"
+)
+
+if(MARIADB_INCLUDE_DIR AND MARIADB_LIBRARY)
+    set(MARIADB_FOUND TRUE)
+else()
+    set(MARIADB_FOUND FALSE)
+endif()
+mark_as_advanced(
+    MARIADB_INCLUDE_DIR
+    MARIADB_LIBRARY
+)

--- a/docs/docs/setup/installing.md
+++ b/docs/docs/setup/installing.md
@@ -255,6 +255,7 @@ NSClient++ consists of the following features most which can be disabled when do
 | FirewallConfig    | Firewall Exception     | A firewall exception to allow NSClient++ to open ports                                    |
 | LuaScript         | Lua Scripting          | Allows running INTERNAL scripts written in Lua                                            |
 | NRPEPlugins       | NRPE Support           | NRPE Server Plugin. Support for the more versatile NRPE protocol (check_nrpe)             |
+| MySQLPlugin       | MySQL Support          | Plugin to check MySQL, MariaDB and Percona servers (includes the MariaDB Connector/C client library) |
 | NSCAPlugin        | NSCA plugin            | Plugin to submit passive results to an NSCA server                                        |
 | CheckMK           | Check MK support       | Experimental support for check_mk server and clients                                      |
 | ElasticPlugin     | Elastic Search support | Support for submitting metrics to elastic                                                 |

--- a/docs/samples/CheckMySQL_check_mysql_desc.md
+++ b/docs/samples/CheckMySQL_check_mysql_desc.md
@@ -1,0 +1,40 @@
+#### About `check_mysql`
+
+`check_mysql` verifies that a MySQL-compatible server is reachable and healthy.
+It connects (TCP by default, or a socket/named pipe via `socket=`), reads the
+server version and a couple of global status values, and reports them. Being
+able to connect is the health signal: a reachable server is **OK** unless you
+add thresholds, and any connection failure is reported as **UNKNOWN** with the
+driver's error message ("Access denied ...", "Can't connect ...").
+
+The check works identically against MySQL, MariaDB and Percona; the `flavor`
+keyword tells them apart when you need to (e.g. `warning=flavor != 'mariadb'`
+to catch an unplanned migration).
+
+Available keywords (for `filter=` / `warning=` / `critical=` / syntax):
+
+| Keyword             | Description                                                        |
+|---------------------|--------------------------------------------------------------------|
+| `version`           | Server version, e.g. `10.11.14-MariaDB-ubu2404` or `8.4.3`         |
+| `version_comment`   | Server version comment (distribution/build description)            |
+| `flavor`            | `mysql`, `mariadb` or `percona`, derived from the version           |
+| `uptime`            | Seconds since the server started; supports units (`uptime < 1h`)    |
+| `threads_connected` | Currently open connections (`Threads_connected`)                    |
+| `max_connections`   | Configured connection limit (`max_connections`)                     |
+| `connections_pct`   | Open connections as a percentage of `max_connections`               |
+
+Common connection options (shared by all CheckMySQL commands, defaults come
+from `/settings/mysql`): `host=`, `port=`, `socket=`, `user=`, `password=`,
+`database=`, `defaults-file=`, `plugin-dir=`, `tls=true`, `timeout=`,
+`query-timeout=`.
+
+Notes:
+
+* `host=localhost` connects over **TCP** like any other host name; use
+  `socket=` when you want the local socket / named pipe (the check does not
+  inherit the mysql client's silent localhost-means-socket behaviour).
+* MySQL 8 accounts default to the `caching_sha2_password` auth plugin, which
+  the connector loads from its plugin directory; if that fails use
+  `plugin-dir=` (or the `plugin dir` setting) to point at it.
+* Give the monitoring user as few privileges as possible; `USAGE` is enough
+  for `check_mysql`.

--- a/docs/samples/CheckMySQL_check_mysql_query_desc.md
+++ b/docs/samples/CheckMySQL_check_mysql_query_desc.md
@@ -1,0 +1,24 @@
+#### About `check_mysql_query`
+
+`check_mysql_query` runs an arbitrary SQL query and applies thresholds to the
+returned rows, CheckWMI-style: every column of the result set is registered as
+a filter keyword, so `filter=`, `warning=` and `critical=` expressions can
+reference columns by name, and `detail-syntax` can render them with
+`%(column)`. The built-in `line` keyword renders a whole row as
+`column=value` pairs.
+
+Notes:
+
+* Each row of the result set is matched separately, so a query returning one
+  row per database/queue/job gives per-item results and `${problem_list}`
+  works as usual.
+* Columns are compared numerically when the threshold side is a number
+  (decimal text such as `99.6` is rounded) and as strings otherwise.
+* Like other generic query checks, performance data is emitted once you choose
+  a `perf-syntax` (there is no meaningful default alias for arbitrary
+  queries); the thresholded columns then appear as perf values.
+* Statements that produce no result set (a lone `UPDATE`, `SET`, ...) are
+  reported as UNKNOWN rather than silently OK — the check is for reading
+  state, not mutating it.
+* Use a read-only monitoring account: the query runs with whatever privileges
+  the configured user has.

--- a/docs/samples/CheckMySQL_check_mysql_query_samples.md
+++ b/docs/samples/CheckMySQL_check_mysql_query_samples.md
@@ -1,0 +1,34 @@
+**List rows returned by a custom query (each column becomes a keyword):**
+
+```
+check_mysql_query host=127.0.0.1 user=monitor password=secret "query=SELECT table_schema AS db, COUNT(*) AS tables_count FROM information_schema.tables GROUP BY table_schema" "detail-syntax=%(db)=%(tables_count)" "top-syntax=${list}"
+information_schema=85, mysql=31, performance_schema=81, sys=102
+```
+
+**Threshold on a column value (e.g. long-running queries):**
+
+```
+check_mysql_query host=127.0.0.1 user=monitor password=secret "query=SELECT COUNT(*) AS slow_queries FROM information_schema.processlist WHERE time > 60 AND command != 'Sleep'" "critical=slow_queries > 0" "top-syntax=${status}: ${list}" "detail-syntax=%(slow_queries) slow queries"
+OK: 0 slow queries
+```
+
+**Emit the thresholded column as performance data (set a perf-syntax):**
+
+```
+check_mysql_query host=127.0.0.1 user=monitor password=secret "query=SELECT COUNT(*) AS tables_count FROM information_schema.tables" "critical=tables_count > 5000" "perf-syntax=tables" "top-syntax=${status}: ${list}" "detail-syntax=%(tables_count) tables"
+OK: 299 tables|'tables_counttables'=299;0;5000
+```
+
+**A statement that returns no result set is reported instead of a silent OK:**
+
+```
+check_mysql_query host=127.0.0.1 user=monitor password=secret "query=SET @x = 1"
+Query returned no result set (the statement produced no columns)
+```
+
+**A missing query is rejected with a clear message:**
+
+```
+check_mysql_query host=127.0.0.1 user=monitor password=secret
+No query specified (use query=<SQL>)
+```

--- a/docs/samples/CheckMySQL_check_mysql_samples.md
+++ b/docs/samples/CheckMySQL_check_mysql_samples.md
@@ -1,0 +1,46 @@
+**Check that a MySQL/MariaDB server is up (connecting is the health signal):**
+
+```
+check_mysql host=127.0.0.1 user=monitor password=secret
+OK: mariadb 11.8.8-MariaDB-ubu2404, uptime 771002s, connections 3/151 (1%)
+```
+
+**Warn when the server restarted recently (uptime keyword supports time units):**
+
+```
+check_mysql host=127.0.0.1 user=monitor password=secret "warning=uptime < 15m"
+WARNING: mariadb 11.8.8-MariaDB-ubu2404, uptime 2s, connections 1/151 (0%)|'mariadb_uptime'=2s;900;0
+```
+
+**Alert when the connection pool is close to max_connections:**
+
+```
+check_mysql host=127.0.0.1 user=monitor password=secret "warning=connections_pct > 60" "critical=connections_pct > 80"
+OK: mariadb 11.8.8-MariaDB-ubu2404, uptime 771002s, connections 3/151 (1%)|'mariadb_connections_pct'=1%;60;80
+```
+
+**An unreachable or refusing server is clearly reported (UNKNOWN):**
+
+```
+check_mysql host=127.0.0.1 port=9999 timeout=2
+Failed to connect to MySQL server '127.0.0.1:9999': Can't connect to server on '127.0.0.1' (110)
+```
+
+```
+check_mysql host=127.0.0.1 user=root password=wrong
+Failed to connect to MySQL server '127.0.0.1:3306': Access denied for user 'root'@'192.168.127.1' (using password: YES)
+```
+
+**Connect through the local socket instead of TCP:**
+
+```
+check_mysql socket=/run/mysqld/mysqld.sock user=monitor password=secret
+OK: mariadb 11.8.8-MariaDB-ubu2404, uptime 771002s, connections 3/151 (1%)
+```
+
+**MySQL 8 with a non-default client-plugin directory (caching_sha2_password):**
+
+```
+check_mysql host=db1 user=monitor password=secret plugin-dir=C:\Program Files\MariaDB\MariaDB Connector C 64-bit\lib\plugin
+OK: mysql 8.4.11, uptime 1011s, connections 1/151 (0%)
+```

--- a/docs/samples/CheckMySQL_desc.md
+++ b/docs/samples/CheckMySQL_desc.md
@@ -1,0 +1,10 @@
+CheckMySQL checks MySQL, MariaDB, Percona and other MySQL-compatible database
+servers on both Windows and Linux. It connects with MariaDB Connector/C
+(speaking the native protocol, so one module covers the whole MySQL family)
+and is only built/shipped when the connector is available.
+
+Default connection settings live under `/settings/mysql` (host, port, socket,
+user, password, TLS, timeouts) and every command accepts the same overrides
+(`host=`, `port=`, `user=`, `password=`, `socket=`, `tls=true`, ...).
+Credentials can also be kept out of `nsclient.ini` entirely via
+`defaults file` pointing at a permission-protected my.cnf-style file.

--- a/installers/installer-NSCP/Product.wxs
+++ b/installers/installer-NSCP/Product.wxs
@@ -153,6 +153,15 @@
               <File Id="ModCheckTaskSched.dll" Name="CheckTaskSched.dll" DiskId="1" Source="$(var.Source)/modules/CheckTaskSched.dll" Vital="no" />
               <File Id="ModCheckSecurity.dll" Name="CheckSecurity.dll" DiskId="1" Source="$(var.Source)/modules/CheckSecurity.dll" Vital="no" />
               <File Id="ModCheckMSSQL.dll" Name="CheckMSSQL.dll" DiskId="1" Source="$(var.Source)/modules/CheckMSSQL.dll" Vital="no" />
+              <!--
+              CheckMySQL is an optional module: it only builds when MariaDB
+              Connector/C is available (see modules/CheckMySQL/module.cmake).
+              Enable these two entries once the connector is part of the
+              Windows build dependencies; libmariadb.dll must be staged next
+              to the module for the DLL to load.
+              <File Id="ModCheckMySQL.dll" Name="CheckMySQL.dll" DiskId="1" Source="$(var.Source)/modules/CheckMySQL.dll" Vital="no" />
+              <File Id="LibMariaDB.dll" Name="libmariadb.dll" DiskId="1" Source="$(var.Source)/modules/libmariadb.dll" Vital="no" />
+              -->
               <File Id="ModSimpleCache.dll" Name="SimpleCache.dll" DiskId="1" Source="$(var.Source)/modules/SimpleCache.dll" Vital="no" />
               <File Id="ModSimpleFileWriter.dll" Name="SimpleFileWriter.dll" DiskId="1" Source="$(var.Source)/modules/SimpleFileWriter.dll" Vital="no" />
               <File Id="ModCheckLogFile.dll" Name="CheckLogFile.dll" DiskId="1" Source="$(var.Source)/modules/CheckLogFile.dll" Vital="no" />

--- a/installers/installer-NSCP/Product.wxs
+++ b/installers/installer-NSCP/Product.wxs
@@ -153,15 +153,6 @@
               <File Id="ModCheckTaskSched.dll" Name="CheckTaskSched.dll" DiskId="1" Source="$(var.Source)/modules/CheckTaskSched.dll" Vital="no" />
               <File Id="ModCheckSecurity.dll" Name="CheckSecurity.dll" DiskId="1" Source="$(var.Source)/modules/CheckSecurity.dll" Vital="no" />
               <File Id="ModCheckMSSQL.dll" Name="CheckMSSQL.dll" DiskId="1" Source="$(var.Source)/modules/CheckMSSQL.dll" Vital="no" />
-              <!--
-              CheckMySQL is an optional module: it only builds when MariaDB
-              Connector/C is available (see modules/CheckMySQL/module.cmake).
-              Enable these two entries once the connector is part of the
-              Windows build dependencies; libmariadb.dll must be staged next
-              to the module for the DLL to load.
-              <File Id="ModCheckMySQL.dll" Name="CheckMySQL.dll" DiskId="1" Source="$(var.Source)/modules/CheckMySQL.dll" Vital="no" />
-              <File Id="LibMariaDB.dll" Name="libmariadb.dll" DiskId="1" Source="$(var.Source)/modules/libmariadb.dll" Vital="no" />
-              -->
               <File Id="ModSimpleCache.dll" Name="SimpleCache.dll" DiskId="1" Source="$(var.Source)/modules/SimpleCache.dll" Vital="no" />
               <File Id="ModSimpleFileWriter.dll" Name="SimpleFileWriter.dll" DiskId="1" Source="$(var.Source)/modules/SimpleFileWriter.dll" Vital="no" />
               <File Id="ModCheckLogFile.dll" Name="CheckLogFile.dll" DiskId="1" Source="$(var.Source)/modules/CheckLogFile.dll" Vital="no" />
@@ -171,6 +162,21 @@
             <Component Id="LuaScript" Guid="C5A3C7E2-77A0-4BE2-B60D-808F4B14F56F" Win64="$(var.Win64)">
               <File Id="ModLUAScript.dll" Name="LUAScript.dll" DiskId="1" Source="$(var.Source)/modules/LUAScript.dll" Vital="no" />
             </Component>
+            <!--
+            CheckMySQL is its own feature (MySQLPlugin) rather than part of
+            "Check Plugins": it is the only check module with a third-party
+            runtime dependency (libmariadb.dll, see MariaDBLibs), so an operator
+            with no MySQL to monitor can leave both out. Installed by default.
+
+            Only built for the dynamic-runtime builds - the legacy static XP
+            build has no connector, so both this and MariaDBLibs are guarded the
+            same way lua.dll is.
+            -->
+            <?if "$(var.Runtime)" = "dynamic"?>
+              <Component Id="CheckMySQL" Guid="1D6F4A83-95E2-4C0B-B3D7-8E2A5C9F41B6" Win64="$(var.Win64)">
+                <File Id="ModCheckMySQL.dll" Name="CheckMySQL.dll" DiskId="1" Source="$(var.Source)/modules/CheckMySQL.dll" Vital="no" />
+              </Component>
+            <?endif?>
             <!--
             <Component Id="DotNetPlugins" Guid="E57F4EE3-D5A6-46ED-BC99-018708258154" Win64="$(var.Win64)">
               <File Id="ModDotnetPlugins.dll" Name="DotnetPlugins.dll" DiskId="1" Source="$(var.Source)/modules/DotnetPlugins.dll" Vital="no" />
@@ -193,6 +199,18 @@
           <?if "$(var.Runtime)" = "dynamic"?>
             <Component Id="LuaLibs" Guid="513b45d4-c0f4-4531-9baf-0db466e4e51c" Win64="$(var.Win64)">
               <File Id="LuaDLL" Name="lua.dll" DiskId="1" Source="$(var.Source)/lua.dll" Vital="no" />
+            </Component>
+            <!--
+            MariaDB Connector/C, the client library CheckMySQL links against.
+            Ships and is removed with the module (both are in the MySQLPlugin
+            feature), but it belongs in this directory rather than in modules\:
+            the plugin loader uses plain LoadLibrary() with a full path, and
+            Windows resolves that module's own imports against the application
+            directory (this one), never against the folder the module was loaded
+            from. The build stages it here, see modules/CheckMySQL/CMakeLists.txt.
+            -->
+            <Component Id="MariaDBLibs" Guid="7C1B0E0A-2F3A-4E51-9D7C-6A1F0E3B2C48" Win64="$(var.Win64)">
+              <File Id="LibMariaDB" Name="libmariadb.dll" DiskId="1" Source="$(var.Source)/libmariadb.dll" Vital="no" />
             </Component>
           <?endif?>
           <!--
@@ -262,6 +280,18 @@
         <Feature Id="CheckPlugins" Title="Check Plugins" Description="Various plugins to check your system. (Includes all check plugins)" Level="1">
           <ComponentRef Id="Plugins" />
         </Feature>
+        <!--
+        Level="1" so it is installed by default (and by ADDLOCAL=ALL), Absent="allow"
+        so it can be deselected - in the feature tree, or with REMOVE=MySQLPlugin
+        on a silent install. The module and its client library go together: the
+        module cannot load without libmariadb.dll, and nothing else uses it.
+        -->
+        <?if "$(var.Runtime)" = "dynamic"?>
+          <Feature Id="MySQLPlugin" Title="MySQL Support" Description="Plugin to check MySQL, MariaDB and Percona servers (includes the MariaDB Connector/C client library)" Level="1" Absent="allow">
+            <ComponentRef Id="CheckMySQL" />
+            <ComponentRef Id="MariaDBLibs" />
+          </Feature>
+        <?endif?>
         <Feature Id="NRPEPlugins" Title="NRPE Support" Description="NRPE Server Plugin (check_nrpe)" Level="1" Absent="allow">
           <ComponentRef Id="NRPEServer" />
           <ComponentRef Id="NRPEServerCert" />

--- a/modules/CheckMySQL/CMakeLists.txt
+++ b/modules/CheckMySQL/CMakeLists.txt
@@ -59,6 +59,29 @@ target_link_libraries(
 
 include(${BUILD_CMAKE_FOLDER}/module.cmake)
 
+# Stage libmariadb.dll next to nscp.exe, NOT next to this module.
+#
+# The plugin loader calls plain LoadLibrary() with a full path
+# (include/dll/impl_w32.hpp), which does not add the loaded DLL's own directory
+# to the dependency search path - so a copy in modules/ is never found and the
+# module fails to load with "the specified module could not be found". The
+# application directory is searched, which is where nscp.exe lives; lua.dll and
+# the Python runtime DLL are shipped the same way (see Product.wxs).
+if(WIN32 AND MARIADB_DLL)
+    add_custom_command(
+        TARGET ${TARGET}
+        POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different "${MARIADB_DLL}"
+            "${NSCP_PROJECT_BINARY_DIR}"
+    )
+elseif(WIN32)
+    message(
+        WARNING
+        "libmariadb.dll not found next to ${MARIADB_LIBRARY}: CheckMySQL will build but not load. Set MARIADB_ROOT_DIR at a Connector/C install tree."
+    )
+endif()
+
 # The unit tests exercise the checks through an injected session factory, so
 # they compile without mysql_session.cpp and never link the connector.
 NSCP_CREATE_TEST(

--- a/modules/CheckMySQL/CMakeLists.txt
+++ b/modules/CheckMySQL/CMakeLists.txt
@@ -1,0 +1,91 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(TARGET CheckMySQL)
+
+project(${TARGET})
+
+CREATE_MODULE(SRCS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+
+# Platform-neutral throughout: MariaDB Connector/C is the data source on both
+# Windows and Linux, and only mysql_session.cpp touches it.
+set(SRCS
+    ${SRCS}
+    "${TARGET}.cpp"
+    check_mysql.cpp
+    check_mysql_query.cpp
+    mysql_client.cpp
+    mysql_session.cpp
+    ${NSCP_DEF_PLUGIN_CPP}
+    ${NSCP_FILTER_CPP}
+    ${NSCP_ERROR_CPP}
+)
+
+if(WIN32)
+    set(SRCS
+        ${SRCS}
+        # Headers (for IDE project generation).
+        "${TARGET}.h"
+        check_mysql.hpp
+        check_mysql_query.hpp
+        mysql_client.hpp
+        mysql_session.hpp
+        mysql_options.hpp
+        mysql_filter_helpers.hpp
+        ${NSCP_DEF_PLUGIN_HPP}
+        ${NSCP_FILTER_HPP}
+        ${NSCP_ERROR_HPP}
+    )
+endif(WIN32)
+
+add_definitions(${NSCP_GLOBAL_DEFINES})
+
+add_library(${TARGET} MODULE ${SRCS})
+NSCP_DEBUG_SYMBOLS(${TARGET})
+
+target_include_directories(${TARGET} PRIVATE ${MARIADB_INCLUDE_DIR})
+
+target_link_libraries(
+    ${TARGET}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_REGEX_LIBRARY}
+    ${Boost_DATE_TIME_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${NSCP_DEF_PLUGIN_LIB}
+    ${NSCP_FILTER_LIB}
+    expression_parser
+    ${MARIADB_LIBRARY}
+)
+
+include(${BUILD_CMAKE_FOLDER}/module.cmake)
+
+# The unit tests exercise the checks through an injected session factory, so
+# they compile without mysql_session.cpp and never link the connector.
+NSCP_CREATE_TEST(
+    check_mysql_test
+    SOURCES
+        check_mysql_test.cpp
+        # Module sources under test.
+        check_mysql.cpp
+        check_mysql_query.cpp
+        mysql_client.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_helper.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_metrics_helper.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_INCLUDEDIR}/parsers/filter/modern_filter.cpp
+        ${NSCP_INCLUDEDIR}/str/utf8.cpp
+    LIBRARIES
+        GTest::gtest_main
+        nscp_protobuf
+        ${NSCP_FILTER_LIB}
+        expression_parser
+        ${PLUGIN_API_TARGET}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
+        ${Boost_REGEX_LIBRARY}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/CheckMySQL/CheckMySQL.cpp
+++ b/modules/CheckMySQL/CheckMySQL.cpp
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "CheckMySQL.h"
+
+#include <nscapi/macros.hpp>
+#include <nscapi/settings/helper.hpp>
+#include <nscapi/settings/proxy.hpp>
+#include <str/utf8.hpp>
+
+#include "check_mysql.hpp"
+#include "check_mysql_query.hpp"
+#include "mysql_session.hpp"
+
+namespace sh = nscapi::settings_helper;
+
+CheckMySQL::CheckMySQL() {}
+
+bool CheckMySQL::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
+  try {
+    sh::settings_registry settings(nscapi::settings_proxy::create(get_id(), get_core()));
+    settings.set_alias(alias, "mysql");
+
+    // clang-format off
+    settings.alias().add_key_to_settings()
+      .add_string("hostname", sh::string_key(&defaults_.host, "localhost"),
+        "MYSQL SERVER", "Default MySQL/MariaDB server to connect to.")
+      .add_int("port", sh::int_key(&defaults_.port, 3306),
+        "MYSQL PORT", "Default TCP port of the server.")
+      .add_string("socket", sh::string_key(&defaults_.socket, ""),
+        "MYSQL SOCKET", "Unix socket path (or Windows named pipe) to connect through instead of TCP.")
+      .add_string("user", sh::string_key(&defaults_.user, ""),
+        "MYSQL USER", "User used to authenticate.")
+      .add_password("password", sh::string_key(&defaults_.password, ""),
+        "MYSQL PASSWORD", "Password used to authenticate.")
+      .add_string("database", sh::string_key(&defaults_.database, ""),
+        "DATABASE", "Default database (schema) to connect to.")
+      .add_string("defaults file", sh::string_key(&defaults_.defaults_file, ""),
+        "DEFAULTS FILE", "my.cnf-style file whose [client] section supplies credentials, so passwords can be kept out of nsclient.ini.", true)
+      .add_string("plugin dir", sh::string_key(&defaults_.plugin_dir, ""),
+        "PLUGIN DIRECTORY", "Directory the connector loads client auth plugins from (needed for MySQL 8's caching_sha2_password when the connector's default is wrong).", true)
+      .add_bool("tls", sh::bool_key(&defaults_.tls, false),
+        "TLS", "Require TLS on the connection.", true)
+      .add_int("timeout", sh::int_key(&defaults_.connect_timeout, 10),
+        "CONNECTION TIMEOUT", "Connection timeout in seconds.", true)
+      .add_int("query timeout", sh::int_key(&defaults_.query_timeout, 30),
+        "QUERY TIMEOUT", "Query (read/write) timeout in seconds.", true)
+      ;
+    // clang-format on
+
+    settings.register_all();
+    settings.notify();
+  } catch (const std::exception &e) {
+    NSC_LOG_ERROR_EXR("loading: ", e);
+    return false;
+  } catch (...) {
+    NSC_LOG_ERROR_EX("loading: ");
+    return false;
+  }
+  return true;
+}
+
+bool CheckMySQL::unloadModule() { return true; }
+
+void CheckMySQL::check_mysql(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+  check_mysql_command::check_with(defaults_, request, response, mysql_session::make_session_factory());
+}
+
+void CheckMySQL::check_mysql_query(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+  check_mysql_query_command::check_with(defaults_, request, response, mysql_session::make_session_factory());
+}

--- a/modules/CheckMySQL/CheckMySQL.h
+++ b/modules/CheckMySQL/CheckMySQL.h
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <nscapi/nscapi_plugin_impl.hpp>
+#include <nscapi/protobuf/command.hpp>
+
+#include "mysql_client.hpp"
+
+class CheckMySQL : public nscapi::impl::simple_plugin {
+  mysql_client::connection_info defaults_;
+
+ public:
+  CheckMySQL();
+  virtual ~CheckMySQL() {}
+
+  // Module calls
+  bool loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode);
+  bool unloadModule();
+
+  // Check commands
+  void check_mysql(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+  void check_mysql_query(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+};

--- a/modules/CheckMySQL/check_mysql.cpp
+++ b/modules/CheckMySQL/check_mysql.cpp
@@ -1,0 +1,105 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "check_mysql.hpp"
+
+#include <memory>
+#include <parsers/filter/cli_helper.hpp>
+#include <parsers/filter/modern_filter.hpp>
+#include <parsers/where/filter_handler_impl.hpp>
+
+#include "mysql_filter_helpers.hpp"
+#include "mysql_options.hpp"
+
+namespace check_mysql_command {
+
+namespace {
+
+// @@version / @@version_comment / @@max_connections work on MySQL 5.7+,
+// MariaDB and Percona alike.
+const char *HEALTH_SQL = "SELECT @@version AS version, @@version_comment AS version_comment, @@max_connections AS max_connections";
+// Rows of (Variable_name, Value); WHERE ... IN works on every supported flavor.
+const char *STATUS_SQL = "SHOW GLOBAL STATUS WHERE Variable_name IN ('Uptime', 'Threads_connected')";
+
+struct filter_obj {
+  std::string version;
+  std::string version_comment;
+  std::string flavor;
+  long long uptime = 0;
+  long long threads_connected = 0;
+  long long max_connections = 0;
+
+  std::string get_version() const { return version; }
+  std::string get_version_comment() const { return version_comment; }
+  std::string get_flavor() const { return flavor; }
+  long long get_uptime() const { return uptime; }
+  long long get_threads_connected() const { return threads_connected; }
+  long long get_max_connections() const { return max_connections; }
+  long long get_connections_pct() const { return max_connections > 0 ? threads_connected * 100 / max_connections : 0; }
+  std::string show() const { return flavor + " " + version; }
+};
+
+typedef parsers::where::filter_handler_impl<std::shared_ptr<filter_obj>> native_context;
+struct filter_obj_handler : native_context {
+  filter_obj_handler() {
+    registry_.add_string_var("version", &filter_obj::get_version, "Server version, e.g. 10.11.14-MariaDB-ubu2404 or 8.4.3")
+        .add_string_var("version_comment", &filter_obj::get_version_comment, "Server version comment (distribution/build description)")
+        .add_string_var("flavor", &filter_obj::get_flavor, "Server flavor derived from the version: mysql, mariadb or percona");
+
+    static const parsers::where::value_type type_custom_uptime = parsers::where::type_custom_int_1;
+    registry_.add_int_var("uptime", type_custom_uptime, &filter_obj::get_uptime, "Seconds since the server started (supports units, e.g. uptime < 1h)")
+        .add_int_perf("s", "", "_uptime");
+    registry_.add_converter(type_custom_uptime, &mysql_filter::parse_time<std::shared_ptr<filter_obj>>);
+
+    registry_.add_int_var("threads_connected", &filter_obj::get_threads_connected, "Currently open connections (Threads_connected)")
+        .add_int_perf("", "", "_connections")
+        .add_int_var("max_connections", &filter_obj::get_max_connections, "Configured connection limit (max_connections)")
+        .add_int_var("connections_pct", &filter_obj::get_connections_pct, "Open connections as a percentage of max_connections")
+        .add_int_perf("%", "", "_connections_pct");
+  }
+};
+typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter_type;
+
+}  // namespace
+
+void check_with(const mysql_client::connection_info &defaults, const PB::Commands::QueryRequestMessage::Request &request,
+                PB::Commands::QueryResponseMessage::Response *response, const mysql_client::session_factory &factory) {
+  modern_filter::data_container data;
+  modern_filter::cli_helper<filter_type> filter_helper(request, response, data);
+  mysql_client::connection_info info = defaults;
+
+  filter_type filter;
+  // No default thresholds: being able to connect is the health signal, so a
+  // reachable server is OK unless the user thresholds uptime/connections.
+  filter_helper.add_options("", "", "", filter.get_filter_syntax(), "unknown");
+  filter_helper.add_syntax("${status}: ${list}",
+                           "${flavor} ${version}, uptime ${uptime}s, connections ${threads_connected}/${max_connections} (${connections_pct}%)",
+                           "${flavor}", "%(status): No server information returned", "");
+  mysql_options::add_connection_options(filter_helper.get_desc(), info);
+
+  if (!filter_helper.parse_options()) return;
+  if (!filter_helper.build_filter(filter)) return;
+
+  mysql_options::with_runner(factory, info, response, [&](const mysql_client::query_runner &run) {
+    const mysql_client::result health = run(HEALTH_SQL);
+    if (health.rows.empty()) throw mysql_client::mysql_exception("Server returned no version information");
+
+    auto record = std::make_shared<filter_obj>();
+    record->version = health.get_string(0, "version");
+    record->version_comment = health.get_string(0, "version_comment");
+    record->max_connections = health.get_int(0, "max_connections");
+    record->flavor = mysql_client::derive_flavor(record->version, record->version_comment);
+
+    const mysql_client::result status = run(STATUS_SQL);
+    for (std::size_t i = 0; i < status.rows.size(); i++) {
+      const std::string name = status.get_string(i, 0);
+      if (name == "Uptime") record->uptime = status.get_int(i, 1);
+      if (name == "Threads_connected") record->threads_connected = status.get_int(i, 1);
+    }
+
+    filter.match(record);
+    filter_helper.post_process(filter);
+  });
+}
+
+}  // namespace check_mysql_command

--- a/modules/CheckMySQL/check_mysql.hpp
+++ b/modules/CheckMySQL/check_mysql.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <nscapi/protobuf/command.hpp>
+
+#include "mysql_client.hpp"
+
+namespace check_mysql_command {
+
+// Connectivity/health check. The session factory is injectable for unit
+// testing; the module wires in mysql_session::make_session_factory().
+void check_with(const mysql_client::connection_info &defaults, const PB::Commands::QueryRequestMessage::Request &request,
+                PB::Commands::QueryResponseMessage::Response *response, const mysql_client::session_factory &factory);
+
+}  // namespace check_mysql_command

--- a/modules/CheckMySQL/check_mysql_query.cpp
+++ b/modules/CheckMySQL/check_mysql_query.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "check_mysql_query.hpp"
+
+#include <boost/program_options.hpp>
+#include <memory>
+#include <parsers/filter/cli_helper.hpp>
+#include <parsers/filter/modern_filter.hpp>
+#include <parsers/where/filter_handler_impl.hpp>
+
+#include "mysql_options.hpp"
+
+namespace po = boost::program_options;
+
+namespace check_mysql_query_command {
+
+namespace {
+
+// One result-set row; columns are resolved by name against the shared result.
+struct filter_obj {
+  const mysql_client::result &res;
+  std::size_t row;
+  filter_obj(const mysql_client::result &res, std::size_t row) : res(res), row(row) {}
+
+  std::string get_string(const std::string &col) const { return res.get_string(row, col); }
+  long long get_int(const std::string &col) const { return res.get_int(row, col); }
+  std::string get_row() const {
+    std::string line;
+    for (const std::string &col : res.columns) {
+      if (!line.empty()) line += ", ";
+      line += col + "=" + res.get_string(row, col);
+    }
+    return line;
+  }
+  std::string show() const { return get_row(); }
+};
+
+typedef parsers::where::filter_handler_impl<std::shared_ptr<filter_obj>> native_context;
+struct filter_obj_handler : native_context {
+  filter_obj_handler() = default;
+};
+typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter_type;
+
+}  // namespace
+
+void check_with(const mysql_client::connection_info &defaults, const PB::Commands::QueryRequestMessage::Request &request,
+                PB::Commands::QueryResponseMessage::Response *response, const mysql_client::session_factory &factory) {
+  modern_filter::data_container data;
+  modern_filter::cli_helper<filter_type> filter_helper(request, response, data);
+  mysql_client::connection_info info = defaults;
+  std::string query;
+
+  filter_type filter;
+  filter_helper.add_options("", "", "", filter.get_filter_syntax(), "ignored");
+  filter_helper.add_syntax("${list}", "%(line)", "", "", "");
+  filter_helper.get_desc().add_options()("query", po::value<std::string>(&query), "The SQL query to execute.");
+  mysql_options::add_connection_options(filter_helper.get_desc(), info);
+
+  if (!filter_helper.parse_options()) return;
+
+  if (query.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No query specified (use query=<SQL>)");
+
+  mysql_options::with_runner(factory, info, response, [&](const mysql_client::query_runner &run) {
+    const mysql_client::result res = run(query);
+
+    // No column-bearing result set at all (e.g. a lone UPDATE): there is
+    // nothing to threshold, and silently reporting OK would hide a mistyped
+    // query behind a green check.
+    if (res.columns.empty())
+      return nscapi::protobuf::functions::set_response_bad(*response, "Query returned no result set (the statement produced no columns)");
+
+    // Register the returned columns as filter keywords, CheckWMI-style: each
+    // column is usable in filter/warn/crit expressions and as perfdata.
+    filter.context->registry_.add_string_var("line", &filter_obj::get_row, "All columns of the row as column=value pairs");
+    for (const std::string &col : res.columns) {
+      filter.context->registry_
+          .add_int_var(
+              col, [col](const auto &obj) { return obj->get_int(col); }, [col](const auto &obj) { return obj->get_string(col); }, "Column: " + col)
+          .add_int_perf("", col, "");
+    }
+
+    if (!filter_helper.build_filter(filter)) return;
+
+    for (std::size_t i = 0; i < res.rows.size(); i++) {
+      auto record = std::make_shared<filter_obj>(res, i);
+      filter.match(record);
+    }
+    filter_helper.post_process(filter);
+  });
+}
+
+}  // namespace check_mysql_query_command

--- a/modules/CheckMySQL/check_mysql_query.hpp
+++ b/modules/CheckMySQL/check_mysql_query.hpp
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <nscapi/protobuf/command.hpp>
+
+#include "mysql_client.hpp"
+
+namespace check_mysql_query_command {
+
+// Custom-query check. The session factory is injectable for unit testing; the
+// module wires in mysql_session::make_session_factory().
+void check_with(const mysql_client::connection_info &defaults, const PB::Commands::QueryRequestMessage::Request &request,
+                PB::Commands::QueryResponseMessage::Response *response, const mysql_client::session_factory &factory);
+
+}  // namespace check_mysql_query_command

--- a/modules/CheckMySQL/check_mysql_test.cpp
+++ b/modules/CheckMySQL/check_mysql_test.cpp
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include <gtest/gtest.h>
+#include <nscapi/nscapi_helper_singleton.hpp>
+
+#include "check_mysql.hpp"
+#include "check_mysql_query.hpp"
+#include "mysql_client.hpp"
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+static nscapi::helper_singleton test_plugin_singleton;
+nscapi::helper_singleton *nscapi::plugin_singleton = &test_plugin_singleton;
+
+using mysql_client::mysql_exception;
+
+namespace {
+
+std::string join_lines(const PB::Commands::QueryResponseMessage::Response &r) {
+  std::string out;
+  for (int i = 0; i < r.lines_size(); ++i) {
+    if (!out.empty()) out += "\n";
+    out += r.lines(i).message();
+  }
+  return out;
+}
+
+mysql_client::result make_result(const std::vector<std::string> &columns, const std::vector<std::vector<std::string>> &rows) {
+  mysql_client::result res;
+  res.columns = columns;
+  for (const auto &row : rows) {
+    std::vector<mysql_client::cell> cells;
+    for (const auto &text : row) {
+      mysql_client::cell c;
+      c.text = text;
+      cells.push_back(c);
+    }
+    res.rows.push_back(cells);
+  }
+  return res;
+}
+
+// A healthy MariaDB server: version/comment/max_connections plus the two
+// GLOBAL STATUS rows check_mysql asks for.
+mysql_client::session_factory healthy_mariadb() {
+  return [](const mysql_client::connection_info &) -> mysql_client::query_runner {
+    return [](const std::string &sql) -> mysql_client::result {
+      if (sql.find("@@version") != std::string::npos)
+        return make_result({"version", "version_comment", "max_connections"}, {{"10.11.14-MariaDB-ubu2404", "Ubuntu 24.04", "151"}});
+      if (sql.find("GLOBAL STATUS") != std::string::npos)
+        return make_result({"Variable_name", "Value"}, {{"Uptime", "86400"}, {"Threads_connected", "3"}});
+      throw mysql_exception("unexpected query: " + sql);
+    };
+  };
+}
+
+mysql_client::session_factory refusing_server(const std::string &error) {
+  return [error](const mysql_client::connection_info &) -> mysql_client::query_runner { throw mysql_exception(error); };
+}
+
+mysql_client::session_factory failing_queries(const std::string &error) {
+  return [error](const mysql_client::connection_info &) -> mysql_client::query_runner {
+    return [error](const std::string &) -> mysql_client::result { throw mysql_exception(error); };
+  };
+}
+
+PB::Common::ResultCode run_health(const mysql_client::session_factory &factory, const std::vector<std::string> &args,
+                                  PB::Commands::QueryResponseMessage::Response &response) {
+  PB::Commands::QueryRequestMessage::Request request;
+  request.set_command("check_mysql");
+  for (const std::string &a : args) request.add_arguments(a);
+  check_mysql_command::check_with(mysql_client::connection_info(), request, &response, factory);
+  return response.result();
+}
+
+PB::Common::ResultCode run_query(const mysql_client::session_factory &factory, const std::vector<std::string> &args,
+                                 PB::Commands::QueryResponseMessage::Response &response) {
+  PB::Commands::QueryRequestMessage::Request request;
+  request.set_command("check_mysql_query");
+  for (const std::string &a : args) request.add_arguments(a);
+  check_mysql_query_command::check_with(mysql_client::connection_info(), request, &response, factory);
+  return response.result();
+}
+
+}  // namespace
+
+// --- flavor derivation -------------------------------------------------------
+
+TEST(DeriveFlavor, ClassifiesTheKnownFamilies) {
+  EXPECT_EQ(mysql_client::derive_flavor("10.11.14-MariaDB-ubu2404", "Ubuntu 24.04"), "mariadb");
+  EXPECT_EQ(mysql_client::derive_flavor("8.4.3", "MySQL Community Server - GPL"), "mysql");
+  EXPECT_EQ(mysql_client::derive_flavor("8.0.36-28", "Percona Server (GPL), Release 28"), "percona");
+  // Flavor hidden in the comment only (e.g. a distro build of MariaDB).
+  EXPECT_EQ(mysql_client::derive_flavor("10.6.1", "mariadb.org binary distribution"), "mariadb");
+}
+
+// --- mysql_client::result ----------------------------------------------------
+
+TEST(Result, GetIntParsesIntegersAndRoundsDecimals) {
+  const mysql_client::result res = make_result({"a", "b", "c"}, {{"42", "99.6", "-99.6"}});
+  EXPECT_EQ(res.get_int(0, "a"), 42);
+  EXPECT_EQ(res.get_int(0, "b"), 100);
+  EXPECT_EQ(res.get_int(0, "c"), -100);
+}
+
+TEST(Result, MissingColumnThrows) {
+  const mysql_client::result res = make_result({"a"}, {{"1"}});
+  EXPECT_THROW(res.get_string(0, "nope"), mysql_exception);
+}
+
+// --- check_mysql -------------------------------------------------------------
+
+TEST(CheckMysql, HealthyServerIsOk) {
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_health(healthy_mariadb(), {}, response), PB::Common::ResultCode::OK) << join_lines(response);
+  const std::string msg = join_lines(response);
+  EXPECT_NE(msg.find("mariadb 10.11.14-MariaDB-ubu2404"), std::string::npos) << msg;
+  EXPECT_NE(msg.find("uptime 86400s"), std::string::npos) << msg;
+  EXPECT_NE(msg.find("connections 3/151"), std::string::npos) << msg;
+}
+
+TEST(CheckMysql, UptimeThresholdSupportsTimeUnits) {
+  // Uptime is 86400s = 1d, so warning on "< 2d" must trip.
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_health(healthy_mariadb(), {"warning=uptime < 2d"}, response), PB::Common::ResultCode::WARNING) << join_lines(response);
+}
+
+TEST(CheckMysql, ConnectionThresholdsWork) {
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_health(healthy_mariadb(), {"critical=threads_connected > 2"}, response), PB::Common::ResultCode::CRITICAL) << join_lines(response);
+}
+
+TEST(CheckMysql, ConnectFailureIsUnknownWithTarget) {
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_health(refusing_server("Access denied for user 'x'"), {}, response), PB::Common::ResultCode::UNKNOWN);
+  const std::string msg = join_lines(response);
+  EXPECT_NE(msg.find("Failed to connect to MySQL server 'localhost:3306'"), std::string::npos) << msg;
+  EXPECT_NE(msg.find("Access denied"), std::string::npos) << msg;
+}
+
+TEST(CheckMysql, QueryFailureIsUnknown) {
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_health(failing_queries("server has gone away"), {}, response), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Query failed: server has gone away"), std::string::npos) << join_lines(response);
+}
+
+// --- check_mysql_query -------------------------------------------------------
+
+TEST(CheckMysqlQuery, NoQuerySpecifiedReturnsUnknown) {
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_query(healthy_mariadb(), {}, response), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("No query specified"), std::string::npos) << join_lines(response);
+}
+
+TEST(CheckMysqlQuery, ColumnsBecomeKeywordsAndThresholdsApply) {
+  const auto factory = [](const mysql_client::connection_info &) -> mysql_client::query_runner {
+    return [](const std::string &) -> mysql_client::result {
+      return make_result({"name", "value"}, {{"queue_a", "3"}, {"queue_b", "12"}});
+    };
+  };
+  PB::Commands::QueryResponseMessage::Response response;
+  PB::Commands::QueryRequestMessage::Request request;
+  request.set_command("check_mysql_query");
+  request.add_arguments("query=SELECT name, value FROM queues");
+  request.add_arguments("warning=value > 10");
+  request.add_arguments("detail-syntax=%(name)=%(value)");
+  request.add_arguments("top-syntax=${status}: ${problem_list}");
+  check_mysql_query_command::check_with(mysql_client::connection_info(), request, &response, factory);
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::WARNING) << join_lines(response);
+  EXPECT_NE(join_lines(response).find("queue_b=12"), std::string::npos) << join_lines(response);
+}
+
+TEST(CheckMysqlQuery, StatementWithoutResultSetIsUnknown) {
+  const auto factory = [](const mysql_client::connection_info &) -> mysql_client::query_runner {
+    return [](const std::string &) -> mysql_client::result { return mysql_client::result(); };
+  };
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_query(factory, {"query=SET @x = 1"}, response), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("no result set"), std::string::npos) << join_lines(response);
+}

--- a/modules/CheckMySQL/module.cmake
+++ b/modules/CheckMySQL/module.cmake
@@ -1,0 +1,11 @@
+# Requires MariaDB Connector/C (LGPL), which speaks the native protocol to
+# MySQL, MariaDB, Percona and other MySQL-compatible servers on both Windows
+# and Linux.
+find_package(MariaDB)
+if(MARIADB_FOUND)
+    set(BUILD_MODULE 1)
+else()
+    set(BUILD_MODULE_SKIP_REASON
+        "MariaDB Connector/C not found (install libmariadb-dev or set MARIADB_ROOT_DIR)"
+    )
+endif()

--- a/modules/CheckMySQL/module.json
+++ b/modules/CheckMySQL/module.json
@@ -1,0 +1,14 @@
+{
+	"module"		: {
+		"title"			: "MySQL/MariaDB checker",
+		"description"		: "Check MySQL, MariaDB, Percona and other MySQL-compatible servers: connectivity, health and custom queries.",
+		"name"			: "CheckMySQL",
+		"alias"			: "mysql",
+		"version"		: "auto"
+	},
+
+	"commands" : {
+		"check_mysql"		: "Check MySQL/MariaDB server connectivity and health (version, flavor, uptime, connections).",
+		"check_mysql_query"	: "Run a custom SQL query and apply thresholds to the returned rows."
+	}
+}

--- a/modules/CheckMySQL/mysql_client.cpp
+++ b/modules/CheckMySQL/mysql_client.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "mysql_client.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+
+namespace mysql_client {
+
+std::size_t result::find_column(const std::string &col) const {
+  for (std::size_t i = 0; i < columns.size(); i++) {
+    if (columns[i] == col) return i;
+  }
+  throw mysql_exception("Column not found in result set: " + col);
+}
+
+std::string result::get_string(std::size_t row, const std::string &col) const { return get_string(row, find_column(col)); }
+
+long long result::get_int(std::size_t row, const std::string &col) const { return get_int(row, find_column(col)); }
+
+bool result::is_null(std::size_t row, const std::string &col) const { return rows[row][find_column(col)].null; }
+
+std::string result::get_string(std::size_t row, std::size_t col) const { return rows[row][col].text; }
+
+long long result::get_int(std::size_t row, std::size_t col) const {
+  const cell &c = rows[row][col];
+  if (c.null) return 0;
+  char *end = nullptr;
+  const long long value = std::strtoll(c.text.c_str(), &end, 10);
+  // Numeric text like "99.2" parses better as a double. llround, not +0.5:
+  // the latter rounds -99.6 toward zero (-99) instead of to nearest (-100).
+  if (end != nullptr && *end == '.') return std::llround(std::strtod(c.text.c_str(), nullptr));
+  return value;
+}
+
+std::string derive_flavor(const std::string &version, const std::string &version_comment) {
+  std::string haystack = version + " " + version_comment;
+  std::transform(haystack.begin(), haystack.end(), haystack.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+  if (haystack.find("mariadb") != std::string::npos) return "mariadb";
+  if (haystack.find("percona") != std::string::npos) return "percona";
+  return "mysql";
+}
+
+}  // namespace mysql_client

--- a/modules/CheckMySQL/mysql_client.cpp
+++ b/modules/CheckMySQL/mysql_client.cpp
@@ -4,6 +4,9 @@
 #include "mysql_client.hpp"
 
 #include <algorithm>
+// std::tolower lives in <cctype>. libstdc++ drags it in through <algorithm>,
+// MSVC's does not, so leaving it out builds on Linux and fails on Windows.
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 

--- a/modules/CheckMySQL/mysql_client.hpp
+++ b/modules/CheckMySQL/mysql_client.hpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <exception>
+#include <functional>
+#include <string>
+#include <vector>
+
+// Client-side types shared by all CheckMySQL commands. Deliberately free of
+// any libmariadb dependency: the checks and the unit tests consume these
+// types plus an injectable session factory, and only mysql_session.cpp (not
+// compiled into the test binary) touches the connector.
+namespace mysql_client {
+
+class mysql_exception : public std::exception {
+  std::string message_;
+
+ public:
+  explicit mysql_exception(std::string message) : message_(std::move(message)) {}
+  const char *what() const noexcept override { return message_.c_str(); }
+  std::string reason() const { return message_; }
+};
+
+struct connection_info {
+  std::string host = "localhost";  // TCP host (ignored when socket is set)
+  int port = 3306;                 // TCP port
+  std::string socket;              // unix socket path / Windows named pipe; wins over host when set
+  std::string database;            // optional default schema
+  std::string user;                // empty => the connector's default (current OS user)
+  std::string password;
+  std::string defaults_file;  // my.cnf-style option file read for [client] credentials
+  std::string plugin_dir;     // client auth-plugin directory (e.g. for MySQL 8's caching_sha2_password)
+  bool tls = false;           // require TLS on the connection
+  int connect_timeout = 10;   // seconds
+  int query_timeout = 30;     // seconds (read/write timeout per query)
+
+  // Human-readable connection target for error messages ("host:port" or the socket path).
+  std::string display_target() const { return socket.empty() ? host + ":" + std::to_string(port) : socket; }
+};
+
+struct cell {
+  std::string text;
+  bool null = false;
+};
+
+// A fully materialized result set. Check result sets are small, and
+// materializing lets check_mysql_query get columns and rows from one execute.
+struct result {
+  std::vector<std::string> columns;
+  std::vector<std::vector<cell>> rows;
+
+  std::size_t find_column(const std::string &col) const;  // throws mysql_exception if absent
+  std::string get_string(std::size_t row, const std::string &col) const;
+  long long get_int(std::size_t row, const std::string &col) const;
+  bool is_null(std::size_t row, const std::string &col) const;
+  std::string get_string(std::size_t row, std::size_t col) const;
+  long long get_int(std::size_t row, std::size_t col) const;
+};
+
+// Executes one SQL statement against a connected session; throws
+// mysql_exception on query failure.
+typedef std::function<result(const std::string &sql)> query_runner;
+
+// Called once per check with the final (defaults + options) connection info;
+// returns a runner bound to a live connection, or throws mysql_exception when
+// the connection cannot be established. Injectable for unit tests.
+typedef std::function<query_runner(const connection_info &info)> session_factory;
+
+// Classify a server as mysql / mariadb / percona from its version string and
+// version_comment ("10.11.14-MariaDB-ubu2404", "Percona Server (GPL), ...").
+std::string derive_flavor(const std::string &version, const std::string &version_comment);
+
+}  // namespace mysql_client

--- a/modules/CheckMySQL/mysql_filter_helpers.hpp
+++ b/modules/CheckMySQL/mysql_filter_helpers.hpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <cctype>
+#include <list>
+#include <parsers/where/helpers.hpp>
+#include <str/format.hpp>
+#include <str/xtos.hpp>
+#include <string>
+
+namespace mysql_filter {
+
+// True for an optionally-signed run of digits ("0", "-1", "+259200").
+inline bool is_plain_integer(const std::string &expr) {
+  std::size_t i = 0;
+  if (i < expr.size() && (expr[i] == '-' || expr[i] == '+')) ++i;
+  if (i >= expr.size()) return false;
+  for (; i < expr.size(); ++i) {
+    if (!std::isdigit(static_cast<unsigned char>(expr[i]))) return false;
+  }
+  return true;
+}
+
+// Duration-literal converter for the uptime keyword (register with
+// add_converter on a type_custom_int_* keyword): turns "30m" / "2d" — or the
+// tokenized [number, unit] list form — into seconds, so expressions like
+// uptime < 1h work. Same shape as mssql_filter::parse_time in CheckMSSQL.
+// Plain integers pass straight through (see that helper for why).
+template <class TObject>
+parsers::where::node_type parse_time(TObject object, parsers::where::evaluation_context context, parsers::where::node_type subject) {
+  using namespace parsers::where;
+  std::list<node_type> tokens = subject->get_list_value(context);
+  std::string expr;
+  if (tokens.size() == 2) {
+    auto cit = tokens.begin();
+    const long long n = (*cit)->get_int_value(context);
+    ++cit;
+    const std::string unit = (*cit)->get_value(context, type_string).get_string("");
+    expr = str::xtos(n) + unit;
+  } else {
+    expr = subject->get_string_value(context);
+  }
+  if (is_plain_integer(expr)) return factory::create_int(str::stox<long long>(expr, 0));
+  return factory::create_int(str::format::stox_as_time_sec<long long>(expr, "s"));
+}
+
+}  // namespace mysql_filter

--- a/modules/CheckMySQL/mysql_options.hpp
+++ b/modules/CheckMySQL/mysql_options.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <boost/program_options.hpp>
+#include <nscapi/protobuf/functions_response.hpp>
+#include <string>
+
+#include "mysql_client.hpp"
+
+namespace mysql_options {
+
+// Shared connection options for all CheckMySQL commands. `info` arrives
+// pre-populated with the module's /settings/mysql defaults, so options only
+// override what the user passes explicitly.
+inline void add_connection_options(boost::program_options::options_description &desc, mysql_client::connection_info &info) {
+  namespace po = boost::program_options;
+  // clang-format off
+  desc.add_options()
+    ("host", po::value<std::string>(&info.host)->default_value(info.host), "MySQL/MariaDB server to connect to.")
+    ("port", po::value<int>(&info.port)->default_value(info.port), "TCP port of the server.")
+    ("socket", po::value<std::string>(&info.socket), "Unix socket path (or Windows named pipe) to connect through instead of TCP.")
+    ("database", po::value<std::string>(&info.database), "Default database (schema) to connect to.")
+    ("user", po::value<std::string>(&info.user), "User to authenticate with.")
+    ("password", po::value<std::string>(&info.password), "Password to authenticate with.")
+    ("defaults-file", po::value<std::string>(&info.defaults_file), "my.cnf-style file whose [client] section supplies credentials, so passwords can be kept out of nsclient.ini.")
+    ("plugin-dir", po::value<std::string>(&info.plugin_dir), "Directory the connector loads client auth plugins from (needed for MySQL 8's caching_sha2_password when the connector's default is wrong).")
+    ("tls", po::value<bool>(&info.tls)->implicit_value(true)->default_value(info.tls), "Require TLS on the connection.")
+    ("timeout", po::value<int>(&info.connect_timeout)->default_value(info.connect_timeout), "Connection timeout in seconds.")
+    ("query-timeout", po::value<int>(&info.query_timeout)->default_value(info.query_timeout), "Query (read/write) timeout in seconds.")
+    ;
+  // clang-format on
+}
+
+// set_response_bad appends, so a failure raised after post_process() has
+// already written the result line would produce a garbled two-line UNKNOWN.
+// Drop anything already rendered so the error is the only thing reported.
+inline void fail(PB::Commands::QueryResponseMessage::Response *response, const std::string &message) {
+  response->clear_lines();
+  nscapi::protobuf::functions::set_response_bad(*response, message);
+}
+
+// Connect via the factory and run `body(runner)` with the module's stable
+// error contract: connect failures become "Failed to connect to MySQL server
+// '<target>': ...", query failures "Query failed: ..." and anything else
+// raised while running the check "Check failed: ..." — all UNKNOWN.
+template <class TBody>
+void with_runner(const mysql_client::session_factory &factory, const mysql_client::connection_info &info,
+                 PB::Commands::QueryResponseMessage::Response *response, TBody body) {
+  try {
+    mysql_client::query_runner run;
+    try {
+      run = factory(info);
+    } catch (const mysql_client::mysql_exception &e) {
+      return fail(response, "Failed to connect to MySQL server '" + info.display_target() + "': " + e.reason());
+    }
+    try {
+      body(run);
+    } catch (const mysql_client::mysql_exception &e) {
+      return fail(response, "Query failed: " + e.reason());
+    } catch (const std::exception &e) {
+      // The connection succeeded, so this is a rendering/threshold failure,
+      // not a connect failure; label it accordingly instead of misdirecting
+      // the operator to the network.
+      return fail(response, std::string("Check failed: ") + e.what());
+    }
+  } catch (const std::exception &e) {
+    // Only factory/session construction can reach here.
+    return fail(response, std::string("Failed to connect to MySQL server: ") + e.what());
+  }
+}
+
+}  // namespace mysql_options

--- a/modules/CheckMySQL/mysql_session.cpp
+++ b/modules/CheckMySQL/mysql_session.cpp
@@ -1,0 +1,120 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "mysql_session.hpp"
+
+#include <memory>
+#include <mysql.h>
+
+namespace mysql_session {
+
+namespace {
+MYSQL *handle(void *p) { return static_cast<MYSQL *>(p); }
+
+std::string client_error(MYSQL *mysql) {
+  const char *msg = mysql_error(mysql);
+  return msg != nullptr && *msg != '\0' ? std::string(msg) : "unknown MySQL client error";
+}
+}  // namespace
+
+session::session(mysql_client::connection_info info) : info_(std::move(info)) {
+  mysql_ = mysql_init(nullptr);
+  if (mysql_ == nullptr) throw mysql_client::mysql_exception("mysql_init failed (out of memory)");
+}
+
+session::~session() {
+  if (mysql_ != nullptr) mysql_close(handle(mysql_));
+}
+
+void session::connect() {
+  MYSQL *mysql = handle(mysql_);
+
+  const unsigned int connect_timeout = info_.connect_timeout > 0 ? static_cast<unsigned int>(info_.connect_timeout) : 10;
+  const unsigned int query_timeout = info_.query_timeout > 0 ? static_cast<unsigned int>(info_.query_timeout) : 30;
+  mysql_options(mysql, MYSQL_OPT_CONNECT_TIMEOUT, &connect_timeout);
+  mysql_options(mysql, MYSQL_OPT_READ_TIMEOUT, &query_timeout);
+  mysql_options(mysql, MYSQL_OPT_WRITE_TIMEOUT, &query_timeout);
+  if (!info_.defaults_file.empty()) {
+    // Credentials from a my.cnf-style file ([client] group) so passwords can
+    // live in a permission-protected file instead of nsclient.ini.
+    mysql_options(mysql, MYSQL_READ_DEFAULT_FILE, info_.defaults_file.c_str());
+    mysql_options(mysql, MYSQL_READ_DEFAULT_GROUP, "client");
+  }
+  if (info_.socket.empty()) {
+    // The connector silently turns host "localhost" into a default-socket
+    // connection; a monitoring check's transport must be explicit instead:
+    // TCP unless a socket/pipe was requested.
+    unsigned int protocol = MYSQL_PROTOCOL_TCP;
+    mysql_options(mysql, MYSQL_OPT_PROTOCOL, &protocol);
+  }
+  if (!info_.plugin_dir.empty()) {
+    // Where the connector loads client auth plugins from (MySQL 8 accounts
+    // default to caching_sha2_password, which is such a plugin). Only needed
+    // when the connector's compiled-in default is wrong for this install.
+    mysql_options(mysql, MYSQL_PLUGIN_DIR, info_.plugin_dir.c_str());
+  }
+  if (info_.tls) {
+    my_bool enforce = 1;
+    mysql_options(mysql, MYSQL_OPT_SSL_ENFORCE, &enforce);
+  }
+
+  const char *host = info_.socket.empty() ? (info_.host.empty() ? nullptr : info_.host.c_str()) : nullptr;
+  const char *user = info_.user.empty() ? nullptr : info_.user.c_str();
+  const char *password = info_.password.empty() ? nullptr : info_.password.c_str();
+  const char *database = info_.database.empty() ? nullptr : info_.database.c_str();
+  const char *socket = info_.socket.empty() ? nullptr : info_.socket.c_str();
+  const unsigned int port = info_.socket.empty() ? static_cast<unsigned int>(info_.port) : 0;
+
+  if (mysql_real_connect(mysql, host, user, password, database, port, socket, 0) == nullptr) {
+    throw mysql_client::mysql_exception(client_error(mysql));
+  }
+}
+
+mysql_client::result session::execute(const std::string &sql) {
+  MYSQL *mysql = handle(mysql_);
+  if (mysql_real_query(mysql, sql.c_str(), static_cast<unsigned long>(sql.size())) != 0) {
+    throw mysql_client::mysql_exception(client_error(mysql));
+  }
+
+  mysql_client::result res;
+  MYSQL_RES *store = mysql_store_result(mysql);
+  if (store == nullptr) {
+    // A statement without a result set (e.g. SET) yields field_count 0;
+    // anything else is a real retrieval error.
+    if (mysql_field_count(mysql) == 0) return res;
+    throw mysql_client::mysql_exception(client_error(mysql));
+  }
+
+  const unsigned int num_fields = mysql_num_fields(store);
+  const MYSQL_FIELD *fields = mysql_fetch_fields(store);
+  for (unsigned int i = 0; i < num_fields; i++) {
+    res.columns.push_back(fields[i].name != nullptr ? fields[i].name : "");
+  }
+  for (MYSQL_ROW row = mysql_fetch_row(store); row != nullptr; row = mysql_fetch_row(store)) {
+    const unsigned long *lengths = mysql_fetch_lengths(store);
+    std::vector<mysql_client::cell> cells;
+    cells.reserve(num_fields);
+    for (unsigned int i = 0; i < num_fields; i++) {
+      mysql_client::cell c;
+      if (row[i] == nullptr) {
+        c.null = true;
+      } else {
+        c.text.assign(row[i], lengths != nullptr ? lengths[i] : 0);
+      }
+      cells.push_back(std::move(c));
+    }
+    res.rows.push_back(std::move(cells));
+  }
+  mysql_free_result(store);
+  return res;
+}
+
+mysql_client::session_factory make_session_factory() {
+  return [](const mysql_client::connection_info &info) -> mysql_client::query_runner {
+    auto live = std::make_shared<session>(info);
+    live->connect();
+    return [live](const std::string &sql) { return live->execute(sql); };
+  };
+}
+
+}  // namespace mysql_session

--- a/modules/CheckMySQL/mysql_session.hpp
+++ b/modules/CheckMySQL/mysql_session.hpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include "mysql_client.hpp"
+
+// The libmariadb-backed session. Only this pair of files includes the
+// connector headers; everything else works against mysql_client types.
+namespace mysql_session {
+
+// RAII connection (MYSQL*). Speaks the native protocol to MySQL, MariaDB,
+// Percona and other compatible servers via MariaDB Connector/C.
+class session {
+ public:
+  explicit session(mysql_client::connection_info info);
+  ~session();
+  session(const session &) = delete;
+  session &operator=(const session &) = delete;
+
+  // mysql_real_connect with the configured timeouts/TLS/defaults-file; throws
+  // mysql_client::mysql_exception with the server/client error on failure.
+  void connect();
+  // One statement per call; throws mysql_client::mysql_exception. Statements
+  // that produce no result set return a result with no columns.
+  mysql_client::result execute(const std::string &sql);
+
+ private:
+  mysql_client::connection_info info_;
+  void *mysql_ = nullptr;  // MYSQL*
+};
+
+// The production session_factory: connects a session (throwing on failure)
+// and returns a runner bound to it. The connection lives as long as the
+// returned runner.
+mysql_client::session_factory make_session_factory();
+
+}  // namespace mysql_session

--- a/service/plugins/plugin_manager.cpp
+++ b/service/plugins/plugin_manager.cpp
@@ -92,7 +92,9 @@ std::string installer_feature_hint(const std::string &module) {
       {"CheckTaskSched", "Check Plugins"},
       {"CheckSecurity", "Check Plugins"},
       {"CheckMSSQL", "Check Plugins"},
-      {"CheckMySQL", "Check Plugins"},
+      // Its own feature, not part of "Check Plugins": it is the one check
+      // module that carries a third-party runtime library (libmariadb.dll).
+      {"CheckMySQL", "MySQL Support"},
       {"SimpleCache", "Check Plugins"},
       {"SimpleFileWriter", "Check Plugins"},
       {"CheckLogFile", "Check Plugins"},

--- a/service/plugins/plugin_manager.cpp
+++ b/service/plugins/plugin_manager.cpp
@@ -92,6 +92,7 @@ std::string installer_feature_hint(const std::string &module) {
       {"CheckTaskSched", "Check Plugins"},
       {"CheckSecurity", "Check Plugins"},
       {"CheckMSSQL", "Check Plugins"},
+      {"CheckMySQL", "Check Plugins"},
       {"SimpleCache", "Check Plugins"},
       {"SimpleFileWriter", "Check Plugins"},
       {"CheckLogFile", "Check Plugins"},

--- a/tests/checkmysql-commands.test.ts
+++ b/tests/checkmysql-commands.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Exercises the CheckMySQL module end-to-end against a real MariaDB server
+ * started with testcontainers.
+ *
+ * Each case runs a one-shot client query — `nscp client --module CheckMySQL
+ * --boot --query <cmd> ...` — which passes k=v as single tokens (same as
+ * REST), so this exercises the same argument parsing the REST API uses.
+ * Output is the raw Nagios "message|perfdata" line without a status-word
+ * prefix.
+ *
+ * The module is optional (it needs MariaDB Connector/C at build time), so the
+ * suite skips itself when the binary was built without it. It also needs a
+ * docker daemon for the server container (NSCP_SKIP_DOCKER=1 skips).
+ */
+import * as fs from "fs";
+import * as path from "path";
+import { NscpInstance } from "@fixtures/index";
+import { dockerOrSkip, GenericContainer, Wait, type StartedTestContainer } from "./src/docker";
+
+jest.setTimeout(300_000);
+
+const ROOT_PASSWORD = "nscp-integration-test";
+
+function moduleBuilt(): boolean {
+  if (!process.env.NSCP_BIN) return false;
+  const dir = path.join(path.dirname(process.env.NSCP_BIN), "modules");
+  return (
+    fs.existsSync(path.join(dir, "libCheckMySQL.so")) ||
+    fs.existsSync(path.join(dir, "CheckMySQL.dll")) ||
+    fs.existsSync(path.join(dir, "CheckMySQL.so"))
+  );
+}
+
+dockerOrSkip()("CheckMySQL commands", () => {
+  let nscp: NscpInstance;
+  let mariadb: StartedTestContainer | undefined;
+  let host = "";
+  let port = 0;
+
+  /** Run a CheckMySQL query and return the combined output. */
+  async function query(command: string, args: string[] = []): Promise<string> {
+    const r = await nscp.run(["client", "--module", "CheckMySQL", "--boot", "--query", command, ...args], {
+      allowFailure: true,
+    });
+    return r.all ?? `${r.stdout}\n${r.stderr}`;
+  }
+
+  /** Connection arguments for the containerized server. */
+  function conn(): string[] {
+    return [`host=${host}`, `port=${port}`, "user=root", `password=${ROOT_PASSWORD}`];
+  }
+
+  beforeAll(async () => {
+    if (!moduleBuilt()) return; // cases below turn into cheap no-ops via guards
+    nscp = new NscpInstance();
+    // The mariadb entrypoint starts a bootstrap server first; "ready for
+    // connections" only counts when the real server (with networking) is up,
+    // which is the second occurrence.
+    mariadb = await new GenericContainer("mariadb:11")
+      .withEnvironment({ MARIADB_ROOT_PASSWORD: ROOT_PASSWORD })
+      .withExposedPorts(3306)
+      .withWaitStrategy(Wait.forLogMessage(/ready for connections/, 2))
+      .start();
+    host = mariadb.getHost();
+    port = mariadb.getMappedPort(3306);
+  });
+
+  afterAll(async () => {
+    await mariadb?.stop();
+  });
+
+  it("check_mysql reports a healthy server with flavor, uptime and connections", async () => {
+    if (!moduleBuilt()) return;
+    const out = await query("check_mysql", conn());
+    expect(out).toMatch(/mariadb \d+\.\d+.*MariaDB/i);
+    expect(out).toMatch(/uptime \d+s/);
+    expect(out).toMatch(/connections \d+\/\d+ \(\d+%\)/);
+  });
+
+  it("check_mysql uptime threshold trips and emits perf data", async () => {
+    if (!moduleBuilt()) return;
+    // The container started seconds ago, so warning on "< 1000d" must trip.
+    const out = await query("check_mysql", [...conn(), "warning=uptime < 1000d"]);
+    expect(out).toMatch(/^WARNING/m);
+    expect(out).toMatch(/uptime'?=\d+s/);
+  });
+
+  it("check_mysql accepts tls=true as a valued boolean (REST k=v token path)", async () => {
+    if (!moduleBuilt()) return;
+    // The container may or may not speak TLS; the regression under test is the
+    // argument parsing (bool_switch would reject the k=v form outright).
+    const out = await query("check_mysql", [...conn(), "tls=true"]);
+    expect(out).not.toMatch(/does not take any arguments/i);
+  });
+
+  it("check_mysql_query exposes result columns as keywords with thresholds", async () => {
+    if (!moduleBuilt()) return;
+    const out = await query("check_mysql_query", [
+      ...conn(),
+      "query=SELECT COUNT(*) AS tables_count FROM information_schema.tables",
+      "critical=tables_count > 5",
+      "detail-syntax=tables=%(tables_count)",
+      "top-syntax=${list}",
+      // Like CheckWMI/CheckMSSQL, generic query checks emit perf data only
+      // once a perf-syntax is chosen (there is no meaningful default alias).
+      "perf-syntax=tables",
+    ]);
+    // information_schema alone holds far more than 5 tables.
+    expect(out).toMatch(/tables=\d\d+/);
+    expect(out).toMatch(/'tables_counttables'=\d+;0;5/); // perf data from the threshold
+  });
+
+  it("check_mysql_query rejects a missing query with a clear message", async () => {
+    if (!moduleBuilt()) return;
+    const out = await query("check_mysql_query", conn());
+    expect(out).toMatch(/No query specified/);
+  });
+
+  it("rejects bad credentials with the connect-failure contract", async () => {
+    if (!moduleBuilt()) return;
+    const out = await query("check_mysql", [`host=${host}`, `port=${port}`, "user=root", "password=wrong"]);
+    expect(out).toMatch(/Failed to connect to MySQL server/);
+    expect(out).toMatch(/Access denied/);
+  });
+
+  it("reports an unreachable server distinctly", async () => {
+    if (!moduleBuilt()) return;
+    const out = await query("check_mysql", ["host=127.0.0.1", "port=1", "timeout=2"]);
+    expect(out).toMatch(/Failed to connect to MySQL server '127\.0\.0\.1:1'/);
+  });
+});

--- a/tests/msi/helpers.py
+++ b/tests/msi/helpers.py
@@ -252,3 +252,26 @@ def validate_files(target_folder, required_files):
             missing_files_str = ", ".join(missing_files)
             print(f"! Required file in {file_group} does not exist: {missing_files_str}", flush=True)
     return all_exist
+
+
+def validate_files_absent(target_folder, forbidden_files):
+    """Validate that files which a deselected feature owns are NOT installed.
+
+    The mirror of validate_files: a feature that can be turned off is only
+    really optional if leaving it out actually leaves its files out, and that
+    is exactly what a stray ComponentRef in another feature breaks without
+    anything else failing.
+    """
+    none_exist = True
+    for file_group in forbidden_files.keys():
+        present_files = []
+        print(f"- Validating absent files in block: {file_group}", flush=True)
+        for bad_file in forbidden_files[file_group]:
+            file_path = path.join(target_folder, bad_file.replace('/', path.sep))
+            if path.exists(file_path):
+                present_files.append(bad_file)
+                none_exist = False
+        if present_files:
+            present_files_str = ", ".join(present_files)
+            print(f"! File in {file_group} should not have been installed: {present_files_str}", flush=True)
+    return none_exist

--- a/tests/msi/test-install.py
+++ b/tests/msi/test-install.py
@@ -2,7 +2,7 @@ from os import path, listdir
 from glob import glob
 from argparse import ArgumentParser
 
-from helpers import ensure_uninstalled, read_config, install, compare_file, create_upgrade_config, validate_files
+from helpers import ensure_uninstalled, read_config, install, compare_file, create_upgrade_config, validate_files, validate_files_absent
 
 # Argument parsing for test selection
 parser = ArgumentParser(description="Run NSCP MSI installer tests.")
@@ -60,6 +60,10 @@ for test_case_file in test_cases:
         failure = True
     if 'required_files' in test_case:
         if not validate_files(target_folder, test_case['required_files']):
+            print("! Test failed.", flush=True)
+            failure = True
+    if 'forbidden_files' in test_case:
+        if not validate_files_absent(target_folder, test_case['forbidden_files']):
             print("! Test failed.", flush=True)
             failure = True
 

--- a/tests/msi/tests/mysql-plugin-deselected.yaml
+++ b/tests/msi/tests/mysql-plugin-deselected.yaml
@@ -1,0 +1,47 @@
+# CheckMySQL is its own installer feature (MySQLPlugin) so an operator with no
+# MySQL to monitor can leave out both the module and the third-party client
+# library it needs. Installing everything *except* that feature must therefore
+# leave neither file behind - a stray ComponentRef in another feature would ship
+# them anyway, and nothing else in the suite would notice.
+#
+# The rest of the install is expected to be identical to normal-install.yaml:
+# no other module depends on the connector, so dropping the feature must not
+# change the generated configuration at all.
+command_line: ["msiexec.exe", "/i", "$MSI-FILE", "/qn", "/l*", "log.txt", "ADDLOCAL=ALL", "REMOVE=MySQLPlugin" ]
+replace_password: true
+boot.ini: |
+  [settings]
+  1 = ini://${shared-path}/nsclient.ini
+
+nsclient.ini: |
+  [/modules]
+  checkdisk = enabled
+  checkeventlog = enabled
+  checkexternalscripts = enabled
+  checkhelpers = enabled
+  checknscp = enabled
+  checksystem = enabled
+  nrpeserver = enabled
+  webserver = enabled
+
+  [/settings/NRPE/server]
+  insecure = false
+  tls version = tlsv1.2+
+  verify mode = peer-cert
+
+  [/settings/default]
+  allowed hosts = 127.0.0.1
+  password = $$PASSWORD$$
+
+forbidden_files:
+  mysql:
+    - libmariadb.dll
+    - modules/CheckMySQL.dll
+
+required_files:
+  # The agent itself and a neighbouring check module still have to be there:
+  # this proves the feature was deselected, not that the install failed.
+  exe-files:
+    - nscp.exe
+  other-modules:
+    - modules/CheckDisk.dll

--- a/tests/msi/tests/normal-install.yaml
+++ b/tests/msi/tests/normal-install.yaml
@@ -44,6 +44,13 @@ required_files:
     - _socket.pyd
     - _ctypes.pyd
     - unicodedata.pyd
+  # The MySQLPlugin feature: installed by default (Level="1"), so ADDLOCAL=ALL
+  # brings both the module and its client library. libmariadb.dll sits next to
+  # nscp.exe, not in modules\ - see the mysql-plugin-deselected case for the
+  # other half of this.
+  mysql:
+    - libmariadb.dll
+    - modules/CheckMySQL.dll
   exe-files:
     - check_nrpe.exe
     - check_nsclient.exe


### PR DESCRIPTION
New cross-platform check module built on MariaDB Connector/C (LGPL), which speaks the native protocol to the whole MySQL family:

- check_mysql: connectivity/health with version, flavor (mysql/mariadb/ percona), uptime (time-unit thresholds) and connection-pool keywords. Connection failures are UNKNOWN with the driver's error message.
- check_mysql_query: arbitrary SQL with result columns registered as filter keywords (CheckWMI-style), per-row matching and perf data via perf-syntax.

The module is optional: it builds when the connector is found (FindMariaDB, libmariadb-dev or -DMARIADB_ROOT_DIR) and is skipped with a clear reason otherwise. Only mysql_session.cpp touches the connector; the checks consume an injectable session factory, so the unit tests run without libmariadb.

Notable behaviour: TCP is forced unless socket= is given (the connector silently turns host=localhost into a socket connection), and plugin-dir= supports MySQL 8's caching_sha2_password auth plugin from non-default locations. Verified live against MariaDB 11 and MySQL 8.4; the integration suite starts a MariaDB testcontainer and skips itself without docker or without the module built. MSI entries are present but commented until the connector is part of the Windows build dependencies.

Assisted-by: Claude Code:claude-fable-5