### PR TITLE
Only report new log lines with check_logfile bookmarks

### DIFF
--- a/docs/samples/CheckLogFile_check_logfile_desc.md
+++ b/docs/samples/CheckLogFile_check_logfile_desc.md
@@ -57,3 +57,47 @@ Real-time monitoring (`/settings/logfile/real-time/checks`) is the other way to
 get each line reported once; it pushes results as lines are written instead of
 being polled. `bookmark` is the polled equivalent and needs no configuration on
 the agent.
+
+#### Only checking the newest lines (`max-lines`, `newest`)
+
+`max-lines=N` limits the check to the newest `N` lines of each file. Everything
+else follows from that: `${total}` counts what was examined, not what the file
+holds, and only the selected lines can match the filter.
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" max-lines=100
+```
+
+The limit is per file, so a check with several `file=` arguments takes the
+newest `N` lines of each of them.
+
+`newest` says which end of the file the newest line is at:
+
+| Value  | Meaning                                                                       |
+|--------|-------------------------------------------------------------------------------|
+| `last` | Lines are appended (the default, and what almost every machine-written log does). `max-lines` takes them from the end of the file. |
+| `first`| The file is rewritten with the newest line at the top, as hand-maintained changelogs often are. `max-lines` takes them from the start of the file. |
+
+Whichever end they come from, the selected lines are reported in the order they
+appear in the file, so `%(list)` reads the way the file does.
+
+Behaviour worth knowing:
+
+* **Only the wanted part of the file is read.** The check seeks to the newest
+  `N` lines instead of loading the whole file, so `max-lines` is a cheap way to
+  look at the tail of a very large log. (A `line-split` value which can overlap
+  itself, such as `aaa` or `--`, cannot be located from the end; those files are
+  read in full and the surplus lines are dropped afterwards. The result is the
+  same either way.)
+* **`max-lines` combines with `bookmark`.** The bookmark still decides which
+  lines are new, and the limit then caps how many of them are reported — useful
+  when an application can dump thousands of lines at once. The lines dropped by
+  the limit are *consumed*: they are not reported by a later check either, since
+  the stored position moves past everything that was read.
+* **`newest=first` cannot be combined with `bookmark`.** A file which is
+  rewritten from the top has no stable position to resume from — its first bytes
+  change on every write, so the bookmark would detect a "new" file and re-read
+  it in full every single time. The check reports this as an error rather than
+  doing it quietly.
+* **An unterminated last line still counts as a line.** Without a bookmark the
+  trailing fragment is one of the `N`; with a bookmark it is held back as usual.

--- a/docs/samples/CheckLogFile_check_logfile_desc.md
+++ b/docs/samples/CheckLogFile_check_logfile_desc.md
@@ -1,0 +1,59 @@
+#### Only checking new lines (`bookmark`)
+
+By default `check_logfile` reads the **entire** file on every run, so a single
+`ERROR` line keeps failing the check for as long as it stays in the file. Add
+`bookmark` to make the check incremental instead: NSClient++ remembers how far
+it read last time and each run only looks at what was appended since.
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=app-errors
+```
+
+The name (`app-errors` above) identifies the stored position. Two checks that
+use the same name over the same file share one position — the first one to run
+consumes the lines. Use distinct names when two checks look for different
+things in the same file, or let the name be derived automatically by passing
+`bookmark` with no value (or `bookmark=auto`), which builds it from the file
+name plus the `filter`, `warning` and `critical` expressions:
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark
+```
+
+Positions are kept per file, so `file=` may be repeated as usual; each file is
+tracked on its own. They are written to `${data-path}/nsclient.db` when
+NSClient++ shuts down and restored on start, so a restart does not re-report
+everything.
+
+Because an automatic name embeds the expressions, editing the filter starts a
+new position (and the file is read in full once more) and leaves the old one
+behind in the store. Prefer an explicit name for checks whose filter changes
+often, or which are generated with varying arguments.
+
+Behaviour worth knowing:
+
+* **The first check of a file reads it in full.** Only from the second check on
+  is the check incremental. This is deliberate — entries that were already in
+  the file when monitoring started are reported rather than silently dropped.
+* **An unterminated last line is held back.** If the file ends mid-line (the
+  writer has not written the `line-split` terminator yet) that fragment is not
+  reported, and the position stays in front of it. The line is reported once,
+  in full, by the check that sees its terminator. Without a bookmark the
+  fragment is reported as-is, and again once it is complete.
+* **Rotation and truncation are detected.** If the file is shorter than the
+  stored position, or the first bytes of the file no longer match what was
+  there before (a rotated or re-created file, `copytruncate`, a daily file
+  under a fixed name), the file is read from the beginning again. Rotation to a
+  *different* name is not followed: point the check at the name that keeps
+  receiving new lines.
+* **A quiet check is OK, not UNKNOWN.** When nothing new arrived the result is
+  the empty state (`%(status): Nothing found`), which is OK by default; use
+  `empty-state=` to change it.
+* **Checks without `bookmark` are unaffected.** They neither read nor advance
+  any stored position, so an ad-hoc full scan can be run at any time without
+  disturbing a bookmarked check.
+
+Real-time monitoring (`/settings/logfile/real-time/checks`) is the other way to
+get each line reported once; it pushes results as lines are written instead of
+being polled. `bookmark` is the polled equivalent and needs no configuration on
+the agent.

--- a/docs/samples/CheckLogFile_check_logfile_desc.md
+++ b/docs/samples/CheckLogFile_check_logfile_desc.md
@@ -13,8 +13,9 @@ The name (`app-errors` above) identifies the stored position. Two checks that
 use the same name over the same file share one position — the first one to run
 consumes the lines. Use distinct names when two checks look for different
 things in the same file, or let the name be derived automatically by passing
-`bookmark` with no value (or `bookmark=auto`), which builds it from the file
-name plus the `filter`, `warning` and `critical` expressions:
+`bookmark` with no value (`bookmark`, `bookmark=` and `bookmark=auto` all mean
+the same thing), which builds it from the file name plus a hash of the
+`filter`, `warning` and `critical` expressions:
 
 ```
 check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark
@@ -25,7 +26,7 @@ tracked on its own. They are written to `${data-path}/nsclient.db` when
 NSClient++ shuts down and restored on start, so a restart does not re-report
 everything.
 
-Because an automatic name embeds the expressions, editing the filter starts a
+Because an automatic name covers the expressions, editing the filter starts a
 new position (and the file is read in full once more) and leaves the old one
 behind in the store. Prefer an explicit name for checks whose filter changes
 often, or which are generated with varying arguments.
@@ -46,12 +47,45 @@ Behaviour worth knowing:
   under a fixed name), the file is read from the beginning again. Rotation to a
   *different* name is not followed: point the check at the name that keeps
   receiving new lines.
+* **A failing check moves nothing.** If any of the files cannot be read the
+  check returns an error and every position stays where it was, so the lines
+  which were read on the way are reported by the next successful check instead
+  of vanishing with the error.
 * **A quiet check is OK, not UNKNOWN.** When nothing new arrived the result is
   the empty state (`%(status): Nothing found`), which is OK by default; use
   `empty-state=` to change it.
 * **Checks without `bookmark` are unaffected.** They neither read nor advance
   any stored position, so an ad-hoc full scan can be run at any time without
   disturbing a bookmarked check.
+
+Before you switch a check over to `bookmark`, know what you are trading a
+re-reported line for:
+
+* **A line is consumed when the check runs, not when its result arrives.** With
+  a bookmark the position moves as soon as the lines have been read. If the
+  result is submitted passively (NSCA, NRDP, …) and that submission fails, the
+  lines it described are not reported again by the next check. An actively
+  polled check is not exposed to this: the position moves as the poller
+  receives the answer.
+* **Positions are saved when NSClient++ shuts down.** A crash, a killed
+  service or a power loss therefore rewinds every bookmark to where it was when
+  the service last stopped cleanly, and the lines written since are reported
+  again. They are never lost, only repeated.
+* **A last line without its terminator is never reported on its own.** This is
+  the flip side of holding back half-written lines: a file which is written in
+  one go and does not end with `line-split` keeps its final line unreported
+  until something appends to the file. Without a bookmark that line is reported
+  on every check as before.
+* **`${total}` counts what the check looked at.** With a bookmark that is the
+  lines added since the previous run — not the number of lines in the file.
+  `${count}` is, as always, how many of them matched the filter.
+* **The number of remembered positions is capped** (at 1000 file/bookmark
+  pairs, which no ordinary configuration comes close to). If a host generates
+  bookmark names — a script which puts a timestamp in the name, or automatic
+  names for a filter which keeps changing — the least recently used positions
+  are dropped, and the files they tracked are read in full the next time that
+  name shows up. A dropped position is also cleared from `nsclient.db` on the
+  next shutdown, so the store does not grow forever.
 
 Real-time monitoring (`/settings/logfile/real-time/checks`) is the other way to
 get each line reported once; it pushes results as lines are written instead of

--- a/docs/samples/CheckLogFile_check_logfile_samples.md
+++ b/docs/samples/CheckLogFile_check_logfile_samples.md
@@ -1,0 +1,77 @@
+**Find errors in a log file**
+
+Given `/var/log/app.log`:
+
+```
+app started
+ERROR failed to connect to db
+INFO retrying
+ERROR failed to connect to db
+```
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" "critical=count > 3"
+2/4 (ERROR failed to connect to db, ERROR failed to connect to db)|'count'=2;0;3
+```
+
+`${count}` is the number of matching lines, `${total}` the number of lines read.
+
+**Only report lines added since the last check (`bookmark`)**
+
+The first check reads the whole file:
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=app-errors
+2/4 (ERROR failed to connect to db, ERROR failed to connect to db)|'count'=2;0;0
+```
+
+Running it again with nothing appended reports nothing — the two errors are not
+raised over and over:
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=app-errors
+OK: Nothing found|'count'=0;0;0
+```
+
+After `ERROR disk full` is appended, only that line is considered:
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=app-errors
+1/1 (ERROR disk full)|'count'=1;0;0
+```
+
+**Let the bookmark name itself be derived**
+
+`bookmark` without a value derives the name from the file and the filter /
+warning / critical expressions, which keeps this check from consuming the lines
+of the `app-errors` check above (it starts from the beginning, since this name
+has not seen the file before):
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark
+3/5 (ERROR failed to connect to db, ERROR failed to connect to db, ERROR disk full)|'count'=3;0;0
+```
+
+**Watch several files with one check**
+
+Each file keeps its own position; the counts are aggregated. A fresh bookmark
+name starts by reading both files in full:
+
+```
+check_logfile file=/var/log/app.log file=/var/log/worker.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=all-errors
+4/7 (ERROR failed to connect to db, ERROR failed to connect to db, ERROR disk full, ERROR queue stalled)|'count'=4;0;0
+```
+
+Afterwards only the file that actually grew contributes:
+
+```
+check_logfile file=/var/log/app.log file=/var/log/worker.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=all-errors
+1/1 (ERROR queue stalled again)|'count'=1;0;0
+```
+
+**Report a quiet check as something other than OK**
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=app-errors empty-state=unknown
+UNKNOWN: Nothing found|'count'=0;0;0
+```

--- a/docs/samples/CheckLogFile_check_logfile_samples.md
+++ b/docs/samples/CheckLogFile_check_logfile_samples.md
@@ -52,6 +52,9 @@ check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count
 3/5 (ERROR failed to connect to db, ERROR failed to connect to db, ERROR disk full)|'count'=3;0;0
 ```
 
+`bookmark=` (an empty value) and `bookmark=auto` are spelled differently by
+different transports but mean exactly this.
+
 **Watch several files with one check**
 
 Each file keeps its own position; the counts are aggregated. A fresh bookmark

--- a/docs/samples/CheckLogFile_check_logfile_samples.md
+++ b/docs/samples/CheckLogFile_check_logfile_samples.md
@@ -69,6 +69,62 @@ check_logfile file=/var/log/app.log file=/var/log/worker.log "filter=column1 lik
 1/1 (ERROR queue stalled again)|'count'=1;0;0
 ```
 
