### PR TITLE
feat: Add a CheckActiveDirectory module for AD/identity health

### DIFF
--- a/docs/docs/scenarios/active-directory.md
+++ b/docs/docs/scenarios/active-directory.md
@@ -1,0 +1,238 @@
+# Active Directory & Identity Monitoring
+
+**Goal:** Monitor the Windows identity stack end to end: domain controller replication,
+the machine-account secure channel on every domain member, Kerberos KDC availability,
+and — via performance counters — the NTDS directory service, AD Certificate Services
+and AD FS.
+
+Domain controllers are the most business-critical Windows role there is: when AD is
+degraded, "everything is broken" for users while per-service port checks stay green.
+The checks below catch the failure modes that matter, in rough order of blast radius.
+
+---
+
+## Prerequisites
+
+Enable the `CheckActiveDirectory` module (and `CheckSystem` for the counter-based
+checks) in `nsclient.ini`:
+
+```ini
+[/modules]
+CheckActiveDirectory = enabled
+CheckSystem          = enabled   ; check_pdh for NTDS / ADCS / ADFS counters
+```
+
+All checks in this guide are Windows-only.
+
+---
+
+## Domain controller replication
+
+Replication failures are the classic silent AD killer: a DC that has not replicated
+for longer than the tombstone lifetime is permanently orphaned and must be rebuilt.
+Run this on **every** domain controller (replication state is per-DC):
+
+```
+check_ad_replication
+```
+
+### Expected output (healthy)
+
+```
+OK: all 6 replication links are healthy|'DC02 DC=example,DC=com'=0;0;4 ...
+```
+
+### Alert output
+
+```
+CRITICAL: DC02 DC=example,DC=com: 7 failures, last success 2026-08-10 03:11:42|...
+```
+
+Defaults: WARNING on the first failed sync (`consecutive_failures > 0`), CRITICAL
+after five in a row or 24 hours without a successful sync. On a non-DC the check
+returns UNKNOWN ("Not a domain controller"), so it is safe to deploy fleet-wide.
+
+### Customisation
+
+```
+# Only alert on prolonged outages, ignore single hiccups:
+check_ad_replication "warning=none" "critical=last_success < -24h"
+
+# Check a remote DC:
+check_ad_replication server=dc02.example.com
+```
+
+---
+
+## Machine-account secure channel (every domain member)
+
+A broken secure channel ("the trust relationship between this workstation and the
+primary domain failed") blocks every domain logon on that host. The check actively
+verifies the channel, like `Test-ComputerSecureChannel`:
+
+```
+check_secure_channel
+```
+
+### Expected output
+
+```
+OK: secure channel to EXAMPLE via DC01.example.com: OK
+```
+
+Workgroup machines return UNKNOWN ("not joined to a domain"), so the same check can
+go to the whole fleet. Use `verify=false` for a passive status query that does not
+contact the DC.
+
+---
+
+## Kerberos KDC availability
+
+`check_kdc` sends a real (unauthenticated) Kerberos `AS-REQ` to the KDC and expects
+a Kerberos answer — typically `KDC_ERR_PREAUTH_REQUIRED`, which is the *healthy*
+response. A plain port check cannot see a KDC that accepts connections but no longer
+issues tickets; this can.
+
+```
+check_kdc
+```
+
+### Expected output
+
+```
+OK: dc01.example.com: KRB-ERROR KDC_ERR_PREAUTH_REQUIRED (2ms)|'dc01.example.com'=2ms;1000;0
+```
+
+On a domain-joined machine the KDC and realm are discovered automatically; from
+anywhere else, name them explicitly — no domain membership, account or Kerberos
+configuration is needed:
+
+```
+check_kdc server=dc01.example.com server=dc02.example.com realm=EXAMPLE.COM
+```
+
+Defaults: WARNING when the round trip exceeds 1 second, CRITICAL when a KDC does not
+answer with a well-formed Kerberos message.
+
+---
+
+## NTDS directory service counters (check_pdh)
+
+The directory service exposes rich health counters under the `NTDS` object. Predefine
+the interesting ones in `nsclient.ini` so checks are shell-quoting-free and can be
+averaged over time (see the [PDH scenario](counters.md) for the mechanics):
+
+```ini
+[/settings/system/windows/counters/ad_repl_queue]
+collection strategy = rrd
+counter             = \NTDS\DRA Pending Replication Synchronizations
+
+[/settings/system/windows/counters/ad_ldap_bind_time]
+collection strategy = rrd
+counter             = \NTDS\LDAP Bind Time
+
+[/settings/system/windows/counters/ad_ldap_sessions]
+collection strategy = rrd
+counter             = \NTDS\LDAP Client Sessions
+
+[/settings/system/windows/counters/ad_ldap_searches]
+collection strategy = rrd
+counter             = \NTDS\LDAP Searches/sec
+```
+
+Then alert on averages instead of instantaneous spikes:
+
+```
+# Replication backlog building up:
+check_pdh counter=ad_repl_queue time=5m "warn=value > 50" "crit=value > 500"
+
+# LDAP binds getting slow (milliseconds):
+check_pdh counter=ad_ldap_bind_time time=5m "warn=value > 30" "crit=value > 100"
+
+# Session count for capacity trending (no thresholds, perf data only):
+check_pdh counter=ad_ldap_sessions time=5m
+```
+
+Other counters worth knowing: `\NTDS\DRA Inbound Bytes Total/sec`,
+`\NTDS\DRA Outbound Bytes Total/sec` (replication volume), `\NTDS\DS Directory
+Reads/sec`, `\NTDS\DS Directory Writes/sec` (directory load), and
+`\NTDS\Kerberos Authentications/sec` / `\NTDS\NTLM Authentications/sec` (an NTLM
+uptick often means Kerberos trouble).
+
+---
+
+## AD Certificate Services (check_pdh)
+
+A stalled enterprise CA silently breaks certificate auto-enrolment for the whole
+estate. The `Certification Authority` counter object (one instance per CA) makes it
+visible; `check_certificate` (CheckSecurity) covers the CA's own certificate expiry.
+
+```ini
+[/settings/system/windows/counters/ca_failed_requests]
+collection strategy = rrd
+counter             = \Certification Authority(*)\Failed Requests/sec
+
+[/settings/system/windows/counters/ca_request_time]
+collection strategy = rrd
+counter             = \Certification Authority(*)\Request processing time (ms)
+```
+
+```
+# Any failed request is worth a look, a stream of them is an incident:
+check_pdh counter=ca_failed_requests time=5m "warn=value > 0" "crit=value > 1"
+
+# Issuance latency:
+check_pdh counter=ca_request_time time=5m "warn=value > 500" "crit=value > 2000"
+```
+
+The instance wildcard `(*)` covers the (normally single) CA instance; use
+`nscp sys -- --expand-path "\Certification Authority(*)\Requests/sec"` to see yours.
+
+---
+
+## AD FS token issuance (check_pdh)
+
+ADFS outages break SSO to Microsoft 365 and every federated SaaS app. The `AD FS`
+counter object exposes issuance rates and failures:
+
+```ini
+[/settings/system/windows/counters/adfs_token_requests]
+collection strategy = rrd
+counter             = \AD FS\Token Requests/sec
+
+[/settings/system/windows/counters/adfs_federation_requests]
+collection strategy = rrd
+counter             = \AD FS\Federation Metadata Requests/sec
+```
+
+```
+# Token issuance flatlining at 0 during business hours usually means broken SSO:
+check_pdh counter=adfs_token_requests time=15m
+
+# Pair with a service check on the ADFS service itself:
+check_service service=adfssrv
+```
+
+On WAP/proxy nodes the counter set is `AD FS Proxy`. Counter availability varies by
+ADFS version — validate with `nscp sys -- --validate "AD FS" --all` before wiring
+alerts.
+
+---
+
+## Suggested per-role check sets
+
+| Role                    | Checks                                                                                       |
+|-------------------------|----------------------------------------------------------------------------------------------|
+| Every domain member     | `check_secure_channel`                                                                       |
+| Every domain controller | `check_ad_replication`, `check_kdc`, `check_service service=ntds service=netlogon service=kdc service=dns`, NTDS counters |
+| Enterprise CA           | `Certification Authority` counters, `check_certificate` on the CA certificate               |
+| ADFS farm               | `AD FS` counters, `check_service service=adfssrv`, `check_certificate` on the token-signing certificate |
+
+---
+
+## Next Steps
+
+- [Performance Counter (PDH) Monitoring](counters.md) — predefined counters, averaging, localisation gotchas
+- [Host Security Posture](security-posture.md) — `check_certificate` for CA / token-signing certificate expiry
+- [Service & Process Monitoring](service-monitoring.md) — keep `ntds`, `netlogon`, `kdc`, `adfssrv` running
+- [Reference: CheckActiveDirectory](../reference/check/CheckActiveDirectory.md) — full command reference

--- a/docs/docs/scenarios/active-directory.md
+++ b/docs/docs/scenarios/active-directory.md
@@ -100,7 +100,7 @@ check_kdc
 ### Expected output
 
 ```
-OK: dc01.example.com: KRB-ERROR KDC_ERR_PREAUTH_REQUIRED (2ms)|'dc01.example.com'=2ms;1000;0
+OK: dc01.example.com: KRB-ERROR KDC_ERR_PREAUTH_REQUIRED (2ms)|'dc01.example.com'=2ms;1000
 ```
 
 On a domain-joined machine the KDC and realm are discovered automatically; from

--- a/docs/docs/scenarios/index.md
+++ b/docs/docs/scenarios/index.md
@@ -51,6 +51,7 @@ Each scenario follows the same structure:
 | Scenario                                        | Description                                                                     |
 |-------------------------------------------------|---------------------------------------------------------------------------------|
 | [Host Security Posture](security-posture.md)    | Certificate expiry/hygiene and logon sessions (Windows & Linux), plus Windows firewall, antivirus, BitLocker and Secure Boot |
+| [Active Directory & Identity](active-directory.md) | DC replication, machine secure channel, Kerberos KDC probing, plus NTDS/ADCS/ADFS performance counters |
 
 ### Monitoring Server Integration
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,6 +44,7 @@ nav:
       - SQL Server Monitoring: scenarios/sql-server.md
       - Network Checks: scenarios/network-checks.md
       - Host Security Posture: scenarios/security-posture.md
+      - Active Directory & Identity: scenarios/active-directory.md
       - Active Monitoring with NRPE: scenarios/nrpe.md
       - Passive Monitoring (NSCA/NRDP): scenarios/passive-monitoring-nsca.md
       - Passive Monitoring (NSCA-NG): scenarios/passive-monitoring-nsca-ng.md

--- a/docs/samples/CheckActiveDirectory_check_ad_replication_desc.md
+++ b/docs/samples/CheckActiveDirectory_check_ad_replication_desc.md
@@ -31,14 +31,16 @@ synced trips the 24-hour rule by design.
 
 Options: `server=<dc>` checks another domain controller (default: the local
 machine — replication state is per-DC, so run the check on every DC).
+`timeout=<ms>` (default 5000) bounds the reachability probe made before binding
+to a remote `server=`.
 
-**Not-a-DC contract:** run without `server=` on a host that does not run the
-directory service, the check returns **UNKNOWN** with a "Not a domain
-controller" message rather than a hard error, so it is safe to deploy
-fleet-wide. The contract only applies locally: a `server=` target that cannot
-be bound is reported as a plain failure — an explicitly named DC being
-unreachable (powered off, firewalled, NTDS stopped) is an outage, not an
-ignorable non-DC. Remote targets are first probed on TCP port 135 (the RPC
-endpoint mapper) with a 5 second deadline so a black-holed host fails fast
-instead of hanging the check. A single-DC domain (no replication partners)
-returns **OK** with an explanatory empty-state message.
+**Not-a-DC contract:** on a host that is not a domain controller, the check
+returns **UNKNOWN** with a "Not a domain controller" message rather than a hard
+error, so it is safe to deploy fleet-wide. The machine role is what decides
+this (`DsRoleGetPrimaryDomainInformation`), not the bind failure itself: a real
+domain controller that fails to answer — stopped NTDS, access denied, RPC
+unavailable — is reported as a plain failure, because that is the outage this
+check exists to surface. Remote targets are first probed on TCP port 135 (the
+RPC endpoint mapper) within `timeout=` so a black-holed host fails fast instead
+of hanging the check. A single-DC domain (no replication partners) returns
+**OK** with an explanatory empty-state message.

--- a/docs/samples/CheckActiveDirectory_check_ad_replication_desc.md
+++ b/docs/samples/CheckActiveDirectory_check_ad_replication_desc.md
@@ -1,0 +1,38 @@
+#### About `check_ad_replication`
+
+`check_ad_replication` reads the inbound replication state of a domain
+controller straight from the directory service (`DsReplicaGetInfo`, the same
+source `repadmin /showrepl` uses). Each inbound replication link — a (naming
+context, source DC) pair — becomes one row: when it last attempted and last
+managed to sync, and how many attempts in a row have failed.
+
+Replication failures are the classic silent AD killer: a DC that has not
+replicated for longer than the tombstone lifetime (typically 60–180 days) is
+permanently orphaned and must be rebuilt. This check alerts long before that.
+
+Keywords (one row per inbound replication link):
+
+| Keyword                | Description                                                       |
+|------------------------|-------------------------------------------------------------------|
+| `naming_context`       | The replicated partition DN (e.g. `DC=example,DC=com`)            |
+| `source`               | The source domain controller of the link                          |
+| `source_dsa`           | Full DN of the source directory service agent                     |
+| `source_address`       | Transport address of the source (GUID-based DNS name)             |
+| `last_attempt`         | When a sync was last attempted (date)                             |
+| `last_success`         | When a sync last succeeded (date; epoch 0 = never)                |
+| `consecutive_failures` | Consecutive failed sync attempts (perf data)                      |
+| `last_error`           | Win32 result of the last sync attempt (0 = success)               |
+| `last_error_message`   | Human readable message for `last_error` (empty when ok)           |
+| `failed`               | True when the last sync attempt failed                            |
+
+Defaults: **WARNING** when `consecutive_failures > 0`, **CRITICAL** when
+`consecutive_failures > 4 or last_success < -24h`. A link that has *never*
+synced trips the 24-hour rule by design.
+
+Options: `server=<dc>` checks another domain controller (default: the local
+machine — replication state is per-DC, so run the check on every DC).
+
+**Not-a-DC contract:** on a host that does not run the directory service the
+check returns **UNKNOWN** with a "Not a domain controller" message rather than
+a hard error, so it is safe to deploy fleet-wide. A single-DC domain (no
+replication partners) returns **OK** with an explanatory empty-state message.

--- a/docs/samples/CheckActiveDirectory_check_ad_replication_desc.md
+++ b/docs/samples/CheckActiveDirectory_check_ad_replication_desc.md
@@ -32,7 +32,13 @@ synced trips the 24-hour rule by design.
 Options: `server=<dc>` checks another domain controller (default: the local
 machine — replication state is per-DC, so run the check on every DC).
 
-**Not-a-DC contract:** on a host that does not run the directory service the
-check returns **UNKNOWN** with a "Not a domain controller" message rather than
-a hard error, so it is safe to deploy fleet-wide. A single-DC domain (no
-replication partners) returns **OK** with an explanatory empty-state message.
+**Not-a-DC contract:** run without `server=` on a host that does not run the
+directory service, the check returns **UNKNOWN** with a "Not a domain
+controller" message rather than a hard error, so it is safe to deploy
+fleet-wide. The contract only applies locally: a `server=` target that cannot
+be bound is reported as a plain failure — an explicitly named DC being
+unreachable (powered off, firewalled, NTDS stopped) is an outage, not an
+ignorable non-DC. Remote targets are first probed on TCP port 135 (the RPC
+endpoint mapper) with a 5 second deadline so a black-holed host fails fast
+instead of hanging the check. A single-DC domain (no replication partners)
+returns **OK** with an explanatory empty-state message.

--- a/docs/samples/CheckActiveDirectory_check_ad_replication_samples.md
+++ b/docs/samples/CheckActiveDirectory_check_ad_replication_samples.md
@@ -1,0 +1,48 @@
+**Default check (healthy domain controller):**
+
+```
+check_ad_replication
+OK: all 6 replication links are healthy|'DC02 DC=example,DC=com'=0;0;4 'DC02 CN=Configuration,DC=example,DC=com'=0;0;4 ...
+```
+
+**A partner has been failing for a while:**
+
+```
+check_ad_replication
+CRITICAL: DC02 DC=example,DC=com: 7 failures, last success 2026-08-10 03:11:42|'DC02 DC=example,DC=com'=7;0;4 ...
+```
+
+**Only alert on prolonged outages (ignore single hiccups):**
+
+```
+check_ad_replication "warning=none" "critical=last_success < -24h"
+OK: all 6 replication links are healthy
+```
+
+**Check a remote domain controller:**
+
+```
+check_ad_replication server=dc02.example.com
+OK: all 6 replication links are healthy
+```
+
+**Custom output listing every link and its last error:**
+
+```
+check_ad_replication "top-syntax=${status}: ${list}" "detail-syntax=${source} -> ${naming_context}: ${last_error_message}"
+WARNING: DC02 -> DC=example,DC=com: The RPC server is unavailable., DC03 -> DC=example,DC=com: 
+```
+
+**On a host that is not a domain controller (the fleet-wide-safe contract):**
+
+```
+check_ad_replication
+Not a domain controller: Failed to bind to the directory service on WEB01: 6d9: There are no more endpoints available from the endpoint mapper.
+```
+
+**On the only domain controller of a single-DC domain:**
+
+```
+check_ad_replication
+No replication partners found (single domain controller?)
+```

--- a/docs/samples/CheckActiveDirectory_check_kdc_desc.md
+++ b/docs/samples/CheckActiveDirectory_check_kdc_desc.md
@@ -1,0 +1,33 @@
+#### About `check_kdc`
+
+`check_kdc` verifies that a Kerberos KDC is actually issuing responses — not
+just that port 88 is open. It sends a real (unauthenticated) `AS-REQ` over TCP
+and classifies the answer: an `AS-REP` or any `KRB-ERROR` (typically
+`KDC_ERR_PREAUTH_REQUIRED`) proves a live KDC, while silence, a reset or a
+non-Kerberos answer means authentication is down even though a port probe
+would still pass. Kerberos failure looks like "everything is broken" to users,
+so this is the check to point at every domain controller.
+
+The probe uses a throwaway principal (`nscp-probe`) and never completes
+authentication: no account, no password and no Kerberos configuration is
+needed on the monitoring side.
+
+Keywords (one row per probed KDC):
+
+| Keyword      | Description                                                          |
+|--------------|----------------------------------------------------------------------|
+| `kdc`        | The host that was probed                                             |
+| `realm`      | The Kerberos realm the probe requested a ticket for                  |
+| `port`       | TCP port probed (default 88)                                         |
+| `responding` | True when a well-formed Kerberos answer arrived                      |
+| `response`   | What came back (`KRB-ERROR ...`, `AS-REP ...`, or the transport error) |
+| `error_code` | KRB-ERROR code from the response (-1 when none)                      |
+| `time`       | Round-trip time in milliseconds (perf data)                          |
+
+Defaults: **WARNING** when `time > 1000`, **CRITICAL** when `responding = 0`.
+
+Options: `server=<host>` (repeatable) picks the KDC(s) to probe and
+`realm=<REALM>` the realm; both default to what the domain join discovers
+(`DsGetDcName`). On a machine that is not domain-joined, `server=` and
+`realm=` are required and the check says so with **UNKNOWN**. `timeout=<s>`
+(default 5) bounds each probe.

--- a/docs/samples/CheckActiveDirectory_check_kdc_desc.md
+++ b/docs/samples/CheckActiveDirectory_check_kdc_desc.md
@@ -29,5 +29,6 @@ Defaults: **WARNING** when `time > 1000`, **CRITICAL** when `responding = 0`.
 Options: `server=<host>` (repeatable) picks the KDC(s) to probe and
 `realm=<REALM>` the realm; both default to what the domain join discovers
 (`DsGetDcName`). On a machine that is not domain-joined, `server=` and
-`realm=` are required and the check says so with **UNKNOWN**. `timeout=<s>`
-(default 5) bounds each probe.
+`realm=` are required and the check says so with **UNKNOWN**. `timeout=<ms>`
+(default 5000) bounds the probes; all KDCs are probed concurrently, so it also
+bounds the whole check even when several KDCs are unreachable.

--- a/docs/samples/CheckActiveDirectory_check_kdc_desc.md
+++ b/docs/samples/CheckActiveDirectory_check_kdc_desc.md
@@ -22,13 +22,21 @@ Keywords (one row per probed KDC):
 | `responding` | True when a well-formed Kerberos answer arrived                      |
 | `response`   | What came back (`KRB-ERROR ...`, `AS-REP ...`, or the transport error) |
 | `error_code` | KRB-ERROR code from the response (-1 when none)                      |
-| `time`       | Round-trip time in milliseconds (perf data)                          |
+| `time`       | Round-trip time in milliseconds (perf data; `?` when the host never resolved) |
 
 Defaults: **WARNING** when `time > 1000`, **CRITICAL** when `responding = 0`.
 
+A host whose name does not resolve never starts an exchange, so it has no
+round-trip time to report: `time` renders as `?` and contributes no perf data
+rather than putting a sentinel into the series. It still goes **CRITICAL** on
+`responding = 0`.
+
 Options: `server=<host>` (repeatable) picks the KDC(s) to probe and
 `realm=<REALM>` the realm; both default to what the domain join discovers
-(`DsGetDcName`). On a machine that is not domain-joined, `server=` and
-`realm=` are required and the check says so with **UNKNOWN**. `timeout=<ms>`
-(default 5000) bounds the probes; all KDCs are probed concurrently, so it also
-bounds the whole check even when several KDCs are unreachable.
+(`DsGetDcName`). A discovered realm is uppercased the way Active Directory
+reports it; an explicit `realm=` is sent exactly as typed, since Kerberos
+realms are case sensitive and a non-AD KDC may serve a lowercase one (max 255
+characters). On a machine that is not domain-joined, `server=` and `realm=` are
+required and the check says so with **UNKNOWN**. `timeout=<ms>` (default 5000)
+bounds the probes; all KDCs are probed concurrently, so it also bounds the
+whole check even when several KDCs are unreachable.

--- a/docs/samples/CheckActiveDirectory_check_kdc_samples.md
+++ b/docs/samples/CheckActiveDirectory_check_kdc_samples.md
@@ -1,8 +1,8 @@
-**Default check (domain-joined; probes the discovered KDC):**
+﻿**Default check (domain-joined; probes the discovered KDC):**
 
 ```
 check_kdc
-OK: dc01.example.com: KRB-ERROR KDC_ERR_PREAUTH_REQUIRED (2ms)|'dc01.example.com'=2ms;1000;0
+OK: dc01.example.com: KRB-ERROR KDC_ERR_PREAUTH_REQUIRED (2ms)|'dc01.example.com'=2ms;1000
 ```
 
 `KDC_ERR_PREAUTH_REQUIRED` is the *healthy* answer: the KDC processed the
@@ -12,21 +12,21 @@ request and asked for pre-authentication.
 
 ```
 check_kdc server=dc01.example.com server=dc02.example.com realm=EXAMPLE.COM
-OK: all 2 KDC(s) are responding|'dc01.example.com'=2ms;1000;0 'dc02.example.com'=3ms;1000;0
+OK: all 2 KDC(s) are responding|'dc01.example.com'=2ms;1000 'dc02.example.com'=3ms;1000
 ```
 
 **KDC down (nothing answering on the port):**
 
 ```
 check_kdc server=dc01.example.com realm=EXAMPLE.COM
-CRITICAL: dc01.example.com: connect failed: No connection could be made because the target machine actively refused it (2028ms)|'dc01.example.com'=2028ms;1000;0
+CRITICAL: dc01.example.com: connect failed: No connection could be made because the target machine actively refused it (2028ms)|'dc01.example.com'=2028ms;1000
 ```
 
 **Something answered, but it does not speak Kerberos:**
 
 ```
 check_kdc server=dc01.example.com realm=EXAMPLE.COM
-CRITICAL: dc01.example.com: invalid response (5ms)|'dc01.example.com'=5ms;1000;0
+CRITICAL: dc01.example.com: invalid response (5ms)|'dc01.example.com'=5ms;1000
 ```
 
 **Tighten the latency alert (Kerberos slowness precedes logon storms):**

--- a/docs/samples/CheckActiveDirectory_check_kdc_samples.md
+++ b/docs/samples/CheckActiveDirectory_check_kdc_samples.md
@@ -1,0 +1,52 @@
+**Default check (domain-joined; probes the discovered KDC):**
+
+```
+check_kdc
+OK: dc01.example.com: KRB-ERROR KDC_ERR_PREAUTH_REQUIRED (2ms)|'dc01.example.com'=2ms;1000;0
+```
+
+`KDC_ERR_PREAUTH_REQUIRED` is the *healthy* answer: the KDC processed the
+request and asked for pre-authentication.
+
+**Probe specific KDCs explicitly (works from any machine, no domain join needed):**
+
+```
+check_kdc server=dc01.example.com server=dc02.example.com realm=EXAMPLE.COM
+OK: all 2 KDC(s) are responding|'dc01.example.com'=2ms;1000;0 'dc02.example.com'=3ms;1000;0
+```
+
+**KDC down (nothing answering on the port):**
+
+```
+check_kdc server=dc01.example.com realm=EXAMPLE.COM
+CRITICAL: dc01.example.com: connect failed: No connection could be made because the target machine actively refused it (2028ms)|'dc01.example.com'=2028ms;1000;0
+```
+
+**Something answered, but it does not speak Kerberos:**
+
+```
+check_kdc server=dc01.example.com realm=EXAMPLE.COM
+CRITICAL: dc01.example.com: invalid response (5ms)|'dc01.example.com'=5ms;1000;0
+```
+
+**Tighten the latency alert (Kerberos slowness precedes logon storms):**
+
+```
+check_kdc "warning=time > 200" "critical=responding = 0 or time > 2000"
+OK: dc01.example.com: KRB-ERROR KDC_ERR_PREAUTH_REQUIRED (2ms)|'dc01.example.com'=2ms;200;2000
+```
+
+**Custom output with the raw error code:**
+
+```
+check_kdc "detail-syntax=${kdc} port ${port} realm ${realm}: ${response} code=${error_code}"
+OK: dc01.example.com port 88 realm EXAMPLE.COM: KRB-ERROR KDC_ERR_PREAUTH_REQUIRED code=25
+```
+
+**On a machine that is not domain-joined (no server= given):**
+
+```
+check_kdc
+Failed to locate a KDC (is this machine domain-joined?): 54b: The specified domain either does not exist or could not be contacted.
+. Specify server= and realm=.
+```

--- a/docs/samples/CheckActiveDirectory_check_kdc_samples.md
+++ b/docs/samples/CheckActiveDirectory_check_kdc_samples.md
@@ -1,4 +1,4 @@
-﻿**Default check (domain-joined; probes the discovered KDC):**
+**Default check (domain-joined; probes the discovered KDC):**
 
 ```
 check_kdc
@@ -47,6 +47,5 @@ OK: dc01.example.com port 88 realm EXAMPLE.COM: KRB-ERROR KDC_ERR_PREAUTH_REQUIR
 
 ```
 check_kdc
-Failed to locate a KDC (is this machine domain-joined?): 54b: The specified domain either does not exist or could not be contacted.
-. Specify server= and realm=.
+Failed to locate a KDC (is this machine domain-joined?): 54b: The specified domain either does not exist or could not be contacted. Specify server= and realm=.
 ```

--- a/docs/samples/CheckActiveDirectory_check_secure_channel_desc.md
+++ b/docs/samples/CheckActiveDirectory_check_secure_channel_desc.md
@@ -1,0 +1,36 @@
+#### About `check_secure_channel`
+
+`check_secure_channel` verifies the machine-account secure channel — the
+authenticated netlogon session every domain member maintains to a domain
+controller. A broken secure channel ("the trust relationship between this
+workstation and the primary domain failed") blocks every domain logon on the
+host while port- and service-level checks keep reporting green, which makes it
+one of the highest-signal single-bit checks a domain estate can run.
+
+By default the check actively *verifies* the channel (netlogon `TC_VERIFY`,
+the same operation as `nltest /sc_verify` / `Test-ComputerSecureChannel`),
+which contacts the DC. Pass `verify=false` for a passive status query only.
+
+Keywords (a single row):
+
+| Keyword         | Description                                                        |
+|-----------------|--------------------------------------------------------------------|
+| `domain`        | The trusted domain the secure channel points at                    |
+| `dc`            | The domain controller the channel is established with              |
+| `healthy`       | True when the channel is established (and verified)                |
+| `error_code`    | Win32 status of the channel (0 = healthy)                          |
+| `error_message` | `OK` or the formatted failure message                              |
+
+Defaults: **CRITICAL** when `healthy = 0`; no warning threshold.
+
+Options: `domain=<name>` checks the channel to a specific trusted domain
+(default: the domain this machine is joined to); `server=<host>` queries
+another computer's netlogon service.
+
+**Not-joined contract:** on a workgroup or standalone machine the check
+returns **UNKNOWN** ("not joined to a domain") rather than a hard error, so it
+is safe to deploy fleet-wide.
+
+Note: verifying the channel requires administrator rights on the target, which
+the NSClient++ service (LocalSystem) has; running the check as an unprivileged
+user may yield access-denied instead.

--- a/docs/samples/CheckActiveDirectory_check_secure_channel_desc.md
+++ b/docs/samples/CheckActiveDirectory_check_secure_channel_desc.md
@@ -24,13 +24,18 @@ Keywords (a single row):
 Defaults: **CRITICAL** when `healthy = 0`; no warning threshold.
 
 Options: `domain=<name>` checks the channel to a specific trusted domain
-(default: the domain this machine is joined to); `server=<host>` queries
-another computer's netlogon service.
+(default: the domain the checked machine is joined to); `server=<host>`
+queries another computer's netlogon service (its join state is then also read
+from that computer when `domain=` is not given).
 
 **Not-joined contract:** on a workgroup or standalone machine the check
 returns **UNKNOWN** ("not joined to a domain") rather than a hard error, so it
 is safe to deploy fleet-wide.
 
-Note: verifying the channel requires administrator rights on the target, which
-the NSClient++ service (LocalSystem) has; running the check as an unprivileged
-user may yield access-denied instead.
+**CRITICAL means a broken channel, nothing else:** when the netlogon query
+itself fails — the service is stopped or restarting, the caller lacks
+administrator rights, or the RPC connection to `server=` fails — the check
+returns **UNKNOWN** with the failure message instead of scoring the channel as
+broken. Verifying the channel requires administrator rights on the target,
+which the NSClient++ service (LocalSystem) has; running the check as an
+unprivileged user yields that UNKNOWN.

--- a/docs/samples/CheckActiveDirectory_check_secure_channel_samples.md
+++ b/docs/samples/CheckActiveDirectory_check_secure_channel_samples.md
@@ -1,0 +1,41 @@
+**Default check (healthy domain member; actively verifies the channel):**
+
+```
+check_secure_channel
+OK: secure channel to EXAMPLE via DC01.example.com: OK
+```
+
+**Broken secure channel (machine-account password out of sync):**
+
+```
+check_secure_channel
+CRITICAL: secure channel to EXAMPLE via : The trust relationship between this workstation and the primary domain failed.
+```
+
+**Passive status query only (do not contact the DC):**
+
+```
+check_secure_channel verify=false
+OK: secure channel to EXAMPLE via DC01.example.com: OK
+```
+
+**Check the channel to a specific trusted domain:**
+
+```
+check_secure_channel domain=PARTNER
+OK: secure channel to PARTNER via DC05.partner.example: OK
+```
+
+**Custom output with the raw status code:**
+
+```
+check_secure_channel "detail-syntax=${domain}: dc=${dc} code=${error_code}"
+OK: EXAMPLE: dc=DC01.example.com code=0
+```
+
+**On a workgroup machine (the fleet-wide-safe contract):**
+
+```
+check_secure_channel
+This machine is not joined to a domain (workgroup WORKGROUP); there is no secure channel to check
+```

--- a/include/parsers/where/variable.hpp
+++ b/include/parsers/where/variable.hpp
@@ -20,8 +20,11 @@ struct number_performance_generator_interface {
   virtual ~number_performance_generator_interface() = default;
   virtual bool is_configured() = 0;
   virtual void configure(std::string key, object_factory context) = 0;
-  virtual void eval(perf_list_type &list, evaluation_context context, std::string alias, TDataType current_value, TDataType warn, TDataType crit,
-                    TObject object) = 0;
+  // warn/crit are empty when the warning/critical expression carries no bound
+  // for this variable; the emitted perfdata must leave the field empty then,
+  // not default it to 0 (perf consumers read crit=0 as "critical when > 0").
+  virtual void eval(perf_list_type &list, evaluation_context context, std::string alias, TDataType current_value, boost::optional<TDataType> warn,
+                    boost::optional<TDataType> crit, TObject object) = 0;
 };
 
 // Parse a perf-config string (e.g. "0", "12345", "3.14") as a double. Returns
@@ -71,14 +74,14 @@ struct simple_number_performance_generator : number_performance_generator_interf
     if (!maximum) maximum = parse_optional_perf_bound(context->get_performance_config_key(p, k, s, "max", ""));
     configured = true;
   }
-  void eval(perf_list_type &list, evaluation_context context, const std::string alias, TDataType current_value, TDataType warn, TDataType crit,
-            TContext object) override {
+  void eval(perf_list_type &list, evaluation_context context, const std::string alias, TDataType current_value, boost::optional<TDataType> warn,
+            boost::optional<TDataType> crit, TContext object) override {
     if (ignored) return;
     performance_data data;
     performance_data::perf_value int_data;
     int_data.value = static_cast<double>(current_value);
-    int_data.warn = static_cast<double>(warn);
-    int_data.crit = static_cast<double>(crit);
+    if (warn) int_data.warn = static_cast<double>(*warn);
+    if (crit) int_data.crit = static_cast<double>(*crit);
     if (minimum) int_data.minimum = *minimum;
     if (maximum) int_data.maximum = *maximum;
     data.set(int_data);
@@ -111,16 +114,16 @@ struct percentage_int_performance_generator : number_performance_generator_inter
     configured = true;
   }
   double round(double number) { return number < 0.0 ? ceil(number - 0.5) : floor(number + 0.5); }
-  void eval(perf_list_type &list, evaluation_context context, std::string alias, long long current_value, long long warn, long long crit,
-            TContext object) override {
+  void eval(perf_list_type &list, evaluation_context context, std::string alias, long long current_value, boost::optional<long long> warn,
+            boost::optional<long long> crit, TContext object) override {
     if (ignored) return;
     long long maximum = maxfun(object, context);
     performance_data data;
     performance_data::perf_value double_data;
     if (maximum > 0) {
       double_data.value = round(static_cast<double>(current_value * 100) / maximum);
-      double_data.warn = round(static_cast<double>(warn * 100) / maximum);
-      double_data.crit = round(static_cast<double>(crit * 100) / maximum);
+      if (warn) double_data.warn = round(static_cast<double>(*warn * 100) / maximum);
+      if (crit) double_data.crit = round(static_cast<double>(*crit * 100) / maximum);
       double_data.maximum = 100;
       double_data.minimum = 0;
       data.set(double_data);
@@ -160,8 +163,8 @@ struct scaled_byte_int_performance_generator : number_performance_generator_inte
     if (context->get_performance_config_key(p, k, s, "ignored", "false") == "true") ignored = true;
     configured = true;
   }
-  void eval(perf_list_type &list, evaluation_context context, const std::string alias, const long long current_value, const long long warn,
-            const long long crit, TContext object) override {
+  void eval(perf_list_type &list, evaluation_context context, const std::string alias, const long long current_value, const boost::optional<long long> warn,
+            const boost::optional<long long> crit, TContext object) override {
     if (ignored) return;
     std::string active_unit = unit;
     long long max_value = 0;
@@ -170,8 +173,8 @@ struct scaled_byte_int_performance_generator : number_performance_generator_inte
     if (minfun) min_value = minfun(object, context);
     if (active_unit.empty()) {
       long long m = current_value;
-      if (warn > 0) m = (std::max)(m, warn);
-      if (crit > 0) m = (std::max)(m, crit);
+      if (warn && *warn > 0) m = (std::max)(m, *warn);
+      if (crit && *crit > 0) m = (std::max)(m, *crit);
       if (max_value > 0) m = (std::min)(m, max_value);
       if (min_value > 0) m = (std::min)(m, min_value);
       active_unit = str::format::find_proper_unit_BKMG(m);
@@ -190,8 +193,8 @@ struct scaled_byte_int_performance_generator : number_performance_generator_inte
       else
         double_data.minimum = min_value;
     }
-    double_data.warn = str::format::convert_to_byte_units(warn, active_unit);
-    double_data.crit = str::format::convert_to_byte_units(crit, active_unit);
+    if (warn) double_data.warn = str::format::convert_to_byte_units(*warn, active_unit);
+    if (crit) double_data.crit = str::format::convert_to_byte_units(*crit, active_unit);
     double_data.value = str::format::convert_to_byte_units(current_value, active_unit);
     performance_data data;
     data.set(double_data);
@@ -279,8 +282,8 @@ struct int_variable_node : any_node {
     perf_list_type ret;
     native_context_type native_context = reinterpret_cast<native_context_type>(context.get());
     if (native_context != nullptr && native_context->has_object()) {
-      long long warn_value = 0;
-      long long crit_value = 0;
+      boost::optional<long long> warn_value;
+      boost::optional<long long> crit_value;
       long long current_value = get_int_value(context);
       if (warn) warn_value = warn->get_int_value(context);
       if (crit) crit_value = crit->get_int_value(context);
@@ -367,8 +370,8 @@ struct float_variable_node : any_node {
     perf_list_type ret;
     native_context_type native_context = reinterpret_cast<native_context_type>(context.get());
     if (native_context != nullptr && native_context->has_object()) {
-      double warn_value = 0;
-      double crit_value = 0;
+      boost::optional<double> warn_value;
+      boost::optional<double> crit_value;
       double current_value = get_float_value(context);
       if (warn) warn_value = warn->get_float_value(context);
       if (crit) crit_value = crit->get_float_value(context);
@@ -590,8 +593,8 @@ struct dual_variable_node : any_node {
     perf_list_type ret;
     native_context_type native_context = reinterpret_cast<native_context_type>(context.get());
     if (native_context != nullptr && native_context->has_object()) {
-      long long warn_value = 0;
-      long long crit_value = 0;
+      boost::optional<long long> warn_value;
+      boost::optional<long long> crit_value;
       long long current_value = get_int_value(context);
       if (warn) warn_value = warn->get_int_value(context);
       if (crit) crit_value = crit->get_int_value(context);
@@ -719,8 +722,8 @@ struct optional_int_variable_node : any_node {
       const boost::optional<long long> v = fun(native_context->get_object(), context);
       // No value, no metric: plotting a sentinel would poison the series.
       if (!v) return ret;
-      long long warn_value = 0;
-      long long crit_value = 0;
+      boost::optional<long long> warn_value;
+      boost::optional<long long> crit_value;
       if (warn) warn_value = warn->get_int_value(context);
       if (crit) crit_value = crit->get_int_value(context);
       for (int_performance_generator &p : perfgen) {
@@ -857,16 +860,12 @@ struct summary_int_variable_node : any_node {
     perf_list_type ret;
     native_context_type native_context = reinterpret_cast<native_context_type>(context.get());
     if (native_context != nullptr && !native_context->has_object()) {
-      long long warn_value = 0;
-      long long crit_value = 0;
       const long long current_value = get_int_value(context);
-      if (warn) warn_value = warn->get_int_value(context);
-      if (crit) crit_value = crit->get_int_value(context);
       performance_data data;
       performance_data::perf_value int_data;
       int_data.value = static_cast<double>(current_value);
-      int_data.warn = static_cast<double>(warn_value);
-      int_data.crit = static_cast<double>(crit_value);
+      if (warn) int_data.warn = static_cast<double>(warn->get_int_value(context));
+      if (crit) int_data.crit = static_cast<double>(crit->get_int_value(context));
       data.set(int_data);
       data.alias = name_;
       ret.push_back(data);

--- a/installers/installer-NSCP/Product.wxs
+++ b/installers/installer-NSCP/Product.wxs
@@ -152,6 +152,7 @@
               <File Id="ModCheckDisk.dll" Name="CheckDisk.dll" DiskId="1" Source="$(var.Source)/modules/CheckDisk.dll" Vital="no" />
               <File Id="ModCheckTaskSched.dll" Name="CheckTaskSched.dll" DiskId="1" Source="$(var.Source)/modules/CheckTaskSched.dll" Vital="no" />
               <File Id="ModCheckSecurity.dll" Name="CheckSecurity.dll" DiskId="1" Source="$(var.Source)/modules/CheckSecurity.dll" Vital="no" />
+              <File Id="ModCheckActiveDirectory.dll" Name="CheckActiveDirectory.dll" DiskId="1" Source="$(var.Source)/modules/CheckActiveDirectory.dll" Vital="no" />
               <File Id="ModCheckMSSQL.dll" Name="CheckMSSQL.dll" DiskId="1" Source="$(var.Source)/modules/CheckMSSQL.dll" Vital="no" />
               <File Id="ModSimpleCache.dll" Name="SimpleCache.dll" DiskId="1" Source="$(var.Source)/modules/SimpleCache.dll" Vital="no" />
               <File Id="ModSimpleFileWriter.dll" Name="SimpleFileWriter.dll" DiskId="1" Source="$(var.Source)/modules/SimpleFileWriter.dll" Vital="no" />

--- a/modules/CheckActiveDirectory/CMakeLists.txt
+++ b/modules/CheckActiveDirectory/CMakeLists.txt
@@ -1,0 +1,85 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(TARGET CheckActiveDirectory)
+
+project(${TARGET})
+
+CREATE_MODULE(SRCS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+
+# The module is Windows-only (module.cmake gates it), so all sources are
+# unconditional. kdc_probe.cpp and ad_replication_filter.cpp are pure
+# (no win32 API) so the unit test below can link them without ntdsapi.
+set(SRCS
+    ${SRCS}
+    "${TARGET}.cpp"
+    check_ad_replication.cpp
+    ad_replication_filter.cpp
+    ad_replication_source_win.cpp
+    check_secure_channel.cpp
+    check_kdc.cpp
+    kdc_probe.cpp
+    ${NSCP_DEF_PLUGIN_CPP}
+    ${NSCP_FILTER_CPP}
+    ${NSCP_ERROR_CPP}
+    # Headers (for IDE project generation).
+    "${TARGET}.h"
+    check_ad_replication.hpp
+    ad_replication_filter.hpp
+    ad_replication_source.hpp
+    check_secure_channel.hpp
+    check_kdc.hpp
+    kdc_probe.hpp
+    ${NSCP_DEF_PLUGIN_HPP}
+    ${NSCP_FILTER_HPP}
+    ${NSCP_ERROR_HPP}
+)
+
+add_definitions(${NSCP_GLOBAL_DEFINES})
+
+add_library(${TARGET} MODULE ${SRCS})
+NSCP_DEBUG_SYMBOLS(${TARGET})
+
+# Ntdsapi (DsBind/DsReplicaGetInfo), Netapi32 (I_NetLogonControl2,
+# NetGetJoinInformation, DsGetDcName), ws2_32/mswsock (asio KDC probe).
+set(EXTRA_LIBS Ntdsapi Netapi32 ws2_32 mswsock)
+
+target_link_libraries(
+    ${TARGET}
+    ${Boost_FILESYSTEM_LIBRARY}
+    ${Boost_REGEX_LIBRARY}
+    ${Boost_DATE_TIME_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
+    ${Boost_PROGRAM_OPTIONS_LIBRARY}
+    ${NSCP_DEF_PLUGIN_LIB}
+    ${NSCP_FILTER_LIB}
+    expression_parser
+    ${EXTRA_LIBS}
+)
+
+include(${BUILD_CMAKE_FOLDER}/module.cmake)
+
+NSCP_CREATE_TEST(
+    check_activedirectory_test
+    SOURCES
+        check_activedirectory_test.cpp
+        kdc_probe.cpp
+        ad_replication_filter.cpp
+        ${NSCP_FILTER_CPP}
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_helper.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_INCLUDEDIR}/str/utf8.cpp
+    LIBRARIES
+        GTest::gtest_main
+        nscp_protobuf
+        ${NSCP_FILTER_LIB}
+        expression_parser
+        ${PLUGIN_API_TARGET}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
+        ${Boost_REGEX_LIBRARY}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/CheckActiveDirectory/CMakeLists.txt
+++ b/modules/CheckActiveDirectory/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SRCS
     check_secure_channel.hpp
     check_kdc.hpp
     kdc_probe.hpp
+    netapi_buffer.hpp
+    win32_error.hpp
     ${NSCP_DEF_PLUGIN_HPP}
     ${NSCP_FILTER_HPP}
     ${NSCP_ERROR_HPP}
@@ -40,7 +42,8 @@ add_library(${TARGET} MODULE ${SRCS})
 NSCP_DEBUG_SYMBOLS(${TARGET})
 
 # Ntdsapi (DsBind/DsReplicaGetInfo), Netapi32 (I_NetLogonControl2,
-# NetGetJoinInformation, DsGetDcName), ws2_32/mswsock (asio KDC probe).
+# NetGetJoinInformation, DsGetDcName, DsRoleGetPrimaryDomainInformation),
+# ws2_32/mswsock (asio KDC probe).
 set(EXTRA_LIBS Ntdsapi Netapi32 ws2_32 mswsock)
 
 target_link_libraries(

--- a/modules/CheckActiveDirectory/CheckActiveDirectory.cpp
+++ b/modules/CheckActiveDirectory/CheckActiveDirectory.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "CheckActiveDirectory.h"
+
+#include "check_ad_replication.hpp"
+#include "check_kdc.hpp"
+#include "check_secure_channel.hpp"
+
+CheckActiveDirectory::CheckActiveDirectory() {}
+
+bool CheckActiveDirectory::loadModuleEx(std::string, NSCAPI::moduleLoadMode) { return true; }
+
+bool CheckActiveDirectory::unloadModule() { return true; }
+
+void CheckActiveDirectory::check_ad_replication(const PB::Commands::QueryRequestMessage::Request &request,
+                                                PB::Commands::QueryResponseMessage::Response *response) {
+  check_ad_replication_command::check(request, response);
+}
+
+void CheckActiveDirectory::check_secure_channel(const PB::Commands::QueryRequestMessage::Request &request,
+                                                PB::Commands::QueryResponseMessage::Response *response) {
+  check_secure_channel_command::check(request, response);
+}
+
+void CheckActiveDirectory::check_kdc(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+  check_kdc_command::check(request, response);
+}

--- a/modules/CheckActiveDirectory/CheckActiveDirectory.h
+++ b/modules/CheckActiveDirectory/CheckActiveDirectory.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <nscapi/nscapi_plugin_impl.hpp>
+#include <nscapi/protobuf/command.hpp>
+
+class CheckActiveDirectory : public nscapi::impl::simple_plugin {
+ public:
+  CheckActiveDirectory();
+  virtual ~CheckActiveDirectory() {}
+
+  // Module calls
+  bool loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode);
+  bool unloadModule();
+
+  // Check commands
+  void check_ad_replication(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+  void check_secure_channel(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+  void check_kdc(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+};

--- a/modules/CheckActiveDirectory/ad_replication_filter.cpp
+++ b/modules/CheckActiveDirectory/ad_replication_filter.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "ad_replication_filter.hpp"
+
+namespace ad_replication_filter {
+
+using parsers::where::type_bool;
+using parsers::where::type_date;
+using parsers::where::type_int;
+
+std::string extract_server_from_ntds_dn(const std::string &dn) {
+  // The source DSA DN is "CN=NTDS Settings,CN=<server>,CN=Servers,...": the
+  // server is the second RDN. Anything else (unexpected shape) is returned
+  // verbatim so the operator still sees a usable identifier.
+  const std::string::size_type first = dn.find(',');
+  if (first == std::string::npos) return dn;
+  std::string::size_type start = first + 1;
+  while (start < dn.size() && dn[start] == ' ') ++start;
+  const std::string::size_type end = dn.find(',', start);
+  std::string rdn = dn.substr(start, end == std::string::npos ? std::string::npos : end - start);
+  if (rdn.compare(0, 3, "CN=") == 0 || rdn.compare(0, 3, "cn=") == 0) return rdn.substr(3);
+  return dn;
+}
+
+filter_obj_handler::filter_obj_handler() {
+  // clang-format off
+  registry_.add_string_var("naming_context", &filter_obj::get_naming_context, "The replicated directory partition (naming context) DN")
+      .add_string_var("source", &filter_obj::get_source, "The source domain controller this link replicates from")
+      .add_string_var("source_dsa", &filter_obj::get_source_dsa, "Full DN of the source directory service agent")
+      .add_string_var("source_address", &filter_obj::get_source_address, "Transport address of the source (GUID-based DNS name)")
+      .add_string_var("last_error_message", &filter_obj::get_last_error_message, "Human readable message for the last sync result (empty when ok)");
+
+  registry_.add_int_var("consecutive_failures", type_int, &filter_obj::get_consecutive_failures, "Number of consecutive failed sync attempts on this link")
+      .add_int_perf("");
+  registry_.add_int_var("last_error", type_int, &filter_obj::get_last_error, "Win32 result code of the last sync attempt (0 = success)");
+  registry_.add_int_var("failed", type_bool, &filter_obj::get_failed, "True when the last sync attempt failed");
+  registry_.add_int_var("last_attempt", type_date, &filter_obj::get_last_attempt, "When the last sync was attempted");
+  registry_.add_int_var("last_success", type_date, &filter_obj::get_last_success, "When the last sync succeeded (epoch 0 = never)");
+
+  registry_.add_human_string("last_attempt", &filter_obj::get_last_attempt_su, "")
+      .add_human_string("last_success", &filter_obj::get_last_success_su, "");
+  // clang-format on
+}
+
+}  // namespace ad_replication_filter

--- a/modules/CheckActiveDirectory/ad_replication_filter.hpp
+++ b/modules/CheckActiveDirectory/ad_replication_filter.hpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <memory>
+#include <parsers/filter/modern_filter.hpp>
+#include <parsers/helpers.hpp>
+#include <parsers/where/filter_handler_impl.hpp>
+#include <str/format.hpp>
+#include <string>
+
+namespace ad_replication_filter {
+
+// One inbound replication link (neighbor) of a domain controller: a
+// (naming context, source DC) pair. Timestamps are unix epoch seconds
+// (0 = never) so the where-engine date keywords work unmodified; the
+// win32 acquisition (ad_replication_source_win.cpp) converts FILETIMEs.
+struct filter_obj {
+  filter_obj() : last_attempt(0), last_success(0), last_error(0), consecutive_failures(0) {}
+
+  std::string get_naming_context() const { return naming_context; }
+  std::string get_source() const { return source_server; }
+  std::string get_source_dsa() const { return source_dsa_dn; }
+  std::string get_source_address() const { return source_address; }
+  std::string get_last_error_message() const { return last_error_message; }
+
+  long long get_last_attempt() const { return last_attempt; }
+  long long get_last_success() const { return last_success; }
+  long long get_last_error() const { return last_error; }
+  long long get_consecutive_failures() const { return consecutive_failures; }
+  long long get_failed() const { return last_error != 0 ? 1 : 0; }
+
+  std::string get_last_attempt_su() const { return last_attempt == 0 ? "never" : str::format::format_date(static_cast<std::time_t>(last_attempt)); }
+  std::string get_last_success_su() const { return last_success == 0 ? "never" : str::format::format_date(static_cast<std::time_t>(last_success)); }
+
+  std::string show() const { return source_server + " " + naming_context; }
+
+  std::string naming_context;      // DN of the replicated partition
+  std::string source_server;       // friendly source DC name (from the DSA DN)
+  std::string source_dsa_dn;       // full source DSA object DN
+  std::string source_address;      // transport address (GUID-based DNS name)
+  std::string last_error_message;  // formatted win32 message for last_error ("" when ok)
+  long long last_attempt;          // unix epoch seconds, 0 = never
+  long long last_success;          // unix epoch seconds, 0 = never
+  long long last_error;            // win32 result of the last sync (0 = ok)
+  long long consecutive_failures;  // consecutive failed sync attempts
+};
+
+typedef std::shared_ptr<filter_obj> filter_obj_ptr;
+
+// "CN=NTDS Settings,CN=DC02,CN=Servers,CN=Site,CN=Sites,..." -> "DC02".
+// Falls back to the full DN when the shape is not the expected NTDS DSA DN.
+std::string extract_server_from_ntds_dn(const std::string &dn);
+
+typedef parsers::where::filter_handler_impl<filter_obj_ptr> native_context;
+struct filter_obj_handler : native_context {
+  filter_obj_handler();
+};
+typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;
+
+}  // namespace ad_replication_filter

--- a/modules/CheckActiveDirectory/ad_replication_source.hpp
+++ b/modules/CheckActiveDirectory/ad_replication_source.hpp
@@ -11,10 +11,11 @@
 namespace ad_replication_source {
 
 // Fetch the inbound replication neighbors of `server` (empty = the local
-// machine) via DsBind/DsReplicaGetInfo. Returns false on failure with `error`
-// set; `not_a_dc` is true when the failure means the target does not run the
-// directory service (the common "checked a non-DC" case) rather than a
-// replication problem.
-bool fetch(const std::string &server, std::vector<ad_replication_filter::filter_obj_ptr> &out, std::string &error, bool &not_a_dc);
+// machine) via DsBind/DsReplicaGetInfo. `timeout_ms` bounds the reachability
+// pre-check made before binding to a named remote server. Returns false on
+// failure with `error` set; `not_a_dc` is true when the target is known not to
+// be a domain controller (the common "checked a member server" case) rather
+// than a domain controller that failed to answer.
+bool fetch(const std::string &server, int timeout_ms, std::vector<ad_replication_filter::filter_obj_ptr> &out, std::string &error, bool &not_a_dc);
 
 }  // namespace ad_replication_source

--- a/modules/CheckActiveDirectory/ad_replication_source.hpp
+++ b/modules/CheckActiveDirectory/ad_replication_source.hpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "ad_replication_filter.hpp"
+
+namespace ad_replication_source {
+
+// Fetch the inbound replication neighbors of `server` (empty = the local
+// machine) via DsBind/DsReplicaGetInfo. Returns false on failure with `error`
+// set; `not_a_dc` is true when the failure means the target does not run the
+// directory service (the common "checked a non-DC" case) rather than a
+// replication problem.
+bool fetch(const std::string &server, std::vector<ad_replication_filter::filter_obj_ptr> &out, std::string &error, bool &not_a_dc);
+
+}  // namespace ad_replication_source

--- a/modules/CheckActiveDirectory/ad_replication_source_win.cpp
+++ b/modules/CheckActiveDirectory/ad_replication_source_win.cpp
@@ -6,32 +6,102 @@
 // boost/asio must precede Windows.h so winsock2.h is included first.
 #include <boost/asio.hpp>
 
-// Windows.h must precede ntdsapi.h; the capital W keeps clang-format's
-// case-sensitive include sort from breaking that order. asio defines
-// WIN32_LEAN_AND_MEAN, which drops rpc.h from Windows.h, so pull it in
+// Windows.h must precede ntdsapi.h/dsrole.h; the capital W keeps
+// clang-format's case-sensitive include sort from breaking that order. asio
+// defines WIN32_LEAN_AND_MEAN, which drops rpc.h from Windows.h, so pull it in
 // explicitly: ntdsapi.h needs RPC_AUTH_IDENTITY_HANDLE.
 #include <Windows.h>
 #include <rpc.h>
 
+#include <dsrole.h>
 #include <ntdsapi.h>
 
 #include <chrono>
-#include <error/error.hpp>
+#include <memory>
 #include <str/utf8.hpp>
 #include <str/xtos.hpp>
 #include <vector>
+
+#include "win32_error.hpp"
 
 namespace ad_replication_source {
 
 namespace {
 
+// --- RAII wrappers over the directory-service handles -----------------------
+
+// DsBindW hands out a binding that DsUnBindW must take back (by address).
+class ds_binding {
+ public:
+  ds_binding() = default;
+  ~ds_binding() {
+    if (handle_ != nullptr) DsUnBindW(&handle_);
+  }
+  ds_binding(const ds_binding &) = delete;
+  ds_binding &operator=(const ds_binding &) = delete;
+
+  DWORD bind(const std::wstring &server) { return DsBindW(server.c_str(), nullptr, &handle_); }
+  HANDLE get() const { return handle_; }
+
+ private:
+  HANDLE handle_ = nullptr;
+};
+
+// DsReplicaGetInfoW allocates a result that DsReplicaFreeInfo releases, and
+// the release needs the same info type the fetch was made with - so the two
+// belong together rather than in a bare pointer plus a matching free call.
+class ds_replica_info {
+ public:
+  explicit ds_replica_info(DS_REPL_INFO_TYPE type) : type_(type) {}
+  ~ds_replica_info() {
+    if (data_ != nullptr) DsReplicaFreeInfo(type_, data_);
+  }
+  ds_replica_info(const ds_replica_info &) = delete;
+  ds_replica_info &operator=(const ds_replica_info &) = delete;
+
+  DWORD fetch(HANDLE binding) { return DsReplicaGetInfoW(binding, type_, nullptr, nullptr, &data_); }
+  const DS_REPL_NEIGHBORSW *neighbors() const { return static_cast<const DS_REPL_NEIGHBORSW *>(data_); }
+
+ private:
+  DS_REPL_INFO_TYPE type_;
+  VOID *data_ = nullptr;
+};
+
+// DsRoleGetPrimaryDomainInformation has its own allocator (not NetApiBuffer).
+struct ds_role_deleter {
+  void operator()(void *buffer) const noexcept {
+    if (buffer != nullptr) DsRoleFreeMemory(buffer);
+  }
+};
+typedef std::unique_ptr<DSROLE_PRIMARY_DOMAIN_INFO_BASIC, ds_role_deleter> ds_role_ptr;
+
+// --- helpers ----------------------------------------------------------------
+
 std::string local_dns_hostname() {
   DWORD size = 0;
   GetComputerNameExW(ComputerNameDnsHostname, nullptr, &size);
   if (size == 0) return "";
-  std::vector<wchar_t> buf(size + 1, L'\0');
-  if (!GetComputerNameExW(ComputerNameDnsHostname, buf.data(), &size)) return "";
-  return utf8::cvt<std::string>(std::wstring(buf.data()));
+  std::wstring buf(size, L'\0');
+  if (!GetComputerNameExW(ComputerNameDnsHostname, &buf[0], &size)) return "";
+  buf.resize(size);
+  return utf8::cvt<std::string>(buf);
+}
+
+// Is the target actually a domain controller? A failed DsBind says nothing
+// about that on its own: a member server and a DC whose NTDS service has
+// stopped both refuse the bind the same way. Asking the machine role first is
+// what separates "there is nothing here to check" (benign, deploy fleet-wide)
+// from "this DC is not answering" - the very outage this check exists for.
+// Returns false only when the role is known and is not a DC; an unavailable
+// role lookup leaves the benign reading in place rather than raising a false
+// alarm.
+bool looks_like_a_domain_controller(const std::string &server) {
+  const std::wstring server_w = utf8::cvt<std::wstring>(server);
+  PBYTE raw = nullptr;
+  if (DsRoleGetPrimaryDomainInformation(server.empty() ? nullptr : server_w.c_str(), DsRolePrimaryDomainInfoBasic, &raw) != ERROR_SUCCESS) return true;
+  const ds_role_ptr info(reinterpret_cast<DSROLE_PRIMARY_DOMAIN_INFO_BASIC *>(raw));
+  if (!info) return true;
+  return info->MachineRole == DsRole_RoleBackupDomainController || info->MachineRole == DsRole_RolePrimaryDomainController;
 }
 
 // DsBindW itself has no timeout: against a black-holed host it blocks for the
@@ -79,7 +149,7 @@ long long filetime_to_epoch(const FILETIME &ft) {
 
 }  // namespace
 
-bool fetch(const std::string &server, std::vector<ad_replication_filter::filter_obj_ptr> &out, std::string &error, bool &not_a_dc) {
+bool fetch(const std::string &server, int timeout_ms, std::vector<ad_replication_filter::filter_obj_ptr> &out, std::string &error, bool &not_a_dc) {
   not_a_dc = false;
   // DsBind with a NULL server binds to *some* DC in the domain, not this host,
   // so always name the target explicitly: replication state is per-DC.
@@ -88,39 +158,41 @@ bool fetch(const std::string &server, std::vector<ad_replication_filter::filter_
     error = "Failed to resolve the local computer name";
     return false;
   }
-  const std::wstring target_w = utf8::cvt<std::wstring>(target);
 
   if (!server.empty()) {
     std::string reach_error;
-    if (!can_reach_rpc(server, 5000, reach_error)) {
+    if (!can_reach_rpc(server, timeout_ms, reach_error)) {
       error = "Cannot reach the RPC endpoint mapper on " + server + " (port 135): " + reach_error;
       return false;
     }
   }
 
-  HANDLE hds = nullptr;
-  DWORD rc = DsBindW(target_w.c_str(), nullptr, &hds);
+  ds_binding binding;
+  DWORD rc = binding.bind(utf8::cvt<std::wstring>(target));
   if (rc != ERROR_SUCCESS) {
-    // Only the local host gets the benign not-a-DC contract: deployed
-    // fleet-wide, a local bind failure means a non-DC (or a stopped NTDS).
-    // An explicitly named server failing to bind is a dead or unreachable
-    // domain controller — the very outage the check exists to surface.
-    not_a_dc = server.empty();
-    error = "Failed to bind to the directory service on " + target + ": " + error::lookup::last_error(rc);
+    // Only a machine that is genuinely not a domain controller gets the benign
+    // contract. A DC that fails to bind (stopped NTDS, access denied, RPC
+    // unavailable) is a real failure and must not be filed as "nothing here".
+    not_a_dc = !looks_like_a_domain_controller(server);
+    error = "Failed to bind to the directory service on " + target + ": " + check_ad::win32_error(rc);
     return false;
   }
 
-  DS_REPL_NEIGHBORSW *neighbors = nullptr;
-  rc = DsReplicaGetInfoW(hds, DS_REPL_INFO_NEIGHBORS, nullptr, nullptr, reinterpret_cast<VOID **>(&neighbors));
+  ds_replica_info info(DS_REPL_INFO_NEIGHBORS);
+  rc = info.fetch(binding.get());
   if (rc != ERROR_SUCCESS) {
-    error = "Failed to read replication state from " + target + ": " + error::lookup::last_error(rc);
-    DsUnBindW(&hds);
+    error = "Failed to read replication state from " + target + ": " + check_ad::win32_error(rc);
+    return false;
+  }
+  const DS_REPL_NEIGHBORSW *neighbors = info.neighbors();
+  if (neighbors == nullptr) {
+    error = "The directory service on " + target + " returned no replication state";
     return false;
   }
 
   for (DWORD i = 0; i < neighbors->cNumNeighbors; ++i) {
     const DS_REPL_NEIGHBORW &n = neighbors->rgNeighbor[i];
-    ad_replication_filter::filter_obj_ptr obj(new ad_replication_filter::filter_obj());
+    ad_replication_filter::filter_obj_ptr obj = std::make_shared<ad_replication_filter::filter_obj>();
     if (n.pszNamingContext != nullptr) obj->naming_context = utf8::cvt<std::string>(std::wstring(n.pszNamingContext));
     if (n.pszSourceDsaDN != nullptr) {
       obj->source_dsa_dn = utf8::cvt<std::string>(std::wstring(n.pszSourceDsaDN));
@@ -131,12 +203,10 @@ bool fetch(const std::string &server, std::vector<ad_replication_filter::filter_
     obj->last_success = filetime_to_epoch(n.ftimeLastSyncSuccess);
     obj->last_error = n.dwLastSyncResult;
     obj->consecutive_failures = n.cNumConsecutiveSyncFailures;
-    if (n.dwLastSyncResult != ERROR_SUCCESS) obj->last_error_message = error::lookup::last_error(n.dwLastSyncResult);
+    if (n.dwLastSyncResult != ERROR_SUCCESS) obj->last_error_message = check_ad::win32_error(n.dwLastSyncResult);
     out.push_back(obj);
   }
 
-  DsReplicaFreeInfo(DS_REPL_INFO_NEIGHBORS, neighbors);
-  DsUnBindW(&hds);
   return true;
 }
 

--- a/modules/CheckActiveDirectory/ad_replication_source_win.cpp
+++ b/modules/CheckActiveDirectory/ad_replication_source_win.cpp
@@ -3,13 +3,22 @@
 
 #include "ad_replication_source.hpp"
 
+// boost/asio must precede Windows.h so winsock2.h is included first.
+#include <boost/asio.hpp>
+
 // Windows.h must precede ntdsapi.h; the capital W keeps clang-format's
-// case-sensitive include sort from breaking that order.
+// case-sensitive include sort from breaking that order. asio defines
+// WIN32_LEAN_AND_MEAN, which drops rpc.h from Windows.h, so pull it in
+// explicitly: ntdsapi.h needs RPC_AUTH_IDENTITY_HANDLE.
 #include <Windows.h>
+#include <rpc.h>
+
 #include <ntdsapi.h>
 
+#include <chrono>
 #include <error/error.hpp>
 #include <str/utf8.hpp>
+#include <str/xtos.hpp>
 #include <vector>
 
 namespace ad_replication_source {
@@ -23,6 +32,40 @@ std::string local_dns_hostname() {
   std::vector<wchar_t> buf(size + 1, L'\0');
   if (!GetComputerNameExW(ComputerNameDnsHostname, buf.data(), &size)) return "";
   return utf8::cvt<std::string>(std::wstring(buf.data()));
+}
+
+// DsBindW itself has no timeout: against a black-holed host it blocks for the
+// full TCP retransmit window (~21s+, possibly per RPC endpoint), blowing the
+// transport's command timeout. Before binding to an explicitly named remote
+// server, require its RPC endpoint mapper (port 135) to answer a TCP connect
+// within a bounded deadline so an unreachable DC fails fast instead.
+bool can_reach_rpc(const std::string &host, int timeout_ms, std::string &error) {
+  namespace asio = boost::asio;
+  using boost::asio::ip::tcp;
+
+  asio::io_context io;
+  tcp::resolver resolver(io);
+  tcp::socket socket(io);
+  bool connected = false;
+
+  resolver.async_resolve(host, "135", [&](const boost::system::error_code &ec, tcp::resolver::results_type results) {
+    if (ec) {
+      error = "resolve failed: " + ec.message();
+      return;
+    }
+    asio::async_connect(socket, results, [&](const boost::system::error_code &ec, const tcp::endpoint &) {
+      if (ec)
+        error = "connect failed: " + ec.message();
+      else
+        connected = true;
+    });
+  });
+
+  io.run_for(std::chrono::milliseconds(timeout_ms));
+  if (!connected && error.empty()) error = "no answer within " + str::xtos(timeout_ms) + "ms";
+  boost::system::error_code ignored;
+  socket.close(ignored);
+  return connected;
 }
 
 long long filetime_to_epoch(const FILETIME &ft) {
@@ -47,13 +90,22 @@ bool fetch(const std::string &server, std::vector<ad_replication_filter::filter_
   }
   const std::wstring target_w = utf8::cvt<std::wstring>(target);
 
+  if (!server.empty()) {
+    std::string reach_error;
+    if (!can_reach_rpc(server, 5000, reach_error)) {
+      error = "Cannot reach the RPC endpoint mapper on " + server + " (port 135): " + reach_error;
+      return false;
+    }
+  }
+
   HANDLE hds = nullptr;
   DWORD rc = DsBindW(target_w.c_str(), nullptr, &hds);
   if (rc != ERROR_SUCCESS) {
-    // The directory service not being reachable on the target is what a bind
-    // failure means in practice: a non-DC (or a stopped NTDS). Report it as
-    // the not-a-DC contract rather than a replication failure.
-    not_a_dc = true;
+    // Only the local host gets the benign not-a-DC contract: deployed
+    // fleet-wide, a local bind failure means a non-DC (or a stopped NTDS).
+    // An explicitly named server failing to bind is a dead or unreachable
+    // domain controller — the very outage the check exists to surface.
+    not_a_dc = server.empty();
     error = "Failed to bind to the directory service on " + target + ": " + error::lookup::last_error(rc);
     return false;
   }

--- a/modules/CheckActiveDirectory/ad_replication_source_win.cpp
+++ b/modules/CheckActiveDirectory/ad_replication_source_win.cpp
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "ad_replication_source.hpp"
+
+// Windows.h must precede ntdsapi.h; the capital W keeps clang-format's
+// case-sensitive include sort from breaking that order.
+#include <Windows.h>
+#include <ntdsapi.h>
+
+#include <error/error.hpp>
+#include <str/utf8.hpp>
+#include <vector>
+
+namespace ad_replication_source {
+
+namespace {
+
+std::string local_dns_hostname() {
+  DWORD size = 0;
+  GetComputerNameExW(ComputerNameDnsHostname, nullptr, &size);
+  if (size == 0) return "";
+  std::vector<wchar_t> buf(size + 1, L'\0');
+  if (!GetComputerNameExW(ComputerNameDnsHostname, buf.data(), &size)) return "";
+  return utf8::cvt<std::string>(std::wstring(buf.data()));
+}
+
+long long filetime_to_epoch(const FILETIME &ft) {
+  const unsigned long long ticks = (static_cast<unsigned long long>(ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+  if (ticks == 0) return 0;
+  // FILETIME epoch (1601) to unix epoch (1970) in 100ns ticks.
+  const unsigned long long kEpochDelta = 116444736000000000ULL;
+  if (ticks < kEpochDelta) return 0;
+  return static_cast<long long>((ticks - kEpochDelta) / 10000000ULL);
+}
+
+}  // namespace
+
+bool fetch(const std::string &server, std::vector<ad_replication_filter::filter_obj_ptr> &out, std::string &error, bool &not_a_dc) {
+  not_a_dc = false;
+  // DsBind with a NULL server binds to *some* DC in the domain, not this host,
+  // so always name the target explicitly: replication state is per-DC.
+  const std::string target = server.empty() ? local_dns_hostname() : server;
+  if (target.empty()) {
+    error = "Failed to resolve the local computer name";
+    return false;
+  }
+  const std::wstring target_w = utf8::cvt<std::wstring>(target);
+
+  HANDLE hds = nullptr;
+  DWORD rc = DsBindW(target_w.c_str(), nullptr, &hds);
+  if (rc != ERROR_SUCCESS) {
+    // The directory service not being reachable on the target is what a bind
+    // failure means in practice: a non-DC (or a stopped NTDS). Report it as
+    // the not-a-DC contract rather than a replication failure.
+    not_a_dc = true;
+    error = "Failed to bind to the directory service on " + target + ": " + error::lookup::last_error(rc);
+    return false;
+  }
+
+  DS_REPL_NEIGHBORSW *neighbors = nullptr;
+  rc = DsReplicaGetInfoW(hds, DS_REPL_INFO_NEIGHBORS, nullptr, nullptr, reinterpret_cast<VOID **>(&neighbors));
+  if (rc != ERROR_SUCCESS) {
+    error = "Failed to read replication state from " + target + ": " + error::lookup::last_error(rc);
+    DsUnBindW(&hds);
+    return false;
+  }
+
+  for (DWORD i = 0; i < neighbors->cNumNeighbors; ++i) {
+    const DS_REPL_NEIGHBORW &n = neighbors->rgNeighbor[i];
+    ad_replication_filter::filter_obj_ptr obj(new ad_replication_filter::filter_obj());
+    if (n.pszNamingContext != nullptr) obj->naming_context = utf8::cvt<std::string>(std::wstring(n.pszNamingContext));
+    if (n.pszSourceDsaDN != nullptr) {
+      obj->source_dsa_dn = utf8::cvt<std::string>(std::wstring(n.pszSourceDsaDN));
+      obj->source_server = ad_replication_filter::extract_server_from_ntds_dn(obj->source_dsa_dn);
+    }
+    if (n.pszSourceDsaAddress != nullptr) obj->source_address = utf8::cvt<std::string>(std::wstring(n.pszSourceDsaAddress));
+    obj->last_attempt = filetime_to_epoch(n.ftimeLastSyncAttempt);
+    obj->last_success = filetime_to_epoch(n.ftimeLastSyncSuccess);
+    obj->last_error = n.dwLastSyncResult;
+    obj->consecutive_failures = n.cNumConsecutiveSyncFailures;
+    if (n.dwLastSyncResult != ERROR_SUCCESS) obj->last_error_message = error::lookup::last_error(n.dwLastSyncResult);
+    out.push_back(obj);
+  }
+
+  DsReplicaFreeInfo(DS_REPL_INFO_NEIGHBORS, neighbors);
+  DsUnBindW(&hds);
+  return true;
+}
+
+}  // namespace ad_replication_source

--- a/modules/CheckActiveDirectory/check_activedirectory_test.cpp
+++ b/modules/CheckActiveDirectory/check_activedirectory_test.cpp
@@ -184,6 +184,25 @@ TEST_F(AsReqTest, EncodesTillNonceAndEtypes) {
   EXPECT_EQ(23, read_int(etype_list[2]));  // rc4-hmac
 }
 
+TEST(AsReq, EncodesElementsLargerThan64k) {
+  // A realm this large pushes the req-body (where the realm appears twice)
+  // past 0xFFFF, forcing 3-byte long-form DER lengths; an encoder that
+  // truncates to 2 length octets would emit a self-inconsistent blob this
+  // independent reader could not walk.
+  const std::string realm(70000, 'R');
+  const bytes req = kdc_probe::build_as_req(realm, "c", 1UL);
+  const std::vector<tlv> outer = parse_tlvs(req);
+  ASSERT_EQ(1u, outer.size());
+  ASSERT_EQ(0x6a, outer[0].tag);
+  const std::vector<tlv> fields = parse_tlvs(parse_tlvs(outer[0].content)[0].content);
+  const tlv *body = find_tag(fields, 0xa4);
+  ASSERT_NE(nullptr, body);
+  const std::vector<tlv> body_fields = parse_tlvs(parse_tlvs(body->content)[0].content);
+  const tlv *realm_field = find_tag(body_fields, 0xa2);
+  ASSERT_NE(nullptr, realm_field);
+  EXPECT_EQ(realm, read_string(parse_tlvs(realm_field->content)[0]));
+}
+
 TEST(AsReq, NonceWithHighBitGetsLeadingZeroByte) {
   // 0x80000000 would read as negative without a leading 0x00 pad octet.
   const bytes req = kdc_probe::build_as_req("R", "c", 0x80000000UL);

--- a/modules/CheckActiveDirectory/check_activedirectory_test.cpp
+++ b/modules/CheckActiveDirectory/check_activedirectory_test.cpp
@@ -38,11 +38,13 @@ bool read_der_len(const bytes &d, std::size_t &pos, std::size_t &out) {
     out = first;
   } else {
     const std::size_t count = first & 0x7f;
-    if (count == 0 || count > 4 || pos + count > d.size()) return false;
+    if (count == 0 || count > 4 || d.size() - pos < count) return false;
     out = 0;
     for (std::size_t i = 0; i < count; ++i) out = (out << 8) | d[pos++];
   }
-  return pos + out <= d.size();
+  // Against the bytes remaining, never `pos + out`: that overflows size_t on a
+  // 32-bit build and lets a crafted length walk the offset backwards.
+  return out <= d.size() - pos;
 }
 
 // Parse a run of sibling TLVs covering `data` exactly.
@@ -243,13 +245,41 @@ TEST(ClassifyResponse, KrbErrorPreauthRequiredIsAliveWithCode) {
 
 TEST(ClassifyResponse, SkipsUnknownFieldsBeforeErrorCode) {
   // Realistic KRB-ERROR carries stime [4]/susec [5] before error-code [6].
-  const bytes krb_error = {0x7e, 0x2b, 0x30, 0x29, 0xa0, 0x03, 0x02, 0x01, 0x05, 0xa1, 0x03, 0x02, 0x01, 0x1e, 0xa4, 0x11,
+  const bytes krb_error = {0x7e, 0x2c, 0x30, 0x2a, 0xa0, 0x03, 0x02, 0x01, 0x05, 0xa1, 0x03, 0x02, 0x01, 0x1e, 0xa4, 0x11,
                            0x18, 0x0f, '2',  '0',  '2',  '6',  '0',  '1',  '0',  '1',  '0',  '0',  '0',  '0',  '0',  '0',
                            'Z',  0xa5, 0x05, 0x02, 0x03, 0x01, 0x02, 0x03, 0xa6, 0x04, 0x02, 0x02, 0x00, 0x44};
   const kdc_probe::classification c = kdc_probe::classify_response(krb_error);
   EXPECT_EQ(kdc_probe::response_kind::krb_error, c.kind);
   EXPECT_EQ(68, c.error_code);
   EXPECT_NE(std::string::npos, c.describe().find("KRB_ERR_WRONG_REALM"));
+}
+
+TEST(ClassifyResponse, NegativeErrorCodeSignExtends) {
+  // error-code [6] is an Int32, so a short two's-complement encoding must
+  // extend rather than read as a huge positive number.
+  const bytes krb_error = {0x7e, 0x09, 0x30, 0x07, 0xa6, 0x05, 0x02, 0x03, 0xff, 0xff, 0xfb};
+  EXPECT_EQ(-5, kdc_probe::classify_response(krb_error).error_code);
+}
+
+TEST(ClassifyResponse, WrappingFieldLengthTerminates) {
+  // A 4-octet length of 0xfffffff2 at this offset makes `pos + len` wrap on a
+  // 32-bit build: the old bounds check passed and the walk offset then moved
+  // *backwards*, spinning the parser forever on a response the probe took from
+  // whatever host it was pointed at. The length must be rejected against the
+  // bytes remaining instead. (On 64-bit there is no wrap, so this only guards
+  // the rule - it is the x86 packages that were exposed.)
+  const bytes krb_error = {0x7e, 0x18, 0x30, 0x16, 0xa0, 0x03, 0x02, 0x01, 0x05, 0xa1, 0x03, 0x02, 0x01,
+                           0x1e, 0xa4, 0x84, 0xff, 0xff, 0xff, 0xf2, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
+  const kdc_probe::classification c = kdc_probe::classify_response(krb_error);
+  EXPECT_EQ(kdc_probe::response_kind::krb_error, c.kind);
+  EXPECT_EQ(-1, c.error_code);
+}
+
+TEST(ClassifyResponse, TruncatedFieldInsideSequenceTerminates) {
+  const bytes krb_error = {0x7e, 0x06, 0x30, 0x04, 0xa6, 0x7f, 0x02, 0x01};
+  const kdc_probe::classification c = kdc_probe::classify_response(krb_error);
+  EXPECT_EQ(kdc_probe::response_kind::krb_error, c.kind);
+  EXPECT_EQ(-1, c.error_code);
 }
 
 TEST(ClassifyResponse, GarbageIsInvalid) {

--- a/modules/CheckActiveDirectory/check_activedirectory_test.cpp
+++ b/modules/CheckActiveDirectory/check_activedirectory_test.cpp
@@ -1,0 +1,276 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Pure-logic tests for CheckActiveDirectory: the Kerberos AS-REQ probe
+// encoder/classifier and the replication filter helpers. The encoder is
+// verified with an independent DER reader written here (not the encoder's own
+// helpers), so a structural encoding bug cannot cancel itself out.
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <parsers/helpers.hpp>
+#include <string>
+#include <vector>
+
+#include "ad_replication_filter.hpp"
+#include "kdc_probe.hpp"
+
+// Normally provided by NSC_WRAP_DLL() in the auto-generated module.cpp; in the
+// test binary there is no generated module, so define the singleton here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+using kdc_probe::bytes;
+
+// --- independent minimal DER reader ----------------------------------------
+
+struct tlv {
+  unsigned char tag;
+  bytes content;
+};
+
+bool read_der_len(const bytes &d, std::size_t &pos, std::size_t &out) {
+  if (pos >= d.size()) return false;
+  const unsigned char first = d[pos++];
+  if ((first & 0x80) == 0) {
+    out = first;
+  } else {
+    const std::size_t count = first & 0x7f;
+    if (count == 0 || count > 4 || pos + count > d.size()) return false;
+    out = 0;
+    for (std::size_t i = 0; i < count; ++i) out = (out << 8) | d[pos++];
+  }
+  return pos + out <= d.size();
+}
+
+// Parse a run of sibling TLVs covering `data` exactly.
+std::vector<tlv> parse_tlvs(const bytes &data) {
+  std::vector<tlv> out;
+  std::size_t pos = 0;
+  while (pos < data.size()) {
+    tlv t;
+    t.tag = data[pos++];
+    std::size_t len = 0;
+    if (!read_der_len(data, pos, len)) {
+      ADD_FAILURE() << "malformed DER at offset " << pos;
+      return out;
+    }
+    t.content.assign(data.begin() + pos, data.begin() + pos + len);
+    pos += len;
+    out.push_back(t);
+  }
+  return out;
+}
+
+const tlv *find_tag(const std::vector<tlv> &fields, unsigned char tag) {
+  for (const tlv &t : fields) {
+    if (t.tag == tag) return &t;
+  }
+  return nullptr;
+}
+
+long long read_int(const tlv &t) {
+  EXPECT_EQ(0x02, t.tag) << "expected INTEGER";
+  long long v = 0;
+  for (const unsigned char b : t.content) v = (v << 8) | b;
+  return v;
+}
+
+std::string read_string(const tlv &t) {
+  EXPECT_EQ(0x1b, t.tag) << "expected GeneralString";
+  return std::string(t.content.begin(), t.content.end());
+}
+
+// --- AS-REQ encoder ---------------------------------------------------------
+
+class AsReqTest : public ::testing::Test {
+ protected:
+  bytes req;
+  std::vector<tlv> body_fields;
+
+  void SetUp() override {
+    req = kdc_probe::build_as_req("EXAMPLE.COM", "nscp-probe", 12345678UL);
+
+    const std::vector<tlv> outer = parse_tlvs(req);
+    ASSERT_EQ(1u, outer.size());
+    ASSERT_EQ(0x6a, outer[0].tag) << "AS-REQ is [APPLICATION 10]";
+
+    const std::vector<tlv> kdc_req = parse_tlvs(outer[0].content);
+    ASSERT_EQ(1u, kdc_req.size());
+    ASSERT_EQ(0x30, kdc_req[0].tag);
+
+    const std::vector<tlv> fields = parse_tlvs(kdc_req[0].content);
+    const tlv *pvno = find_tag(fields, 0xa1);
+    const tlv *msg_type = find_tag(fields, 0xa2);
+    const tlv *body = find_tag(fields, 0xa4);
+    ASSERT_NE(nullptr, pvno);
+    ASSERT_NE(nullptr, msg_type);
+    ASSERT_NE(nullptr, body);
+    EXPECT_EQ(5, read_int(parse_tlvs(pvno->content)[0]));
+    EXPECT_EQ(10, read_int(parse_tlvs(msg_type->content)[0]));
+
+    const std::vector<tlv> body_seq = parse_tlvs(body->content);
+    ASSERT_EQ(1u, body_seq.size());
+    ASSERT_EQ(0x30, body_seq[0].tag);
+    body_fields = parse_tlvs(body_seq[0].content);
+  }
+
+  const tlv *body_field(unsigned char tag) { return find_tag(body_fields, tag); }
+};
+
+TEST_F(AsReqTest, EncodesKdcOptionsAsEmpty32BitString) {
+  const tlv *options = body_field(0xa0);
+  ASSERT_NE(nullptr, options);
+  const std::vector<tlv> bits = parse_tlvs(options->content);
+  ASSERT_EQ(1u, bits.size());
+  EXPECT_EQ(0x03, bits[0].tag);
+  EXPECT_EQ(bytes({0x00, 0x00, 0x00, 0x00, 0x00}), bits[0].content);
+}
+
+TEST_F(AsReqTest, EncodesClientPrincipal) {
+  const tlv *cname = body_field(0xa1);
+  ASSERT_NE(nullptr, cname);
+  const std::vector<tlv> pn = parse_tlvs(parse_tlvs(cname->content)[0].content);
+  const tlv *name_type = find_tag(pn, 0xa0);
+  const tlv *name_string = find_tag(pn, 0xa1);
+  ASSERT_NE(nullptr, name_type);
+  ASSERT_NE(nullptr, name_string);
+  EXPECT_EQ(1, read_int(parse_tlvs(name_type->content)[0]));  // NT-PRINCIPAL
+  const std::vector<tlv> names = parse_tlvs(parse_tlvs(name_string->content)[0].content);
+  ASSERT_EQ(1u, names.size());
+  EXPECT_EQ("nscp-probe", read_string(names[0]));
+}
+
+TEST_F(AsReqTest, EncodesRealmAndKrbtgtServicePrincipal) {
+  const tlv *realm = body_field(0xa2);
+  ASSERT_NE(nullptr, realm);
+  EXPECT_EQ("EXAMPLE.COM", read_string(parse_tlvs(realm->content)[0]));
+
+  const tlv *sname = body_field(0xa3);
+  ASSERT_NE(nullptr, sname);
+  const std::vector<tlv> pn = parse_tlvs(parse_tlvs(sname->content)[0].content);
+  const tlv *name_type = find_tag(pn, 0xa0);
+  const tlv *name_string = find_tag(pn, 0xa1);
+  ASSERT_NE(nullptr, name_type);
+  ASSERT_NE(nullptr, name_string);
+  EXPECT_EQ(2, read_int(parse_tlvs(name_type->content)[0]));  // NT-SRV-INST
+  const std::vector<tlv> names = parse_tlvs(parse_tlvs(name_string->content)[0].content);
+  ASSERT_EQ(2u, names.size());
+  EXPECT_EQ("krbtgt", read_string(names[0]));
+  EXPECT_EQ("EXAMPLE.COM", read_string(names[1]));
+}
+
+TEST_F(AsReqTest, EncodesTillNonceAndEtypes) {
+  const tlv *till = body_field(0xa5);
+  ASSERT_NE(nullptr, till);
+  const std::vector<tlv> time = parse_tlvs(till->content);
+  ASSERT_EQ(1u, time.size());
+  EXPECT_EQ(0x18, time[0].tag);  // GeneralizedTime
+  ASSERT_EQ(15u, time[0].content.size());
+  EXPECT_EQ('Z', time[0].content.back());
+
+  const tlv *nonce = body_field(0xa7);
+  ASSERT_NE(nullptr, nonce);
+  EXPECT_EQ(12345678, read_int(parse_tlvs(nonce->content)[0]));
+
+  const tlv *etypes = body_field(0xa8);
+  ASSERT_NE(nullptr, etypes);
+  const std::vector<tlv> etype_list = parse_tlvs(parse_tlvs(etypes->content)[0].content);
+  ASSERT_EQ(3u, etype_list.size());
+  EXPECT_EQ(18, read_int(etype_list[0]));  // aes256-cts-hmac-sha1-96
+  EXPECT_EQ(17, read_int(etype_list[1]));  // aes128-cts-hmac-sha1-96
+  EXPECT_EQ(23, read_int(etype_list[2]));  // rc4-hmac
+}
+
+TEST(AsReq, NonceWithHighBitGetsLeadingZeroByte) {
+  // 0x80000000 would read as negative without a leading 0x00 pad octet.
+  const bytes req = kdc_probe::build_as_req("R", "c", 0x80000000UL);
+  // Locate the nonce ([7]) via the reader and confirm the INTEGER is 5 bytes.
+  const std::vector<tlv> outer = parse_tlvs(req);
+  ASSERT_EQ(1u, outer.size());
+  const std::vector<tlv> fields = parse_tlvs(parse_tlvs(outer[0].content)[0].content);
+  const tlv *body = find_tag(fields, 0xa4);
+  ASSERT_NE(nullptr, body);
+  const std::vector<tlv> body_fields = parse_tlvs(parse_tlvs(body->content)[0].content);
+  const tlv *nonce = find_tag(body_fields, 0xa7);
+  ASSERT_NE(nullptr, nonce);
+  const tlv integer = parse_tlvs(nonce->content)[0];
+  ASSERT_EQ(5u, integer.content.size());
+  EXPECT_EQ(0x00, integer.content[0]);
+  EXPECT_EQ(0x80, integer.content[1]);
+}
+
+// --- response classifier ----------------------------------------------------
+
+TEST(ClassifyResponse, AsRepMeansAlive) {
+  const bytes as_rep = {0x6b, 0x03, 0x30, 0x01, 0x00};
+  const kdc_probe::classification c = kdc_probe::classify_response(as_rep);
+  EXPECT_EQ(kdc_probe::response_kind::as_rep, c.kind);
+  EXPECT_TRUE(c.alive());
+  EXPECT_EQ(-1, c.error_code);
+}
+
+TEST(ClassifyResponse, KrbErrorPreauthRequiredIsAliveWithCode) {
+  // KRB-ERROR { pvno [0] 5, msg-type [1] 30, error-code [6] 25 }
+  const bytes krb_error = {0x7e, 0x11, 0x30, 0x0f, 0xa0, 0x03, 0x02, 0x01, 0x05, 0xa1, 0x03, 0x02, 0x01, 0x1e, 0xa6, 0x03, 0x02, 0x01, 0x19};
+  const kdc_probe::classification c = kdc_probe::classify_response(krb_error);
+  EXPECT_EQ(kdc_probe::response_kind::krb_error, c.kind);
+  EXPECT_TRUE(c.alive());
+  EXPECT_EQ(25, c.error_code);
+  EXPECT_NE(std::string::npos, c.describe().find("KDC_ERR_PREAUTH_REQUIRED"));
+}
+
+TEST(ClassifyResponse, SkipsUnknownFieldsBeforeErrorCode) {
+  // Realistic KRB-ERROR carries stime [4]/susec [5] before error-code [6].
+  const bytes krb_error = {0x7e, 0x2b, 0x30, 0x29, 0xa0, 0x03, 0x02, 0x01, 0x05, 0xa1, 0x03, 0x02, 0x01, 0x1e, 0xa4, 0x11,
+                           0x18, 0x0f, '2',  '0',  '2',  '6',  '0',  '1',  '0',  '1',  '0',  '0',  '0',  '0',  '0',  '0',
+                           'Z',  0xa5, 0x05, 0x02, 0x03, 0x01, 0x02, 0x03, 0xa6, 0x04, 0x02, 0x02, 0x00, 0x44};
+  const kdc_probe::classification c = kdc_probe::classify_response(krb_error);
+  EXPECT_EQ(kdc_probe::response_kind::krb_error, c.kind);
+  EXPECT_EQ(68, c.error_code);
+  EXPECT_NE(std::string::npos, c.describe().find("KRB_ERR_WRONG_REALM"));
+}
+
+TEST(ClassifyResponse, GarbageIsInvalid) {
+  EXPECT_FALSE(kdc_probe::classify_response({}).alive());
+  EXPECT_FALSE(kdc_probe::classify_response({0x00}).alive());
+  EXPECT_FALSE(kdc_probe::classify_response({0x42, 0x01, 0x00}).alive());
+  EXPECT_EQ(kdc_probe::response_kind::invalid, kdc_probe::classify_response({0x16, 0x03, 0x01}).kind);  // e.g. a TLS server on the port
+}
+
+TEST(ClassifyResponse, TruncatedKrbErrorIsStillAliveWithoutCode) {
+  // The tag byte proves a Kerberos speaker even when the body is cut short.
+  const kdc_probe::classification c = kdc_probe::classify_response({0x7e, 0x82});
+  EXPECT_EQ(kdc_probe::response_kind::krb_error, c.kind);
+  EXPECT_TRUE(c.alive());
+  EXPECT_EQ(-1, c.error_code);
+}
+
+// --- replication filter helpers ----------------------------------------------
+
+TEST(ReplicationFilter, ExtractsServerFromNtdsDsaDn) {
+  EXPECT_EQ("DC02", ad_replication_filter::extract_server_from_ntds_dn(
+                        "CN=NTDS Settings,CN=DC02,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=example,DC=com"));
+  EXPECT_EQ("DC02", ad_replication_filter::extract_server_from_ntds_dn("CN=NTDS Settings, CN=DC02, CN=Servers"));
+}
+
+TEST(ReplicationFilter, FallsBackToVerbatimDnOnUnexpectedShape) {
+  EXPECT_EQ("just-a-name", ad_replication_filter::extract_server_from_ntds_dn("just-a-name"));
+  EXPECT_EQ("CN=NTDS Settings,OU=weird", ad_replication_filter::extract_server_from_ntds_dn("CN=NTDS Settings,OU=weird"));
+}
+
+TEST(ReplicationFilter, DerivedFieldsAndNeverDates) {
+  ad_replication_filter::filter_obj obj;
+  EXPECT_EQ(0, obj.get_failed());
+  EXPECT_EQ("never", obj.get_last_success_su());
+  EXPECT_EQ("never", obj.get_last_attempt_su());
+
+  obj.last_error = 8524;  // ERROR_DS_DRA_GENERIC / "the DSA operation..."
+  obj.last_success = 1700000000;
+  EXPECT_EQ(1, obj.get_failed());
+  EXPECT_NE("never", obj.get_last_success_su());
+}
+
+}  // namespace

--- a/modules/CheckActiveDirectory/check_ad_replication.cpp
+++ b/modules/CheckActiveDirectory/check_ad_replication.cpp
@@ -22,6 +22,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   modern_filter::cli_helper<ad_replication_filter::filter> filter_helper(request, response, data);
 
   std::string server;
+  int timeout_ms = 5000;
 
   ad_replication_filter::filter filter;
   // A link is suspect on its first failed sync and clearly broken after
@@ -37,6 +38,8 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   // clang-format off
   filter_helper.get_desc().add_options()
     ("server", po::value<std::string>(&server), "The domain controller to check (default: the local machine).")
+    ("timeout", po::value<int>(&timeout_ms)->default_value(5000),
+        "Timeout in milliseconds for reaching a remote server= before binding to it (ignored for the local machine).")
     ;
   // clang-format on
 
@@ -46,7 +49,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   std::vector<ad_replication_filter::filter_obj_ptr> neighbors;
   std::string error;
   bool not_a_dc = false;
-  if (!ad_replication_source::fetch(server, neighbors, error, not_a_dc)) {
+  if (!ad_replication_source::fetch(server, timeout_ms, neighbors, error, not_a_dc)) {
     // Both branches are UNKNOWN; the message distinguishes "this host is not a
     // domain controller" (safe to deploy fleet-wide) from a real read failure.
     return nscapi::protobuf::functions::set_response_bad(*response, not_a_dc ? "Not a domain controller: " + error : error);

--- a/modules/CheckActiveDirectory/check_ad_replication.cpp
+++ b/modules/CheckActiveDirectory/check_ad_replication.cpp
@@ -1,0 +1,60 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "check_ad_replication.hpp"
+
+#include <nscapi/nscapi_program_options.hpp>
+#include <parsers/filter/cli_helper.hpp>
+#include <parsers/filter/modern_filter.hpp>
+#include <parsers/helpers.hpp>
+#include <string>
+#include <vector>
+
+#include "ad_replication_filter.hpp"
+#include "ad_replication_source.hpp"
+
+namespace po = boost::program_options;
+
+namespace check_ad_replication_command {
+
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+  modern_filter::data_container data;
+  modern_filter::cli_helper<ad_replication_filter::filter> filter_helper(request, response, data);
+
+  std::string server;
+
+  ad_replication_filter::filter filter;
+  // A link is suspect on its first failed sync and clearly broken after
+  // several in a row or a day without a successful sync. A never-synced link
+  // (last_success = epoch 0) trips the 24h rule by design.
+  filter_helper.add_options("consecutive_failures > 0", "consecutive_failures > 4 or last_success < -24h", "", filter.get_filter_syntax(), "ok");
+  filter_helper.add_syntax("${status}: ${problem_list}", "${source} ${naming_context}: ${consecutive_failures} failures, last success ${last_success}",
+                           "${source} ${naming_context}", "No replication partners found (single domain controller?)",
+                           "%(status): all %(count) replication links are healthy");
+  // Thresholding on the date keywords must not spray epoch-seconds perfdata;
+  // consecutive_failures (registered with perf) is the useful series.
+  filter_helper.set_default_perf_config("last_success(ignored:true)last_attempt(ignored:true)");
+  // clang-format off
+  filter_helper.get_desc().add_options()
+    ("server", po::value<std::string>(&server), "The domain controller to check (default: the local machine).")
+    ;
+  // clang-format on
+
+  if (!filter_helper.parse_options()) return;
+  if (!filter_helper.build_filter(filter)) return;
+
+  std::vector<ad_replication_filter::filter_obj_ptr> neighbors;
+  std::string error;
+  bool not_a_dc = false;
+  if (!ad_replication_source::fetch(server, neighbors, error, not_a_dc)) {
+    // Both branches are UNKNOWN; the message distinguishes "this host is not a
+    // domain controller" (safe to deploy fleet-wide) from a real read failure.
+    return nscapi::protobuf::functions::set_response_bad(*response, not_a_dc ? "Not a domain controller: " + error : error);
+  }
+
+  parsers::where::constants::reset();
+  for (const ad_replication_filter::filter_obj_ptr &n : neighbors) filter.match(n);
+  filter_helper.post_process(filter);
+}
+
+}  // namespace check_ad_replication_command

--- a/modules/CheckActiveDirectory/check_ad_replication.hpp
+++ b/modules/CheckActiveDirectory/check_ad_replication.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <nscapi/protobuf/command.hpp>
+
+namespace check_ad_replication_command {
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+}  // namespace check_ad_replication_command

--- a/modules/CheckActiveDirectory/check_kdc.cpp
+++ b/modules/CheckActiveDirectory/check_kdc.cpp
@@ -1,0 +1,253 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "check_kdc.hpp"
+
+// boost/asio must precede Windows.h so winsock2.h is included first.
+#include <boost/asio.hpp>
+
+// Windows.h must precede dsgetdc.h/lm.h; the capital W keeps clang-format's
+// case-sensitive include sort from breaking that order.
+#include <Windows.h>
+#include <dsgetdc.h>
+#include <lm.h>
+
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <error/error.hpp>
+#include <memory>
+#include <nscapi/nscapi_program_options.hpp>
+#include <parsers/filter/cli_helper.hpp>
+#include <parsers/filter/modern_filter.hpp>
+#include <parsers/helpers.hpp>
+#include <parsers/where/filter_handler_impl.hpp>
+#include <str/utf8.hpp>
+#include <str/xtos.hpp>
+#include <string>
+#include <vector>
+
+#include "kdc_probe.hpp"
+
+namespace po = boost::program_options;
+
+namespace kdc_filter {
+
+// The result of probing one KDC: did it answer the AS-REQ, with what, and how fast.
+struct filter_obj {
+  filter_obj() : port(0), responding(0), error_code(-1), time(-1) {}
+
+  std::string get_kdc() const { return kdc; }
+  std::string get_realm() const { return realm; }
+  std::string get_response() const { return response; }
+  long long get_port() const { return port; }
+  long long get_responding() const { return responding; }
+  long long get_error_code() const { return error_code; }
+  long long get_time() const { return time; }
+
+  std::string show() const { return kdc; }
+
+  std::string kdc;       // host probed
+  std::string realm;     // realm the AS-REQ was for
+  std::string response;  // what came back ("KRB-ERROR ..." / "AS-REP ..." / transport error)
+  long long port;
+  long long responding;  // 1 when a well-formed Kerberos answer arrived
+  long long error_code;  // KRB-ERROR code (-1 when none)
+  long long time;        // round-trip in milliseconds
+};
+
+typedef std::shared_ptr<filter_obj> filter_obj_ptr;
+
+typedef parsers::where::filter_handler_impl<filter_obj_ptr> native_context;
+struct filter_obj_handler : native_context {
+  filter_obj_handler() {
+    using parsers::where::type_bool;
+    using parsers::where::type_int;
+    // clang-format off
+    registry_.add_string_var("kdc", &filter_obj::get_kdc, "The KDC host that was probed")
+        .add_string_var("realm", &filter_obj::get_realm, "The Kerberos realm the probe requested a ticket for")
+        .add_string_var("response", &filter_obj::get_response, "What the KDC answered (or the transport error)");
+    registry_.add_int_var("time", type_int, &filter_obj::get_time, "Probe round-trip time in milliseconds").add_int_perf("ms");
+    registry_.add_int_var("port", type_int, &filter_obj::get_port, "TCP port probed");
+    registry_.add_int_var("responding", type_bool, &filter_obj::get_responding, "True when the KDC answered the AS-REQ with a well-formed Kerberos message");
+    registry_.add_int_var("error_code", type_int, &filter_obj::get_error_code, "KRB-ERROR code from the response (-1 when none)");
+    // clang-format on
+  }
+};
+typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;
+
+}  // namespace kdc_filter
+
+namespace check_kdc_command {
+
+namespace {
+
+struct probe_outcome {
+  bool exchanged;
+  std::string error;
+  kdc_probe::bytes response;
+  long long time_ms;
+
+  probe_outcome() : exchanged(false), time_ms(-1) {}
+};
+
+// One framed request/response exchange (RFC 4120 7.2.2: 4-byte big-endian
+// length prefix) against host:port with an overall deadline.
+probe_outcome exchange_with_kdc(const std::string &host, int port, int timeout_ms, const kdc_probe::bytes &request) {
+  namespace asio = boost::asio;
+  using boost::asio::ip::tcp;
+
+  probe_outcome out;
+
+  kdc_probe::bytes framed;
+  framed.reserve(request.size() + 4);
+  framed.push_back(static_cast<unsigned char>((request.size() >> 24) & 0xff));
+  framed.push_back(static_cast<unsigned char>((request.size() >> 16) & 0xff));
+  framed.push_back(static_cast<unsigned char>((request.size() >> 8) & 0xff));
+  framed.push_back(static_cast<unsigned char>(request.size() & 0xff));
+  framed.insert(framed.end(), request.begin(), request.end());
+
+  asio::io_context io;
+  tcp::resolver resolver(io);
+  tcp::socket socket(io);
+  unsigned char header[4] = {0, 0, 0, 0};
+  bool done = false;
+  std::string error;
+
+  const auto start = std::chrono::steady_clock::now();
+  resolver.async_resolve(host, str::xtos(port), [&](const boost::system::error_code &ec, tcp::resolver::results_type results) {
+    if (ec) {
+      error = "resolve failed: " + ec.message();
+      done = true;
+      return;
+    }
+    asio::async_connect(socket, results, [&](const boost::system::error_code &ec, const tcp::endpoint &) {
+      if (ec) {
+        error = "connect failed: " + ec.message();
+        done = true;
+        return;
+      }
+      asio::async_write(socket, asio::buffer(framed), [&](const boost::system::error_code &ec, std::size_t) {
+        if (ec) {
+          error = "send failed: " + ec.message();
+          done = true;
+          return;
+        }
+        asio::async_read(socket, asio::buffer(header), [&](const boost::system::error_code &ec, std::size_t) {
+          if (ec) {
+            error = "read failed: " + ec.message();
+            done = true;
+            return;
+          }
+          const std::size_t len = (static_cast<std::size_t>(header[0]) << 24) | (static_cast<std::size_t>(header[1]) << 16) |
+                                  (static_cast<std::size_t>(header[2]) << 8) | static_cast<std::size_t>(header[3]);
+          if (len == 0 || len > 512 * 1024) {
+            error = "invalid response length";
+            done = true;
+            return;
+          }
+          out.response.resize(len);
+          asio::async_read(socket, asio::buffer(out.response), [&](const boost::system::error_code &ec, std::size_t) {
+            if (ec) {
+              error = "read failed: " + ec.message();
+              out.response.clear();
+              done = true;
+              return;
+            }
+            out.exchanged = true;
+            done = true;
+          });
+        });
+      });
+    });
+  });
+
+  io.run_for(std::chrono::milliseconds(timeout_ms));
+  out.time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+  if (!done) {
+    error = "timeout after " + str::xtos(timeout_ms) + "ms";
+    boost::system::error_code ignored;
+    socket.close(ignored);
+  }
+  out.error = error;
+  return out;
+}
+
+std::string strip_leading_backslashes(std::string s) {
+  while (!s.empty() && s[0] == '\\') s.erase(0, 1);
+  return s;
+}
+
+}  // namespace
+
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+  modern_filter::data_container data;
+  modern_filter::cli_helper<kdc_filter::filter> filter_helper(request, response, data);
+
+  std::vector<std::string> servers;
+  std::string realm;
+  int port = 88;
+  int timeout = 5;
+
+  kdc_filter::filter filter;
+  filter_helper.add_options("time > 1000", "responding = 0", "", filter.get_filter_syntax(), "ignored");
+  filter_helper.add_syntax("${status}: ${list}", "${kdc}: ${response} (${time}ms)", "${kdc}", "", "%(status): all %(count) KDC(s) are responding");
+  // The bool threshold keyword is for alerting; time (registered with perf) is
+  // the series worth graphing.
+  filter_helper.set_default_perf_config("responding(ignored:true)error_code(ignored:true)port(ignored:true)");
+  // clang-format off
+  filter_helper.get_desc().add_options()
+    ("server", po::value<std::vector<std::string>>(&servers), "KDC host to probe; can be given multiple times (default: the KDC located via the domain join).")
+    ("realm", po::value<std::string>(&realm), "Kerberos realm to request a ticket for (default: the joined domain; required when not domain-joined).")
+    ("port", po::value<int>(&port)->default_value(88), "TCP port to probe.")
+    ("timeout", po::value<int>(&timeout)->default_value(5), "Seconds to wait for each KDC before considering it down.")
+    ;
+  // clang-format on
+
+  if (!filter_helper.parse_options()) return;
+  if (!filter_helper.build_filter(filter)) return;
+
+  if (servers.empty() || realm.empty()) {
+    DOMAIN_CONTROLLER_INFOW *info = nullptr;
+    const DWORD rc = DsGetDcNameW(nullptr, nullptr, nullptr, nullptr, DS_KDC_REQUIRED | DS_RETURN_DNS_NAME, &info);
+    if (rc == ERROR_SUCCESS) {
+      if (servers.empty() && info->DomainControllerName != nullptr) {
+        servers.push_back(strip_leading_backslashes(utf8::cvt<std::string>(std::wstring(info->DomainControllerName))));
+      }
+      if (realm.empty() && info->DomainName != nullptr) realm = utf8::cvt<std::string>(std::wstring(info->DomainName));
+      NetApiBufferFree(info);
+    } else if (servers.empty()) {
+      return nscapi::protobuf::functions::set_response_bad(
+          *response, "Failed to locate a KDC (is this machine domain-joined?): " + error::lookup::last_error(rc) + ". Specify server= and realm=.");
+    }
+  }
+  if (realm.empty()) {
+    return nscapi::protobuf::functions::set_response_bad(*response, "realm= is required when no realm can be discovered from the domain join");
+  }
+  std::transform(realm.begin(), realm.end(), realm.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+
+  const kdc_probe::bytes as_req = kdc_probe::build_as_req(realm, "nscp-probe", 12345678UL);
+
+  parsers::where::constants::reset();
+  for (const std::string &server : servers) {
+    kdc_filter::filter_obj_ptr obj(new kdc_filter::filter_obj());
+    obj->kdc = server;
+    obj->realm = realm;
+    obj->port = port;
+    const probe_outcome outcome = exchange_with_kdc(server, port, timeout * 1000, as_req);
+    obj->time = outcome.time_ms;
+    if (outcome.exchanged) {
+      const kdc_probe::classification c = kdc_probe::classify_response(outcome.response);
+      obj->responding = c.alive() ? 1 : 0;
+      obj->response = c.describe();
+      obj->error_code = c.error_code;
+    } else {
+      obj->responding = 0;
+      obj->response = outcome.error;
+    }
+    filter.match(obj);
+  }
+  filter_helper.post_process(filter);
+}
+
+}  // namespace check_kdc_command

--- a/modules/CheckActiveDirectory/check_kdc.cpp
+++ b/modules/CheckActiveDirectory/check_kdc.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cctype>
 #include <chrono>
+#include <deque>
 #include <error/error.hpp>
 #include <memory>
 #include <nscapi/nscapi_program_options.hpp>
@@ -91,13 +92,44 @@ struct probe_outcome {
   probe_outcome() : exchanged(false), time_ms(-1) {}
 };
 
+// The in-flight state of one KDC probe on the shared io_context.
+struct probe_state {
+  explicit probe_state(boost::asio::io_context &io) : resolver(io), socket(io), done(false), timed(false) { header[0] = header[1] = header[2] = header[3] = 0; }
+
+  boost::asio::ip::tcp::resolver resolver;
+  boost::asio::ip::tcp::socket socket;
+  unsigned char header[4];
+  bool done;
+  // Round-trip time is measured from when the resolver answered (timed set),
+  // so a slow DNS server is not billed to the KDC.
+  bool timed;
+  std::chrono::steady_clock::time_point exchange_start;
+  probe_outcome out;
+
+  void start_exchange() {
+    exchange_start = std::chrono::steady_clock::now();
+    timed = true;
+  }
+  // Terminal handlers stamp the time here; measuring after the event loop
+  // exits would bill a fast KDC for the full deadline whenever a slow one
+  // keeps the loop running.
+  void finish(const std::string &error) {
+    out.error = error;
+    if (timed) out.time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - exchange_start).count();
+    done = true;
+  }
+};
+
 // One framed request/response exchange (RFC 4120 7.2.2: 4-byte big-endian
-// length prefix) against host:port with an overall deadline.
-probe_outcome exchange_with_kdc(const std::string &host, int port, int timeout_ms, const kdc_probe::bytes &request) {
+// length prefix) per host against host:port. All hosts are probed concurrently
+// on one io_context with a single deadline, so the worst case costs one
+// timeout rather than one per unreachable KDC. A DNS lookup the OS never
+// answers can still hold the io_context destructor past the deadline (asio
+// runs getaddrinfo on a worker thread it joins on shutdown), but at most once
+// for the whole batch.
+std::vector<probe_outcome> exchange_with_kdcs(const std::vector<std::string> &hosts, int port, int timeout_ms, const kdc_probe::bytes &request) {
   namespace asio = boost::asio;
   using boost::asio::ip::tcp;
-
-  probe_outcome out;
 
   kdc_probe::bytes framed;
   framed.reserve(request.size() + 4);
@@ -108,68 +140,67 @@ probe_outcome exchange_with_kdc(const std::string &host, int port, int timeout_m
   framed.insert(framed.end(), request.begin(), request.end());
 
   asio::io_context io;
-  tcp::resolver resolver(io);
-  tcp::socket socket(io);
-  unsigned char header[4] = {0, 0, 0, 0};
-  bool done = false;
-  std::string error;
+  // deque: the completion handlers hold references into the container.
+  std::deque<probe_state> states;
 
-  const auto start = std::chrono::steady_clock::now();
-  resolver.async_resolve(host, str::xtos(port), [&](const boost::system::error_code &ec, tcp::resolver::results_type results) {
-    if (ec) {
-      error = "resolve failed: " + ec.message();
-      done = true;
-      return;
-    }
-    asio::async_connect(socket, results, [&](const boost::system::error_code &ec, const tcp::endpoint &) {
+  for (const std::string &host : hosts) {
+    states.emplace_back(io);
+    probe_state &st = states.back();
+    st.resolver.async_resolve(host, str::xtos(port), [&st, &framed](const boost::system::error_code &ec, tcp::resolver::results_type results) {
       if (ec) {
-        error = "connect failed: " + ec.message();
-        done = true;
+        st.finish("resolve failed: " + ec.message());
         return;
       }
-      asio::async_write(socket, asio::buffer(framed), [&](const boost::system::error_code &ec, std::size_t) {
+      st.start_exchange();
+      asio::async_connect(st.socket, results, [&st, &framed](const boost::system::error_code &ec, const tcp::endpoint &) {
         if (ec) {
-          error = "send failed: " + ec.message();
-          done = true;
+          st.finish("connect failed: " + ec.message());
           return;
         }
-        asio::async_read(socket, asio::buffer(header), [&](const boost::system::error_code &ec, std::size_t) {
+        asio::async_write(st.socket, asio::buffer(framed), [&st](const boost::system::error_code &ec, std::size_t) {
           if (ec) {
-            error = "read failed: " + ec.message();
-            done = true;
+            st.finish("send failed: " + ec.message());
             return;
           }
-          const std::size_t len = (static_cast<std::size_t>(header[0]) << 24) | (static_cast<std::size_t>(header[1]) << 16) |
-                                  (static_cast<std::size_t>(header[2]) << 8) | static_cast<std::size_t>(header[3]);
-          if (len == 0 || len > 512 * 1024) {
-            error = "invalid response length";
-            done = true;
-            return;
-          }
-          out.response.resize(len);
-          asio::async_read(socket, asio::buffer(out.response), [&](const boost::system::error_code &ec, std::size_t) {
+          asio::async_read(st.socket, asio::buffer(st.header), [&st](const boost::system::error_code &ec, std::size_t) {
             if (ec) {
-              error = "read failed: " + ec.message();
-              out.response.clear();
-              done = true;
+              st.finish("read failed: " + ec.message());
               return;
             }
-            out.exchanged = true;
-            done = true;
+            const std::size_t len = (static_cast<std::size_t>(st.header[0]) << 24) | (static_cast<std::size_t>(st.header[1]) << 16) |
+                                    (static_cast<std::size_t>(st.header[2]) << 8) | static_cast<std::size_t>(st.header[3]);
+            if (len == 0 || len > 512 * 1024) {
+              st.finish("invalid response length");
+              return;
+            }
+            st.out.response.resize(len);
+            asio::async_read(st.socket, asio::buffer(st.out.response), [&st](const boost::system::error_code &ec, std::size_t) {
+              if (ec) {
+                st.out.response.clear();
+                st.finish("read failed: " + ec.message());
+                return;
+              }
+              st.out.exchanged = true;
+              st.finish("");
+            });
           });
         });
       });
     });
-  });
+  }
 
   io.run_for(std::chrono::milliseconds(timeout_ms));
-  out.time_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
-  if (!done) {
-    error = "timeout after " + str::xtos(timeout_ms) + "ms";
-    boost::system::error_code ignored;
-    socket.close(ignored);
+
+  std::vector<probe_outcome> out;
+  for (probe_state &st : states) {
+    if (!st.done) {
+      boost::system::error_code ignored;
+      st.socket.close(ignored);
+      st.resolver.cancel();
+      st.finish("timeout after " + str::xtos(timeout_ms) + "ms");
+    }
+    out.push_back(st.out);
   }
-  out.error = error;
   return out;
 }
 
@@ -187,7 +218,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   std::vector<std::string> servers;
   std::string realm;
   int port = 88;
-  int timeout = 5;
+  int timeout_ms = 5000;
 
   kdc_filter::filter filter;
   filter_helper.add_options("time > 1000", "responding = 0", "", filter.get_filter_syntax(), "ignored");
@@ -200,7 +231,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
     ("server", po::value<std::vector<std::string>>(&servers), "KDC host to probe; can be given multiple times (default: the KDC located via the domain join).")
     ("realm", po::value<std::string>(&realm), "Kerberos realm to request a ticket for (default: the joined domain; required when not domain-joined).")
     ("port", po::value<int>(&port)->default_value(88), "TCP port to probe.")
-    ("timeout", po::value<int>(&timeout)->default_value(5), "Seconds to wait for each KDC before considering it down.")
+    ("timeout", po::value<int>(&timeout_ms)->default_value(5000), "Timeout in milliseconds. All KDCs are probed concurrently, so this also bounds the whole check.")
     ;
   // clang-format on
 
@@ -228,13 +259,15 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
 
   const kdc_probe::bytes as_req = kdc_probe::build_as_req(realm, "nscp-probe", 12345678UL);
 
+  const std::vector<probe_outcome> outcomes = exchange_with_kdcs(servers, port, timeout_ms, as_req);
+
   parsers::where::constants::reset();
-  for (const std::string &server : servers) {
+  for (std::size_t i = 0; i < servers.size(); ++i) {
     kdc_filter::filter_obj_ptr obj(new kdc_filter::filter_obj());
-    obj->kdc = server;
+    obj->kdc = servers[i];
     obj->realm = realm;
     obj->port = port;
-    const probe_outcome outcome = exchange_with_kdc(server, port, timeout * 1000, as_req);
+    const probe_outcome &outcome = outcomes[i];
     obj->time = outcome.time_ms;
     if (outcome.exchanged) {
       const kdc_probe::classification c = kdc_probe::classify_response(outcome.response);

--- a/modules/CheckActiveDirectory/check_kdc.cpp
+++ b/modules/CheckActiveDirectory/check_kdc.cpp
@@ -12,11 +12,10 @@
 #include <dsgetdc.h>
 #include <lm.h>
 
-#include <algorithm>
-#include <cctype>
+#include <array>
+#include <boost/optional.hpp>
 #include <chrono>
 #include <deque>
-#include <error/error.hpp>
 #include <memory>
 #include <nscapi/nscapi_program_options.hpp>
 #include <parsers/filter/cli_helper.hpp>
@@ -26,9 +25,12 @@
 #include <str/utf8.hpp>
 #include <str/xtos.hpp>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "kdc_probe.hpp"
+#include "netapi_buffer.hpp"
+#include "win32_error.hpp"
 
 namespace po = boost::program_options;
 
@@ -36,7 +38,7 @@ namespace kdc_filter {
 
 // The result of probing one KDC: did it answer the AS-REQ, with what, and how fast.
 struct filter_obj {
-  filter_obj() : port(0), responding(0), error_code(-1), time(-1) {}
+  filter_obj() : port(0), responding(0), error_code(-1) {}
 
   std::string get_kdc() const { return kdc; }
   std::string get_realm() const { return realm; }
@@ -44,7 +46,7 @@ struct filter_obj {
   long long get_port() const { return port; }
   long long get_responding() const { return responding; }
   long long get_error_code() const { return error_code; }
-  long long get_time() const { return time; }
+  boost::optional<long long> get_time() const { return time; }
 
   std::string show() const { return kdc; }
 
@@ -54,7 +56,10 @@ struct filter_obj {
   long long port;
   long long responding;  // 1 when a well-formed Kerberos answer arrived
   long long error_code;  // KRB-ERROR code (-1 when none)
-  long long time;        // round-trip in milliseconds
+  // Round-trip in milliseconds, empty when the exchange never started (a name
+  // that will not resolve). There is no round trip to report then, and a
+  // sentinel would put a negative latency into the graph for good.
+  boost::optional<long long> time;
 };
 
 typedef std::shared_ptr<filter_obj> filter_obj_ptr;
@@ -68,7 +73,10 @@ struct filter_obj_handler : native_context {
     registry_.add_string_var("kdc", &filter_obj::get_kdc, "The KDC host that was probed")
         .add_string_var("realm", &filter_obj::get_realm, "The Kerberos realm the probe requested a ticket for")
         .add_string_var("response", &filter_obj::get_response, "What the KDC answered (or the transport error)");
-    registry_.add_int_var("time", type_int, &filter_obj::get_time, "Probe round-trip time in milliseconds").add_int_perf("ms");
+    registry_
+        .add_optional_int_var("time", type_int, &filter_obj::get_time, "?",
+                              "Probe round-trip time in milliseconds (none when the host never resolved)")
+        .add_int_perf("ms");
     registry_.add_int_var("port", type_int, &filter_obj::get_port, "TCP port probed");
     registry_.add_int_var("responding", type_bool, &filter_obj::get_responding, "True when the KDC answered the AS-REQ with a well-formed Kerberos message");
     registry_.add_int_var("error_code", type_int, &filter_obj::get_error_code, "KRB-ERROR code from the response (-1 when none)");
@@ -87,18 +95,18 @@ struct probe_outcome {
   bool exchanged;
   std::string error;
   kdc_probe::bytes response;
-  long long time_ms;
+  boost::optional<long long> time_ms;  // empty until the exchange actually starts
 
-  probe_outcome() : exchanged(false), time_ms(-1) {}
+  probe_outcome() : exchanged(false) {}
 };
 
 // The in-flight state of one KDC probe on the shared io_context.
 struct probe_state {
-  explicit probe_state(boost::asio::io_context &io) : resolver(io), socket(io), done(false), timed(false) { header[0] = header[1] = header[2] = header[3] = 0; }
+  explicit probe_state(boost::asio::io_context &io) : resolver(io), socket(io), header{}, done(false), timed(false) {}
 
   boost::asio::ip::tcp::resolver resolver;
   boost::asio::ip::tcp::socket socket;
-  unsigned char header[4];
+  std::array<unsigned char, 4> header;  // RFC 4120 7.2.2 length prefix
   bool done;
   // Round-trip time is measured from when the resolver answered (timed set),
   // so a slow DNS server is not billed to the KDC.
@@ -131,12 +139,12 @@ std::vector<probe_outcome> exchange_with_kdcs(const std::vector<std::string> &ho
   namespace asio = boost::asio;
   using boost::asio::ip::tcp;
 
+  const std::size_t size = request.size();
+  const std::array<unsigned char, 4> prefix = {static_cast<unsigned char>((size >> 24) & 0xff), static_cast<unsigned char>((size >> 16) & 0xff),
+                                               static_cast<unsigned char>((size >> 8) & 0xff), static_cast<unsigned char>(size & 0xff)};
   kdc_probe::bytes framed;
-  framed.reserve(request.size() + 4);
-  framed.push_back(static_cast<unsigned char>((request.size() >> 24) & 0xff));
-  framed.push_back(static_cast<unsigned char>((request.size() >> 16) & 0xff));
-  framed.push_back(static_cast<unsigned char>((request.size() >> 8) & 0xff));
-  framed.push_back(static_cast<unsigned char>(request.size() & 0xff));
+  framed.reserve(size + prefix.size());
+  framed.insert(framed.end(), prefix.begin(), prefix.end());
   framed.insert(framed.end(), request.begin(), request.end());
 
   asio::io_context io;
@@ -199,7 +207,7 @@ std::vector<probe_outcome> exchange_with_kdcs(const std::vector<std::string> &ho
       st.resolver.cancel();
       st.finish("timeout after " + str::xtos(timeout_ms) + "ms");
     }
-    out.push_back(st.out);
+    out.push_back(std::move(st.out));
   }
   return out;
 }
@@ -208,6 +216,20 @@ std::string strip_leading_backslashes(std::string s) {
   while (!s.empty() && s[0] == '\\') s.erase(0, 1);
   return s;
 }
+
+// Kerberos realms are conventionally the uppercase DNS domain, and AD always
+// reports them that way. Uppercase ASCII only: std::toupper is locale
+// dependent and would mangle the UTF-8 bytes of an internationalised realm.
+std::string upper_ascii(std::string s) {
+  for (char &c : s) {
+    if (c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
+  }
+  return s;
+}
+
+// A Kerberos realm is a domain name, so it fits comfortably; the cap keeps a
+// caller from making the agent write a large payload at an arbitrary host.
+const std::size_t kMaxRealmLength = 255;
 
 }  // namespace
 
@@ -238,24 +260,39 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   if (!filter_helper.parse_options()) return;
   if (!filter_helper.build_filter(filter)) return;
 
+  if (realm.size() > kMaxRealmLength) {
+    return nscapi::protobuf::functions::set_response_bad(*response,
+                                                         "realm= is too long (max " + str::xtos(kMaxRealmLength) + " characters, got " +
+                                                             str::xtos(realm.size()) + ")");
+  }
+
+  const bool realm_was_given = !realm.empty();
   if (servers.empty() || realm.empty()) {
-    DOMAIN_CONTROLLER_INFOW *info = nullptr;
-    const DWORD rc = DsGetDcNameW(nullptr, nullptr, nullptr, nullptr, DS_KDC_REQUIRED | DS_RETURN_DNS_NAME, &info);
-    if (rc == ERROR_SUCCESS) {
+    DOMAIN_CONTROLLER_INFOW *raw_info = nullptr;
+    const DWORD rc = DsGetDcNameW(nullptr, nullptr, nullptr, nullptr, DS_KDC_REQUIRED | DS_RETURN_DNS_NAME, &raw_info);
+    const check_ad::net_api_ptr<DOMAIN_CONTROLLER_INFOW> info = check_ad::adopt_net_api(raw_info);
+    if (rc == ERROR_SUCCESS && info) {
       if (servers.empty() && info->DomainControllerName != nullptr) {
         servers.push_back(strip_leading_backslashes(utf8::cvt<std::string>(std::wstring(info->DomainControllerName))));
       }
       if (realm.empty() && info->DomainName != nullptr) realm = utf8::cvt<std::string>(std::wstring(info->DomainName));
-      NetApiBufferFree(info);
     } else if (servers.empty()) {
       return nscapi::protobuf::functions::set_response_bad(
-          *response, "Failed to locate a KDC (is this machine domain-joined?): " + error::lookup::last_error(rc) + ". Specify server= and realm=.");
+          *response, "Failed to locate a KDC (is this machine domain-joined?): " + check_ad::win32_error(rc) + ". Specify server= and realm=.");
     }
   }
   if (realm.empty()) {
     return nscapi::protobuf::functions::set_response_bad(*response, "realm= is required when no realm can be discovered from the domain join");
   }
-  std::transform(realm.begin(), realm.end(), realm.begin(), [](unsigned char c) { return static_cast<char>(std::toupper(c)); });
+  if (servers.empty()) {
+    // The join lookup succeeded but named no controller. Probing nothing would
+    // otherwise render the ok-syntax as "all 0 KDC(s) are responding".
+    return nscapi::protobuf::functions::set_response_bad(*response, "No KDC could be discovered from the domain join; specify server=");
+  }
+  // Only normalise what we discovered: an explicit realm= is passed through as
+  // typed, since Kerberos realms are case sensitive and a non-AD KDC may well
+  // serve a lowercase one.
+  if (!realm_was_given) realm = upper_ascii(realm);
 
   const kdc_probe::bytes as_req = kdc_probe::build_as_req(realm, "nscp-probe", 12345678UL);
 
@@ -263,7 +300,7 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
 
   parsers::where::constants::reset();
   for (std::size_t i = 0; i < servers.size(); ++i) {
-    kdc_filter::filter_obj_ptr obj(new kdc_filter::filter_obj());
+    kdc_filter::filter_obj_ptr obj = std::make_shared<kdc_filter::filter_obj>();
     obj->kdc = servers[i];
     obj->realm = realm;
     obj->port = port;

--- a/modules/CheckActiveDirectory/check_kdc.hpp
+++ b/modules/CheckActiveDirectory/check_kdc.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <nscapi/protobuf/command.hpp>
+
+namespace check_kdc_command {
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+}  // namespace check_kdc_command

--- a/modules/CheckActiveDirectory/check_secure_channel.cpp
+++ b/modules/CheckActiveDirectory/check_secure_channel.cpp
@@ -8,7 +8,6 @@
 #include <Windows.h>
 #include <lm.h>
 
-#include <error/error.hpp>
 #include <memory>
 #include <nscapi/nscapi_program_options.hpp>
 #include <parsers/filter/cli_helper.hpp>
@@ -17,6 +16,9 @@
 #include <parsers/where/filter_handler_impl.hpp>
 #include <str/utf8.hpp>
 #include <string>
+
+#include "netapi_buffer.hpp"
+#include "win32_error.hpp"
 
 // Older SDK headers spell only some of the netlogon function codes out.
 #ifndef NETLOGON_CONTROL_TC_QUERY
@@ -79,17 +81,21 @@ namespace {
 // failure — which says nothing about the channel and must not be scored as a
 // broken one; only netlog2_tc_connection_status judges channel health.
 secure_channel_filter::filter_obj_ptr query_channel(const std::string &server, const std::string &domain, bool verify, std::string &error) {
-  secure_channel_filter::filter_obj_ptr obj(new secure_channel_filter::filter_obj());
+  secure_channel_filter::filter_obj_ptr obj = std::make_shared<secure_channel_filter::filter_obj>();
   obj->domain = domain;
 
   const std::wstring server_w = utf8::cvt<std::wstring>(server);
+  // I_NetLogonControl2 takes the trusted domain name by address, so the buffer
+  // has to outlive the call; data() is valid (and NUL-terminated) since C++11
+  // even for an empty string, and check() has already rejected an empty domain.
   std::wstring domain_w = utf8::cvt<std::wstring>(domain);
-  LPWSTR domain_ptr = &domain_w[0];
-  PNETLOGON_INFO_2 info = nullptr;
+  LPWSTR domain_ptr = domain_w.data();
+  PNETLOGON_INFO_2 raw_info = nullptr;
   const DWORD rc = I_NetLogonControl2(server.empty() ? nullptr : server_w.c_str(), verify ? NETLOGON_CONTROL_TC_VERIFY : NETLOGON_CONTROL_TC_QUERY, 2,
-                                      reinterpret_cast<LPBYTE>(&domain_ptr), reinterpret_cast<LPBYTE *>(&info));
-  if (rc != NERR_Success) {
-    error = "Failed to query the netlogon service" + (server.empty() ? std::string() : " on " + server) + ": " + error::lookup::last_error(rc);
+                                      reinterpret_cast<LPBYTE>(&domain_ptr), reinterpret_cast<LPBYTE *>(&raw_info));
+  const check_ad::net_api_ptr<NETLOGON_INFO_2> info = check_ad::adopt_net_api(raw_info);
+  if (rc != NERR_Success || !info) {
+    error = "Failed to query the netlogon service" + (server.empty() ? std::string() : " on " + server) + ": " + check_ad::win32_error(rc);
     return secure_channel_filter::filter_obj_ptr();
   }
   obj->error_code = info->netlog2_tc_connection_status;
@@ -98,8 +104,7 @@ secure_channel_filter::filter_obj_ptr query_channel(const std::string &server, c
     while (!dc.empty() && dc[0] == '\\') dc.erase(0, 1);
     obj->dc = dc;
   }
-  obj->error_message = obj->error_code == 0 ? "OK" : error::lookup::last_error(static_cast<unsigned long>(obj->error_code));
-  NetApiBufferFree(info);
+  obj->error_message = obj->error_code == 0 ? "OK" : check_ad::win32_error(static_cast<unsigned long>(obj->error_code));
   return obj;
 }
 
@@ -136,15 +141,21 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
     // monitoring host would wrongly conclude there is nothing to check).
     const std::wstring server_w = utf8::cvt<std::wstring>(server);
     const std::string target = server.empty() ? "This machine" : server;
-    LPWSTR name_buf = nullptr;
+    LPWSTR raw_name = nullptr;
     NETSETUP_JOIN_STATUS status = NetSetupUnknownStatus;
-    if (NetGetJoinInformation(server.empty() ? nullptr : server_w.c_str(), &name_buf, &status) == NERR_Success) {
-      const std::string join_name = name_buf != nullptr ? utf8::cvt<std::string>(std::wstring(name_buf)) : "";
-      if (name_buf != nullptr) NetApiBufferFree(name_buf);
+    if (NetGetJoinInformation(server.empty() ? nullptr : server_w.c_str(), &raw_name, &status) == NERR_Success) {
+      const check_ad::net_api_ptr<WCHAR> name_buf = check_ad::adopt_net_api(raw_name);
+      const std::string join_name = name_buf ? utf8::cvt<std::string>(std::wstring(name_buf.get())) : "";
       if (status != NetSetupDomainName) {
         return nscapi::protobuf::functions::set_response_bad(*response, target + " is not joined to a domain (" +
                                                                             (join_name.empty() ? std::string("standalone") : "workgroup " + join_name) +
                                                                             "); there is no secure channel to check");
+      }
+      if (join_name.empty()) {
+        // A domain join with no name to query the channel for: nothing sane to
+        // pass to netlogon, so say so rather than asking about the empty domain.
+        return nscapi::protobuf::functions::set_response_bad(
+            *response, target + " reports a domain join but no domain name; pass domain= to name the trusted domain explicitly");
       }
       domain = join_name;
     } else {

--- a/modules/CheckActiveDirectory/check_secure_channel.cpp
+++ b/modules/CheckActiveDirectory/check_secure_channel.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "check_secure_channel.hpp"
+
+// Windows.h must precede lm.h; the capital W keeps clang-format's
+// case-sensitive include sort from breaking that order.
+#include <Windows.h>
+#include <lm.h>
+
+#include <error/error.hpp>
+#include <memory>
+#include <nscapi/nscapi_program_options.hpp>
+#include <parsers/filter/cli_helper.hpp>
+#include <parsers/filter/modern_filter.hpp>
+#include <parsers/helpers.hpp>
+#include <parsers/where/filter_handler_impl.hpp>
+#include <str/utf8.hpp>
+#include <string>
+
+// Older SDK headers spell only some of the netlogon function codes out.
+#ifndef NETLOGON_CONTROL_TC_QUERY
+#define NETLOGON_CONTROL_TC_QUERY 6
+#endif
+#ifndef NETLOGON_CONTROL_TC_VERIFY
+#define NETLOGON_CONTROL_TC_VERIFY 10
+#endif
+
+namespace po = boost::program_options;
+
+namespace secure_channel_filter {
+
+// The state of the machine-account secure channel to one trusted domain,
+// as reported (and optionally re-established) by the netlogon service.
+struct filter_obj {
+  filter_obj() : error_code(0) {}
+
+  std::string get_domain() const { return domain; }
+  std::string get_dc() const { return dc; }
+  std::string get_error_message() const { return error_message; }
+  long long get_error_code() const { return error_code; }
+  long long get_healthy() const { return error_code == 0 ? 1 : 0; }
+
+  std::string show() const { return domain; }
+
+  std::string domain;         // the trusted domain the channel points at
+  std::string dc;             // the DC the channel is established with ("" when broken)
+  std::string error_message;  // "OK" or the formatted win32 failure
+  long long error_code;       // win32 status of the channel (0 = healthy)
+};
+
+typedef std::shared_ptr<filter_obj> filter_obj_ptr;
+
+typedef parsers::where::filter_handler_impl<filter_obj_ptr> native_context;
+struct filter_obj_handler : native_context {
+  filter_obj_handler() {
+    using parsers::where::type_bool;
+    using parsers::where::type_int;
+    // clang-format off
+    registry_.add_string_var("domain", &filter_obj::get_domain, "The trusted domain the secure channel points at")
+        .add_string_var("dc", &filter_obj::get_dc, "The domain controller the secure channel is established with")
+        .add_string_var("error_message", &filter_obj::get_error_message, "Human readable channel state (OK or the failure message)");
+    registry_.add_int_var("error_code", type_int, &filter_obj::get_error_code, "Win32 status of the secure channel (0 = healthy)");
+    registry_.add_int_var("healthy", type_bool, &filter_obj::get_healthy, "True when the secure channel is established and verified");
+    // clang-format on
+  }
+};
+typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;
+
+}  // namespace secure_channel_filter
+
+namespace check_secure_channel_command {
+
+namespace {
+
+// Query (or verify, which re-pings the DC) the secure channel for `domain` on
+// `server` (empty = local). Always produces a row: netlogon call failures land
+// in error_code/error_message so thresholds and rendering stay uniform.
+secure_channel_filter::filter_obj_ptr query_channel(const std::string &server, const std::string &domain, bool verify) {
+  secure_channel_filter::filter_obj_ptr obj(new secure_channel_filter::filter_obj());
+  obj->domain = domain;
+
+  const std::wstring server_w = utf8::cvt<std::wstring>(server);
+  std::wstring domain_w = utf8::cvt<std::wstring>(domain);
+  LPWSTR domain_ptr = &domain_w[0];
+  PNETLOGON_INFO_2 info = nullptr;
+  const DWORD rc = I_NetLogonControl2(server.empty() ? nullptr : server_w.c_str(), verify ? NETLOGON_CONTROL_TC_VERIFY : NETLOGON_CONTROL_TC_QUERY, 2,
+                                      reinterpret_cast<LPBYTE>(&domain_ptr), reinterpret_cast<LPBYTE *>(&info));
+  if (rc != NERR_Success) {
+    obj->error_code = rc;
+    obj->error_message = error::lookup::last_error(rc);
+    return obj;
+  }
+  obj->error_code = info->netlog2_tc_connection_status;
+  if (info->netlog2_trusted_dc_name != nullptr) {
+    std::string dc = utf8::cvt<std::string>(std::wstring(info->netlog2_trusted_dc_name));
+    while (!dc.empty() && dc[0] == '\\') dc.erase(0, 1);
+    obj->dc = dc;
+  }
+  obj->error_message = obj->error_code == 0 ? "OK" : error::lookup::last_error(static_cast<unsigned long>(obj->error_code));
+  NetApiBufferFree(info);
+  return obj;
+}
+
+}  // namespace
+
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+  modern_filter::data_container data;
+  modern_filter::cli_helper<secure_channel_filter::filter> filter_helper(request, response, data);
+
+  std::string domain;
+  std::string server;
+  bool verify = true;
+
+  secure_channel_filter::filter filter;
+  filter_helper.add_options("", "healthy = 0", "", filter.get_filter_syntax(), "ignored");
+  filter_helper.add_syntax("${status}: ${list}", "secure channel to ${domain} via ${dc}: ${error_message}", "${domain}", "", "");
+  // The bool threshold keyword is for alerting, not graphing.
+  filter_helper.set_default_perf_config("healthy(ignored:true)error_code(ignored:true)");
+  // clang-format off
+  filter_helper.get_desc().add_options()
+    ("domain", po::value<std::string>(&domain), "The trusted domain to check the channel to (default: the domain this machine is joined to).")
+    ("server", po::value<std::string>(&server), "The computer whose secure channel to check (default: the local machine).")
+    ("verify", po::value<bool>(&verify)->implicit_value(true)->default_value(true),
+        "Actively verify the channel by contacting the DC (netlogon TC_VERIFY). Set verify=false for a passive status query only.")
+    ;
+  // clang-format on
+
+  if (!filter_helper.parse_options()) return;
+  if (!filter_helper.build_filter(filter)) return;
+
+  if (domain.empty()) {
+    LPWSTR name_buf = nullptr;
+    NETSETUP_JOIN_STATUS status = NetSetupUnknownStatus;
+    if (NetGetJoinInformation(nullptr, &name_buf, &status) == NERR_Success) {
+      const std::string join_name = name_buf != nullptr ? utf8::cvt<std::string>(std::wstring(name_buf)) : "";
+      if (name_buf != nullptr) NetApiBufferFree(name_buf);
+      if (status != NetSetupDomainName) {
+        return nscapi::protobuf::functions::set_response_bad(*response, "This machine is not joined to a domain (" +
+                                                                            (join_name.empty() ? std::string("standalone") : "workgroup " + join_name) +
+                                                                            "); there is no secure channel to check");
+      }
+      domain = join_name;
+    } else {
+      return nscapi::protobuf::functions::set_response_bad(*response, "Failed to read the domain join state (and no domain= was given)");
+    }
+  }
+
+  filter.match(query_channel(server, domain, verify));
+  filter_helper.post_process(filter);
+}
+
+}  // namespace check_secure_channel_command

--- a/modules/CheckActiveDirectory/check_secure_channel.cpp
+++ b/modules/CheckActiveDirectory/check_secure_channel.cpp
@@ -86,10 +86,12 @@ secure_channel_filter::filter_obj_ptr query_channel(const std::string &server, c
 
   const std::wstring server_w = utf8::cvt<std::wstring>(server);
   // I_NetLogonControl2 takes the trusted domain name by address, so the buffer
-  // has to outlive the call; data() is valid (and NUL-terminated) since C++11
-  // even for an empty string, and check() has already rejected an empty domain.
+  // has to outlive the call. Take it by &[0] rather than data(): the non-const
+  // data() overload is C++17 and the oldest supported MSVC toolset compiles
+  // this as C++14. check() has already rejected an empty domain, so index 0 is
+  // a real character, and netlogon only reads through the pointer.
   std::wstring domain_w = utf8::cvt<std::wstring>(domain);
-  LPWSTR domain_ptr = domain_w.data();
+  LPWSTR domain_ptr = &domain_w[0];
   PNETLOGON_INFO_2 raw_info = nullptr;
   const DWORD rc = I_NetLogonControl2(server.empty() ? nullptr : server_w.c_str(), verify ? NETLOGON_CONTROL_TC_VERIFY : NETLOGON_CONTROL_TC_QUERY, 2,
                                       reinterpret_cast<LPBYTE>(&domain_ptr), reinterpret_cast<LPBYTE *>(&raw_info));

--- a/modules/CheckActiveDirectory/check_secure_channel.cpp
+++ b/modules/CheckActiveDirectory/check_secure_channel.cpp
@@ -74,9 +74,11 @@ namespace check_secure_channel_command {
 namespace {
 
 // Query (or verify, which re-pings the DC) the secure channel for `domain` on
-// `server` (empty = local). Always produces a row: netlogon call failures land
-// in error_code/error_message so thresholds and rendering stay uniform.
-secure_channel_filter::filter_obj_ptr query_channel(const std::string &server, const std::string &domain, bool verify) {
+// `server` (empty = local). Returns an empty pointer (with `error` set) when
+// the netlogon call itself failed — service stopped, access denied, RPC
+// failure — which says nothing about the channel and must not be scored as a
+// broken one; only netlog2_tc_connection_status judges channel health.
+secure_channel_filter::filter_obj_ptr query_channel(const std::string &server, const std::string &domain, bool verify, std::string &error) {
   secure_channel_filter::filter_obj_ptr obj(new secure_channel_filter::filter_obj());
   obj->domain = domain;
 
@@ -87,9 +89,8 @@ secure_channel_filter::filter_obj_ptr query_channel(const std::string &server, c
   const DWORD rc = I_NetLogonControl2(server.empty() ? nullptr : server_w.c_str(), verify ? NETLOGON_CONTROL_TC_VERIFY : NETLOGON_CONTROL_TC_QUERY, 2,
                                       reinterpret_cast<LPBYTE>(&domain_ptr), reinterpret_cast<LPBYTE *>(&info));
   if (rc != NERR_Success) {
-    obj->error_code = rc;
-    obj->error_message = error::lookup::last_error(rc);
-    return obj;
+    error = "Failed to query the netlogon service" + (server.empty() ? std::string() : " on " + server) + ": " + error::lookup::last_error(rc);
+    return secure_channel_filter::filter_obj_ptr();
   }
   obj->error_code = info->netlog2_tc_connection_status;
   if (info->netlog2_trusted_dc_name != nullptr) {
@@ -130,23 +131,33 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   if (!filter_helper.build_filter(filter)) return;
 
   if (domain.empty()) {
+    // The join state must come from the machine being checked: with server=
+    // given, the local join state is the wrong computer's (and a workgroup
+    // monitoring host would wrongly conclude there is nothing to check).
+    const std::wstring server_w = utf8::cvt<std::wstring>(server);
+    const std::string target = server.empty() ? "This machine" : server;
     LPWSTR name_buf = nullptr;
     NETSETUP_JOIN_STATUS status = NetSetupUnknownStatus;
-    if (NetGetJoinInformation(nullptr, &name_buf, &status) == NERR_Success) {
+    if (NetGetJoinInformation(server.empty() ? nullptr : server_w.c_str(), &name_buf, &status) == NERR_Success) {
       const std::string join_name = name_buf != nullptr ? utf8::cvt<std::string>(std::wstring(name_buf)) : "";
       if (name_buf != nullptr) NetApiBufferFree(name_buf);
       if (status != NetSetupDomainName) {
-        return nscapi::protobuf::functions::set_response_bad(*response, "This machine is not joined to a domain (" +
+        return nscapi::protobuf::functions::set_response_bad(*response, target + " is not joined to a domain (" +
                                                                             (join_name.empty() ? std::string("standalone") : "workgroup " + join_name) +
                                                                             "); there is no secure channel to check");
       }
       domain = join_name;
     } else {
-      return nscapi::protobuf::functions::set_response_bad(*response, "Failed to read the domain join state (and no domain= was given)");
+      return nscapi::protobuf::functions::set_response_bad(*response,
+                                                           "Failed to read the domain join state" + (server.empty() ? std::string() : " of " + server) +
+                                                               " (and no domain= was given)");
     }
   }
 
-  filter.match(query_channel(server, domain, verify));
+  std::string error;
+  const secure_channel_filter::filter_obj_ptr channel = query_channel(server, domain, verify, error);
+  if (!channel) return nscapi::protobuf::functions::set_response_bad(*response, error);
+  filter.match(channel);
   filter_helper.post_process(filter);
 }
 

--- a/modules/CheckActiveDirectory/check_secure_channel.hpp
+++ b/modules/CheckActiveDirectory/check_secure_channel.hpp
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <nscapi/protobuf/command.hpp>
+
+namespace check_secure_channel_command {
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+}  // namespace check_secure_channel_command

--- a/modules/CheckActiveDirectory/kdc_probe.cpp
+++ b/modules/CheckActiveDirectory/kdc_probe.cpp
@@ -23,13 +23,14 @@ bytes der(unsigned char tag, const bytes &content) {
   const std::size_t len = content.size();
   if (len < 0x80) {
     out.push_back(static_cast<unsigned char>(len));
-  } else if (len <= 0xff) {
-    out.push_back(0x81);
-    out.push_back(static_cast<unsigned char>(len));
   } else {
-    out.push_back(0x82);
-    out.push_back(static_cast<unsigned char>(len >> 8));
-    out.push_back(static_cast<unsigned char>(len & 0xff));
+    // Long form with however many length octets the size needs: a probe
+    // request is tiny, but the realm is caller-supplied and a truncated
+    // length octet string would silently corrupt the whole request.
+    bytes len_octets;
+    for (std::size_t v = len; v != 0; v >>= 8) len_octets.insert(len_octets.begin(), static_cast<unsigned char>(v & 0xff));
+    out.push_back(static_cast<unsigned char>(0x80 | len_octets.size()));
+    out.insert(out.end(), len_octets.begin(), len_octets.end());
   }
   out.insert(out.end(), content.begin(), content.end());
   return out;

--- a/modules/CheckActiveDirectory/kdc_probe.cpp
+++ b/modules/CheckActiveDirectory/kdc_probe.cpp
@@ -3,6 +3,7 @@
 
 #include "kdc_probe.hpp"
 
+#include <boost/optional.hpp>
 #include <str/xtos.hpp>
 
 namespace kdc_probe {
@@ -61,19 +62,76 @@ bytes principal_name(unsigned long name_type, std::initializer_list<std::string>
 
 // --- minimal DER reader (for KRB-ERROR) -------------------------------------
 
-bool read_len(const bytes &d, std::size_t &pos, std::size_t &out) {
-  if (pos >= d.size()) return false;
-  const unsigned char first = d[pos++];
-  if ((first & 0x80) == 0) {
-    out = first;
-  } else {
-    const std::size_t count = first & 0x7f;
-    if (count == 0 || count > 4 || pos + count > d.size()) return false;
-    out = 0;
-    for (std::size_t i = 0; i < count; ++i) out = (out << 8) | d[pos++];
+// A bounds-checked read cursor over a slice of a DER buffer. Everything the
+// classifier reads goes through here, so no caller can index the buffer or
+// advance an offset by hand.
+//
+// Every length is validated against the bytes *remaining* (`remaining() < n`),
+// never by comparing `pos + n` to the size: a response is attacker-supplied
+// (the probe talks to whatever host:port the check was pointed at) and on a
+// 32-bit build `pos + n` wraps, so a crafted 4-octet length such as
+// 0xfffffff2 passed the old check and then drove the walk offset *backwards* -
+// an unterminated parse loop that spun a worker thread forever.
+class cursor {
+ public:
+  explicit cursor(const bytes &data) : data_(&data), pos_(0), end_(data.size()) {}
+
+  bool done() const { return pos_ >= end_; }
+  std::size_t remaining() const { return done() ? 0 : end_ - pos_; }
+
+  boost::optional<unsigned char> take_byte() {
+    if (done()) return boost::none;
+    return (*data_)[pos_++];
   }
-  return pos + out <= d.size();
-}
+
+  // One TLV: returns a cursor over its contents and reports the tag, or an
+  // empty optional when the buffer is truncated or the length is malformed.
+  boost::optional<cursor> take_tlv(unsigned char &tag) {
+    const boost::optional<unsigned char> t = take_byte();
+    if (!t) return boost::none;
+    const boost::optional<std::size_t> len = take_length();
+    if (!len) return boost::none;
+    // Safe: take_length() guarantees *len <= remaining(), so pos_ + *len <= end_.
+    const cursor content(*data_, pos_, pos_ + *len);
+    pos_ += *len;
+    tag = *t;
+    return content;
+  }
+
+  // The whole remaining slice as a two's-complement big-endian DER INTEGER.
+  // Accumulated unsigned: shifting a negative value left is undefined before
+  // C++20, and the sign seed makes short encodings extend correctly.
+  boost::optional<long long> take_integer() {
+    const std::size_t len = remaining();
+    if (len < 1 || len > sizeof(long long)) return boost::none;
+    unsigned long long acc = ((*data_)[pos_] & 0x80) != 0 ? ~0ULL : 0ULL;
+    for (std::size_t i = 0; i < len; ++i) acc = (acc << 8) | *take_byte();
+    return static_cast<long long>(acc);
+  }
+
+ private:
+  cursor(const bytes &data, std::size_t from, std::size_t to) : data_(&data), pos_(from), end_(to) {}
+
+  // DER length octets: short form, or long form with up to 4 length octets
+  // (a Kerberos message is capped well below 4GB by the caller anyway).
+  boost::optional<std::size_t> take_length() {
+    const boost::optional<unsigned char> first = take_byte();
+    if (!first) return boost::none;
+    std::size_t len = *first & 0x7f;
+    if ((*first & 0x80) != 0) {
+      const std::size_t count = len;
+      if (count == 0 || count > 4 || remaining() < count) return boost::none;
+      len = 0;
+      for (std::size_t i = 0; i < count; ++i) len = (len << 8) | *take_byte();
+    }
+    if (remaining() < len) return boost::none;
+    return len;
+  }
+
+  const bytes *data_;  // pointer, not reference, so the cursor stays copyable
+  std::size_t pos_;
+  std::size_t end_;
+};
 
 }  // namespace
 
@@ -115,31 +173,21 @@ classification classify_response(const bytes &data) {
   // Walk KRB-ERROR ::= [APPLICATION 30] SEQUENCE { ... error-code [6] Int32 ... }
   // for the error code; a parse failure still counts as a live KDC, we just
   // cannot name the error.
-  std::size_t pos = 1, len = 0;
-  if (!read_len(data, pos, len)) return result;
-  if (pos >= data.size() || data[pos] != 0x30) return result;
-  ++pos;
-  std::size_t seq_len = 0;
-  if (!read_len(data, pos, seq_len)) return result;
-  const std::size_t seq_end = pos + seq_len;
-  while (pos < seq_end && pos < data.size()) {
-    const unsigned char tag = data[pos++];
-    std::size_t field_len = 0;
-    if (!read_len(data, pos, field_len)) return result;
-    if (tag == 0xa6) {  // error-code [6]: INTEGER
-      std::size_t ipos = pos;
-      if (ipos < data.size() && data[ipos] == 0x02) {
-        ++ipos;
-        std::size_t ilen = 0;
-        if (read_len(data, ipos, ilen) && ilen >= 1 && ilen <= 8) {
-          long long code = (data[ipos] & 0x80) != 0 ? -1 : 0;  // sign-extend
-          for (std::size_t i = 0; i < ilen; ++i) code = (code << 8) | data[ipos + i];
-          result.error_code = code;
-        }
-      }
-      return result;
+  cursor outer(data);
+  unsigned char tag = 0;
+  boost::optional<cursor> application = outer.take_tlv(tag);
+  if (!application) return result;
+  boost::optional<cursor> sequence = application->take_tlv(tag);
+  if (!sequence || tag != 0x30) return result;
+  while (!sequence->done()) {
+    boost::optional<cursor> field = sequence->take_tlv(tag);
+    if (!field) return result;
+    if (tag != 0xa6) continue;  // error-code [6]
+    boost::optional<cursor> integer = field->take_tlv(tag);
+    if (integer && tag == 0x02) {
+      if (const boost::optional<long long> code = integer->take_integer()) result.error_code = *code;
     }
-    pos += field_len;
+    return result;
   }
   return result;
 }

--- a/modules/CheckActiveDirectory/kdc_probe.cpp
+++ b/modules/CheckActiveDirectory/kdc_probe.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "kdc_probe.hpp"
+
+#include <str/xtos.hpp>
+
+namespace kdc_probe {
+
+namespace {
+
+// --- minimal DER writer -----------------------------------------------------
+
+bytes cat(std::initializer_list<bytes> parts) {
+  bytes out;
+  for (const bytes &p : parts) out.insert(out.end(), p.begin(), p.end());
+  return out;
+}
+
+bytes der(unsigned char tag, const bytes &content) {
+  bytes out;
+  out.push_back(tag);
+  const std::size_t len = content.size();
+  if (len < 0x80) {
+    out.push_back(static_cast<unsigned char>(len));
+  } else if (len <= 0xff) {
+    out.push_back(0x81);
+    out.push_back(static_cast<unsigned char>(len));
+  } else {
+    out.push_back(0x82);
+    out.push_back(static_cast<unsigned char>(len >> 8));
+    out.push_back(static_cast<unsigned char>(len & 0xff));
+  }
+  out.insert(out.end(), content.begin(), content.end());
+  return out;
+}
+
+bytes seq(const bytes &content) { return der(0x30, content); }
+// Context-specific constructed tag [n] (Kerberos uses explicit tagging throughout).
+bytes ctx(int n, const bytes &content) { return der(static_cast<unsigned char>(0xa0 | n), content); }
+
+bytes der_int(unsigned long v) {
+  bytes content;
+  do {
+    content.insert(content.begin(), static_cast<unsigned char>(v & 0xff));
+    v >>= 8;
+  } while (v != 0);
+  if ((content[0] & 0x80) != 0) content.insert(content.begin(), 0x00);  // keep it non-negative
+  return der(0x02, content);
+}
+
+bytes general_string(const std::string &s) { return der(0x1b, bytes(s.begin(), s.end())); }
+
+// PrincipalName ::= SEQUENCE { name-type [0] Int32, name-string [1] SEQUENCE OF KerberosString }
+bytes principal_name(unsigned long name_type, std::initializer_list<std::string> names) {
+  bytes name_strings;
+  for (const std::string &n : names) name_strings = cat({name_strings, general_string(n)});
+  return seq(cat({ctx(0, der_int(name_type)), ctx(1, seq(name_strings))}));
+}
+
+// --- minimal DER reader (for KRB-ERROR) -------------------------------------
+
+bool read_len(const bytes &d, std::size_t &pos, std::size_t &out) {
+  if (pos >= d.size()) return false;
+  const unsigned char first = d[pos++];
+  if ((first & 0x80) == 0) {
+    out = first;
+  } else {
+    const std::size_t count = first & 0x7f;
+    if (count == 0 || count > 4 || pos + count > d.size()) return false;
+    out = 0;
+    for (std::size_t i = 0; i < count; ++i) out = (out << 8) | d[pos++];
+  }
+  return pos + out <= d.size();
+}
+
+}  // namespace
+
+bytes build_as_req(const std::string &realm, const std::string &client_name, unsigned long nonce) {
+  // KDCOptions ::= BIT STRING (32 bits), none set.
+  const bytes kdc_options = der(0x03, {0x00, 0x00, 0x00, 0x00, 0x00});
+  // KerberosTime "till": the classic krb5 end-of-time value; the probe never
+  // uses the ticket, it only needs a syntactically valid request.
+  static const char kTill[] = "20370913024805Z";
+  const bytes till = der(0x18, bytes(kTill, kTill + sizeof(kTill) - 1));
+  // aes256-cts-hmac-sha1-96 (18), aes128-cts-hmac-sha1-96 (17), rc4-hmac (23).
+  const bytes etypes = seq(cat({der_int(18), der_int(17), der_int(23)}));
+
+  const bytes req_body = seq(cat({
+      ctx(0, kdc_options),
+      ctx(1, principal_name(1, {client_name})),      // cname, NT-PRINCIPAL
+      ctx(2, general_string(realm)),                 // realm
+      ctx(3, principal_name(2, {"krbtgt", realm})),  // sname, NT-SRV-INST
+      ctx(5, till),                                  // till
+      ctx(7, der_int(nonce)),                        // nonce
+      ctx(8, etypes),                                // etype preference list
+  }));
+
+  // AS-REQ ::= [APPLICATION 10] KDC-REQ; KDC-REQ ::= SEQUENCE { pvno [1] 5, msg-type [2] 10, req-body [4] }
+  return der(0x6a, seq(cat({ctx(1, der_int(5)), ctx(2, der_int(10)), ctx(4, req_body)})));
+}
+
+classification classify_response(const bytes &data) {
+  classification result;
+  if (data.size() < 2) return result;
+
+  if (data[0] == 0x6b) {  // [APPLICATION 11] AS-REP
+    result.kind = response_kind::as_rep;
+    return result;
+  }
+  if (data[0] != 0x7e) return result;  // not [APPLICATION 30] KRB-ERROR
+
+  result.kind = response_kind::krb_error;
+  // Walk KRB-ERROR ::= [APPLICATION 30] SEQUENCE { ... error-code [6] Int32 ... }
+  // for the error code; a parse failure still counts as a live KDC, we just
+  // cannot name the error.
+  std::size_t pos = 1, len = 0;
+  if (!read_len(data, pos, len)) return result;
+  if (pos >= data.size() || data[pos] != 0x30) return result;
+  ++pos;
+  std::size_t seq_len = 0;
+  if (!read_len(data, pos, seq_len)) return result;
+  const std::size_t seq_end = pos + seq_len;
+  while (pos < seq_end && pos < data.size()) {
+    const unsigned char tag = data[pos++];
+    std::size_t field_len = 0;
+    if (!read_len(data, pos, field_len)) return result;
+    if (tag == 0xa6) {  // error-code [6]: INTEGER
+      std::size_t ipos = pos;
+      if (ipos < data.size() && data[ipos] == 0x02) {
+        ++ipos;
+        std::size_t ilen = 0;
+        if (read_len(data, ipos, ilen) && ilen >= 1 && ilen <= 8) {
+          long long code = (data[ipos] & 0x80) != 0 ? -1 : 0;  // sign-extend
+          for (std::size_t i = 0; i < ilen; ++i) code = (code << 8) | data[ipos + i];
+          result.error_code = code;
+        }
+      }
+      return result;
+    }
+    pos += field_len;
+  }
+  return result;
+}
+
+std::string krb_error_name(long long code) {
+  switch (code) {
+    case 6:
+      return "KDC_ERR_C_PRINCIPAL_UNKNOWN";
+    case 7:
+      return "KDC_ERR_S_PRINCIPAL_UNKNOWN";
+    case 10:
+      return "KDC_ERR_CANNOT_POSTDATE";
+    case 14:
+      return "KDC_ERR_ETYPE_NOSUPP";
+    case 23:
+      return "KDC_ERR_KEY_EXPIRED";
+    case 24:
+      return "KDC_ERR_PREAUTH_FAILED";
+    case 25:
+      return "KDC_ERR_PREAUTH_REQUIRED";
+    case 37:
+      return "KRB_AP_ERR_SKEW";
+    case 52:
+      return "KRB_ERR_RESPONSE_TOO_BIG";
+    case 68:
+      return "KRB_ERR_WRONG_REALM";
+    default:
+      return "error " + str::xtos(code);
+  }
+}
+
+std::string classification::describe() const {
+  switch (kind) {
+    case response_kind::as_rep:
+      return "AS-REP (ticket issued)";
+    case response_kind::krb_error:
+      return error_code < 0 ? "KRB-ERROR" : "KRB-ERROR " + krb_error_name(error_code);
+    default:
+      return "invalid response";
+  }
+}
+
+}  // namespace kdc_probe

--- a/modules/CheckActiveDirectory/kdc_probe.hpp
+++ b/modules/CheckActiveDirectory/kdc_probe.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+// Pure Kerberos AS-REQ probe encoding/decoding (RFC 4120), no network or
+// platform code: build a minimal unauthenticated AS-REQ and classify what the
+// KDC sent back. Any well-formed Kerberos answer — an AS-REP or, far more
+// commonly, a KRB-ERROR such as KDC_ERR_PREAUTH_REQUIRED — proves the KDC is
+// up and processing requests, which is exactly what a port check cannot.
+namespace kdc_probe {
+
+typedef std::vector<unsigned char> bytes;
+
+// DER-encode an AS-REQ for client_name@realm requesting a krbtgt/realm ticket
+// (no pre-auth, aes256/aes128/rc4 etypes). The principal does not need to
+// exist: an unknown principal still yields a KRB-ERROR, i.e. a live KDC.
+bytes build_as_req(const std::string &realm, const std::string &client_name, unsigned long nonce);
+
+enum class response_kind { as_rep, krb_error, invalid };
+
+struct classification {
+  response_kind kind;
+  long long error_code;  // KRB-ERROR error-code; -1 when absent or not applicable
+
+  classification() : kind(response_kind::invalid), error_code(-1) {}
+
+  // True when the response proves a live KDC (AS-REP or any KRB-ERROR).
+  bool alive() const { return kind == response_kind::as_rep || kind == response_kind::krb_error; }
+  std::string describe() const;
+};
+
+// Classify a raw Kerberos response message (without the TCP length prefix).
+classification classify_response(const bytes &data);
+
+// Symbolic name for the common KRB-ERROR codes ("error <n>" otherwise).
+std::string krb_error_name(long long code);
+
+}  // namespace kdc_probe

--- a/modules/CheckActiveDirectory/module.cmake
+++ b/modules/CheckActiveDirectory/module.cmake
@@ -1,0 +1,5 @@
+if(WIN32)
+    set(BUILD_MODULE 1)
+else()
+    set(BUILD_MODULE_SKIP_REASON "Not supported on linux")
+endif()

--- a/modules/CheckActiveDirectory/module.cmake
+++ b/modules/CheckActiveDirectory/module.cmake
@@ -1,5 +1,5 @@
 if(WIN32)
     set(BUILD_MODULE 1)
 else()
-    set(BUILD_MODULE_SKIP_REASON "Not supported on linux")
+    set(BUILD_MODULE_SKIP_REASON "Not supported on Linux")
 endif()

--- a/modules/CheckActiveDirectory/module.json
+++ b/modules/CheckActiveDirectory/module.json
@@ -1,0 +1,14 @@
+{
+	"module"		: {
+		"title"			: "Active Directory checker",
+		"description"	: "CheckActiveDirectory checks Active Directory health: replication on domain controllers, the machine-account secure channel and Kerberos KDC availability.",
+		"name"			: "CheckActiveDirectory",
+		"alias"			: "ad",
+		"version"		: "auto"
+	},
+	"commands" : {
+		"check_ad_replication"	: "Check inbound Active Directory replication links on a domain controller (last success, consecutive failures). Windows only.",
+		"check_secure_channel"	: "Verify the machine-account secure channel to the domain via netlogon. Windows only.",
+		"check_kdc"				: "Check that Kerberos KDCs answer an AS-REQ probe on port 88 (a real Kerberos exchange, not just a port check). Windows only."
+	}
+}

--- a/modules/CheckActiveDirectory/netapi_buffer.hpp
+++ b/modules/CheckActiveDirectory/netapi_buffer.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+// Windows.h must precede lm.h; the capital W keeps clang-format's
+// case-sensitive include sort from breaking that order.
+#include <Windows.h>
+#include <lm.h>
+
+#include <memory>
+
+namespace check_ad {
+
+// Buffers handed out by the netapi32 family - NetGetJoinInformation,
+// I_NetLogonControl2, DsGetDcName - are all released with NetApiBufferFree.
+// Owning them through unique_ptr puts that release on every path, including
+// the early returns these checks take whenever a lookup fails.
+struct net_api_deleter {
+  void operator()(void *buffer) const noexcept {
+    if (buffer != nullptr) NetApiBufferFree(buffer);
+  }
+};
+
+template <typename T>
+using net_api_ptr = std::unique_ptr<T, net_api_deleter>;
+
+// Adopt a raw out-parameter the API just filled in:
+//   T *raw = nullptr;
+//   const DWORD rc = SomeNetApi(..., &raw);
+//   const auto owned = check_ad::adopt_net_api(raw);
+template <typename T>
+net_api_ptr<T> adopt_net_api(T *buffer) {
+  return net_api_ptr<T>(buffer);
+}
+
+}  // namespace check_ad

--- a/modules/CheckActiveDirectory/win32_error.hpp
+++ b/modules/CheckActiveDirectory/win32_error.hpp
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <boost/algorithm/string/trim.hpp>
+#include <error/error.hpp>
+#include <string>
+
+namespace check_ad {
+
+// FormatMessage terminates its text with CRLF, which error::lookup::last_error
+// passes through verbatim. A check result is a single Nagios line (NRPE/NSCA
+// keep the first line and drop or relegate the rest), so the newline must never
+// reach a message - least of all mid-sentence, where it splits the text in two.
+inline std::string win32_error(unsigned long code) { return boost::algorithm::trim_copy(error::lookup::last_error(code)); }
+
+}  // namespace check_ad

--- a/service/plugins/plugin_manager.cpp
+++ b/service/plugins/plugin_manager.cpp
@@ -91,6 +91,7 @@ std::string installer_feature_hint(const std::string &module) {
       {"CheckDisk", "Check Plugins"},
       {"CheckTaskSched", "Check Plugins"},
       {"CheckSecurity", "Check Plugins"},
+      {"CheckActiveDirectory", "Check Plugins"},
       {"CheckMSSQL", "Check Plugins"},
       {"SimpleCache", "Check Plugins"},
       {"SimpleFileWriter", "Check Plugins"},

--- a/tests/checkactivedirectory-commands.test.ts
+++ b/tests/checkactivedirectory-commands.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Exercises the CheckActiveDirectory module end-to-end against the real nscp
+ * binary.
+ *
+ * Each case runs a one-shot client query — `nscp client --module
+ * CheckActiveDirectory --boot --query <cmd> ...` — which loads the module,
+ * runs the check and prints the Nagios-style result line. No server/port/
+ * docker needed, and the `k=v` tokens exercise the same REST-style argument
+ * parsing as the web API (including valued booleans like verify=false).
+ *
+ * The interesting data sources (a domain controller, a live KDC) do not exist
+ * on a build machine, so the suite pins what CAN be deterministic:
+ *  - check_kdc is probed against a fake KDC (a Node TCP server speaking
+ *    canned Kerberos: KRB-ERROR/AS-REP/garbage) and against a closed port.
+ *  - check_secure_channel / check_ad_replication assert their documented
+ *    contract for whichever state the host is in (domain-joined or not),
+ *    never a hard error.
+ *
+ * The module is Windows-only, so the whole suite is skipped elsewhere.
+ */
+import type { AddressInfo } from "net";
+import * as net from "net";
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(120_000);
+
+const onWindows = process.platform === "win32" ? describe : describe.skip;
+
+/** A canned Kerberos message, framed with the RFC 4120 4-byte length prefix. */
+function framed(message: number[]): Buffer {
+  const body = Buffer.from(message);
+  const header = Buffer.alloc(4);
+  header.writeUInt32BE(body.length, 0);
+  return Buffer.concat([header, body]);
+}
+
+// KRB-ERROR { pvno 5, msg-type 30, error-code 25 (KDC_ERR_PREAUTH_REQUIRED) } —
+// what a healthy AD KDC answers an unauthenticated AS-REQ with.
+const KRB_ERROR_PREAUTH = framed([
+  0x7e, 0x11, 0x30, 0x0f, 0xa0, 0x03, 0x02, 0x01, 0x05, 0xa1, 0x03, 0x02, 0x01, 0x1e, 0xa6, 0x03, 0x02, 0x01, 0x19,
+]);
+// A (structurally minimal) AS-REP: a KDC that issued a ticket outright.
+const AS_REP = framed([0x6b, 0x03, 0x30, 0x01, 0x00]);
+// A non-Kerberos speaker (e.g. a TLS server squatting on the port).
+const NOT_KERBEROS = framed([0x16, 0x03, 0x01, 0x00, 0x00]);
+
+interface FakeKdc {
+  port: number;
+  close: () => Promise<void>;
+}
+
+/** A TCP server that answers every request with the given canned response. */
+function startFakeKdc(response: Buffer): Promise<FakeKdc> {
+  return new Promise((resolve) => {
+    const server = net.createServer((socket) => {
+      socket.on("data", () => socket.write(response));
+      socket.on("error", () => socket.destroy());
+    });
+    server.listen(0, "127.0.0.1", () => {
+      resolve({
+        port: (server.address() as AddressInfo).port,
+        close: () => new Promise<void>((done) => server.close(() => done())),
+      });
+    });
+  });
+}
+
+onWindows("CheckActiveDirectory", () => {
+  let nscp: NscpInstance;
+
+  /** Run a CheckActiveDirectory query and return the combined output. */
+  async function query(command: string, args: string[] = []): Promise<string> {
+    const r = await nscp.run(["client", "--module", "CheckActiveDirectory", "--boot", "--query", command, ...args], {
+      allowFailure: true,
+    });
+    return r.all ?? `${r.stdout}\n${r.stderr}`;
+  }
+
+  beforeAll(() => {
+    nscp = new NscpInstance();
+  });
+
+  // --- check_kdc: deterministic via the fake KDC -----------------------------
+
+  it("check_kdc reports OK when the KDC answers with KRB-ERROR preauth-required", async () => {
+    const kdc = await startFakeKdc(KRB_ERROR_PREAUTH);
+    try {
+      const out = await query("check_kdc", ["server=127.0.0.1", `port=${kdc.port}`, "realm=EXAMPLE.TEST", "warning=none"]);
+      expect(out).toMatch(/^OK/m);
+      expect(out).toMatch(/KDC_ERR_PREAUTH_REQUIRED/);
+    } finally {
+      await kdc.close();
+    }
+  });
+
+  it("check_kdc treats an outright AS-REP as a responding KDC", async () => {
+    const kdc = await startFakeKdc(AS_REP);
+    try {
+      const out = await query("check_kdc", ["server=127.0.0.1", `port=${kdc.port}`, "realm=EXAMPLE.TEST", "warning=none"]);
+      expect(out).toMatch(/^OK/m);
+      expect(out).toMatch(/AS-REP/);
+    } finally {
+      await kdc.close();
+    }
+  });
+
+  it("check_kdc goes CRITICAL when a non-Kerberos service answers", async () => {
+    const kdc = await startFakeKdc(NOT_KERBEROS);
+    try {
+      const out = await query("check_kdc", ["server=127.0.0.1", `port=${kdc.port}`, "realm=EXAMPLE.TEST", "warning=none"]);
+      expect(out).toMatch(/^CRITICAL/m);
+      expect(out).toMatch(/invalid response/);
+    } finally {
+      await kdc.close();
+    }
+  });
+
+  it("check_kdc goes CRITICAL when nothing listens on the port", async () => {
+    // Port 1 is never serviced; Windows retries a refused connect internally
+    // for ~2s, comfortably inside the 5s default timeout.
+    const out = await query("check_kdc", ["server=127.0.0.1", "port=1", "realm=EXAMPLE.TEST"]);
+    expect(out).toMatch(/^CRITICAL/m);
+    expect(out).toMatch(/connect failed|timeout/);
+  });
+
+  it("check_kdc emits round-trip perfdata in ms", async () => {
+    const kdc = await startFakeKdc(KRB_ERROR_PREAUTH);
+    try {
+      // The default warning (time > 1000) references `time`, which is what
+      // makes the perf series appear; keep it and pin only critical.
+      const out = await query("check_kdc", ["server=127.0.0.1", `port=${kdc.port}`, "realm=EXAMPLE.TEST"]);
+      expect(out).toMatch(/'127\.0\.0\.1'=\d+ms/);
+    } finally {
+      await kdc.close();
+    }
+  });
+
+  it("check_kdc accepts custom rendering keywords", async () => {
+    const kdc = await startFakeKdc(KRB_ERROR_PREAUTH);
+    try {
+      const out = await query("check_kdc", [
+        "server=127.0.0.1",
+        `port=${kdc.port}`,
+        "realm=EXAMPLE.TEST",
+        "warning=none",
+        "detail-syntax=${kdc} port ${port} realm ${realm}: ${response} code=${error_code}",
+      ]);
+      expect(out).toMatch(new RegExp(`127\\.0\\.0\\.1 port ${kdc.port} realm EXAMPLE\\.TEST: KRB-ERROR \\S+ code=25`));
+    } finally {
+      await kdc.close();
+    }
+  });
+
+  it("check_kdc without server= reports KDC state or the no-domain guidance", async () => {
+    // Domain-joined runner: probes the discovered KDC (any status word is
+    // legitimate — the DC may be slow). Workgroup runner: the documented
+    // guidance to pass server=/realm=. Never an argument error.
+    const out = await query("check_kdc", []);
+    expect(out).toMatch(/OK|WARNING|CRITICAL|Failed to locate a KDC/);
+    expect(out).not.toMatch(/does not take any arguments|unknown option/i);
+  });
+
+  // --- check_secure_channel ---------------------------------------------------
+
+  it("check_secure_channel reports the channel state or the not-joined contract", async () => {
+    const out = await query("check_secure_channel", []);
+    // Domain-joined: a row rendering "secure channel to <domain> via <dc>".
+    // Workgroup/standalone: the documented UNKNOWN with remediation-free text.
+    expect(out).toMatch(/secure channel to|not joined to a domain/i);
+    expect(out).not.toMatch(/does not take any arguments|unknown option/i);
+  });
+
+  it("check_secure_channel accepts a valued boolean over the query path (verify=false)", async () => {
+    // The REST transport passes booleans as `verify=false` tokens; bool_switch
+    // style options reject that, so pin the contract here.
+    const out = await query("check_secure_channel", ["verify=false"]);
+    expect(out).toMatch(/secure channel to|not joined to a domain/i);
+    expect(out).not.toMatch(/does not take any arguments/i);
+  });
+
+  it("check_secure_channel accepts its threshold keywords", async () => {
+    const out = await query("check_secure_channel", ["critical=healthy = 0 or error_code != 0", "warning=none"]);
+    expect(out).not.toMatch(/does not take any arguments|invalid expression|error parsing/i);
+  });
+
+  // --- check_ad_replication ----------------------------------------------------
+
+  it("check_ad_replication reports link health or the not-a-DC contract", async () => {
+    // On a DC: link summary (or the single-DC empty state). Anywhere else the
+    // documented UNKNOWN names the host so fleet-wide deployment is safe.
+    const out = await query("check_ad_replication", []);
+    expect(out).toMatch(/replication links|replication partners|Not a domain controller/i);
+    expect(out).not.toMatch(/does not take any arguments|unknown option/i);
+  });
+
+  it("check_ad_replication accepts its threshold keywords", async () => {
+    const out = await query("check_ad_replication", [
+      "warning=consecutive_failures > 0",
+      "critical=consecutive_failures > 4 or last_success < -24h",
+    ]);
+    expect(out).not.toMatch(/does not take any arguments|invalid expression|error parsing/i);
+  });
+});

--- a/tests/checkactivedirectory-commands.test.ts
+++ b/tests/checkactivedirectory-commands.test.ts
@@ -129,10 +129,35 @@ onWindows("CheckActiveDirectory", () => {
       // The default warning (time > 1000) references `time`, which is what
       // makes the perf series appear; keep it and pin only critical.
       const out = await query("check_kdc", ["server=127.0.0.1", `port=${kdc.port}`, "realm=EXAMPLE.TEST"]);
-      expect(out).toMatch(/'127\.0\.0\.1'=\d+ms/);
+      expect(out).toMatch(/'127\.0\.0\.1'=\d+ms;1000/);
+      // The default critical (responding = 0) carries no `time` bound, so the
+      // crit field must stay empty — a crit of 0 reads as "always critical"
+      // to perfdata consumers.
+      expect(out).not.toMatch(/'127\.0\.0\.1'=\d+ms;1000;/);
     } finally {
       await kdc.close();
     }
+  });
+
+  it("check_kdc timeout= is in milliseconds and bounds all probes together", async () => {
+    // 127.0.0.1:1 is never serviced and Windows retries the refused connect
+    // internally for ~2s (per probe), so with four servers a sequential
+    // implementation needs 4 x 1500ms of deadline while the concurrent one
+    // finishes in ~1.5s. The wall-clock bound is deliberately generous to
+    // absorb process startup on a loaded CI machine.
+    const started = Date.now();
+    const out = await query("check_kdc", [
+      "server=127.0.0.1",
+      "server=127.0.0.2",
+      "server=127.0.0.3",
+      "server=127.0.0.4",
+      "port=1",
+      "realm=EXAMPLE.TEST",
+      "timeout=1500",
+    ]);
+    expect(out).toMatch(/^CRITICAL/m);
+    expect(out).toMatch(/timeout after 1500ms|connect failed/);
+    expect(Date.now() - started).toBeLessThan(5500);
   });
 
   it("check_kdc accepts custom rendering keywords", async () => {

--- a/tests/checkactivedirectory-commands.test.ts
+++ b/tests/checkactivedirectory-commands.test.ts
@@ -160,6 +160,20 @@ onWindows("CheckActiveDirectory", () => {
     expect(Date.now() - started).toBeLessThan(5500);
   });
 
+  it("check_kdc omits perfdata (not a negative sample) when the host never resolves", async () => {
+    // Nothing resolves, so no exchange ever starts and there is no round trip
+    // to report: `time` must render as `?` and emit no perf sample rather than
+    // planting a -1ms point in the series for good.
+    const out = await query("check_kdc", ["server=nx.invalid.nscp-test", "realm=EXAMPLE.TEST"]);
+    expect(out).toMatch(/^CRITICAL/m);
+    expect(out).not.toMatch(/=-\d+ms/);
+  });
+
+  it("check_kdc rejects an oversized realm rather than sending it", async () => {
+    const out = await query("check_kdc", ["server=127.0.0.1", "port=1", `realm=${"R".repeat(300)}`]);
+    expect(out).toMatch(/realm= is too long/);
+  });
+
   it("check_kdc accepts custom rendering keywords", async () => {
     const kdc = await startFakeKdc(KRB_ERROR_PREAUTH);
     try {
@@ -216,6 +230,16 @@ onWindows("CheckActiveDirectory", () => {
     const out = await query("check_ad_replication", []);
     expect(out).toMatch(/replication links|replication partners|Not a domain controller/i);
     expect(out).not.toMatch(/does not take any arguments|unknown option/i);
+  });
+
+  it("check_ad_replication bounds an unreachable server= by timeout=", async () => {
+    // 127.0.0.1:135 refuses immediately on a CI runner; the point is that the
+    // option parses and the check returns well inside its own deadline rather
+    // than blocking on the RPC bind.
+    const started = Date.now();
+    const out = await query("check_ad_replication", ["server=127.0.0.1", "timeout=1500"]);
+    expect(out).not.toMatch(/does not take any arguments|unknown option/i);
+    expect(Date.now() - started).toBeLessThan(20_000);
   });
 
   it("check_ad_replication accepts its threshold keywords", async () => {


### PR DESCRIPTION
Add a new Windows-only CheckActiveDirectory module covering the domain health signals NSClient++ had no answer for, plus a scenario guide that extends coverage to NTDS/ADCS/ADFS via existing check_pdh counters.

New commands:

- check_ad_replication: inbound replication links on a domain controller via DsBind/DsReplicaGetInfo (last success/attempt as date keywords, consecutive_failures as perfdata). WARN on the first failed sync, CRIT after five in a row or 24h without success. Non-DCs get a fleet-safe UNKNOWN contract; single-DC domains an explanatory OK empty state.
- check_secure_channel: verify the machine-account secure channel via netlogon TC_VERIFY (the Test-ComputerSecureChannel operation), with verify=false for a passive TC_QUERY. Workgroup machines return the documented not-joined UNKNOWN.
- check_kdc: send a real unauthenticated Kerberos AS-REQ over TCP 88 and classify the answer; KDC_ERR_PREAUTH_REQUIRED is the healthy response. This catches a KDC that accepts connections but no longer issues tickets, which a port check cannot. KDC/realm are discovered from the domain join or given explicitly, with round-trip perfdata.

The AS-REQ encoder/KRB-ERROR classifier is pure (kdc_probe.cpp) and covered by gtest against an independent DER reader. The integration suite drives all three commands over the client-query path and pins the Kerberos exchange deterministically against a canned fake KDC, including the valued-boolean (verify=false) REST parsing contract.

Only system import libraries are added (ntdsapi, netapi32, winsock), so the installer grows by just the module DLL. The MSI, plugin feature-hint map and reference docs samples are wired up, and a new Active Directory & Identity scenario documents the module together with curated NTDS, Certification Authority and AD FS counter checks over check_pdh.

Assisted-by: Claude Code:claude-fable-5