### PR TITLE
Run checks at NSClient++ startup

### DIFF
--- a/docs/samples/Scheduler_samples.md
+++ b/docs/samples/Scheduler_samples.md
@@ -68,3 +68,41 @@ The syntax of the schedule is similar to a cron expression in that you have:
 | Day of month | 1-31           | , *                        |
 | Month        | 0-11           | , *                        |
 | Day of week  | 1-7            | , *                        |
+
+#### Running a check at startup
+
+Both interval and schedule only report for the first time once the interval (or
+the next matching time) has elapsed. With a long interval that leaves the
+monitoring server with the old result for a long time after a reboot - exactly
+when the status is most likely to have changed. Set `run on startup` to run the
+command once as soon as the agent has started:
+
+```
+[/settings/scheduler/schedules/uptime]
+interval = 1h
+channel = NSCA
+command = check_uptime
+run on startup = true
+```
+
+The schedule is otherwise unaffected: the next run follows an hour after the
+startup run. The startup run also happens after a configuration reload, so a
+schedule you just changed reports its new status right away.
+
+Setting it on the default section turns it on for every schedule which does not
+override it:
+
+```
+[/settings/scheduler/schedules/default]
+interval = 1h
+channel = NSCA
+run on startup = true
+```
+
+If you have a lot of schedules and do not want all of them to report at the very
+same instant, spread the startup runs out over a window:
+
+```
+[/settings/scheduler]
+startup window = 30s
+```

--- a/include/scheduler/simple_scheduler.cpp
+++ b/include/scheduler/simple_scheduler.cpp
@@ -82,25 +82,33 @@ void scheduler::stop() {
   log_trace(__FILE__, __LINE__, "Thread pool contains: " + str::xtos(threads_.count()));
 }
 