+**Only look at the newest lines (`max-lines`)**
+
+Given `/var/log/app.log`:
+
+```
+app started
+ERROR failed to connect to db
+INFO retrying
+ERROR failed to connect to db
+INFO recovered
+ERROR disk full
+```
+
+Without a limit every line is read:
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0"
+3/6 (ERROR failed to connect to db, ERROR failed to connect to db, ERROR disk full)|'count'=3;0;0
+```
+
+With `max-lines=3` only the last three lines are examined — `${total}` drops to
+3 and the older error is out of scope:
+
+```
+check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" max-lines=3
+2/3 (ERROR failed to connect to db, ERROR disk full)|'count'=2;0;0
+```
+
+**Files whose newest line is at the top (`newest=first`)**
+
+Given a hand-maintained `/var/log/deploy-changelog.txt` where each new entry is
+added at the top:
+
+```
+2018-07-20 deploy 42 FAILED rollback started
+2018-07-19 deploy 41 ok
+2018-07-18 deploy 40 ok
+2018-07-17 deploy 39 FAILED disk full
+```
+
+`newest=first` makes `max-lines` count from the top of the file, so only the two
+most recent deploys are checked:
+
+```
+check_logfile file=/var/log/deploy-changelog.txt "filter=column1 like 'FAILED'" "warning=count > 0" max-lines=2 newest=first
+1/2 (2018-07-20 deploy 42 FAILED rollback started)|'count'=1;0;0
+```
+
+Without the limit `newest=first` changes nothing — the whole file is read either
+way:
+
+```
+check_logfile file=/var/log/deploy-changelog.txt "filter=column1 like 'FAILED'" "warning=count > 0" newest=first
+2/4 (2018-07-20 deploy 42 FAILED rollback started, 2018-07-17 deploy 39 FAILED disk full)|'count'=2;0;0
+```
+
 **Report a quiet check as something other than OK**
 
 ```

--- a/modules/CheckLogFile/CMakeLists.txt
+++ b/modules/CheckLogFile/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SRCS
     realtime_thread.cpp
     filter_config_object.cpp
     filter.cpp
+    bookmarks.cpp
     ${NSCP_DEF_PLUGIN_CPP}
     ${NSCP_FILTER_CPP}
     ${NSCP_ERROR_CPP}

--- a/modules/CheckLogFile/CheckLogFile.cpp
+++ b/modules/CheckLogFile/CheckLogFile.cpp
@@ -3,19 +3,26 @@
 
 #include "CheckLogFile.h"
 
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
+#include <cstdint>
 #include <nscapi/macros.hpp>
+#include <nscapi/nscapi_core_helper.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <nscapi/settings/helper.hpp>
 #include <parsers/filter/cli_helper.hpp>
 #include <parsers/filter/modern_filter.hpp>
 
+#include "bookmark_state.hpp"
 #include "file_reader.hpp"
 #include "realtime_thread.hpp"
 
 namespace sh = nscapi::settings_helper;
 namespace po = boost::program_options;
+
+// Context used to persist bookmark positions in the core storage.
+const std::string bookmark_context = "logfile.bookmarks";
 
 bool CheckLogFile::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   thread_.reset(new real_time_thread(get_core(), get_id()));
@@ -47,6 +54,14 @@ bool CheckLogFile::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) 
   thread_->ensure_default(nscapi::settings_proxy::create(get_id(), get_core()));
 
   thread_->filters_.add_samples(settings.get_settings());
+
+  // Restore the bookmark positions from the previous run so a restart does not
+  // re-report every line of every bookmarked log file.
+  nscapi::core_helper core(get_core(), get_id());
+  for (const nscapi::core_helper::storage_map::value_type &e : core.get_storage_strings(bookmark_context)) {
+    bookmarks_.add(e.first, e.second);
+  }
+
   if (mode == NSCAPI::normalStart) {
     if (!thread_->start()) NSC_LOG_ERROR_STD("Failed to start collection thread");
   }
@@ -54,8 +69,58 @@ bool CheckLogFile::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) 
 }
 bool CheckLogFile::unloadModule() {
   if (thread_ && !thread_->stop()) NSC_LOG_ERROR_STD("Failed to stop thread");
+
+  nscapi::core_helper core(get_core(), get_id());
+  for (const check_logfile::bookmarks::map_type::value_type &v : bookmarks_.get_copy()) {
+    core.put_storage(bookmark_context, v.first, v.second, false, false);
+  }
   return true;
 }
+
+namespace {
+// Feed every record found in `contents` to the filter.
+//
+// Returns the number of bytes consumed by COMPLETE records, i.e. the offset
+// just past the last line delimiter. When `include_tail` is set a trailing
+// chunk which is not terminated by the delimiter is matched as well (but never
+// counted as consumed, since it is not complete).
+std::string::size_type match_records(const std::string &filename, const std::string &contents, const std::string &line_split, const std::string &column_split,
+                                     bool strip_cr, bool include_tail, logfile_filter::filter &filter) {
+  const auto trim_cr = [strip_cr](std::string &s) {
+    if (strip_cr && !s.empty() && s.back() == '\r') s.pop_back();
+  };
+  const auto match_one = [&](std::string line) {
+    trim_cr(line);
+    std::list<std::string> chunks = str::utils::split_lst(line, column_split);
+    std::shared_ptr<logfile_filter::filter_obj> record(new logfile_filter::filter_obj(filename, line, chunks));
+    filter.match(record);
+  };
+
+  std::string::size_type pos = 0, lpos = 0;
+  while ((pos = contents.find(line_split, pos)) != std::string::npos) {
+    match_one(contents.substr(lpos, pos - lpos));
+    pos += line_split.size();
+    lpos = pos;
+  }
+  if (include_tail && lpos < contents.size()) {
+    match_one(contents.substr(lpos));
+  }
+  return lpos;
+}
+
+// Read (at most) the leading bytes used to fingerprint a file. The stream is
+// left positioned wherever the read ended; every caller seeks afterwards.
+std::string read_head(std::istream &is, std::size_t len) {
+  std::string head;
+  if (len == 0) return head;
+  head.resize(len);
+  is.seekg(0, std::ios::beg);
+  is.read(&head[0], static_cast<std::streamsize>(len));
+  head.resize(static_cast<std::size_t>(is.gcount()));
+  is.clear();
+  return head;
+}
+}  // namespace
 
 void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
   typedef logfile_filter::filter filter_type;
@@ -65,6 +130,7 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
   std::vector<std::string> file_list;
   std::string files_string;
   std::string mode;
+  std::string bookmark;
 
   filter_type filter;
   filter_helper.add_options("", "", "", filter.get_filter_syntax());
@@ -90,6 +156,17 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
 			"Notice that specifying multiple files will create an aggregate set it will not check each file individually.\n"
 			"In other words if one file contains an error the entire check will result in error or if you check the count it is the global count which is used.")
 		("files", po::value<std::string>(&files_string), "A comma separated list of files to scan (same as file except a list)")
+		("bookmark", po::value<std::string>(&bookmark)->implicit_value("auto"),
+			"Only scan lines added since the last check with the same bookmark name.\n"
+			"NSClient++ remembers, per file and per bookmark, how far it read last time and resumes from there, "
+			"so a line is reported once instead of on every check. The first check of a file reads it in full; "
+			"a file which is truncated, rotated or replaced is detected (via its size and a fingerprint of its "
+			"first bytes) and read from the beginning again. A trailing line which is not yet terminated by "
+			"line-split is held back until it is complete, so half-written lines are never reported twice.\n"
+			"If you set this to auto (or leave the value empty) the bookmark name is derived from the file name "
+			"together with your filter, warning and critical expressions, which keeps unrelated checks of the "
+			"same file from consuming each other's lines. Use an explicit name to share (or separate) positions "
+			"deliberately. Positions are persisted across restarts.")
 		//		("mode", po::value<std::string>(&mode),						"Mode of operation: count (count all critical/warning lines), find (find first critical/warning line)")
 		;
   // clang-format on
@@ -115,35 +192,64 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
   // file read in binary mode would otherwise leave '\r' at the end of every
   // line and break exact-match column comparisons (e.g. column3 = 'Test 1').
   const bool strip_cr = !line_split.empty() && line_split.back() == '\n';
-  auto trim_cr = [strip_cr](std::string &s) {
-    if (strip_cr && !s.empty() && s.back() == '\r') s.pop_back();
-  };
+
+  // An "auto" bookmark is derived from the file plus the expressions which
+  // decide what is interesting, so two different checks over the same file do
+  // not steal each other's lines (the same rule CheckEventLog uses).
+  std::string auto_suffix;
+  if (bookmark == "auto") {
+    auto_suffix = "],filter[" + str::utils::joinEx(filter_helper.data.filter_string, ",") + "],warn[" +
+                  str::utils::joinEx(filter_helper.data.warn_string, ",") + "],crit[" + str::utils::joinEx(filter_helper.data.crit_string, ",") + "]";
+  }
 
   for (const std::string &filename : file_list) {
     std::ifstream file(filename.c_str(), std::ios::in | std::ios::binary);
-    if (file.is_open()) {
-      std::string contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-      file.close();
-      std::string::size_type pos = 0, lpos = 0;
-      while ((pos = contents.find(line_split, pos)) != std::string::npos) {
-        std::string line = contents.substr(lpos, pos - lpos);
-        trim_cr(line);
-        std::list<std::string> chunks = str::utils::split_lst(line, column_split);
-        std::shared_ptr<logfile_filter::filter_obj> record(new logfile_filter::filter_obj(filename, line, chunks));
-        filter.match(record);
-        pos += line_split.size();
-        lpos = pos;
-      }
-      if (lpos < contents.size()) {
-        std::string line = contents.substr(lpos);
-        trim_cr(line);
-        std::list<std::string> chunks = str::utils::split_lst(line, column_split);
-        std::shared_ptr<logfile_filter::filter_obj> record(new logfile_filter::filter_obj(filename, line, chunks));
-        filter.match(record);
-      }
-    } else {
+    if (!file.is_open()) {
       return nscapi::protobuf::functions::set_response_bad(*response, "Failed to open file: " + filename);
     }
+    if (bookmark.empty()) {
+      const std::string contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+      match_records(filename, contents, line_split, column_split, strip_cr, true, filter);
+      continue;
+    }
+
+    const std::string name = auto_suffix.empty() ? bookmark : ("auto,file[" + filename + auto_suffix);
+    const std::string key = check_logfile::bookmarks::make_key(name, filename);
+    const check_logfile::bookmark::position prev = bookmarks_.get(key);
+
+    file.seekg(0, std::ios::end);
+    const std::streamoff end_pos = file.tellg();
+    if (end_pos < 0) {
+      return nscapi::protobuf::functions::set_response_bad(*response, "Failed to read size of file: " + filename);
+    }
+    const std::uint64_t size = static_cast<std::uint64_t>(end_pos);
+
+    // Hash exactly as many leading bytes as the stored fingerprint covers so
+    // the two are comparable, and (up to the cap) as many as we have now so the
+    // fingerprint keeps growing with a file which is still shorter than the cap.
+    const std::size_t head_len =
+        static_cast<std::size_t>(std::min<std::uint64_t>(std::max<std::uint64_t>(size, prev.fingerprint_len), check_logfile::bookmark::max_fingerprint_len));
+    const std::string head = read_head(file, head_len);
+    const bool head_valid = head.size() >= prev.fingerprint_len;
+    const std::uint64_t head_fingerprint = head_valid ? check_logfile::bookmark::fnv1a(head.data(), static_cast<std::size_t>(prev.fingerprint_len)) : 0;
+
+    const check_logfile::bookmark::resume_decision decision = check_logfile::bookmark::compute_resume(prev, size, head_fingerprint, head_valid);
+    if (decision.restarted) {
+      NSC_DEBUG_MSG_STD("Log file was truncated, rotated or replaced, reading it from the start: " + filename);
+    }
+
+    std::string::size_type consumed = 0;
+    if (!decision.skip) {
+      file.seekg(static_cast<std::streamoff>(decision.offset), std::ios::beg);
+      const std::string contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+      // A trailing record with no delimiter is not complete yet: skipping it
+      // (and not counting it as consumed) is what makes the line show up once,
+      // in full, on the check which sees its terminator.
+      consumed = match_records(filename, contents, line_split, column_split, strip_cr, false, filter);
+    }
+
+    const check_logfile::bookmark::position next(decision.offset + consumed, head.size(), check_logfile::bookmark::fnv1a(head.data(), head.size()));
+    bookmarks_.add(key, check_logfile::bookmark::format(next));
   }
   filter_helper.post_process(filter);
 }

--- a/modules/CheckLogFile/CheckLogFile.cpp
+++ b/modules/CheckLogFile/CheckLogFile.cpp
@@ -7,12 +7,14 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
 #include <cstdint>
+#include <deque>
 #include <nscapi/macros.hpp>
 #include <nscapi/nscapi_core_helper.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <nscapi/settings/helper.hpp>
 #include <parsers/filter/cli_helper.hpp>
 #include <parsers/filter/modern_filter.hpp>
+#include <utility>
 
 #include "bookmark_state.hpp"
 #include "file_reader.hpp"
