### PR TITLE
ci+fix: Validate RedHat/Rocky builds, and fix the CA bundle they exposed

### DIFF
--- a/.github/workflows/integration-tests-linux.yml
+++ b/.github/workflows/integration-tests-linux.yml
@@ -180,14 +180,19 @@ jobs:
       # dependent scenario (icinga, nrpe, nsca, …) skip itself so this stage
       # runs without a docker daemon. Each rest-* test spins its own nscp
       # via NscpInstance, so no manual start/kill/log-tail is needed here.
+      #
+      # This used to be deb-only, from when the harness still needed a docker
+      # daemon. NSCP_SKIP_DOCKER removed that, but the condition stayed - which
+      # left the rpm packages with only acceptance-tests.sh for coverage, so
+      # anything that behaves differently on RHEL went untested. The RPM base
+      # dependencies already install Node 20 from nodesource, so both package
+      # types run the same suite.
       - name: Install integration harness deps
-        if: inputs.package-type == 'deb'
         working-directory: tests
         shell: bash
         run: npm install
 
       - name: Run REST scenarios (no-docker)
-        if: inputs.package-type == 'deb'
         working-directory: tests
         shell: bash
         env:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ endif()
 
 # ##############################################################################
 #
-# Setup cmake enviornment and include custom config overrides
+# Setup cmake environment and include custom config overrides
 #
 # ##############################################################################
 if(NSCP_CMAKE_CONFIG)
@@ -328,7 +328,7 @@ if(NOT HAVE_REQUIRED_DEPENDENCIES)
 else(NOT HAVE_REQUIRED_DEPENDENCIES)
     message(
         STATUS
-        " - All required dependecies found! (some modules and features migh stil be missing though)"
+        " - All required dependencies found! (some modules and features might still be missing though)"
     )
 endif(NOT HAVE_REQUIRED_DEPENDENCIES)
 
@@ -729,7 +729,7 @@ else(WIN32)
     set(MAIN_CONFIGURATION
         /etc/nscp/nscp.xml
         CACHE PATH
-        "Path for the client configurtion file"
+        "Path for the client configuration file"
     )
     set(DEPLOYROOT /usr/bin CACHE PATH "Path to deploy examples into)")
 endif(WIN32)
@@ -927,7 +927,7 @@ else()
     set(CONFIG_CERT_FOLDER
         "\${shared-path}/security"
         CACHE STRING
-        "securoty (certificates) folder"
+        "security (certificates) folder"
     )
 
     # The trusted CA bundle belongs to the distribution, so this is an absolute
@@ -1240,7 +1240,7 @@ set(NSCP_CLIENT_HPP
 
 # ##############################################################################
 #
-# Build everything (not already built lik libraries)!
+# Build everything (not already built like libraries)!
 #
 # ##############################################################################
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -863,6 +863,13 @@ if(WIN32)
         CACHE STRING
         "security (certificates) folder"
     )
+    # The service exports the Windows ROOT store here at boot (windows_ca_store),
+    # so unlike unix this is a path we own rather than one the platform ships.
+    set(CONFIG_CA_PATH
+        "\${certificate-path}/windows-ca.pem"
+        CACHE STRING
+        "Trusted CA bundle used when a check does not name its own"
+    )
     set(CONFIG_DEFAULT_CACHE_PATH
         "\${shared-path}/cache"
         CACHE STRING
@@ -922,6 +929,51 @@ else()
         CACHE STRING
         "securoty (certificates) folder"
     )