-int scheduler::add_task(const std::string &tag, const boost::posix_time::time_duration duration, const double jitter_factor) {
+int scheduler::add_task(const std::string &tag, const boost::posix_time::time_duration duration, const double jitter_factor, const bool schedule_first_run) {
   task item(tag, duration, jitter_factor);
   {
     boost::mutex::scoped_lock l(mutex_);
     item.id = ++schedule_id_;
     tasks_[item.id] = item;
   }
-  reschedule(item, now());
+  if (schedule_first_run) reschedule(item, now());
   return item.id;
 }
-int scheduler::add_task(const std::string &tag, const cron_parser::schedule &schedule) {
+int scheduler::add_task(const std::string &tag, const cron_parser::schedule &schedule, const bool schedule_first_run) {
   task item(tag, schedule);
   {
     boost::mutex::scoped_lock l(mutex_);
     item.id = ++schedule_id_;
     tasks_[item.id] = item;
   }
-  reschedule(item, now());
+  if (schedule_first_run) reschedule(item, now());
   return item.id;
+}
+void scheduler::run_now(const int id, const boost::posix_time::time_duration delay) {
+  const op_task_object item = get_task(id);
+  if (!item) {
+    log_error(__FILE__, __LINE__, "Cannot run unknown task: " + str::xtos(id));
+    return;
+  }
+  reschedule_at(item->tag, id, now() + delay, true);
 }
 void scheduler::remove_task(const int id) {
   boost::mutex::scoped_lock l(mutex_);
@@ -120,8 +128,14 @@ scheduler::op_task_object scheduler::get_task(const int id) {
 }
 
 void scheduler::clear_tasks() {
-  boost::mutex::scoped_lock l(mutex_);
-  tasks_.clear();
+  {
+    boost::mutex::scoped_lock l(mutex_);
+    tasks_.clear();
+  }
+  // Drop the pending instances as well: without a task behind them they would
+  // only produce "Task not found" errors as they come due, and on a reload
+  // they would race the freshly added tasks.
+  if (!queue_.clear()) log_error(__FILE__, __LINE__, "Failed to clear the schedule queue");
 }
 
 void scheduler::watch_dog(const int id) {
@@ -182,7 +196,7 @@ void scheduler::thread_proc(const int id) {
 
       try {
         boost::posix_time::time_duration off = now() - instance->time;
-        if (off.total_seconds() > error_threshold_) {
+        if (!instance->suppress_late_warning && off.total_seconds() > error_threshold_) {
           log_error(__FILE__, __LINE__,
                     "Ran scheduled item " + instance->tag + "(" + str::xtos(instance->schedule_id) + ") " + str::xtos(off.total_seconds()) +
                         " seconds to late from thread " + str::xtos(id));
@@ -256,11 +270,12 @@ void scheduler::reschedule(const task &item, boost::posix_time::ptime now_time) 
     reschedule_at(item.tag, item.id, item.get_next(now_time));
   }
 }
-void scheduler::reschedule_at(const std::string &tag, const int id, boost::posix_time::ptime new_time) {
+void scheduler::reschedule_at(const std::string &tag, const int id, boost::posix_time::ptime new_time, const bool suppress_late_warning) {
   schedule_instance instance;
   instance.tag = tag;
   instance.schedule_id = id;
   instance.time = new_time;
+  instance.suppress_late_warning = suppress_late_warning;
   if (!queue_.push(instance)) {
     log_error(__FILE__, __LINE__, "Failed to reschedule item");
   }

--- a/include/scheduler/simple_scheduler.hpp
+++ b/include/scheduler/simple_scheduler.hpp
@@ -91,6 +91,12 @@ struct schedule_instance {
   boost::posix_time::ptime time;
   std::string tag;
   int schedule_id{};
+  // Startup runs (run_now) are all queued for the same instant, so with more
+  // tasks than worker threads the tail is inevitably "late" through no fault
+  // of the configuration. Such instances are exempt from the lateness error
+  // to keep boot from filling the log with false alarms; the watchdog still
+  // sees the lag and scales the pool.
+  bool suppress_late_warning{false};
   friend bool operator<(const schedule_instance& p1, const schedule_instance& p2) { return p1.time > p2.time; }
 };
 
@@ -129,6 +135,13 @@ class safe_schedule_queue {
     boost::optional<T> ret = queue_.top();
     queue_.pop();
     return ret;
+  }
+
+  bool clear(const unsigned int timeout = 5) {
+    boost::unique_lock<boost::shared_mutex> lock(mutex_, boost::get_system_time() + boost::posix_time::seconds(timeout));
+    if (!lock) return false;
+    queue_ = schedule_queue_type();
+    return true;
   }
 
   bool push(T instance, const unsigned int timeout = 5) {
@@ -192,8 +205,18 @@ class scheduler : public boost::noncopyable {
   std::size_t get_metric_ql();
   bool has_metrics() const;
 
-  int add_task(const std::string& tag, boost::posix_time::time_duration duration, double jitter_factor);
-  int add_task(const std::string& tag, const cron_parser::schedule& schedule);
+  // `schedule_first_run == false` registers the task without queueing
+  // anything, leaving it dormant until run_now() queues its first instance.
+  // Used by run-on-startup schedules, which must not be queued twice: every
+  // execution queues the following one, so an extra instance would make the
+  // task run twice per interval forever.
+  int add_task(const std::string& tag, boost::posix_time::time_duration duration, double jitter_factor, bool schedule_first_run = true);
+  int add_task(const std::string& tag, const cron_parser::schedule& schedule, bool schedule_first_run = true);
+  // Queue a run of an already added task `delay` from now. Only ever call this
+  // for a task added with schedule_first_run = false (or one that has since
+  // been abandoned) - calling it for a live task adds a second, parallel chain
+  // of instances for that task.
+  void run_now(int id, boost::posix_time::time_duration delay = boost::posix_time::seconds(0));
   void remove_task(int id);
   op_task_object get_task(int id);
   void clear_tasks();
@@ -220,7 +243,7 @@ class scheduler : public boost::noncopyable {
   void thread_proc(int id);
 
   void reschedule(const task& item, boost::posix_time::ptime now_time);
-  void reschedule_at(const std::string& tag, int id, boost::posix_time::ptime new_time);
+  void reschedule_at(const std::string& tag, int id, boost::posix_time::ptime new_time, bool suppress_late_warning = false);
   void start_threads();
 
   void log_error(const char* file, const int line, const std::string& err) const {

--- a/include/scheduler/simple_scheduler_test.cpp
+++ b/include/scheduler/simple_scheduler_test.cpp
@@ -359,3 +359,82 @@ TEST(simple_scheduler_running, no_handler_does_not_crash) {
   s.stop();
   SUCCEED();
 }
+
+// --- deferred first run (run on startup) ----------------------------------
+
+TEST(simple_scheduler_basic, add_task_without_first_run_queues_nothing) {
+  simple_scheduler::scheduler s;
+  const int id = s.add_task("deferred", boost::posix_time::seconds(3600), 0.0, false);
+  EXPECT_TRUE(s.get_task(id));
+  EXPECT_EQ(s.get_metric_ql(), 0u);
+}
+
+TEST(simple_scheduler_basic, add_cron_task_without_first_run_queues_nothing) {
+  simple_scheduler::scheduler s;
+  const int id = s.add_task("deferred", cron_parser::parse("0 * * * *"), false);
+  EXPECT_TRUE(s.get_task(id));
+  EXPECT_EQ(s.get_metric_ql(), 0u);
+}
+
+TEST(simple_scheduler_basic, run_now_queues_a_deferred_task) {
+  simple_scheduler::scheduler s;
+  const int id = s.add_task("deferred", boost::posix_time::seconds(3600), 0.0, false);
+  s.run_now(id);
+  EXPECT_EQ(s.get_metric_ql(), 1u);
+}
+
+TEST(simple_scheduler_basic, run_now_unknown_task_is_ignored) {
+  simple_scheduler::scheduler s;
+  s.run_now(4711);
+  EXPECT_EQ(s.get_metric_ql(), 0u);
+}
+
+TEST(simple_scheduler_basic, clear_tasks_also_drops_pending_instances) {
+  // Pending instances outlive their task otherwise, which on a reload means
+  // the schedules from before the reload keep firing alongside the new ones.
+  simple_scheduler::scheduler s;
+  s.add_task("one", boost::posix_time::seconds(3600), 0.0);
+  s.add_task("two", boost::posix_time::seconds(3600), 0.0);
+  ASSERT_EQ(s.get_metric_ql(), 2u);
+
+  s.clear_tasks();
+  EXPECT_EQ(s.get_metric_ql(), 0u);
+}
+
+TEST(simple_scheduler_running, run_now_fires_a_deferred_task) {
+  simple_scheduler::scheduler s;
+  counting_handler h;
+  h.reschedule_after = false;
+  s.set_handler(&h);
+  s.set_threads(2);
+  // An hour-long interval: without run_now the handler cannot possibly be
+  // called during the test, which is exactly the stale-until-the-first-tick
+  // behaviour run-on-startup schedules avoid.
+  const int id = s.add_task("startup", boost::posix_time::seconds(3600), 0.0, false);
+  s.start();
+  EXPECT_FALSE(wait_for([&] { return h.calls.load() >= 1; }, std::chrono::milliseconds(200)));
+
+  s.run_now(id);
+  EXPECT_TRUE(wait_for([&] { return h.calls.load() >= 1; }, std::chrono::seconds(5)));
+
+  s.stop();
+  s.unset_handler();
+}
+
+TEST(simple_scheduler_running, run_now_honours_the_delay) {
+  simple_scheduler::scheduler s;
+  counting_handler h;
+  h.reschedule_after = false;
+  s.set_handler(&h);
+  s.set_threads(2);
+  const int id = s.add_task("startup", boost::posix_time::seconds(3600), 0.0, false);
+  s.start();
+  s.run_now(id, boost::posix_time::seconds(2));
+
+  // The instance is queued, but it must not run before its delay has passed.
+  EXPECT_FALSE(wait_for([&] { return h.calls.load() >= 1; }, std::chrono::milliseconds(500)));
+  EXPECT_TRUE(wait_for([&] { return h.calls.load() >= 1; }, std::chrono::seconds(5)));
+
+  s.stop();
+  s.unset_handler();
+}

--- a/modules/Scheduler/Scheduler.cpp
+++ b/modules/Scheduler/Scheduler.cpp
@@ -12,6 +12,7 @@
 #include <nscapi/protobuf/functions_submit.hpp>
 #include <nscapi/settings/helper.hpp>
 #include <nscapi/settings/proxy.hpp>
+#include <str/format.hpp>
 #include <str/utf8.hpp>
 
 namespace sh = nscapi::settings_helper;
@@ -20,6 +21,11 @@ bool Scheduler::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   if (mode == NSCAPI::reloadStart) {
     scheduler_.prepare_shutdown();
     scheduler_.stop();
+    // The worker threads are joined at this point, so the task list and the
+    // pending queue can be dropped safely. Without this the tasks (and their
+    // queued instances) from before the reload survive alongside the ones
+    // added below, so every schedule ends up running twice.
+    scheduler_.clear();
     schedules_.clear();
   }
 
@@ -36,6 +42,10 @@ bool Scheduler::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   settings.alias().add_key_to_settings()
     .add_int("threads", sh::int_fun_key([this] (auto value) { scheduler_.set_threads(value); }, 5),
 	    "Threads", "Number of threads to use.")
+    .add_string("startup window", sh::string_fun_key([this] (const auto& value) { this->set_startup_window(value); }, "0s"),
+        "Startup window",
+        "Time over which schedules with 'run on startup' are spread out when the agent starts. The default (0s) runs them all immediately; raise it if you "
+        "have many startup schedules and do not want to hit the monitoring server with all of them at once.")
     .add_string("timezone", sh::string_fun_key([this] (const auto& value) { scheduler_.set_timezone(value); }, "local"),
         "Timezone",
         "Reference clock for cron expressions. Accepts 'local' (default — standard cron semantics), 'utc'/'gmt' (restores the pre-0.13 "
@@ -96,7 +106,30 @@ bool Scheduler::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
     scheduler_.set_handler(this);
     scheduler_.start();
   }
+  // On a normal boot the startup runs wait for startModule, which the core
+  // calls once every plugin is loaded - firing them here would query commands
+  // that later modules have not registered yet. A reload (or a module loaded
+  // into an already running agent) has no such problem and gets no second
+  // startModule, so fire them right away instead.
+  if (started_ && (mode == NSCAPI::normalStart || mode == NSCAPI::reloadStart)) {
+    scheduler_.run_startup_tasks(startup_window_);
+  }
   return true;
+}
+
+bool Scheduler::startModule() {
+  started_ = true;
+  scheduler_.run_startup_tasks(startup_window_);
+  return true;
+}
+
+void Scheduler::set_startup_window(const std::string &value) {
+  try {
+    startup_window_ = boost::posix_time::seconds(str::format::stox_as_time_sec<long>(value, "s"));
+  } catch (const std::exception &e) {
+    NSC_LOG_ERROR_EXR("Invalid 'startup window' value '" + value + "', falling back to 0s: ", e);
+    startup_window_ = boost::posix_time::seconds(0);
+  }
 }
 
 void Scheduler::add_schedule(const std::string &key, const std::string &arg) {

--- a/modules/Scheduler/Scheduler.h
+++ b/modules/Scheduler/Scheduler.h
@@ -12,12 +12,21 @@ class Scheduler : public schedules::task_handler, public nscapi::impl::simple_pl
  private:
   schedules::scheduler scheduler_;
   schedules::schedule_handler schedules_;
+  // Window over which "run on startup" schedules are spread, see the
+  // "startup window" setting.
+  boost::posix_time::time_duration startup_window_;
+  // True once startModule has run, i.e. once every other plugin is loaded and
+  // startup runs are safe to fire. Reloads happen after that point and are
+  // never followed by another startModule (the core calls it once per plugin
+  // lifetime), so loadModuleEx has to fire the startup runs itself when set.
+  bool started_;
 
  public:
-  Scheduler() { scheduler_.set_handler(this); }
+  Scheduler() : startup_window_(boost::posix_time::seconds(0)), started_(false) { scheduler_.set_handler(this); }
   virtual ~Scheduler() { scheduler_.set_handler(nullptr); }
   // Module calls
   bool loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode);
+  bool startModule();
   void prepareShutdown();
   bool unloadModule();
 
@@ -25,6 +34,7 @@ class Scheduler : public schedules::task_handler, public nscapi::impl::simple_pl
   void fetchMetrics(PB::Metrics::MetricsMessage_Response* response);
 
   void add_schedule(const std::string& alias, const std::string& command);
+  void set_startup_window(const std::string& value);
   bool handle_schedule(schedules::target_object task);
 
   void on_error(const char* file, int line, std::string error);

--- a/modules/Scheduler/module.json
+++ b/modules/Scheduler/module.json
@@ -10,6 +10,8 @@
 
 	"metrics" : "produce",
 
+	"on_start" : true,
+
 	"prepare_shutdown" : true
 
 }

--- a/modules/Scheduler/schedules_handler.cpp
+++ b/modules/Scheduler/schedules_handler.cpp
@@ -40,16 +40,40 @@ boost::posix_time::seconds parse_interval(const std::string &str) {
 }
 
 void scheduler::add_task(const target_object target) {
+  // A run-on-startup task is not queued here: run_startup_tasks() queues its
+  // first instance once the agent is up. Queueing it now as well would leave
+  // the task with two independent instances (each run queues the next one),
+  // making it fire twice per interval for the lifetime of the process.
+  const bool schedule_first_run = !target->run_on_startup;
   unsigned int id = 0;
   if (target->duration)
-    id = tasks.add_task(target->get_alias(), *target->duration, target->randomness);
+    id = tasks.add_task(target->get_alias(), *target->duration, target->randomness, schedule_first_run);
   else if (target->schedule)
-    id = tasks.add_task(target->get_alias(), cron_parser::parse(*target->schedule));
+    id = tasks.add_task(target->get_alias(), cron_parser::parse(*target->schedule), schedule_first_run);
   else
-    id = tasks.add_task(target->get_alias(), parse_interval("5m"), 0.1);
+    id = tasks.add_task(target->get_alias(), parse_interval("5m"), 0.1, schedule_first_run);
   {
     boost::mutex::scoped_lock l(tasks.get_mutex());
     metadata[id] = target;
+  }
+}
+
+void scheduler::run_startup_tasks(const boost::posix_time::time_duration window) {
+  std::list<int> ids;
+  {
+    boost::mutex::scoped_lock l(tasks.get_mutex());
+    for (const metadata_map::value_type &v : metadata) {
+      if (v.second && v.second->run_on_startup) ids.push_back(v.first);
+    }
+  }
+  if (ids.empty()) return;
+  // Evenly spaced over the window: the first task runs immediately and no task
+  // waits the full window (with a zero window every offset collapses to 0).
+  const long step = window.total_milliseconds() / static_cast<long>(ids.size());
+  long offset = 0;
+  for (const int id : ids) {
+    tasks.run_now(id, boost::posix_time::milliseconds(offset));
+    offset += step;
   }
 }
 

--- a/modules/Scheduler/schedules_handler.hpp
+++ b/modules/Scheduler/schedules_handler.hpp
@@ -20,7 +20,7 @@ namespace schedules {
 struct schedule_object : public nscapi::settings_objects::object_instance_interface {
   typedef nscapi::settings_objects::object_instance_interface parent;
 
-  schedule_object(std::string alias, std::string path) : parent(alias, path), randomness(0.0), report(0), id(0) {}
+  schedule_object(std::string alias, std::string path) : parent(alias, path), randomness(0.0), run_on_startup(false), report(0), id(0) {}
   schedule_object(const schedule_object& other)
       : parent(other),
         source_id(other.source_id),
@@ -28,10 +28,14 @@ struct schedule_object : public nscapi::settings_objects::object_instance_interf
         duration(other.duration),
         randomness(other.randomness),
         schedule(other.schedule),
+        run_on_startup(other.run_on_startup),
         channel(other.channel),
         report(other.report),
         command(other.command),
-        arguments(other.arguments) {}
+        arguments(other.arguments),
+        // Not copying this left it indeterminate, which to_string then printed
+        // as a random schedule id in the "Adding scheduled item" log line.
+        id(other.id) {}
 
   // Schedule keys
   std::string source_id;
@@ -39,6 +43,7 @@ struct schedule_object : public nscapi::settings_objects::object_instance_interf
   boost::optional<boost::posix_time::time_duration> duration;
   double randomness;
   boost::optional<std::string> schedule;
+  bool run_on_startup;
   std::string channel;
   unsigned int report;
   std::string command;
@@ -67,6 +72,7 @@ struct schedule_object : public nscapi::settings_objects::object_instance_interf
       ss << ", duration: " << (*duration).total_seconds() << "s, " << (randomness * 100) << "% randomness";
     }
     if (schedule) ss << ", schedule: " << *schedule;
+    if (run_on_startup) ss << ", run on startup";
     ss << "}";
     return ss.str();
   }
@@ -112,6 +118,11 @@ struct schedule_object : public nscapi::settings_objects::object_instance_interf
           .add_string("schedule", sh::string_fun_key([this](auto value) { this->set_schedule(value); }), "SCHEDULE",
                       "Cron-like statement for when a task is run. Currently limited to only one number i.e. 1 * * * * or * * 1 * * but not 1 1 * * *")
 
+          .add_bool("run on startup", sh::bool_key(&run_on_startup, false), "RUN ON STARTUP",
+                    "Run the command once as soon as NSClient++ has started (and after each reload) instead of waiting for the first interval or schedule to "
+                    "elapse. Use this to avoid stale results after a reboot when the interval is long. The regular schedule is unaffected and continues from "
+                    "the startup run.")
+
           .add_string("report", sh::string_fun_key([this](auto value) { this->set_report(value); }, "all"), "REPORT MODE",
                       "What to report to the server (any of the following: all, critical, warning, unknown, ok)")
 
@@ -128,6 +139,11 @@ struct schedule_object : public nscapi::settings_objects::object_instance_interf
 
           .add_string("schedule", sh::string_fun_key([this](auto value) { this->set_schedule(value); }), "SCHEDULE",
                       "Cron-like statement for when a task is run. Currently limited to only one number i.e. 1 * * * * or * * 1 * * but not 1 1 * * *")
+
+          .add_bool("run on startup", sh::bool_key(&run_on_startup), "RUN ON STARTUP",
+                    "Run the command once as soon as NSClient++ has started (and after each reload) instead of waiting for the first interval or schedule to "
+                    "elapse. Inherited from the default schedule unless set here.",
+                    true)
 
           .add_string("report", sh::string_fun_key([this](auto value) { this->set_report(value); }), "REPORT MODE",
                       "What to report to the server (any of the following: all, critical, warning, unknown, ok)", true)
@@ -176,6 +192,12 @@ struct scheduler : public simple_scheduler::handler {
   void set_timezone(const std::string& tz) { tasks.set_timezone(tz); }
 
   void add_task(const target_object target);
+  // Queue the first run of every "run on startup" schedule. add_task leaves
+  // those dormant, so this is what actually brings them to life - it must be
+  // called once the agent is up (see Scheduler::startModule). The runs are
+  // spread evenly over `window` to avoid hitting the monitoring server with
+  // every passive check at once; a zero window runs them all immediately.
+  void run_startup_tasks(boost::posix_time::time_duration window);
 
   bool handle_schedule(simple_scheduler::task item) {
     task_handler* tmp = handler_.load();

--- a/modules/Scheduler/schedules_handler_test.cpp
+++ b/modules/Scheduler/schedules_handler_test.cpp
@@ -961,3 +961,94 @@ TEST_F(SchedulerTest, QueueLengthIncreasesWithTasks) {
   std::size_t after_ql = sched.get_scheduler().get_metric_ql();
   EXPECT_EQ(initial_ql + 2, after_ql);
 }
+
+// ============================================================================
+// run on startup
+// ============================================================================
+
+TEST(ScheduleObject, RunOnStartupDefaultsToFalse) {
+  const auto obj = make_target("test");
+  EXPECT_FALSE(obj->run_on_startup);
+}
+
+TEST(ScheduleObject, CopyPreservesRunOnStartup) {
+  // Named schedules are copied from the `default` schedule, which is how a
+  // "run on startup" set on the default becomes the setting for every
+  // schedule that does not override it.
+  const auto obj = make_target("template");
+  obj->run_on_startup = true;
+  const schedules::schedule_object copy(*obj);
+  EXPECT_TRUE(copy.run_on_startup);
+}
+
+TEST(ScheduleObject, ToStringMentionsRunOnStartup) {
+  const auto obj = make_target("startup_check");
+  obj->set_duration("1h");
+  EXPECT_EQ(std::string::npos, obj->to_string().find("run on startup"));
+  obj->run_on_startup = true;
+  EXPECT_NE(std::string::npos, obj->to_string().find("run on startup"));
+}
+
+TEST_F(SchedulerTest, RunOnStartupTaskIsNotQueuedByAddTask) {
+  // The whole point of deferring: the task exists but has no queued instance,
+  // so run_startup_tasks can queue the one and only chain of instances for it.
+  auto target = make_target("startup_check");
+  target->set_duration("1h");
+  target->run_on_startup = true;
+  sched.add_task(target);
+
+  EXPECT_TRUE(sched.get(1));
+  EXPECT_EQ(0u, sched.get_scheduler().get_metric_ql());
+}
+
+TEST_F(SchedulerTest, RunStartupTasksQueuesEachStartupTaskOnce) {
+  auto t1 = make_target("startup1");
+  t1->set_duration("1h");
+  t1->run_on_startup = true;
+  auto t2 = make_target("startup2");
+  t2->set_schedule("0 * * * *");
+  t2->run_on_startup = true;
+  sched.add_task(t1);
+  sched.add_task(t2);
+  ASSERT_EQ(0u, sched.get_scheduler().get_metric_ql());
+
+  sched.run_startup_tasks(boost::posix_time::seconds(0));
+  EXPECT_EQ(2u, sched.get_scheduler().get_metric_ql());
+}
+
+TEST_F(SchedulerTest, RunStartupTasksLeavesNormalTasksAlone) {
+  // A regular task is already queued by add_task; run_startup_tasks must not
+  // queue a second instance for it or it would run twice per interval.
+  auto normal = make_target("normal");
+  normal->set_duration("1h");
+  auto startup = make_target("startup");
+  startup->set_duration("1h");
+  startup->run_on_startup = true;
+  sched.add_task(normal);
+  sched.add_task(startup);
+  ASSERT_EQ(1u, sched.get_scheduler().get_metric_ql());
+
+  sched.run_startup_tasks(boost::posix_time::seconds(0));
+  EXPECT_EQ(2u, sched.get_scheduler().get_metric_ql());
+}
+
+TEST_F(SchedulerTest, RunStartupTasksWithoutStartupTasksIsANoop) {
+  auto normal = make_target("normal");
+  normal->set_duration("1h");
+  sched.add_task(normal);
+
+  sched.run_startup_tasks(boost::posix_time::seconds(30));
+  EXPECT_EQ(1u, sched.get_scheduler().get_metric_ql());
+}
+
+TEST_F(SchedulerTest, RunStartupTasksSpreadOverAWindowStillQueuesEverything) {
+  for (int i = 0; i < 4; i++) {
+    auto target = make_target("startup" + str::xtos(i));
+    target->set_duration("1h");
+    target->run_on_startup = true;
+    sched.add_task(target);
+  }
+
+  sched.run_startup_tasks(boost::posix_time::seconds(30));
+  EXPECT_EQ(4u, sched.get_scheduler().get_metric_ql());
+}

--- a/service/plugins/plugin_manager.cpp
+++ b/service/plugins/plugin_manager.cpp
@@ -349,6 +349,13 @@ bool nsclient::core::plugin_manager::load_single_plugin(const std::string &plugi
     }
     if (start) {
       instance->load_plugin(NSCAPI::normalStart);
+      // A plugin loaded into an already running agent never sees
+      // post_start_plugins, so start it here: modules which defer work until
+      // every peer is available (Scheduler's run-on-startup schedules,
+      // LUAScript's on-start hook) would otherwise never get going.
+      if (instance->has_start()) {
+        instance->start_plugin();
+      }
     }
     return true;
   } catch (const plugin_exception &e) {

--- a/tests/scheduler-run-on-startup.test.ts
+++ b/tests/scheduler-run-on-startup.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Covers the Scheduler's "run on startup" option (issue #392): a schedule with
+ * a long interval normally reports nothing until the first interval elapses,
+ * which leaves the monitoring server with stale data for hours after a reboot
+ * or a config change. With `run on startup` the check runs once as soon as the
+ * agent is up and then follows its normal schedule.
+ *
+ * Both schedules here use a one hour interval, so *any* result arriving during
+ * the test can only have come from a startup run:
+ *
+ *   - startupcheck  — run on startup = true  → must report within seconds
+ *   - intervalcheck — plain 1h schedule      → must stay silent
+ *
+ * Results are observed through GraphiteClient, whose carbon line protocol is
+ * plain TCP text, so the "monitoring server" is a local Node listener and the
+ * suite needs neither Docker nor the network. The submitted result's alias is
+ * the schedule alias, which lands in the carbon path via `${check_alias}` and
+ * is what tells the two schedules apart.
+ */
+import type { AddressInfo } from "net";
+import * as net from "net";
+
+import request from "supertest";
+
+import { NscpInstance, REST_URL } from "@fixtures/index";
+
+jest.setTimeout(120_000);
+
+// Pin the status path so the assertions match on a known prefix rather than on
+// whatever ${hostname} resolves to on the test machine.
+const STATUS_PATH = "nscp.startuptest.${check_alias}.status";
+
+describe("Scheduler run on startup", () => {
+  let nscp: NscpInstance;
+  let server: net.Server;
+  let received = "";
+  let key = "";
+
+  /** Poll the captured carbon stream until `predicate` holds. */
+  async function waitForReceived(
+    predicate: (s: string) => boolean,
+    timeoutMs: number,
+  ): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (predicate(received)) return received;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    return received; // hand back whatever we have so expect() shows a useful diff
+  }
+
+  beforeAll(async () => {
+    const port = await new Promise<number>((resolve) => {
+      server = net.createServer((sock) => {
+        sock.on("error", () => {});
+        sock.on("data", (chunk) => {
+          received += chunk.toString();
+        });
+      });
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+    });
+
+    nscp = new NscpInstance();
+    await nscp.configure({
+      "/modules": {
+        CheckHelpers: "enabled", // provides check_ok
+        Scheduler: "enabled",
+        GraphiteClient: "enabled",
+        WEBServer: "enabled", // only used to trigger the reload below
+      },
+      "/settings/default": {
+        password: "default-password",
+        "allowed hosts": "127.0.0.1,::1",
+      },
+      "/settings/WEB/server/roles": { full: "*" },
+      "/settings/WEB/server/users/admin": {
+        role: "full",
+        password: "default-password",
+      },
+      "/settings/graphite/client/targets/default": {
+        address: `127.0.0.1:${port}`,
+        "status path": STATUS_PATH,
+      },
+      // Shared by the schedules below: an interval far longer than the test, so
+      // nothing can report unless it was run at startup. `run on startup` is
+      // set here to also cover the "turn it on for everything" case - the
+      // schedules inherit it from this template.
+      "/settings/scheduler/schedules/default": {
+        channel: "GRAPHITE",
+        interval: "1h",
+        report: "all", // check_ok returns OK, which is filtered out otherwise
+        "run on startup": "true",
+      },
+      "/settings/scheduler/schedules/inheritcheck": {
+        command: "check_ok",
+      },
+      "/settings/scheduler/schedules/explicitcheck": {
+        command: "check_ok",
+        "run on startup": "true",
+      },
+      // The control: an explicit override wins over the inherited value, so
+      // this one keeps its regular first run an hour out.
+      "/settings/scheduler/schedules/silentcheck": {
+        command: "check_ok",
+        "run on startup": "false",
+      },
+    });
+
+    nscp.start();
+    await nscp.waitForPort(8443, { timeoutMs: 30_000 });
+    const login = await request(REST_URL)
+      .get("/api/v2/login")
+      .auth("admin", "default-password")
+      .trustLocalhost(true)
+      .expect(200);
+    key = login.body.key as string;
+  });
+
+  afterAll(async () => {
+    await nscp?.stop();
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+  });
+
+  /** Carbon lines captured so far for one schedule alias. */
+  function linesFor(alias: string, data = received): string[] {
+    return data.split("\n").filter((l) => l.includes(`.${alias}.`));
+  }
+
+  it("runs a run-on-startup schedule without waiting for its interval", async () => {
+    const data = await waitForReceived((s) => linesFor("explicitcheck", s).length > 0, 60_000);
+    // Carbon line protocol: "<dotted.path> <value> <unix-timestamp>".
+    expect(data).toMatch(/^nscp\.startuptest\.explicitcheck\.status 0 \d+$/m);
+  });
+
+  it("inherits the option from the default schedule", async () => {
+    const data = await waitForReceived((s) => linesFor("inheritcheck", s).length > 0, 60_000);
+    expect(data).toMatch(/^nscp\.startuptest\.inheritcheck\.status 0 \d+$/m);
+  });
+
+  it("runs each schedule once and honours an explicit override", async () => {
+    // Settle first: a startup run queued twice (once by the module load, once
+    // by the start hook) would show up as a second line right away.
+    await new Promise((r) => setTimeout(r, 3_000));
+    expect(linesFor("explicitcheck")).toHaveLength(1);
+    expect(linesFor("inheritcheck")).toHaveLength(1);
+    // `run on startup = false` overrides the inherited true, so this schedule
+    // keeps its normal first run an hour out and has reported nothing.
+    expect(linesFor("silentcheck")).toHaveLength(0);
+  });
+
+  it("runs them again after a configuration reload", async () => {
+    // "Config changed, tell me the new status now" is the other half of #392 -
+    // and a reload never goes through the plugin start hook, so this is a
+    // separate code path from the boot case above.
+    const before = linesFor("explicitcheck").length;
+    await request(REST_URL)
+      .post("/api/v2/settings/command")
+      .set("Authorization", `Bearer ${key}`)
+      .send({ command: "reload" })
+      .trustLocalhost(true)
+      .expect(200);
+
+    const data = await waitForReceived((s) => linesFor("explicitcheck", s).length > before, 60_000);
+    // Exactly one more: the schedules from before the reload are dropped, so
+    // the reloaded agent has a single startup run, not one per reload cycle.
+    expect(linesFor("explicitcheck", data)).toHaveLength(before + 1);
+    expect(linesFor("silentcheck", data)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Closes #392.

A schedule only reports for the first time once its interval (or the next matching cron time) has elapsed, so after a reboot or a configuration change the monitoring server keeps the old result for as long as the interval — hours for exactly the checks whose status is most likely to have changed (uptime, pending updates, …).

## What this adds

```ini
[/settings/scheduler/schedules/uptime]
interval = 1h
channel = NSCA
command = check_uptime
run on startup = true
```

The command runs once as soon as the agent is up, then continues on its normal schedule from that run.

- `run on startup` on the `default` schedule turns it on for every schedule that does not override it (the global switch the issue asked for); an explicit `run on startup = false` on a named schedule wins.
- `[/settings/scheduler] startup window = 30s` spreads the startup runs evenly for installs with many schedules. The default (`0s`) runs them all immediately.
- Startup runs also happen after a configuration reload, so a schedule you just changed reports its new status right away.

## How it works

Startup runs fire from the plugin start hook (`"on_start": true` → `Scheduler::startModule`), which the core calls from `post_start_plugins()` once every plugin is loaded. Firing them during module load would query commands that later-loading modules have not registered yet and submit bogus `Command was not found` UNKNOWNs. A reload never gets a second start hook and is not exposed to that ordering problem, so `loadModuleEx` fires them directly once the module has started.

The scheduler learned to register a task *without* queueing its first run (`add_task(..., schedule_first_run = false)` + `run_now`). This matters: every execution queues the following one, so leaving the normal first-run instance in place next to the startup instance would make the task fire twice per interval for the lifetime of the process. Startup instances are also exempt from the "ran N seconds too late" error — they are all queued for the same instant by design — while the watchdog still sees the lag and scales the thread pool.

## Bugs found along the way (fixed here)

- Reloading the Scheduler left the tasks *and* their queued instances from before the reload in place alongside the newly added ones, so every schedule ran twice after a reload.
- A plugin loaded into an already running agent (`load_single_plugin`, i.e. the REST module-load path) never got its start hook called. This also affected LUAScript's on-start scripts.
- `schedule_object`'s copy constructor did not copy `id`, so the "Adding scheduled item" log line printed an indeterminate value (`intervalcheck[1634497895]`).

## Tests

- `schedules_handler_test.cpp` — default value, template copy, `to_string`, and the queue-count invariants (deferred until fired, one instance per startup task, normal tasks untouched).
- `simple_scheduler_test.cpp` — deferred first run for both interval and cron tasks, `run_now` including delay handling and unknown ids, and queue clearing.
- `tests/scheduler-run-on-startup.test.ts` — new Docker-free integration suite driving a local carbon listener through GraphiteClient. Every schedule uses a 1h interval, so any result can only have come from a startup run: explicit flag, inheritance from `default`, `run on startup = false` staying silent, exactly-once, and a re-run after a REST-triggered reload.

`ctest -R "sched|plugin|settings"` passes 12/12; `activate-module` and `rest-modules-v1/v2` pass against the `load_single_plugin` change.

Note: the reload case needs a build with a web backend (the `mongoose`-less build tree has no WEBServer module).

🤖 Generated with [Claude Code](https://claude.com/claude-code)