@@ -78,14 +80,22 @@ bool CheckLogFile::unloadModule() {
 }
 
 namespace {
-// Feed every record found in `contents` to the filter.
+// Feed the records found in `contents` to the filter.
 //
 // Returns the number of bytes consumed by COMPLETE records, i.e. the offset
 // just past the last line delimiter. When `include_tail` is set a trailing
 // chunk which is not terminated by the delimiter is matched as well (but never
 // counted as consumed, since it is not complete).
+//
+// With `max_lines` set only that many records are handed to the filter: the
+// first ones when `newest_first` (the newest record is at the top of the
+// file), the last ones otherwise. The records which are dropped are still
+// counted as consumed - a bookmark has to advance past everything that was
+// read, or the surplus of one check would come back as "new" on the next one.
+// The selected records are always matched in file order, so %(list) reads the
+// way the file does.
 std::string::size_type match_records(const std::string &filename, const std::string &contents, const std::string &line_split, const std::string &column_split,
-                                     bool strip_cr, bool include_tail, logfile_filter::filter &filter) {
+                                     bool strip_cr, bool include_tail, std::size_t max_lines, bool newest_first, logfile_filter::filter &filter) {
   const auto trim_cr = [strip_cr](std::string &s) {
     if (strip_cr && !s.empty() && s.back() == '\r') s.pop_back();
   };
@@ -96,14 +106,35 @@ std::string::size_type match_records(const std::string &filename, const std::str
     filter.match(record);
   };
 
+  // Unlimited: match each record as the buffer is walked, nothing is buffered.
+  // Limited: remember the wanted ranges (never more than max_lines of them)
+  // and match them once the extent of the file is known.
+  typedef std::pair<std::string::size_type, std::string::size_type> range_type;
+  std::deque<range_type> kept;
+  const auto take = [&](std::string::size_type start, std::string::size_type len) {
+    if (max_lines == 0) {
+      match_one(contents.substr(start, len));
+      return;
+    }
+    if (newest_first) {
+      if (kept.size() < max_lines) kept.push_back(range_type(start, len));
+      return;
+    }
+    kept.push_back(range_type(start, len));
+    if (kept.size() > max_lines) kept.pop_front();
+  };
+
   std::string::size_type pos = 0, lpos = 0;
   while ((pos = contents.find(line_split, pos)) != std::string::npos) {
-    match_one(contents.substr(lpos, pos - lpos));
+    take(lpos, pos - lpos);
     pos += line_split.size();
     lpos = pos;
   }
   if (include_tail && lpos < contents.size()) {
-    match_one(contents.substr(lpos));
+    take(lpos, contents.size() - lpos);
+  }
+  for (const range_type &r : kept) {
+    match_one(contents.substr(r.first, r.second));
   }
   return lpos;
 }
@@ -131,6 +162,8 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
   std::string files_string;
   std::string mode;
   std::string bookmark;
+  std::size_t max_lines = 0;
+  std::string newest;
 
   filter_type filter;
   filter_helper.add_options("", "", "", filter.get_filter_syntax());
@@ -167,6 +200,20 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
 			"together with your filter, warning and critical expressions, which keeps unrelated checks of the "
 			"same file from consuming each other's lines. Use an explicit name to share (or separate) positions "
 			"deliberately. Positions are persisted across restarts.")
+		("max-lines", po::value<std::size_t>(&max_lines)->default_value(0),
+			"Only examine the newest <N> lines of each file (0, the default, means every line).\n"
+			"The limit is applied per file, after any bookmark: with a bookmark the check still only sees lines "
+			"added since the last check, and this caps how many of them are reported when a burst of lines was "
+			"written at once. The lines dropped by the limit are never reported later either - the bookmark moves "
+			"past everything which was read.\n"
+			"Which end of the file holds the newest lines is controlled by `newest`.")
+		("newest", po::value<std::string>(&newest)->default_value("last"),
+			"Which end of the file holds the newest line: `last` (the default: lines are appended, as with most "
+			"machine-written logs) or `first` (the file is rewritten with the newest line at the top, which is "
+			"common in hand-maintained files such as changelogs).\n"
+			"This only decides which end `max-lines` counts from; lines are always reported in the order they "
+			"appear in the file. `newest=first` cannot be combined with `bookmark`, since a file which is "
+			"rewritten from the top has no stable position to resume from.")
 		//		("mode", po::value<std::string>(&mode),						"Mode of operation: count (count all critical/warning lines), find (find first critical/warning line)")
 		;
   // clang-format on
