### PR TITLE
fix: correct stale counter name in kernel memory field comment

### DIFF
--- a/modules/CheckSystem/check_kernel_memory.hpp
+++ b/modules/CheckSystem/check_kernel_memory.hpp
@@ -23,7 +23,7 @@ struct kernel_memory_obj {
   long long cache;           // Cache Bytes (system file cache working set)
   double page_faults;        // Page Faults/sec (soft + hard; huge on healthy hosts)
   double transition_faults;  // Transition Faults/sec (the dominant soft-fault kind)
-  double hard_faults;        // Pages Input/sec (faults that had to hit disk)
+  double hard_faults;        // Page Reads/sec (hard-fault events that had to hit disk)
 
   kernel_memory_obj() : pool_paged(0), pool_nonpaged(0), cache(0), page_faults(0.0), transition_faults(0.0), hard_faults(0.0) {}
 


### PR DESCRIPTION
check_kernel_memory reads \Memory\Page Reads/sec for hard_faults, but the struct field comment still named \Memory\Pages Input/sec. Those are different quantities: Page Reads/sec counts hard-fault events, while Pages Input/sec counts the pages those reads bring in (a single read can page in several). The stale comment described exactly the mix-up the counter choice avoids.

Assisted-by: Claude Code:claude-opus-5