+
+    # The trusted CA bundle belongs to the distribution, so this is an absolute
+    # path that must NOT track CMAKE_INSTALL_PREFIX: a --prefix=/usr/local build
+    # still reads the system bundle, not /usr/local/etc/ssl/...
+    #
+    # Where that bundle lives differs per family, and picking wrong is silent -
+    # every TLS check that does not name its own CA then fails with "Failed to
+    # load CA <path>: No such file or directory", including checks against a
+    # local self-signed server with verification disabled, since the file is
+    # loaded before the verify mode is considered. Detecting it here works
+    # because a package is built in a container of the distribution it targets;
+    # a packager who knows better can override with -DCONFIG_CA_PATH=...
+    if(NOT CONFIG_CA_PATH)
+        foreach(
+            _ca_candidate
+            "/etc/ssl/certs/ca-certificates.crt" # Debian, Ubuntu, Gentoo
+            "/etc/pki/tls/certs/ca-bundle.crt" # RHEL, Rocky, Alma, Fedora
+            "/etc/ssl/ca-bundle.pem" # SUSE
+            "/etc/ssl/cert.pem" # Alpine, FreeBSD, macOS
+        )
+            if(EXISTS "${_ca_candidate}")
+                set(_ca_detected "${_ca_candidate}")
+                break()
+            endif()
+        endforeach()
+        if(NOT _ca_detected)
+            # Nothing found: keep the historical value so the define is never
+            # empty, and say so - a build host without a CA bundle is unusual
+            # enough to be worth a line in the configure output.
+            set(_ca_detected "/etc/ssl/certs/ca-certificates.crt")
+            message(
+                WARNING
+                "No system CA bundle found; defaulting ca-path to ${_ca_detected}. "
+                "TLS checks that do not name their own CA will fail unless that file exists at runtime "
+                "(override with -DCONFIG_CA_PATH=/path/to/bundle)."
+            )
+        endif()
+        set(CONFIG_CA_PATH
+            "${_ca_detected}"
+            CACHE STRING
+            "Trusted CA bundle used when a check does not name its own"
+        )
+    endif()
+    message(STATUS "System CA bundle (ca-path): ${CONFIG_CA_PATH}")
+
     set(CONFIG_DEFAULT_CACHE_PATH
         "\${shared-path}/cache"
         CACHE STRING

--- a/check_deps.cmake
+++ b/check_deps.cmake
@@ -11,7 +11,7 @@ set(CMAKE_FIND_LIBRARY_PREFIXES
 set(CMAKE_FIND_LIBRARY_SUFFIXES .lib)
 #############################################################################
 #
-# Setup cmake enviornment and include custom config overrides
+# Setup cmake environment and include custom config overrides
 #
 #############################################################################
 if(EXISTS ${TARGET}/build.cmake)

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -46,6 +46,11 @@
 #define WEB_FOLDER "@CONFIG_WEB_FOLDER@"
 #define SCRIPTS_FOLDER "@CONFIG_SCRIPTS_FOLDER@"
 #define CERT_FOLDER "@CONFIG_CERT_FOLDER@"
+// Trusted CA bundle used whenever a check does not name its own. On Windows the
+// service exports the ROOT store to this file at boot; on unix it is the system
+// bundle, detected at configure time because its location differs per
+// distribution (see CONFIG_CA_PATH in CMakeLists.txt).
+#define CA_PATH "@CONFIG_CA_PATH@"
 #define LOG_FOLDER "@CONFIG_LOG_FOLDER@"
 #ifndef WIN32
 #define UNIX_SHARED_PATH_FOLDER "@UNIX_SHARED_PATH_FOLDER@"

--- a/installer_lib/CMakeLists.txt
+++ b/installer_lib/CMakeLists.txt
@@ -171,7 +171,7 @@ set(CONFIG_SCRIPTS_FOLDER "\${exe-path}/scripts" CACHE STRING "script folder")
 set(CONFIG_CERT_FOLDER
     "\${shared-path}/security"
     CACHE STRING
-    "securoty (certificates) folder"
+    "security (certificates) folder"
 )
 set(CONFIG_DEFAULT_CACHE_PATH
     "\${shared-path}/cache"

--- a/modules/CheckNSCP/CheckNSCP.cpp
+++ b/modules/CheckNSCP/CheckNSCP.cpp
@@ -38,9 +38,10 @@ bool CheckNSCP::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
   NSC_DEBUG_MSG_STD("Crash folder is: " + crashFolder.string());
 
   // Default the CA bundle to the trusted system store (${ca-path} expands to
-  // certificate-path/windows-ca.pem on Windows, /etc/ssl/certs/ca-certificates.crt
-  // on Linux). The same setting is used by CheckNet's check_http and lets the
-  // update check validate api.github.com out of the box.
+  // certificate-path/windows-ca.pem on Windows, and on unix to the
+  // distribution's own bundle, detected at configure time - see CONFIG_CA_PATH).
+  // The same setting is used by CheckNet's check_http and lets the update check
+  // validate api.github.com out of the box.
   const std::string default_ca = get_core()->expand_path("${ca-path}");
 
   // clang-format off

--- a/modules/CheckNet/CheckNet.cpp
+++ b/modules/CheckNet/CheckNet.cpp
@@ -31,8 +31,9 @@ boost::atomic<unsigned short> identifier(0);
 bool CheckNet::loadModuleEx(const std::string &, NSCAPI::moduleLoadMode) {
   // Resolve the trusted CA bundle path once, at module load. ${ca-path}
   // expands to ${certificate-path}/windows-ca.pem on Windows (the auto-
-  // generated system ROOT bundle) and to /etc/ssl/certs/ca-certificates.crt
-  // on Linux. check_http hands this through as the default `ca` so HTTPS
+  // generated system ROOT bundle) and on unix to the distribution's own bundle,
+  // detected at configure time because its location differs per family
+  // (CONFIG_CA_PATH). check_http hands this through as the default `ca` so HTTPS
   // checks against public-CA-signed servers validate out of the box.
   default_ca_ = get_core()->expand_path("${ca-path}");
   return true;

--- a/service/NSClient++.cpp
+++ b/service/NSClient++.cpp
@@ -266,7 +266,7 @@ bool NSClientT::load_configuration_2(const bool override_log) {
     LOG_ERROR_CORE_STD("COM exception: " + e.reason());
     return false;
   } catch (...) {
-    LOG_ERROR_CORE("Unknown exception iniating COM...");
+    LOG_ERROR_CORE("Unknown exception initiating COM...");
     return false;
   }
 
@@ -486,7 +486,7 @@ bool NSClientT::stop_nsclient() {
   } catch (com_helper::com_exception &e) {
     LOG_ERROR_CORE_STD("COM exception: " + e.reason());
   } catch (...) {
-    LOG_ERROR_CORE("Unknown exception uniniating COM...");
+    LOG_ERROR_CORE("Unknown exception uninitiating COM...");
   }
 #endif
   LOG_DEBUG_CORE("Stopping: Settings instance");

--- a/service/path_manager.cpp
+++ b/service/path_manager.cpp
@@ -85,25 +85,20 @@ std::string nsclient::core::path_manager::get_path_for_key(const std::string &ke
   // Static defaults baked in by CMake via config.h. Most are templated on
   // ${shared-path} or ${certificate-path}; expand_path resolves the chain.
   // Note on ca-path: on Windows the service exports the system ROOT store to
-  // this file at boot (see windows_ca_store); on Linux this is the de-facto
-  // Debian/Ubuntu location, overridable via boot.ini's [paths] section
-  // (or the --path-override CLI flag) for other distros.
+  // this file at boot (see windows_ca_store); on unix it is the distribution's
+  // own bundle, whose location differs per family and is therefore detected at
+  // configure time (CONFIG_CA_PATH). Either way it stays overridable via
+  // boot.ini's [paths] section or --path-override ca-path=...
   static const std::map<std::string, std::string> defaults = {
       {"certificate-path", CERT_FOLDER},
       {"module-path", MODULE_FOLDER},
       {"web-path", WEB_FOLDER},
       {"scripts", SCRIPTS_FOLDER},
       {"log-path", LOG_FOLDER},
+      {"ca-path", CA_PATH},
       {CACHE_FOLDER_KEY, DEFAULT_CACHE_PATH},
       {CRASH_ARCHIVE_FOLDER_KEY, "${shared-path}/crash-dumps"},
-#ifdef WIN32
-      {"ca-path", "${certificate-path}/windows-ca.pem"},
-#else
-      // ca-path stays a literal absolute path: the system CA bundle belongs to
-      // the distro, lives at /etc/ssl/... regardless of our install prefix, and
-      // must NOT track ${etc}/NSCP_SYSCONFDIR (a --prefix=/usr/local build still
-      // reads /etc/ssl/certs/..., not /usr/local/etc/ssl/...).
-      {"ca-path", "/etc/ssl/certs/ca-certificates.crt"},
+#ifndef WIN32
       {"shared-path", UNIX_SHARED_PATH_FOLDER},
       {"data-path", UNIX_DATA_PATH_FOLDER},
       // ${etc} tracks this build's config root (NSCP_SYSCONFDIR) so user

--- a/service/path_manager_test.cpp
+++ b/service/path_manager_test.cpp
@@ -6,6 +6,8 @@
 #include <config.h>
 #include <gtest/gtest.h>
 
+#include <boost/filesystem.hpp>
+
 #include <memory>
 #include <nsclient/logger/logger.hpp>
 
@@ -79,6 +81,16 @@ TEST_F(PathManagerTest, CaPathExpandsToBundleFile) {
   EXPECT_NE(expanded.find("windows-ca.pem"), std::string::npos);
 #else
   EXPECT_EQ(expanded.rfind("/etc/", 0), 0u);
+
+  // ...and it must name a bundle that is actually there. This used to be one
+  // hardcoded path for every non-Windows platform - the Debian one - so on
+  // RHEL-family it named a file that does not exist, and every TLS check that
+  // did not carry its own ca= failed with "Failed to load CA <path>: No such
+  // file or directory". CONFIG_CA_PATH now detects the platform bundle at
+  // configure time, and this asserts the detection actually found it: the build
+  // host is the distribution the package targets, so a regression to a
+  // hardcoded value shows up here rather than in the field.
+  EXPECT_TRUE(boost::filesystem::exists(expanded)) << "ca-path does not exist: " << expanded;
 #endif
 }
 

--- a/service/settings_client.cpp
+++ b/service/settings_client.cpp
@@ -116,7 +116,7 @@ int nsclient_core::settings_client::generate(std::string target) {
   }
 }
 
-void nsclient_core::settings_client::switch_context(std::string contect) { get_core()->set_primary(expand_context(contect)); }
+void nsclient_core::settings_client::switch_context(std::string context) { get_core()->set_primary(expand_context(context)); }
 
 int nsclient_core::settings_client::set(std::string path, std::string key, std::string val) {
   get_core()->get()->set_string(path, key, val);

--- a/service/settings_client.hpp
+++ b/service/settings_client.hpp
@@ -35,7 +35,7 @@ class settings_client {
 
   int generate(std::string target);
 
-  void switch_context(std::string contect);
+  void switch_context(std::string context);
   std::string expand_context(const std::string& key) const;
 
   int set(std::string path, std::string key, std::string val);

--- a/tests/acceptance-tests.sh
+++ b/tests/acceptance-tests.sh
@@ -34,5 +34,28 @@ nscp unit --language python --script test_check_helpers || fail
 echo "Running Scheduler tests..."
 nscp unit --language python --script test_scheduler || fail
 
+# check_http with no ca= of its own falls back to ${ca-path}, the platform CA
+# bundle that CheckNet::loadModuleEx resolves at load. That default is a single
+# hardcoded path (service/path_manager.cpp) and it is the Debian/Ubuntu one on
+# every non-Windows platform, so on RHEL-family - where the bundle is
+# /etc/pki/tls/certs/ca-bundle.crt - this fails before a socket is opened:
+#
+#   CRITICAL: ... error: Failed to load CA /etc/ssl/certs/ca-certificates.crt
+#
+# This lives here rather than in the jest suite because the jest steps only run
+# for DEB packages (integration-tests-linux.yml), so nothing else in CI exercises
+# the default bundle on the distribution where it is wrong. Needs egress; it is
+# the only test here that does.
+echo "Running CheckNet platform-trust-store test..."
+http_out=$(nscp client --module CheckNet --boot --query check_http url=https://www.google.com critical="code != 200" 2>&1 | tail -1)
+echo "  $http_out"
+case "$http_out" in
+    OK:*) ;;
+    *)
+        echo "check_http could not validate a public HTTPS site using the platform CA bundle."
+        fail
+        ;;
+esac
+
 echo "All tests passed successfully."
 exit 0

--- a/tests/acceptance-tests.sh
+++ b/tests/acceptance-tests.sh
@@ -34,28 +34,5 @@ nscp unit --language python --script test_check_helpers || fail
 echo "Running Scheduler tests..."
 nscp unit --language python --script test_scheduler || fail
 
-# check_http with no ca= of its own falls back to ${ca-path}, the platform CA
-# bundle that CheckNet::loadModuleEx resolves at load. That default is a single
-# hardcoded path (service/path_manager.cpp) and it is the Debian/Ubuntu one on
-# every non-Windows platform, so on RHEL-family - where the bundle is
-# /etc/pki/tls/certs/ca-bundle.crt - this fails before a socket is opened:
-#
-#   CRITICAL: ... error: Failed to load CA /etc/ssl/certs/ca-certificates.crt
-#
-# This lives here rather than in the jest suite because the jest steps only run
-# for DEB packages (integration-tests-linux.yml), so nothing else in CI exercises
-# the default bundle on the distribution where it is wrong. Needs egress; it is
-# the only test here that does.
-echo "Running CheckNet platform-trust-store test..."
-http_out=$(nscp client --module CheckNet --boot --query check_http url=https://www.google.com critical="code != 200" 2>&1 | tail -1)
-echo "  $http_out"
-case "$http_out" in
-    OK:*) ;;
-    *)
-        echo "check_http could not validate a public HTTPS site using the platform CA bundle."
-        fail
-        ;;
-esac
-
 echo "All tests passed successfully."
 exit 0

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -1026,12 +1026,18 @@ describe("CheckNet commands", () => {
   // suite stays hermetic - but it means one thing is never exercised: the
   // *default* CA bundle, `${ca-path}`, which CheckNet::loadModuleEx resolves
   // once at load and hands to check_http whenever the caller does not override
-  // it. ${ca-path} is a single hardcoded path (service/path_manager.cpp), and it
+  // it. ${ca-path} is a single hardcoded path (service/path_manager.cpp) and it
   // is the Debian/Ubuntu one on every non-Windows platform, so on RHEL-family -
-  // where the bundle is /etc/pki/tls/certs/ca-bundle.crt - every HTTPS check
-  // fails with "Failed to load CA /etc/ssl/certs/ca-certificates.crt". The
-  // integration suite runs in rockylinux containers (build-redhat.yml), so
-  // these two tests catch it there while passing on Debian.
+  // where the bundle is /etc/pki/tls/certs/ca-bundle.crt - it names a file that
+  // does not exist.
+  //
+  // That is not only a public-internet problem: make_context loads the CA
+  // whenever `ca` is non-empty, before verify mode is considered, so
+  // `verify=none` against a local self-signed server fails too. On Rocky 10 it
+  // takes down four of this file's existing tests (ssl_expiry_days, the
+  // redirect-to-plain-http case and both check_nsclient_web_online cases) with
+  // "Failed to load CA /etc/ssl/certs/ca-certificates.crt". They pass on Debian,
+  // which is the only place this suite used to run.
   //
   // These are the only tests here that need egress. Both assert reachability,
   // not latency: thresholds are pinned wide so a slow or busy runner cannot turn

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -1,7 +1,9 @@
 /**
  * Exercises the CheckNet module's recently-added network checks end-to-end
  * against throwaway local servers (net / tls / http / https / dgram), so the
- * suite is fully self-contained and needs no external network:
+ * suite is self-contained apart from the "against the public internet" block at
+ * the end, which is the only place the platform's own CA bundle and real ICMP
+ * are exercised:
  *
  *   - check_tcp   — plain + TLS connect, greeting expect, connection refused
  *   - check_ssh   — SSH banner validation
@@ -1016,6 +1018,48 @@ describe("CheckNet commands", () => {
     });
     expect(messageOf(q)).not.toMatch(/Refusing to send/);
     expect(messageOf(q)).toMatch(/No host specified/);
+  });
+
+  // --- real network, real trust store ---------------------------------------
+  // Everything else in this file talks to a listener on loopback, and every TLS
+  // case passes `verify: none` or an explicit `ca=`. That is deliberate - the
+  // suite stays hermetic - but it means one thing is never exercised: the
+  // *default* CA bundle, `${ca-path}`, which CheckNet::loadModuleEx resolves
+  // once at load and hands to check_http whenever the caller does not override
+  // it. ${ca-path} is a single hardcoded path (service/path_manager.cpp), and it
+  // is the Debian/Ubuntu one on every non-Windows platform, so on RHEL-family -
+  // where the bundle is /etc/pki/tls/certs/ca-bundle.crt - every HTTPS check
+  // fails with "Failed to load CA /etc/ssl/certs/ca-certificates.crt". The
+  // integration suite runs in rockylinux containers (build-redhat.yml), so
+  // these two tests catch it there while passing on Debian.
+  //
+  // These are the only tests here that need egress. Both assert reachability,
+  // not latency: thresholds are pinned wide so a slow or busy runner cannot turn
+  // a working check into a red build.
+  describe("against the public internet", () => {
+    it("check_http validates a public HTTPS site using the platform CA bundle", async () => {
+      const q = await executeQuery(key, "check_http", {
+        url: "https://www.google.com",
+        // No ca= and no verify=none on purpose: the point is the default.
+        critical: "code != 200",
+      });
+      // Assert the CA failure separately from the result, so a broken trust
+      // store reads as itself instead of as a generic CRITICAL.
+      expect(messageOf(q)).not.toMatch(/Failed to load CA/);
+      expect(q.result).toBe(OK);
+    });
+
+    it("check_ping reaches a public host", async () => {
+      const q = await executeQuery(key, "check_ping", {
+        host: "google.com",
+        count: "2",
+        // The defaults are time > 60 / > 100 ms, which say more about the
+        // runner's distance to Google than about whether ICMP works.
+        warning: "loss > 50%",
+        critical: "loss > 99%",
+      });
+      expect(q.result).toBe(OK);
+    });
   });
 
   it("check_ssh honours address-family", async () => {

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -2,8 +2,7 @@
  * Exercises the CheckNet module's recently-added network checks end-to-end
  * against throwaway local servers (net / tls / http / https / dgram), so the
  * suite is self-contained apart from the "against the public internet" block at
- * the end, which is the only place the platform's own CA bundle and real ICMP
- * are exercised:
+ * the end, which is the only place the platform's own CA bundle is exercised:
  *
  *   - check_tcp   — plain + TLS connect, greeting expect, connection refused
  *   - check_ssh   — SSH banner validation
@@ -1039,9 +1038,9 @@ describe("CheckNet commands", () => {
   // "Failed to load CA /etc/ssl/certs/ca-certificates.crt". They pass on Debian,
   // which is the only place this suite used to run.
   //
-  // These are the only tests here that need egress. Both assert reachability,
-  // not latency: thresholds are pinned wide so a slow or busy runner cannot turn
-  // a working check into a red build.
+  // This is the only test here that needs egress, and it asserts reachability
+  // rather than latency, so a slow or busy runner cannot turn a working check
+  // into a red build.
   describe("against the public internet", () => {
     it("check_http validates a public HTTPS site using the platform CA bundle", async () => {
       const q = await executeQuery(key, "check_http", {
@@ -1052,29 +1051,6 @@ describe("CheckNet commands", () => {
       // Assert the CA failure separately from the result, so a broken trust
       // store reads as itself instead of as a generic CRITICAL.
       expect(messageOf(q)).not.toMatch(/Failed to load CA/);
-      expect(q.result).toBe(OK);
-    });
-
-    // GitHub-hosted runners drop outbound ICMP, so this cannot pass in CI on any
-    // platform: it comes back CRITICAL with 100% loss on the Ubuntu containers
-    // and the Windows runners alike, while the identical query is OK from an
-    // ordinary Azure VM (both distros) and from a Windows desktop. That is the
-    // runner's network, not the check, so the test is opt-in rather than deleted
-    // - it is the only thing that proves check_ping actually puts a packet on
-    // the wire. Run it where ICMP is allowed:
-    //
-    //   NSCP_EXTERNAL_ICMP=1 npx jest checknet
-    const itIcmp = process.env.NSCP_EXTERNAL_ICMP === "1" ? it : it.skip;
-    itIcmp("check_ping reaches a public host", async () => {
-      const q = await executeQuery(key, "check_ping", {
-        host: "google.com",
-        count: "2",
-        // The defaults are time > 60 / > 100 ms, which say more about the
-        // runner's distance to Google than about whether ICMP works.
-        warning: "loss > 50%",
-        critical: "loss > 99%",
-      });
-      expect(messageOf(q)).not.toMatch(/loss = 100%/);
       expect(q.result).toBe(OK);
     });
   });

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -1049,7 +1049,17 @@ describe("CheckNet commands", () => {
       expect(q.result).toBe(OK);
     });
 
-    it("check_ping reaches a public host", async () => {
+    // GitHub-hosted runners drop outbound ICMP, so this cannot pass in CI on any
+    // platform: it comes back CRITICAL with 100% loss on the Ubuntu containers
+    // and the Windows runners alike, while the identical query is OK from an
+    // ordinary Azure VM (both distros) and from a Windows desktop. That is the
+    // runner's network, not the check, so the test is opt-in rather than deleted
+    // - it is the only thing that proves check_ping actually puts a packet on
+    // the wire. Run it where ICMP is allowed:
+    //
+    //   NSCP_EXTERNAL_ICMP=1 npx jest checknet
+    const itIcmp = process.env.NSCP_EXTERNAL_ICMP === "1" ? it : it.skip;
+    itIcmp("check_ping reaches a public host", async () => {
       const q = await executeQuery(key, "check_ping", {
         host: "google.com",
         count: "2",
@@ -1058,6 +1068,7 @@ describe("CheckNet commands", () => {
         warning: "loss > 50%",
         critical: "loss > 99%",
       });
+      expect(messageOf(q)).not.toMatch(/loss = 100%/);
       expect(q.result).toBe(OK);
     });
   });


### PR DESCRIPTION
The jest integration harness only ever ran on Debian builds. This turns it on for the RPM jobs too — and fixes the bug that immediately surfaced.

## Why RHEL was untested

The harness has been gated `if: inputs.package-type == 'deb'` since `b83d6bf7`, from when it still needed a docker daemon. `NSCP_SKIP_DOCKER=1` removed that need — it is how the deb job runs today — but the condition stayed. RPM packages were covered by `acceptance-tests.sh` alone, so anything that behaves differently on RHEL went untested. Nothing else was missing: the RPM base dependencies already install Node 20 from nodesource.

## What it caught

`${ca-path}` was one hardcoded path for every non-Windows platform (`service/path_manager.cpp`):

```cpp
{"ca-path", "/etc/ssl/certs/ca-certificates.crt"},
```

That is the Debian/Ubuntu location. On RHEL-family the bundle is `/etc/pki/tls/certs/ca-bundle.crt`, on SUSE `/etc/ssl/ca-bundle.pem` — so the token named a file that does not exist, and **every TLS check that did not carry its own `ca=` failed**.

It was never only a public-internet problem: `make_context` loads the CA whenever `ca` is non-empty, *before* the verify mode is considered, so a check against a local self-signed server with `verify=none` failed too. Turning the suite on for RPM failed five tests, **four of them pre-existing tests that had simply never run on RHEL**:

| Failing test | New? |
| --- | --- |
| `check_http over TLS exposes the certificate expiry via ssl_expiry_days` | no |
| `check_http reports no certificate when a redirect lands on plain http` | no |
| `check_nsclient_web_online reports a reachable REST API` | no |
| `check_nsclient_web_online passes a remote check result through` | no |
| `check_http validates a public HTTPS site using the platform CA bundle` | yes |

It also took `nscp enroll` with it: 0.16.0 defaults `--ca` to the same token, so **fleet enrollment was impossible on RHEL-family** without naming a bundle by hand.

## The fix

Detect the bundle at configure time and pass it through `config.h` like the other path defaults, rather than hardcoding one per `#ifdef`. A package is built in a container of the distribution it targets, so the build host has the right answer; a packager who knows better can override with `-DCONFIG_CA_PATH=…`. This also removes the `WIN32`/`else` pair for this key.

`path_manager_test.cpp` now asserts the bundle **exists**, not merely that it lives under `/etc/` — so a regression to a hardcoded value fails on the build host instead of in the field. That is the hermetic regression test that was missing all along.

## Verified locally, in the CI image

Everything below was run in `rockylinux/rockylinux:10` rather than by pushing and waiting:

- Detection resolves to `/etc/pki/tls/certs/ca-bundle.crt` on Rocky 10 and `/etc/ssl/certs/ca-certificates.crt` on `ubuntu:24.04`; `-DCONFIG_CA_PATH=/opt/custom/bundle.pem` overrides both; the generated `config.h` carries the value.
- Configuring the real project with and without this patch produces the *same* pre-existing CMake error (`file COPY cannot find …/check_nsclient`, an artefact of the local invocation), so the change adds none.
- With `ca-path` resolving to a real bundle, `checknet-commands` on Rocky goes from `5 failed, 48 passed` to `53 passed, 0 failed`.
- The full RPM job locally: `Test Suites: 32 passed`, `Tests: 433 passed` before the fix, with the 20 docker-gated suites skipping exactly as on deb. The existing python acceptance tests pass on Rocky (`OK: 14 test(s) successfull`).

## Also added

`check_ping` against a public host, opt-in behind `NSCP_EXTERNAL_ICMP=1`. Nothing in the suite has ever sent an ICMP packet off the machine. It is opt-in because GitHub-hosted runners drop outbound ICMP — it returns CRITICAL with 100% loss on the Ubuntu containers and the Windows runners alike, while the identical query is OK from an Azure VM on both distros and from a Windows desktop.

## Worth doing separately

- Rocky 9 is commented out of the integration matrix (`build-redhat.yml:177-182`), so only Rocky 10 runs this. The bug reproduced on both.
- `include/net/http/client.hpp` treats an empty `ca` as "trust nothing"; `set_default_verify_paths()` there would be a sensible second line of defence, and the three call sites that load a CA (`client.hpp` throws, `check_tcp.cpp:233` returns a string, `socket_helpers.cpp:230` collects and continues) could converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)