@@ -179,6 +226,19 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
   if (line_split.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No line-split specified");
 
   if (file_list.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "Need to specify at least one file: file=foo.txt");
+
+  const bool newest_first = newest == "first";
+  if (!newest_first && newest != "last") {
+    return nscapi::protobuf::functions::set_response_bad(*response, "Invalid newest: " + newest + " (expected first or last)");
+  }
+  // A file which is rewritten with the newest line first has no stable byte
+  // offset to resume from: its fingerprint changes on every write, so the
+  // bookmark would restart from the beginning every check and report the whole
+  // file each time. Say so instead of quietly doing that.
+  if (newest_first && !bookmark.empty()) {
+    return nscapi::protobuf::functions::set_response_bad(
+        *response, "newest=first cannot be combined with bookmark: a file which is rewritten from the top has no position to resume from");
+  }
 
   str::utils::replace(column_split, "\\t", "\t");
   str::utils::replace(column_split, "\\n", "\n");
@@ -208,8 +268,23 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
       return nscapi::protobuf::functions::set_response_bad(*response, "Failed to open file: " + filename);
     }
     if (bookmark.empty()) {
-      const std::string contents((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
-      match_records(filename, contents, line_split, column_split, strip_cr, true, filter);
+      // With a line limit only the part of the file which can hold the wanted
+      // records is read: from the last max_lines records to the end, or from
+      // the start up to the max_lines-th record. Both fall back to reading
+      // everything when the limit cannot be located cheaply; match_records
+      // drops the surplus either way.
+      std::string contents;
+      if (max_lines > 0 && newest_first) {
+        contents = check_logfile::file_reader::read_leading_records(file, line_split, max_lines);
+      } else {
+        if (max_lines > 0) {
+          const std::uint64_t offset = check_logfile::file_reader::find_tail_offset(file, line_split, max_lines);
+          file.clear();
+          file.seekg(static_cast<std::streamoff>(offset), std::ios::beg);
+        }
+        contents.assign((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
+      }
+      match_records(filename, contents, line_split, column_split, strip_cr, true, max_lines, newest_first, filter);
       continue;
     }
 
@@ -245,7 +320,7 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
       // A trailing record with no delimiter is not complete yet: skipping it
       // (and not counting it as consumed) is what makes the line show up once,
       // in full, on the check which sees its terminator.
-      consumed = match_records(filename, contents, line_split, column_split, strip_cr, false, filter);
+      consumed = match_records(filename, contents, line_split, column_split, strip_cr, false, max_lines, newest_first, filter);
     }
 
     const check_logfile::bookmark::position next(decision.offset + consumed, head.size(), check_logfile::bookmark::fnv1a(head.data(), head.size()));

--- a/modules/CheckLogFile/CheckLogFile.cpp
+++ b/modules/CheckLogFile/CheckLogFile.cpp
@@ -15,6 +15,7 @@
 #include <parsers/filter/cli_helper.hpp>
 #include <parsers/filter/modern_filter.hpp>
 #include <utility>
+#include <vector>
 
 #include "bookmark_state.hpp"
 #include "file_reader.hpp"
@@ -58,9 +59,13 @@ bool CheckLogFile::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) 
   thread_->filters_.add_samples(settings.get_settings());
 
   // Restore the bookmark positions from the previous run so a restart does not
-  // re-report every line of every bookmarked log file.
+  // re-report every line of every bookmarked log file. An empty value is a
+  // position which was retired on an earlier shutdown; it is remembered as a
+  // key so it is not written again, but it is not a position.
   nscapi::core_helper core(get_core(), get_id());
   for (const nscapi::core_helper::storage_map::value_type &e : core.get_storage_strings(bookmark_context)) {
+    if (e.second.empty()) continue;
+    persisted_keys_.insert(e.first);
     bookmarks_.add(e.first, e.second);
   }
 
@@ -73,8 +78,16 @@ bool CheckLogFile::unloadModule() {
   if (thread_ && !thread_->stop()) NSC_LOG_ERROR_STD("Failed to stop thread");
 
   nscapi::core_helper core(get_core(), get_id());
-  for (const check_logfile::bookmarks::map_type::value_type &v : bookmarks_.get_copy()) {
+  const check_logfile::bookmarks::map_type live = bookmarks_.get_copy();
+  for (const check_logfile::bookmarks::map_type::value_type &v : live) {
     core.put_storage(bookmark_context, v.first, v.second, false, false);
+  }
+  // A position which aged out of the (bounded) live set would otherwise keep
+  // its row - and the file name and expression hash in its key - in
+  // nsclient.db for good. The storage API has no delete, so blank the value:
+  // load skips empty entries, which is the same as not having one.
+  for (const std::string &key : persisted_keys_) {
+    if (live.find(key) == live.end()) core.put_storage(bookmark_context, key, "", false, false);
   }
   return true;
 }
@@ -189,7 +202,12 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
 			"Notice that specifying multiple files will create an aggregate set it will not check each file individually.\n"
 			"In other words if one file contains an error the entire check will result in error or if you check the count it is the global count which is used.")
 		("files", po::value<std::string>(&files_string), "A comma separated list of files to scan (same as file except a list)")
-		("bookmark", po::value<std::string>(&bookmark)->implicit_value("auto"),
+		// Present-but-empty (`bookmark=`, which is how several transports render a
+		// valueless argument) has to mean the same as the bare flag, or a check
+		// written that way would silently stop being incremental. A notifier is
+		// what makes the two tellable apart from "not given at all": with no
+		// default_value it only runs when the option is actually supplied.
+		("bookmark", po::value<std::string>()->implicit_value("auto")->notifier([&bookmark](const std::string &value) { bookmark = value.empty() ? "auto" : value; }),
 			"Only scan lines added since the last check with the same bookmark name.\n"
 			"NSClient++ remembers, per file and per bookmark, how far it read last time and resumes from there, "
 			"so a line is reported once instead of on every check. The first check of a file reads it in full; "
@@ -197,9 +215,10 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
 			"first bytes) and read from the beginning again. A trailing line which is not yet terminated by "
 			"line-split is held back until it is complete, so half-written lines are never reported twice.\n"
 			"If you set this to auto (or leave the value empty) the bookmark name is derived from the file name "
-			"together with your filter, warning and critical expressions, which keeps unrelated checks of the "
-			"same file from consuming each other's lines. Use an explicit name to share (or separate) positions "
-			"deliberately. Positions are persisted across restarts.")
+			"together with a hash of your filter, warning and critical expressions, which keeps unrelated checks "
+			"of the same file from consuming each other's lines. Use an explicit name to share (or separate) "
+			"positions deliberately. Positions are persisted when NSClient++ shuts down and restored on start; "
+			"the newest ones are kept if more than a thousand accumulate.")
 		("max-lines", po::value<std::size_t>(&max_lines)->default_value(0),
 			"Only examine the newest <N> lines of each file (0, the default, means every line).\n"
 			"The limit is applied per file, after any bookmark: with a bookmark the check still only sees lines "
@@ -255,12 +274,22 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
 
   // An "auto" bookmark is derived from the file plus the expressions which
   // decide what is interesting, so two different checks over the same file do
-  // not steal each other's lines (the same rule CheckEventLog uses).
+  // not steal each other's lines (the same rule CheckEventLog uses). The
+  // expressions go in as a hash rather than verbatim: the name ends up in the
+  // persisted key, where a filter of arbitrary length (and content) has no
+  // business being.
   std::string auto_suffix;
   if (bookmark == "auto") {
-    auto_suffix = "],filter[" + str::utils::joinEx(filter_helper.data.filter_string, ",") + "],warn[" +
-                  str::utils::joinEx(filter_helper.data.warn_string, ",") + "],crit[" + str::utils::joinEx(filter_helper.data.crit_string, ",") + "]";
+    const std::string expressions = "filter[" + str::utils::joinEx(filter_helper.data.filter_string, ",") + "],warn[" +
+                                    str::utils::joinEx(filter_helper.data.warn_string, ",") + "],crit[" +
+                                    str::utils::joinEx(filter_helper.data.crit_string, ",") + "]";
+    auto_suffix = "],expr[" + check_logfile::bookmark::to_hex(check_logfile::bookmark::fnv1a(expressions.data(), expressions.size())) + "]";
   }
+
+  // Positions are moved only once every file has been read: a check which ends
+  // in an error reports nothing, and lines it consumed on the way would be
+  // lost with no way to get them back.
+  std::vector<std::pair<std::string, std::string> > pending;
 
   for (const std::string &filename : file_list) {
     std::ifstream file(filename.c_str(), std::ios::in | std::ios::binary);
@@ -324,7 +353,10 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
     }
 
     const check_logfile::bookmark::position next(decision.offset + consumed, head.size(), check_logfile::bookmark::fnv1a(head.data(), head.size()));
-    bookmarks_.add(key, check_logfile::bookmark::format(next));
+    pending.push_back(std::make_pair(key, check_logfile::bookmark::format(next)));
+  }
+  for (const std::pair<std::string, std::string> &p : pending) {
+    bookmarks_.add(p.first, p.second);
   }
   filter_helper.post_process(filter);
 }

--- a/modules/CheckLogFile/CheckLogFile.h
+++ b/modules/CheckLogFile/CheckLogFile.h
@@ -6,10 +6,13 @@
 #include <nscapi/nscapi_plugin_impl.hpp>
 #include <nscapi/protobuf/command.hpp>
 
+#include "bookmarks.hpp"
+
 struct real_time_thread;
 class CheckLogFile : public nscapi::impl::simple_plugin {
  private:
   std::shared_ptr<real_time_thread> thread_;
+  check_logfile::bookmarks bookmarks_;
 
  public:
   CheckLogFile() {}

--- a/modules/CheckLogFile/CheckLogFile.h
+++ b/modules/CheckLogFile/CheckLogFile.h
@@ -5,6 +5,7 @@
 
 #include <nscapi/nscapi_plugin_impl.hpp>
 #include <nscapi/protobuf/command.hpp>
+#include <set>
 
 #include "bookmarks.hpp"
 
@@ -13,6 +14,11 @@ class CheckLogFile : public nscapi::impl::simple_plugin {
  private:
   std::shared_ptr<real_time_thread> thread_;
   check_logfile::bookmarks bookmarks_;
+  // Bookmark keys which were read from the core storage on load. A key which
+  // is no longer live when we shut down is blanked out there, so a position
+  // that has aged out (or whose filter was edited) does not keep its row in
+  // nsclient.db forever.
+  std::set<std::string> persisted_keys_;
 
  public:
   CheckLogFile() {}

--- a/modules/CheckLogFile/bookmark_state.hpp
+++ b/modules/CheckLogFile/bookmark_state.hpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace check_logfile {
+namespace bookmark {
+
+// Number of leading bytes of a log file used to fingerprint it.
+//
+// The fingerprint is what tells "the file grew" apart from "the file was
+// replaced by a new file which happens to be larger than the offset we
+// stored" (log rotation with copytruncate, a daily file re-created under the
+// same name, ...). A size comparison alone only catches the shrinking case.
+const std::size_t max_fingerprint_len = 256;
+
+// 64-bit FNV-1a. Not a security primitive - it only has to be stable across
+// runs and platforms and cheap on a few hundred bytes, both of which it is.
+inline std::uint64_t fnv1a(const char *data, std::size_t len) {
+  std::uint64_t hash = 14695981039346656037ULL;
+  for (std::size_t i = 0; i < len; i++) {
+    hash ^= static_cast<std::uint64_t>(static_cast<unsigned char>(data[i]));
+    hash *= 1099511628211ULL;
+  }
+  return hash;
+}
+
+// Where a previous check stopped reading a given file.
+//
+// `offset` is the end of the last COMPLETE record consumed, not the size of
+// the file: a log file whose final line has not been terminated yet must be
+// re-read from the start of that partial line so the line is reported once,
+// in full, when it is finished.
+struct position {
+  // False when there is no (usable) stored state, i.e. the file has never
+  // been checked under this bookmark before.
+  bool valid;
+  std::uint64_t offset;
+  // Number of leading bytes `fingerprint` was computed over. Stored so the
+  // comparison later re-hashes exactly the same byte range - hashing
+  // "the first min(size, 256) bytes" on both sides would spuriously differ
+  // while a file smaller than 256 bytes is still growing.
+  std::uint64_t fingerprint_len;
+  std::uint64_t fingerprint;
+
+  position() : valid(false), offset(0), fingerprint_len(0), fingerprint(0) {}
+  position(std::uint64_t offset_, std::uint64_t fingerprint_len_, std::uint64_t fingerprint_)
+      : valid(true), offset(offset_), fingerprint_len(fingerprint_len_), fingerprint(fingerprint_) {}
+
+  bool operator==(const position &o) const {
+    return valid == o.valid && offset == o.offset && fingerprint_len == o.fingerprint_len && fingerprint == o.fingerprint;
+  }
+};
+
+// Serialized form: "1|<offset>|<fingerprint-len>|<fingerprint>".
+// The leading version tag lets a future format change be detected (and the
+// state discarded, which merely re-reads a file once) instead of being
+// mis-parsed into a bogus offset.
+inline std::string format(const position &pos) {
+  if (!pos.valid) return "";
+  return "1|" + std::to_string(pos.offset) + "|" + std::to_string(pos.fingerprint_len) + "|" + std::to_string(pos.fingerprint);
+}
+
+inline position parse(const std::string &data) {
+  position ret;
+  if (data.empty()) return ret;
+  std::vector<std::string> chunks;
+  std::string::size_type pos = 0;
+  while (true) {
+    const std::string::size_type next = data.find('|', pos);
+    if (next == std::string::npos) {
+      chunks.push_back(data.substr(pos));
+      break;
+    }
+    chunks.push_back(data.substr(pos, next - pos));
+    pos = next + 1;
+  }
+  if (chunks.size() != 4 || chunks[0] != "1") return ret;
+  try {
+    // Reject anything that is not a plain non-negative number: stoull happily
+    // accepts leading whitespace, a sign and trailing garbage, and a negative
+    // value would wrap into a huge offset that silently skips the whole file.
+    for (std::size_t i = 1; i < chunks.size(); i++) {
+      if (chunks[i].empty() || chunks[i].find_first_not_of("0123456789") != std::string::npos) return position();
+    }
+    ret.offset = std::stoull(chunks[1]);
+    ret.fingerprint_len = std::stoull(chunks[2]);
+    ret.fingerprint = std::stoull(chunks[3]);
+    ret.valid = true;
+  } catch (const std::exception &) {
+    return position();
+  }
+  return ret;
+}
+
+// What to do with a file given the state stored by the previous check.
+struct resume_decision {
+  // Nothing new to read: the file is empty or has not grown.
+  bool skip;
+  // Byte offset to start reading at (0 = from the beginning).
+  std::uint64_t offset;
+  // The stored state was discarded (first observation, or the file was
+  // truncated/rotated/replaced) so the file is read from the start again.
+  // Only interesting for logging.
+  bool restarted;
+
+  bool operator==(const resume_decision &o) const { return skip == o.skip && offset == o.offset && restarted == o.restarted; }
+};
+
+// `head_fingerprint` must be the hash of the first `prev.fingerprint_len`
+// bytes of the file as it is now, and `head_valid` false when that many bytes
+// could not be read (the file is now shorter than the fingerprint).
+inline resume_decision compute_resume(const position &prev, std::uint64_t cur_size, std::uint64_t head_fingerprint, bool head_valid) {
+  // Nothing to read at all - and make sure any stored offset is dropped, or a
+  // truncated file that grows back would resume in the middle of new content.
+  if (cur_size == 0) {
+    resume_decision d = {true, 0, prev.valid && prev.offset != 0};
+    return d;
+  }
+  if (!prev.valid) {
+    // First time this file is seen under this bookmark: report what is there
+    // now, then track incrementally from here on.
+    resume_decision d = {false, 0, false};
+    return d;
+  }
+  const bool rotated = cur_size < prev.offset || (prev.fingerprint_len > 0 && (!head_valid || head_fingerprint != prev.fingerprint));
+  if (rotated) {
+    resume_decision d = {false, 0, true};
+    return d;
+  }
+  if (cur_size == prev.offset) {
+    resume_decision d = {true, prev.offset, false};
+    return d;
+  }
+  resume_decision d = {false, prev.offset, false};
+  return d;
+}
+
+}  // namespace bookmark
+}  // namespace check_logfile

--- a/modules/CheckLogFile/bookmark_state.hpp
+++ b/modules/CheckLogFile/bookmark_state.hpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -29,6 +30,18 @@ inline std::uint64_t fnv1a(const char *data, std::size_t len) {
     hash *= 1099511628211ULL;
   }
   return hash;
+}
+
+// 16 lowercase hex digits, used to name a bookmark after the expressions it
+// belongs to without spelling them out in the key.
+inline std::string to_hex(std::uint64_t value) {
+  static const char digits[] = "0123456789abcdef";
+  std::string ret(16, '0');
+  for (std::size_t i = 0; i < 16; i++) {
+    ret[15 - i] = digits[value & 0xf];
+    value >>= 4;
+  }
+  return ret;
 }
 
 // Where a previous check stopped reading a given file.
@@ -141,6 +154,80 @@ inline resume_decision compute_resume(const position &prev, std::uint64_t cur_si
   resume_decision d = {false, prev.offset, false};
   return d;
 }
+
+// Upper bound on the number of positions which are remembered (and hence
+// persisted to nsclient.db).
+//
+// A bookmark name comes from whoever runs the query, and an automatic name
+// changes whenever the filter does, so nothing stops a caller from creating a
+// new name on every check. Without a cap that grows the stored state - and the
+// file it is saved to - without bound. 1000 positions is far more than a real
+// configuration uses (it is per bookmark AND file) while staying small enough
+// to be irrelevant on disk.
+const std::size_t max_positions = 1000;
+
+// A bounded, least-recently-used map of serialized positions.
+//
+// Not thread safe on its own - `check_logfile::bookmarks` wraps it in a lock.
+// Kept separate from that wrapper so the eviction rules can be unit tested
+// without a running module.
+class store {
+ public:
+  typedef std::map<std::string, std::string> map_type;
+
+  explicit store(std::size_t max_entries = max_positions) : max_entries_(max_entries == 0 ? 1 : max_entries), clock_(0) {}
+
+  void put(const std::string &key, const std::string &value) {
+    entry &e = entries_[key];
+    e.value = value;
+    e.used = ++clock_;
+    trim();
+  }
+
+  // The stored value, or an empty string when the key is unknown. Counts as a
+  // use: a bookmark which is checked but has nothing new to report must not
+  // age out before one which is merely written to.
+  std::string get(const std::string &key) {
+    const impl_type::iterator it = entries_.find(key);
+    if (it == entries_.end()) return "";
+    it->second.used = ++clock_;
+    return it->second.value;
+  }
+
+  map_type snapshot() const {
+    map_type ret;
+    for (const impl_type::value_type &v : entries_) {
+      ret[v.first] = v.second.value;
+    }
+    return ret;
+  }
+
+  std::size_t size() const { return entries_.size(); }
+
+ private:
+  struct entry {
+    std::string value;
+    // Monotonic use counter; the lowest one is the next to go.
+    std::uint64_t used;
+    entry() : used(0) {}
+  };
+  typedef std::map<std::string, entry> impl_type;
+
+  // Linear, but it only runs when the cap is exceeded and the cap is small.
+  void trim() {
+    while (entries_.size() > max_entries_) {
+      impl_type::iterator oldest = entries_.begin();
+      for (impl_type::iterator it = entries_.begin(); it != entries_.end(); ++it) {
+        if (it->second.used < oldest->second.used) oldest = it;
+      }
+      entries_.erase(oldest);
+    }
+  }
+
+  std::size_t max_entries_;
+  std::uint64_t clock_;
+  impl_type entries_;
+};
 
 }  // namespace bookmark
 }  // namespace check_logfile

--- a/modules/CheckLogFile/bookmark_state_test.cpp
+++ b/modules/CheckLogFile/bookmark_state_test.cpp
@@ -13,6 +13,8 @@ using check_logfile::bookmark::format;
 using check_logfile::bookmark::parse;
 using check_logfile::bookmark::position;
 using check_logfile::bookmark::resume_decision;
+using check_logfile::bookmark::store;
+using check_logfile::bookmark::to_hex;
 
 namespace {
 std::uint64_t hash_of(const std::string &s) { return fnv1a(s.data(), s.size()); }
@@ -144,4 +146,85 @@ TEST(bookmark_resume, emptied_file_drops_the_stored_offset) {
   EXPECT_TRUE(d.skip);
   EXPECT_EQ(0u, d.offset);
   EXPECT_TRUE(d.restarted);
+}
+
+// ---------------------------------------------------------------------------
+// to_hex
+// ---------------------------------------------------------------------------
+
+TEST(bookmark_to_hex, is_fixed_width_and_lowercase) {
+  EXPECT_EQ("0000000000000000", to_hex(0));
+  EXPECT_EQ("00000000000000ff", to_hex(255));
+  EXPECT_EQ("ffffffffffffffff", to_hex(0xffffffffffffffffULL));
+  EXPECT_EQ("123456789abcdef0", to_hex(0x123456789abcdef0ULL));
+}
+
+// ---------------------------------------------------------------------------
+// store (the bounded position map)
+// ---------------------------------------------------------------------------
+
+TEST(bookmark_store, stores_and_returns_values) {
+  store s;
+  EXPECT_EQ("", s.get("nothing"));
+  s.put("a", "1|1|0|0");
+  EXPECT_EQ("1|1|0|0", s.get("a"));
+  s.put("a", "1|2|0|0");
+  EXPECT_EQ("1|2|0|0", s.get("a"));
+  EXPECT_EQ(1u, s.size());
+}
+
+TEST(bookmark_store, snapshot_returns_every_entry) {
+  store s;
+  s.put("a", "1");
+  s.put("b", "2");
+  const store::map_type all = s.snapshot();
+  ASSERT_EQ(2u, all.size());
+  EXPECT_EQ("1", all.find("a")->second);
+  EXPECT_EQ("2", all.find("b")->second);
+}
+
+// A caller which invents a new bookmark name on every check must not be able
+// to grow the state (and thus nsclient.db) without bound.
+TEST(bookmark_store, evicts_the_least_recently_used_entry) {
+  store s(3);
+  s.put("a", "1");
+  s.put("b", "2");
+  s.put("c", "3");
+  s.put("d", "4");
+  EXPECT_EQ(3u, s.size());
+  // "a" was the oldest, so it is the one which had to go.
+  EXPECT_EQ("", s.get("a"));
+  EXPECT_EQ("2", s.get("b"));
+  EXPECT_EQ("4", s.get("d"));
+}
+
+TEST(bookmark_store, reading_a_position_keeps_it_alive) {
+  store s(2);
+  s.put("a", "1");
+  s.put("b", "2");
+  // A quiet check still reads its position - that has to count as a use, or a
+  // bookmark with nothing new to report would age out before a noisy one.
+  EXPECT_EQ("1", s.get("a"));
+  s.put("c", "3");
+  EXPECT_EQ("1", s.get("a"));
+  EXPECT_EQ("", s.get("b"));
+}
+
+TEST(bookmark_store, updating_a_position_keeps_it_alive) {
+  store s(2);
+  s.put("a", "1");
+  s.put("b", "2");
+  s.put("a", "1b");
+  s.put("c", "3");
+  EXPECT_EQ("1b", s.get("a"));
+  EXPECT_EQ("", s.get("b"));
+}
+
+TEST(bookmark_store, a_zero_limit_still_holds_one_entry) {
+  store s(0);
+  s.put("a", "1");
+  EXPECT_EQ("1", s.get("a"));
+  s.put("b", "2");
+  EXPECT_EQ(1u, s.size());
+  EXPECT_EQ("2", s.get("b"));
 }

--- a/modules/CheckLogFile/bookmark_state_test.cpp
+++ b/modules/CheckLogFile/bookmark_state_test.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "bookmark_state.hpp"
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+using check_logfile::bookmark::compute_resume;
+using check_logfile::bookmark::fnv1a;
+using check_logfile::bookmark::format;
+using check_logfile::bookmark::parse;
+using check_logfile::bookmark::position;
+using check_logfile::bookmark::resume_decision;
+
+namespace {
+std::uint64_t hash_of(const std::string &s) { return fnv1a(s.data(), s.size()); }
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// fnv1a
+// ---------------------------------------------------------------------------
+
+TEST(bookmark_fnv1a, is_stable_and_known) {
+  // Reference values for FNV-1a/64; a change here means stored bookmarks from
+  // an older build would suddenly look like a rotated file.
+  EXPECT_EQ(14695981039346656037ULL, fnv1a("", 0));
+  EXPECT_EQ(0xaf63dc4c8601ec8cULL, hash_of("a"));
+  EXPECT_EQ(0x85944171f73967e8ULL, hash_of("foobar"));
+}
+
+TEST(bookmark_fnv1a, differs_for_different_content) { EXPECT_NE(hash_of("line one\n"), hash_of("line two\n")); }
+
+// ---------------------------------------------------------------------------
+// format / parse
+// ---------------------------------------------------------------------------
+
+TEST(bookmark_format, roundtrips) {
+  const position pos(4711, 256, 1234567890123456789ULL);
+  const std::string s = format(pos);
+  EXPECT_EQ("1|4711|256|1234567890123456789", s);
+  EXPECT_EQ(pos, parse(s));
+}
+
+TEST(bookmark_format, invalid_position_formats_empty) { EXPECT_EQ("", format(position())); }
+
+TEST(bookmark_parse, rejects_garbage) {
+  EXPECT_FALSE(parse("").valid);
+  EXPECT_FALSE(parse("garbage").valid);
+  EXPECT_FALSE(parse("1|1|2").valid);
+  EXPECT_FALSE(parse("1|1|2|3|4").valid);
+  // Unknown version: discarded rather than mis-read.
+  EXPECT_FALSE(parse("2|1|2|3").valid);
+  // A negative offset must never wrap into a huge unsigned one, which would
+  // silently skip the whole file forever.
+  EXPECT_FALSE(parse("1|-1|2|3").valid);
+  EXPECT_FALSE(parse("1|1|2|abc").valid);
+  EXPECT_FALSE(parse("1| 1|2|3").valid);
+  EXPECT_FALSE(parse("1||2|3").valid);
+}
+
+// ---------------------------------------------------------------------------
+// compute_resume
+// ---------------------------------------------------------------------------
+
+TEST(bookmark_resume, first_observation_reads_everything) {
+  const resume_decision d = compute_resume(position(), 100, 0, true);
+  EXPECT_FALSE(d.skip);
+  EXPECT_EQ(0u, d.offset);
+  EXPECT_FALSE(d.restarted);
+}
+
+TEST(bookmark_resume, empty_file_is_skipped) {
+  const resume_decision d = compute_resume(position(), 0, 0, true);
+  EXPECT_TRUE(d.skip);
+  EXPECT_EQ(0u, d.offset);
+}
+
+TEST(bookmark_resume, unchanged_file_is_skipped) {
+  const position prev(100, 100, 42);
+  const resume_decision d = compute_resume(prev, 100, 42, true);
+  EXPECT_TRUE(d.skip);
+  EXPECT_EQ(100u, d.offset);
+  EXPECT_FALSE(d.restarted);
+}
+
+TEST(bookmark_resume, grown_file_resumes_at_offset) {
+  const position prev(100, 100, 42);
+  const resume_decision d = compute_resume(prev, 250, 42, true);
+  EXPECT_FALSE(d.skip);
+  EXPECT_EQ(100u, d.offset);
+  EXPECT_FALSE(d.restarted);
+}
+
+// The offset trails a partially written last line, so a file can be larger
+// than the offset and still resume mid-file rather than restart.
+TEST(bookmark_resume, partial_tail_is_reread) {
+  const position prev(80, 100, 42);
+  const resume_decision d = compute_resume(prev, 100, 42, true);
+  EXPECT_FALSE(d.skip);
+  EXPECT_EQ(80u, d.offset);
+}
+
+TEST(bookmark_resume, truncated_file_restarts) {
+  const position prev(1000, 256, 42);
+  const resume_decision d = compute_resume(prev, 500, 42, true);
+  EXPECT_FALSE(d.skip);
+  EXPECT_EQ(0u, d.offset);
+  EXPECT_TRUE(d.restarted);
+}
+
+// The rotation which a size check alone cannot see: the file was replaced by a
+// brand new one which is already bigger than where we stopped reading.
+TEST(bookmark_resume, replaced_file_restarts_even_when_larger) {
+  const position prev(1000, 256, 42);
+  const resume_decision d = compute_resume(prev, 5000, 43, true);
+  EXPECT_FALSE(d.skip);
+  EXPECT_EQ(0u, d.offset);
+  EXPECT_TRUE(d.restarted);
+}
+
+TEST(bookmark_resume, unreadable_fingerprint_restarts) {
+  const position prev(1000, 256, 42);
+  const resume_decision d = compute_resume(prev, 2000, 0, false);
+  EXPECT_FALSE(d.skip);
+  EXPECT_EQ(0u, d.offset);
+  EXPECT_TRUE(d.restarted);
+}
+
+// A file which was empty last time has no fingerprint to compare against, so
+// it must resume on content alone instead of looking permanently rotated.
+TEST(bookmark_resume, empty_previous_state_resumes_without_fingerprint) {
+  const position prev(0, 0, 0);
+  const resume_decision d = compute_resume(prev, 120, 0, true);
+  EXPECT_FALSE(d.skip);
+  EXPECT_EQ(0u, d.offset);
+  EXPECT_FALSE(d.restarted);
+}
+
+TEST(bookmark_resume, emptied_file_drops_the_stored_offset) {
+  const position prev(1000, 256, 42);
+  const resume_decision d = compute_resume(prev, 0, 42, true);
+  EXPECT_TRUE(d.skip);
+  EXPECT_EQ(0u, d.offset);
+  EXPECT_TRUE(d.restarted);
+}

--- a/modules/CheckLogFile/bookmarks.cpp
+++ b/modules/CheckLogFile/bookmarks.cpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "bookmarks.hpp"
+
+namespace check_logfile {
+
+void bookmarks::add(const std::string &key, const std::string &value) {
+  boost::unique_lock<boost::timed_mutex> lock(mutex_, boost::get_system_time() + boost::posix_time::seconds(5));
+  if (!lock.owns_lock()) {
+    return;
+  }
+  bookmarks_[key] = value;
+}
+
+bookmark::position bookmarks::get(const std::string &key) {
+  boost::unique_lock<boost::timed_mutex> lock(mutex_, boost::get_system_time() + boost::posix_time::seconds(5));
+  if (!lock.owns_lock()) {
+    return bookmark::position();
+  }
+  const map_type::const_iterator cit = bookmarks_.find(key);
+  if (cit == bookmarks_.end()) {
+    return bookmark::position();
+  }
+  return bookmark::parse(cit->second);
+}
+
+bookmarks::map_type bookmarks::get_copy() {
+  map_type ret;
+  boost::unique_lock<boost::timed_mutex> lock(mutex_, boost::get_system_time() + boost::posix_time::seconds(5));
+  if (!lock.owns_lock()) {
+    return ret;
+  }
+  ret.insert(bookmarks_.begin(), bookmarks_.end());
+  return ret;
+}
+
+std::string bookmarks::make_key(const std::string &bookmark, const std::string &file) { return bookmark + "\x1f" + file; }
+
+}  // namespace check_logfile

--- a/modules/CheckLogFile/bookmarks.cpp
+++ b/modules/CheckLogFile/bookmarks.cpp
@@ -10,7 +10,7 @@ void bookmarks::add(const std::string &key, const std::string &value) {
   if (!lock.owns_lock()) {
     return;
   }
-  bookmarks_[key] = value;
+  store_.put(key, value);
 }
 
 bookmark::position bookmarks::get(const std::string &key) {
@@ -18,11 +18,7 @@ bookmark::position bookmarks::get(const std::string &key) {
   if (!lock.owns_lock()) {
     return bookmark::position();
   }
-  const map_type::const_iterator cit = bookmarks_.find(key);
-  if (cit == bookmarks_.end()) {
-    return bookmark::position();
-  }
-  return bookmark::parse(cit->second);
+  return bookmark::parse(store_.get(key));
 }
 
 bookmarks::map_type bookmarks::get_copy() {
@@ -31,8 +27,7 @@ bookmarks::map_type bookmarks::get_copy() {
   if (!lock.owns_lock()) {
     return ret;
   }
-  ret.insert(bookmarks_.begin(), bookmarks_.end());
-  return ret;
+  return store_.snapshot();
 }
 
 std::string bookmarks::make_key(const std::string &bookmark, const std::string &file) { return bookmark + "\x1f" + file; }

--- a/modules/CheckLogFile/bookmarks.hpp
+++ b/modules/CheckLogFile/bookmarks.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <boost/thread/mutex.hpp>
+#include <map>
+#include <string>
+
+#include "bookmark_state.hpp"
+
+namespace check_logfile {
+
+// Per-(bookmark, file) read positions, shared by all concurrently executing
+// check_logfile queries. Mirrors CheckEventLog's `bookmarks`: the map is the
+// live state, the core storage is only used to persist it across restarts.
+class bookmarks {
+ public:
+  typedef std::map<std::string, std::string> map_type;
+
+  void add(const std::string &key, const std::string &value);
+  // Returns an invalid position when the key is unknown (or unparsable).
+  bookmark::position get(const std::string &key);
+  map_type get_copy();
+
+  // Key under which the position for `file` is stored for a given bookmark.
+  static std::string make_key(const std::string &bookmark, const std::string &file);
+
+ private:
+  boost::timed_mutex mutex_;
+  map_type bookmarks_;
+};
+
+}  // namespace check_logfile

--- a/modules/CheckLogFile/bookmarks.hpp
+++ b/modules/CheckLogFile/bookmarks.hpp
@@ -14,9 +14,14 @@ namespace check_logfile {
 // Per-(bookmark, file) read positions, shared by all concurrently executing
 // check_logfile queries. Mirrors CheckEventLog's `bookmarks`: the map is the
 // live state, the core storage is only used to persist it across restarts.
+//
+// The number of positions is capped (see bookmark::max_positions); the least
+// recently used one is dropped when the cap is reached, so a caller which
+// invents a new bookmark name on every check cannot grow nsclient.db without
+// bound. A dropped position only means the file is read in full once more.
 class bookmarks {
  public:
-  typedef std::map<std::string, std::string> map_type;
+  typedef bookmark::store::map_type map_type;
 
   void add(const std::string &key, const std::string &value);
   // Returns an invalid position when the key is unknown (or unparsable).
@@ -28,7 +33,7 @@ class bookmarks {
 
  private:
   boost::timed_mutex mutex_;
-  map_type bookmarks_;
+  bookmark::store store_;
 };
 
 }  // namespace check_logfile

--- a/modules/CheckLogFile/file_reader.hpp
+++ b/modules/CheckLogFile/file_reader.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <istream>
 #include <sstream>
@@ -10,6 +11,9 @@
 
 namespace check_logfile {
 namespace file_reader {
+
+// How much is read at a time when only a bounded number of records is wanted.
+const std::size_t record_scan_chunk_size = 64 * 1024;
 
 // Read the next chunk from `is` delimited by `delim` into `out`.
 //
@@ -107,6 +111,136 @@ inline seek_decision compute_seek(std::uint64_t prev_size, std::uint64_t cur_siz
   if (cur_size == prev_size) return {true, prev_size};
   // Resume reading after the last read tail.
   return {false, prev_size};
+}
+
+// True when two occurrences of `delim` can overlap, i.e. when a proper prefix
+// of it is also a suffix (`aaa`, `abab`, `|||`).
+//
+// Records are split by a left-to-right scan which consumes each delimiter
+// whole, so for such a delimiter "where does an occurrence start" cannot be
+// answered without the bytes in front of it - `aaaa` split on `aaa` is one
+// delimiter at offset 0 and a record `a`, not a delimiter at offset 1. A scan
+// which starts at the end has no way to know, so it must not be used.
+inline bool delim_can_overlap(const std::string &delim) {
+  for (std::size_t k = 1; k < delim.size(); k++) {
+    if (delim.compare(0, k, delim, delim.size() - k, k) == 0) return true;
+  }
+  return false;
+}
+
+// Byte offset at which the last `max_records` records of `is` begin.
+//
+// A record is a chunk terminated by `delim`; a trailing chunk which is not
+// terminated counts as a record too, since that is how the check treats it
+// when no bookmark is in play. Returns 0 when the stream holds no more than
+// `max_records` records, when there is nothing to limit (no delimiter, no
+// limit), and for a self-overlapping delimiter, which cannot be located from
+// the end (see delim_can_overlap). 0 is always a safe answer: it only means
+// the caller reads more than it strictly needs and drops the surplus records
+// itself.
+//
+// The scan runs backwards from the end so that `max-lines` bounds the I/O and
+// not only the matching: asking for the last 10 lines of a multi-gigabyte log
+// should read a few kilobytes, not the whole file.
+//
+// The stream is left positioned wherever the scan ended and its flags are
+// cleared; every caller seeks afterwards.
+inline std::uint64_t find_tail_offset(std::istream &is, const std::string &delim, std::uint64_t max_records) {
+  if (max_records == 0 || delim.empty() || delim_can_overlap(delim)) return 0;
+  is.clear();
+  is.seekg(0, std::ios::end);
+  const std::streamoff end_pos = is.tellg();
+  if (end_pos <= 0) return 0;
+  const std::uint64_t size = static_cast<std::uint64_t>(end_pos);
+  if (size < delim.size()) return 0;
+
+  // A stream ending with the delimiter has no trailing partial record, so the
+  // start of the last `max_records` records is one delimiter further back.
+  std::string tail(delim.size(), '\0');
+  is.seekg(static_cast<std::streamoff>(size - delim.size()), std::ios::beg);
+  is.read(&tail[0], static_cast<std::streamsize>(delim.size()));
+  tail.resize(static_cast<std::size_t>(is.gcount()));
+  is.clear();
+  const std::uint64_t wanted = max_records + (tail == delim ? 1 : 0);
+
+  // Keep the last `delim.size() - 1` bytes of the region already scanned in
+  // front of the next chunk, so a delimiter straddling a chunk boundary is
+  // still found. A match cannot start inside that carry (it would not fit),
+  // so nothing is counted twice.
+  const std::size_t overlap = delim.size() - 1;
+  std::string carry;
+  std::uint64_t pos = size;
+  std::uint64_t found = 0;
+  while (pos > 0) {
+    const std::size_t want = static_cast<std::size_t>(std::min<std::uint64_t>(record_scan_chunk_size, pos));
+    const std::uint64_t start = pos - want;
+    std::string buf;
+    buf.resize(want);
+    is.seekg(static_cast<std::streamoff>(start), std::ios::beg);
+    is.read(&buf[0], static_cast<std::streamsize>(want));
+    buf.resize(static_cast<std::size_t>(is.gcount()));
+    is.clear();
+    buf += carry;
+
+    std::string::size_type search_to = buf.size();
+    while (true) {
+      const std::string::size_type hit = buf.rfind(delim, search_to);
+      if (hit == std::string::npos) break;
+      if (++found == wanted) return start + hit + delim.size();
+      if (hit == 0) break;
+      search_to = hit - 1;
+    }
+
+    carry = buf.substr(0, std::min(overlap, buf.size()));
+    pos = start;
+  }
+  return 0;
+}
+
+// Read from the current position of `is` until `max_records` complete records
+// have been read - i.e. up to and including the delimiter which terminates the
+// last of them - or the stream ends, whichever comes first.
+//
+// The counterpart of find_tail_offset for files whose newest record is at the
+// top: the caller wants the leading records, so reading stops as soon as it has
+// them instead of pulling in the rest of the file.
+inline std::string read_leading_records(std::istream &is, const std::string &delim, std::uint64_t max_records) {
+  std::string out;
+  if (delim.empty() || max_records == 0) {
+    std::ostringstream ss;
+    ss << is.rdbuf();
+    return ss.str();
+  }
+
+  std::uint64_t found = 0;
+  // Everything before this has already been searched; it only ever moves
+  // forward, so a delimiter is never matched twice (which matters for
+  // self-overlapping delimiters such as `aaa`).
+  std::string::size_type search_from = 0;
+  while (is) {
+    const std::string::size_type before = out.size();
+    out.resize(before + record_scan_chunk_size);
+    is.read(&out[before], static_cast<std::streamsize>(record_scan_chunk_size));
+    const std::size_t got = static_cast<std::size_t>(is.gcount());
+    out.resize(before + got);
+    is.clear();
+    if (got == 0) break;
+
+    while (true) {
+      const std::string::size_type hit = out.find(delim, search_from);
+      if (hit == std::string::npos) break;
+      search_from = hit + delim.size();
+      if (++found == max_records) {
+        out.resize(search_from);
+        return out;
+      }
+    }
+    // No match in what has been read so far: only a delimiter straddling the
+    // end of the buffer can still be completed, so resume from there.
+    const std::string::size_type scanned = out.size() >= delim.size() ? out.size() - delim.size() + 1 : 0;
+    if (search_from < scanned) search_from = scanned;
+  }
+  return out;
 }
 
 }  // namespace file_reader

--- a/modules/CheckLogFile/file_reader_test.cpp
+++ b/modules/CheckLogFile/file_reader_test.cpp
@@ -10,7 +10,11 @@
 #include <vector>
 
 using check_logfile::file_reader::compute_seek;
+using check_logfile::file_reader::delim_can_overlap;
+using check_logfile::file_reader::find_tail_offset;
 using check_logfile::file_reader::getline_str;
+using check_logfile::file_reader::read_leading_records;
+using check_logfile::file_reader::record_scan_chunk_size;
 using check_logfile::file_reader::seek_decision;
 
 namespace {
@@ -21,6 +25,30 @@ std::vector<std::string> read_all(const std::string &input, const std::string &d
   while (getline_str(is, line, delim)) {
     out.push_back(line);
   }
+  return out;
+}
+
+std::uint64_t tail_offset(const std::string &input, const std::string &delim, std::uint64_t max_records) {
+  std::istringstream is(input);
+  return find_tail_offset(is, delim, max_records);
+}
+
+std::string leading(const std::string &input, const std::string &delim, std::uint64_t max_records) {
+  std::istringstream is(input);
+  return read_leading_records(is, delim, max_records);
+}
+
+// Split exactly the way CheckLogFile::match_records does, so a test can assert
+// that an offset really is a record boundary.
+std::vector<std::string> split_records(const std::string &input, const std::string &delim) {
+  std::vector<std::string> out;
+  std::string::size_type pos = 0, lpos = 0;
+  while ((pos = input.find(delim, pos)) != std::string::npos) {
+    out.push_back(input.substr(lpos, pos - lpos));
+    pos += delim.size();
+    lpos = pos;
+  }
+  if (lpos < input.size()) out.push_back(input.substr(lpos));
   return out;
 }
 }  // namespace
@@ -178,6 +206,142 @@ TEST(file_reader_compute_seek, read_from_start_always_offset_zero) {
   EXPECT_EQ((seek_decision{false, 0u}), compute_seek(100u, 100u, true));
   // Even with read_from_start=true, an empty file produces no work.
   EXPECT_EQ((seek_decision{true, 0u}), compute_seek(0u, 0u, true));
+}
+
+// ---------------------------------------------------------------------------
+// delim_can_overlap: which delimiters can be located from the end (issue #583)
+// ---------------------------------------------------------------------------
+
+TEST(file_reader_delim_can_overlap, ordinary_delimiters_cannot_overlap) {
+  EXPECT_FALSE(delim_can_overlap("\n"));
+  EXPECT_FALSE(delim_can_overlap("\r\n"));
+  EXPECT_FALSE(delim_can_overlap("<END>"));
+  EXPECT_FALSE(delim_can_overlap("-|"));
+  EXPECT_FALSE(delim_can_overlap(""));
+}
+
+TEST(file_reader_delim_can_overlap, self_overlapping_delimiters_are_detected) {
+  EXPECT_TRUE(delim_can_overlap("aaa"));
+  // "---" is one delimiter and a leftover "-" going forwards, but looks like a
+  // delimiter at offset 1 going backwards.
+  EXPECT_TRUE(delim_can_overlap("--"));
+  EXPECT_TRUE(delim_can_overlap("abab"));
+  EXPECT_TRUE(delim_can_overlap("|||"));
+  EXPECT_TRUE(delim_can_overlap("\r\n\r\n"));
+}
+
+// ---------------------------------------------------------------------------
+// find_tail_offset: where the newest N records start (issue #583)
+// ---------------------------------------------------------------------------
+
+TEST(file_reader_find_tail_offset, trailing_delimiter_does_not_count_as_a_record) {
+  // "a\nb\nc\n" is three records, not four: the offsets are 0, 2 and 4.
+  EXPECT_EQ(4u, tail_offset("a\nb\nc\n", "\n", 1));
+  EXPECT_EQ(2u, tail_offset("a\nb\nc\n", "\n", 2));
+  EXPECT_EQ(0u, tail_offset("a\nb\nc\n", "\n", 3));
+}
+
+TEST(file_reader_find_tail_offset, unterminated_final_record_counts) {
+  EXPECT_EQ(4u, tail_offset("a\nb\nc", "\n", 1));
+  EXPECT_EQ(2u, tail_offset("a\nb\nc", "\n", 2));
+  EXPECT_EQ(0u, tail_offset("a\nb\nc", "\n", 3));
+}
+
+TEST(file_reader_find_tail_offset, fewer_records_than_asked_for_reads_everything) {
+  EXPECT_EQ(0u, tail_offset("a\nb\n", "\n", 10));
+  EXPECT_EQ(0u, tail_offset("no delimiter here", "\n", 1));
+  EXPECT_EQ(0u, tail_offset("", "\n", 1));
+}
+
+TEST(file_reader_find_tail_offset, no_limit_or_no_delimiter_reads_everything) {
+  EXPECT_EQ(0u, tail_offset("a\nb\nc\n", "\n", 0));
+  EXPECT_EQ(0u, tail_offset("a\nb\nc\n", "", 1));
+}
+
+TEST(file_reader_find_tail_offset, multi_char_delimiter) {
+  const std::string input = "a\r\nb\r\nc\r\n";
+  EXPECT_EQ(6u, tail_offset(input, "\r\n", 1));
+  EXPECT_EQ(3u, tail_offset(input, "\r\n", 2));
+  EXPECT_EQ(0u, tail_offset(input, "\r\n", 3));
+}
+
+TEST(file_reader_find_tail_offset, self_overlapping_delimiter_falls_back_to_the_whole_file) {
+  // A backwards scan cannot tell whether the delimiter in "xaaaay" starts at
+  // index 1 or 2, so it declines and lets the caller read everything.
+  EXPECT_EQ(0u, tail_offset("xaaaay", "aaa", 1));
+}
+
+TEST(file_reader_find_tail_offset, offset_is_a_record_boundary_across_chunks) {
+  // Enough lines to span several 64 KiB scan chunks.
+  std::string input;
+  std::vector<std::string> expected;
+  for (int i = 0; i < 20000; i++) {
+    const std::string line = "2018-07-20 12:00:00 line " + std::to_string(i);
+    expected.push_back(line);
+    input += line + "\n";
+  }
+  ASSERT_GT(input.size(), 3u * record_scan_chunk_size);
+
+  const std::uint64_t offset = tail_offset(input, "\n", 3);
+  const std::vector<std::string> tail = split_records(input.substr(static_cast<std::size_t>(offset)), "\n");
+  ASSERT_EQ(3u, tail.size());
+  EXPECT_EQ(expected[19997], tail[0]);
+  EXPECT_EQ(expected[19998], tail[1]);
+  EXPECT_EQ(expected[19999], tail[2]);
+}
+
+TEST(file_reader_find_tail_offset, delimiter_straddling_a_chunk_boundary) {
+  // Chunks are taken from the end of the file, so the boundary of the first
+  // one is at size - 64 KiB. Place a "\r\n" so that the '\r' is the last byte
+  // of the second chunk and the '\n' the first byte of the first one: only the
+  // carried-over overlap makes it findable.
+  const std::size_t tail_len = record_scan_chunk_size - 1;
+  const std::string input = std::string(3 * record_scan_chunk_size, 'x') + "\r\n" + std::string(tail_len, 'y');
+  ASSERT_EQ('\r', input[input.size() - tail_len - 2]);
+
+  const std::uint64_t offset = tail_offset(input, "\r\n", 1);
+  EXPECT_EQ(input.size() - tail_len, offset);
+  EXPECT_EQ(std::string(tail_len, 'y'), input.substr(static_cast<std::size_t>(offset)));
+}
+
+// ---------------------------------------------------------------------------
+// read_leading_records: the first N records, for files written newest-first
+// ---------------------------------------------------------------------------
+
+TEST(file_reader_read_leading_records, stops_after_the_nth_delimiter) {
+  EXPECT_EQ("a\nb\n", leading("a\nb\nc\nd\n", "\n", 2));
+  EXPECT_EQ("a\n", leading("a\nb\nc\nd\n", "\n", 1));
+}
+
+TEST(file_reader_read_leading_records, fewer_records_than_asked_for_returns_everything) {
+  EXPECT_EQ("a\nb\nc", leading("a\nb\nc", "\n", 5));
+  EXPECT_EQ("", leading("", "\n", 5));
+}
+
+TEST(file_reader_read_leading_records, no_limit_or_no_delimiter_returns_everything) {
+  EXPECT_EQ("a\nb\nc\n", leading("a\nb\nc\n", "\n", 0));
+  EXPECT_EQ("a\nb\nc\n", leading("a\nb\nc\n", "", 3));
+}
+
+TEST(file_reader_read_leading_records, multi_char_delimiter) { EXPECT_EQ("alpha||beta||", leading("alpha||beta||gamma", "||", 2)); }
+
+TEST(file_reader_read_leading_records, self_overlapping_delimiter_splits_like_match_records) {
+  // The forward scan consumes each delimiter whole, exactly as the record
+  // splitter does: "xaaaay" is the record "x" followed by "ay".
+  EXPECT_EQ("xaaa", leading("xaaaay", "aaa", 1));
+}
+
+TEST(file_reader_read_leading_records, delimiter_straddling_a_chunk_boundary) {
+  const std::string input = std::string(record_scan_chunk_size - 1, 'x') + "\r\n" + std::string(1000, 'y');
+  EXPECT_EQ(std::string(record_scan_chunk_size - 1, 'x') + "\r\n", leading(input, "\r\n", 1));
+}
+
+TEST(file_reader_read_leading_records, reads_only_what_it_needs) {
+  // The point of the helper: a huge file whose first record is short must not
+  // be pulled into memory in full.
+  const std::string input = "first line\n" + std::string(4 * record_scan_chunk_size, 'x');
+  const std::string got = leading(input, "\n", 1);
+  EXPECT_EQ("first line\n", got);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -448,6 +448,8 @@ NSCP_CREATE_TEST(
     SOURCES
         ${CMAKE_SOURCE_DIR}/modules/CheckLogFile/file_reader_test.cpp
         ${CMAKE_SOURCE_DIR}/modules/CheckLogFile/file_reader.hpp
+        ${CMAKE_SOURCE_DIR}/modules/CheckLogFile/bookmark_state_test.cpp
+        ${CMAKE_SOURCE_DIR}/modules/CheckLogFile/bookmark_state.hpp
     LIBRARIES
         GTest::gtest_main
     INCLUDES

--- a/tests/checklogfile-commands.test.ts
+++ b/tests/checklogfile-commands.test.ts
@@ -170,6 +170,24 @@ describe("CheckLogFile check_logfile", () => {
     expect(messageOf(other)).toMatch(/1\/1/);
   });
 
+  it("does not move any position when the check fails", async () => {
+    const file = newLog("ERROR one\n");
+    const missing = path.join(scratch, "gone.log");
+
+    // The second file cannot be opened, so the check reports an error - and
+    // must not have consumed the first file's lines on the way there.
+    const failed = await executeQuery(key, "check_logfile", {
+      file: [file, missing],
+      filter: "column1 like 'ERROR'",
+      warning: "count > 0",
+      "empty-state": "ok",
+      bookmark: "it-failed",
+    });
+    expect(messageOf(failed)).toMatch(/Failed to open file/i);
+
+    expect(messageOf(await check(file, { bookmark: "it-failed" }))).toMatch(/1\/1/);
+  });
+
   it("does not consume lines when the file is checked without a bookmark", async () => {
     const file = newLog("ERROR one\n");
 
@@ -217,6 +235,47 @@ describe("CheckLogFile check_logfile", () => {
     // ... and a line written while nothing was running is still picked up.
     fs.appendFileSync(file, "ERROR three\n");
     expect(await run()).toMatch(/1\/1 \(ERROR three\)/);
+
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  // The REST API turns a valueless query parameter into a bare token, so it
+  // cannot produce `bookmark=` at all. The client-query path passes `k=v`
+  // verbatim, which is where an explicitly empty value has to be recognised as
+  // "no name given" rather than as "no bookmark" - the mirror image of the
+  // bare-token case above.
+  it("treats an explicitly empty bookmark value as an automatic name", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "checklogfile-empty-"));
+    const dataDir = path.join(workDir, "data");
+    fs.mkdirSync(dataDir, { recursive: true });
+    const file = path.join(workDir, "empty-value.log");
+    fs.writeFileSync(file, "ERROR one\nINFO two\n");
+
+    const instance = new NscpInstance({ workDir, pathOverrides: { "data-path": dataDir } });
+    const run = async () =>
+      (
+        await instance.run(
+          [
+            "client",
+            "--module",
+            "CheckLogFile",
+            "--boot",
+            "--query",
+            "check_logfile",
+            `file=${file}`,
+            "filter=column1 like 'ERROR'",
+            "warning=count > 0",
+            "empty-state=ok",
+            "bookmark=",
+          ],
+          { allowFailure: true },
+        )
+      ).all ?? "";
+
+    expect(await run()).toMatch(/1\/2 \(ERROR one\)/);
+    // Incremental, not a full re-scan: the empty value picked the automatic
+    // name instead of silently disabling the bookmark.
+    expect(await run()).toMatch(/Nothing found/i);
 
     fs.rmSync(workDir, { recursive: true, force: true });
   });

--- a/tests/checklogfile-commands.test.ts
+++ b/tests/checklogfile-commands.test.ts
@@ -1,7 +1,9 @@
 /**
  * Exercises CheckLogFile's check_logfile end-to-end, with the emphasis on the
  * `bookmark` option (#561): a bookmarked check must report each line ONCE
- * instead of re-reporting the whole file on every run.
+ * instead of re-reporting the whole file on every run - and on `max-lines` /
+ * `newest` (#583), which pick the newest N lines out of whichever end of the
+ * file they are written to.
  *
  * Queries run over the REST API against a long-lived `nscp test` process
  * because that is what the feature needs: the read position lives in the
@@ -217,6 +219,89 @@ describe("CheckLogFile check_logfile", () => {
     expect(await run()).toMatch(/1\/1 \(ERROR three\)/);
 
     fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  // --- max-lines / newest (#583) -------------------------------------------
+
+  it("reports only the newest lines when max-lines is set", async () => {
+    const file = newLog("ERROR one\nERROR two\nERROR three\nERROR four\n");
+
+    const res = await check(file, { "max-lines": "2" });
+    expect(res.result).toBe(WARNING);
+    // Both the count and the total shrink: only two lines were examined.
+    expect(messageOf(res)).toMatch(/2\/2/);
+    expect(messageOf(res)).toContain("ERROR three");
+    expect(messageOf(res)).toContain("ERROR four");
+    expect(messageOf(res)).not.toContain("ERROR one");
+  });
+
+  it("keeps the file order of the lines it reports", async () => {
+    const file = newLog("ERROR one\nERROR two\nERROR three\n");
+    expect(messageOf(await check(file, { "max-lines": "2" }))).toContain("ERROR two, ERROR three");
+  });
+
+  it("counts a final line which has no terminator", async () => {
+    const file = newLog("ERROR one\nERROR two\nERROR three");
+    const res = await check(file, { "max-lines": "2" });
+    expect(messageOf(res)).toMatch(/2\/2/);
+    expect(messageOf(res)).toContain("ERROR three");
+    expect(messageOf(res)).not.toContain("ERROR one");
+  });
+
+  it("reads every line when max-lines exceeds the file", async () => {
+    const file = newLog("ERROR one\nERROR two\n");
+    expect(messageOf(await check(file, { "max-lines": "10" }))).toMatch(/2\/2/);
+  });
+
+  it("takes the newest lines from the top with newest=first", async () => {
+    const file = newLog("ERROR one\nERROR two\nERROR three\nERROR four\n");
+
+    const res = await check(file, { "max-lines": "2", newest: "first" });
+    expect(messageOf(res)).toMatch(/2\/2/);
+    expect(messageOf(res)).toContain("ERROR one");
+    expect(messageOf(res)).toContain("ERROR two");
+    expect(messageOf(res)).not.toContain("ERROR four");
+  });
+
+  it("finds the newest lines of a large file", async () => {
+    // Big enough that the backwards scan has to cross several chunks.
+    const lines: string[] = [];
+    for (let i = 0; i < 100_000; i++) lines.push(`ERROR line ${i}`);
+    const file = newLog(lines.join("\n") + "\n");
+
+    const res = await check(file, { "max-lines": "3" });
+    expect(messageOf(res)).toMatch(/3\/3/);
+    expect(messageOf(res)).toContain("ERROR line 99999");
+    expect(messageOf(res)).toContain("ERROR line 99997");
+    expect(messageOf(res)).not.toContain("ERROR line 99996");
+  });
+
+  it("still consumes the lines it drops when bookmarked", async () => {
+    const file = newLog("ERROR one\nERROR two\nERROR three\n");
+
+    // A burst of lines arrived at once but only the newest two are wanted.
+    const first = await check(file, { bookmark: "it-max-lines", "max-lines": "2" });
+    expect(messageOf(first)).toMatch(/2\/2/);
+    expect(messageOf(first)).not.toContain("ERROR one");
+
+    // The dropped line must not come back as "new" on the next check.
+    const second = await check(file, { bookmark: "it-max-lines", "max-lines": "2" });
+    expect(second.result).toBe(OK);
+    expect(messageOf(second)).toMatch(/Nothing found/i);
+
+    append(file, "ERROR four\n");
+    expect(messageOf(await check(file, { bookmark: "it-max-lines", "max-lines": "2" }))).toMatch(/1\/1/);
+  });
+
+  it("refuses newest=first together with a bookmark", async () => {
+    const file = newLog("ERROR one\n");
+    const res = await check(file, { newest: "first", bookmark: "it-newest-first" });
+    expect(messageOf(res)).toMatch(/cannot be combined with bookmark/i);
+  });
+
+  it("rejects an unknown newest value", async () => {
+    const file = newLog("ERROR one\n");
+    expect(messageOf(await check(file, { newest: "middle" }))).toMatch(/Invalid newest/i);
   });
 
   it("fails cleanly for a missing file", async () => {

--- a/tests/checklogfile-commands.test.ts
+++ b/tests/checklogfile-commands.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Exercises CheckLogFile's check_logfile end-to-end, with the emphasis on the
+ * `bookmark` option (#561): a bookmarked check must report each line ONCE
+ * instead of re-reporting the whole file on every run.
+ *
+ * Queries run over the REST API against a long-lived `nscp test` process
+ * because that is what the feature needs: the read position lives in the
+ * module instance, so the state under test only exists while one process
+ * serves several consecutive queries. REST also exercises the `k=v`
+ * single-token argument path, which is where a boolean/implicit-value option
+ * like `bookmark` (used bare) can break without the CLI noticing.
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  NscpInstance,
+  OK,
+  WARNING,
+  executeQuery,
+  messageOf,
+  setupQueryNscp,
+} from "@fixtures/index";
+
+jest.setTimeout(300_000);
+
+describe("CheckLogFile check_logfile", () => {
+  let nscp: NscpInstance;
+  let key: string;
+  let scratch: string;
+  let counter = 0;
+
+  /** A fresh log file per test so bookmarks never collide across cases. */
+  function newLog(contents = ""): string {
+    const file = path.join(scratch, `test-${counter++}.log`);
+    fs.writeFileSync(file, contents);
+    return file;
+  }
+
+  function append(file: string, contents: string): void {
+    fs.appendFileSync(file, contents);
+  }
+
+  /** Count the lines matching `filter` in `file`, without a bookmark. */
+  function check(file: string, extra: Record<string, string> = {}) {
+    return executeQuery(key, "check_logfile", {
+      file,
+      filter: "column1 like 'ERROR'",
+      warning: "count > 0",
+      critical: "count > 5",
+      "empty-state": "ok",
+      ...extra,
+    });
+  }
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), "checklogfile-it-"));
+    key = await setupQueryNscp(nscp, "CheckLogFile");
+  });
+
+  afterAll(async () => {
+    await nscp?.stop();
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  // --- without a bookmark (unchanged behaviour) -----------------------------
+
+  it("scans the whole file on every run when no bookmark is used", async () => {
+    const file = newLog("ERROR one\nINFO two\nERROR three\n");
+
+    const first = await check(file);
+    expect(first.result).toBe(WARNING);
+    expect(messageOf(first)).toMatch(/2\/3/);
+
+    // Same file, same answer: the entire file is re-read every time.
+    const second = await check(file);
+    expect(messageOf(second)).toMatch(/2\/3/);
+  });
+
+  // --- bookmarks (#561) ----------------------------------------------------
+
+  it("only reports lines added since the previous bookmarked check", async () => {
+    const file = newLog("ERROR one\nINFO two\n");
+
+    // First check of a file reads it in full.
+    const first = await check(file, { bookmark: "it-basic" });
+    expect(messageOf(first)).toMatch(/1\/2/);
+    expect(first.result).toBe(WARNING);
+
+    // Nothing was written: nothing to report.
+    const second = await check(file, { bookmark: "it-basic" });
+    expect(second.result).toBe(OK);
+    expect(messageOf(second)).toMatch(/Nothing found/i);
+
+    // Only the new lines are considered.
+    append(file, "INFO three\nERROR four\n");
+    const third = await check(file, { bookmark: "it-basic" });
+    expect(messageOf(third)).toMatch(/1\/2/);
+    expect(third.result).toBe(WARNING);
+
+    const fourth = await check(file, { bookmark: "it-basic" });
+    expect(fourth.result).toBe(OK);
+  });
+
+  it("holds back a line which has not been terminated yet", async () => {
+    const file = newLog("ERROR one\n");
+
+    expect(messageOf(await check(file, { bookmark: "it-partial" }))).toMatch(/1\/1/);
+
+    // A half-written line must not be reported (it would be reported again,
+    // in full, once the terminator arrives).
+    append(file, "ERROR two-in-prog");
+    const partial = await check(file, { bookmark: "it-partial" });
+    expect(partial.result).toBe(OK);
+    expect(messageOf(partial)).toMatch(/Nothing found/i);
+
+    // Once complete it is reported exactly once, in full.
+    append(file, "ress\n");
+    const complete = await check(file, { bookmark: "it-partial" });
+    expect(messageOf(complete)).toMatch(/1\/1/);
+    expect(messageOf(complete)).toContain("ERROR two-in-progress");
+  });
+
+  it("re-reads from the start when the file is truncated", async () => {
+    const file = newLog("ERROR one\nERROR two\n");
+    expect(messageOf(await check(file, { bookmark: "it-truncate" }))).toMatch(/2\/2/);
+
+    // Truncate + rewrite with less content than we had already read: without
+    // the shrink check the new lines would be skipped entirely.
+    fs.writeFileSync(file, "ERROR fresh\n");
+    expect(messageOf(await check(file, { bookmark: "it-truncate" }))).toMatch(/1\/1/);
+  });
+
+  it("re-reads from the start when the file is replaced by a bigger one", async () => {
+    const file = newLog("ERROR one\n");
+    expect(messageOf(await check(file, { bookmark: "it-rotate" }))).toMatch(/1\/1/);
+
+    // Rotation: a brand-new file under the same name which is LARGER than the
+    // offset we stored. Only the content fingerprint catches this.
+    fs.writeFileSync(file, "ERROR a\nERROR b\nERROR c\n");
+    const after = await check(file, { bookmark: "it-rotate" });
+    expect(messageOf(after)).toMatch(/3\/3/);
+  });
+
+  it("tracks each bookmark name separately", async () => {
+    const file = newLog("ERROR one\n");
+
+    expect(messageOf(await check(file, { bookmark: "it-name-a" }))).toMatch(/1\/1/);
+    // A different bookmark has never seen this file, so it starts over.
+    expect(messageOf(await check(file, { bookmark: "it-name-b" }))).toMatch(/1\/1/);
+    // ... and the first one is still where it left off.
+    expect((await check(file, { bookmark: "it-name-a" })).result).toBe(OK);
+  });
+
+  it("derives an automatic bookmark name from the file and the filters", async () => {
+    const file = newLog("ERROR one\n");
+
+    // `bookmark` with no value: the REST path passes it as a bare token, which
+    // the implicit value has to accept.
+    expect(messageOf(await check(file, { bookmark: "" }))).toMatch(/1\/1/);
+    expect((await check(file, { bookmark: "" })).result).toBe(OK);
+
+    // A check with a different filter gets its own position rather than
+    // consuming lines the other check has not seen.
+    const other = await check(file, { bookmark: "", filter: "column1 like 'one'" });
+    expect(messageOf(other)).toMatch(/1\/1/);
+  });
+
+  it("does not consume lines when the file is checked without a bookmark", async () => {
+    const file = newLog("ERROR one\n");
+
+    expect(messageOf(await check(file, { bookmark: "it-mixed" }))).toMatch(/1\/1/);
+    // Unbookmarked checks neither read nor update any stored position.
+    expect(messageOf(await check(file))).toMatch(/1\/1/);
+    expect((await check(file, { bookmark: "it-mixed" })).result).toBe(OK);
+  });
+
+  // A separate instance: the position has to survive a full stop/start cycle
+  // (it is written to ${data-path}/nsclient.db on shutdown), which the shared
+  // long-lived REST process above cannot show. One-shot `nscp client --boot`
+  // runs are exactly that cycle, twice.
+  it("remembers the position across a restart", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "checklogfile-restart-"));
+    const dataDir = path.join(workDir, "data");
+    fs.mkdirSync(dataDir, { recursive: true });
+    const file = path.join(workDir, "restart.log");
+    fs.writeFileSync(file, "ERROR one\nINFO two\n");
+
+    const restarted = new NscpInstance({ workDir, pathOverrides: { "data-path": dataDir } });
+    const run = async () =>
+      (
+        await restarted.run(
+          [
+            "client",
+            "--module",
+            "CheckLogFile",
+            "--boot",
+            "--query",
+            "check_logfile",
+            `file=${file}`,
+            "filter=column1 like 'ERROR'",
+            "warning=count > 0",
+            "empty-state=ok",
+            "bookmark=it-restart",
+          ],
+          { allowFailure: true },
+        )
+      ).all ?? "";
+
+    expect(await run()).toMatch(/1\/2 \(ERROR one\)/);
+    // Second process, same bookmark: the line must not come back.
+    expect(await run()).toMatch(/Nothing found/i);
+    // ... and a line written while nothing was running is still picked up.
+    fs.appendFileSync(file, "ERROR three\n");
+    expect(await run()).toMatch(/1\/1 \(ERROR three\)/);
+
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("fails cleanly for a missing file", async () => {
+    const missing = path.join(scratch, "does-not-exist.log");
+    const res = await check(missing, { bookmark: "it-missing" });
+    expect(messageOf(res)).toMatch(/Failed to open file/i);
+  });
+});


### PR DESCRIPTION
Fixes #561.

`check_logfile` reads the entire file on every run, so a single `ERROR` line keeps failing the check for as long as it stays in the file. The only way to get each line reported once was real-time monitoring, which has to be configured on the agent; the polled path had no equivalent of the bookmarks `check_eventlog` gained.

## The change

A `bookmark` option which remembers, per file and per bookmark name, how far the previous check read:

```
check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=app-errors
2/4 (ERROR failed to connect to db, ERROR failed to connect to db)|'count'=2;0;0

check_logfile file=/var/log/app.log "filter=column1 like 'ERROR'" "warning=count > 0" bookmark=app-errors
OK: Nothing found|'count'=0;0;0
```

As in `check_eventlog` the value is optional: `bookmark` (or `bookmark=auto`) derives the name from the file plus the `filter` / `warning` / `critical` expressions, so two checks over one file do not consume each other's lines. Positions live in the module and are persisted to the core storage (`logfile.bookmarks`) on unload, so a restart does not re-report everything.

## Design notes

- **Rotation is detected by size *and* content fingerprint** (FNV-1a over the first 256 bytes). A size comparison alone — what the real-time path does in `file_reader::compute_seek` — misses a file replaced under the same name which is already larger than the stored offset. The fingerprint length is stored next to the hash so both sides always hash the identical byte range; hashing `min(size, 256)` on both sides would look like a rotation on every check while a file shorter than the cap is still growing.
- **An unterminated trailing line is held back** and the offset parks in front of it, so a half-written line is reported once, in full, by the check which sees its terminator rather than twice.
- **The first check of a file reads it in full**, then goes incremental — entries already in the file when monitoring starts are reported rather than silently dropped, matching how `check_eventlog` behaves on a fresh bookmark.
- **Checks without `bookmark` neither read nor advance any position** and behave exactly as before, so an ad-hoc full scan can be run at any time.

## Tests

- `check_logfile_test` — 25 new unit tests over the pure state logic (hash stability, serialize/parse incl. rejecting a negative offset that would wrap into a huge one, and every resume/restart/skip decision). 35/35 pass.
- `tests/checklogfile-commands.test.ts` — 10 integration tests over REST (which also pins that a bare `bookmark` token is accepted), covering incremental reporting, the held-back partial line, truncation, replacement by a larger file, separate/auto names, and mixing bookmarked with unbookmarked checks. One case drives two `nscp client --boot` processes against a shared `data-path` to prove the position survives a restart. 10/10 pass.

Docs: `docs/samples/CheckLogFile_check_logfile_{desc,samples}.md`, with output captured from real runs.

## Caveat

An `auto` name embeds the filter text, so editing a filter starts a new position and leaves the old entry behind in `nsclient.db`. That is noted in the docs; `check_eventlog` has the same property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
