### PR TITLE
docs: add Security notices and Upgrading pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,3 +141,17 @@ group minor items under a shared subsection (e.g. `### Bug fixes`).
 Conventions: title is a theme sentence, not a version number; lead each highlight
 bullet with a **bold** phrase; prefer tables for option/keyword matrices; always
 end with the compare link.
+
+### Keep the docs upgrade/security pages in sync
+Release notes live on GitHub and get buried over time, so two docs pages mirror
+them durably. Whenever a change introduces a **breaking change, a behaviour
+change that needs operator action, or a new/removed default**, add a
+newest-first entry to `docs/docs/setup/upgrading.md` (the same content as the
+release's `## Upgrade notes`). Whenever a change is **security-relevant** —
+including hardening handled without a CVE — also add an entry to
+`docs/docs/security/notices.md` (under "Published advisories" if it carries a
+CVE/GHSA, otherwise under "Hardening changes (no CVE)"), and mark the matching
+`upgrading.md` item with a 🔒 that links to it. For an embargoed fix, add these
+entries **in the same branch/PR as the fix** so the notice becomes public only
+when the fix does — never describe an unfixed issue on a page that ships ahead
+of the patch.

--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -1,0 +1,55 @@
+# Security notices
+
+This page is the running record of security-relevant changes in NSClient++ —
+both published advisories (with their CVE / GHSA identifiers) and security
+**hardening** that changed behaviour but was not assigned a CVE. It complements
+the GitHub [Security Advisories](https://github.com/mickem/nscp/security/advisories)
+tab, which lists only *published* advisories and so does not capture hardening
+changes.
+
+- To **report** a vulnerability, follow the
+  [security policy](https://github.com/mickem/nscp/blob/main/SECURITY.md).
+- For the concrete operator actions a given release requires, see
+  [Upgrading](../setup/upgrading.md).
+
+---
+
+## Published advisories
+
+| Advisory | CVE | Severity | Affected | Summary |
+|---|---|---|---|---|
+| [GHSA-rhrw-79v5-jc5x](https://github.com/mickem/nscp/security/advisories/GHSA-rhrw-79v5-jc5x) | CVE-2025-34079 | High (7.8) | 0.5.2.35 and earlier | Authenticated remote code execution via `ExternalScripts`. |
+| [GHSA-jr25-22p3-gm6r](https://github.com/mickem/nscp/security/advisories/GHSA-jr25-22p3-gm6r) | CVE-2025-34078 | High (7.8) | 0.5.2.35 and earlier | Local privilege escalation from plaintext credentials in the configuration file. |
+
+### CVE-2025-34079 — Authenticated RCE via ExternalScripts
+
+An attacker who already holds valid administrator credentials can register and
+run an external script, achieving remote code execution. It affects the legacy
+`0.5.2.35` architecture that predates the current REST v2 API.
+
+**What to do:** upgrade to a current supported release, and restrict who can
+configure `ExternalScripts` / hold an administrator role. See the
+[external scripts](../scenarios/external-scripts.md) and
+[permissions](../concepts/permissions.md) guidance. Full detail:
+[GHSA-rhrw-79v5-jc5x](https://github.com/mickem/nscp/security/advisories/GHSA-rhrw-79v5-jc5x).
+
+### CVE-2025-34078 — Local privilege escalation via plaintext credentials
+
+A principal with local filesystem access can read plaintext credentials stored
+in `nsclient.ini` and reuse them. It affects the legacy `0.5.2.35` architecture.
+
+**What to do:** upgrade to a current supported release; lock down the
+configuration file with filesystem ACLs and, where possible, move sensitive
+values into the credential manager (see
+[Securing NSClient++](../setup/securing.md)). Full detail:
+[GHSA-jr25-22p3-gm6r](https://github.com/mickem/nscp/security/advisories/GHSA-jr25-22p3-gm6r).
+
+---
+
+## Hardening changes (no CVE)
+
+Security-relevant changes that are handled as defense-in-depth / consistency
+hardening rather than assigned a CVE are listed here as they ship, newest
+first, alongside the release that contains them.
+
+_No hardening notices recorded yet._

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -1,0 +1,111 @@
+# Upgrading
+
+What to do when upgrading NSClient++, newest release first. Most upgrades are
+in place — defaults are preserved and the default install is usually unaffected
+— but the items below change observable behaviour or want a configuration
+touch. Read the entries between the version you are on and the version you are
+moving to.
+
+Items marked 🔒 are security-relevant; the [Security notices](../security/notices.md)
+page tracks those in one place. Full per-release detail lives in each
+[GitHub release](https://github.com/mickem/nscp/releases).
+
+---
+
+## 0.16.1
+
+- **RHEL/SUSE:** workaround `ca=` arguments can be dropped — `${ca-path}` now
+  resolves on its own (the explicit form still works). Packagers cross-building
+  for another distribution should set `-DCONFIG_CA_PATH=`.
+- **`check_logfile`** is unchanged unless you opt in to `bookmark` / `max-lines`.
+  Adopting `bookmark` is a trade-off: a line is consumed when the check runs
+  (not when its result is submitted) and positions are saved on clean shutdown,
+  so a crash re-reports the backlog. Prefer an explicit bookmark name for a
+  check whose filter changes often.
+- **Settings URLs with a query string now send it.** A server that relied on
+  receiving the bare path will now see the parameters. The offline-boot cache
+  file is migrated to the query-aware name once on first start.
+- **`${hostname}` in an existing config changes meaning** — it is now expanded
+  everywhere `expand_hostname` is used (including submit clients' `hostname`),
+  where it used to be left as literal text.
+- **`run on startup` is off by default** so the default install is unaffected;
+  if you enable it for the `default` schedule use `startup window` to avoid a
+  thundering herd.
+- **Building the HTML docs on non-Windows** now needs `-DNSCP_BUILD_DOCS_HTML=ON`.
+
+## 0.14.1
+
+- **Licence change:** now distributed as **Apache-2.0 OR GPL-2.0-only** — a
+  clarification/relicensing with no code or runtime behaviour change. Review it
+  if your organisation tracks bundled-software licences.
+- **CheckNet perfdata is on by default.** If you added perfdata manually,
+  make sure you are not now emitting it twice.
+- **Boolean check arguments** (`option=true` / `option=false`) now work from the
+  CLI as well as REST; bare-flag usage is unchanged.
+- 🔒 **`CheckSecurity` is not loaded by default.** Enable it before using its
+  checks (`nscp settings --active-module CheckSecurity`). Windows-only checks
+  return UNKNOWN elsewhere.
+
+## 0.12.6
+
+- 🔒 **New permission policy layer, disabled by default.** Existing installs
+  behave exactly as before until an operator sets
+  `/settings/permissions/enabled = true`. If you opt in: per-command rules apply
+  to **queries only** (exec is gated by the separate `allow exec` boolean, which
+  defaults `true`); roll out with `log allows = true` first to inventory real
+  traffic. See [Permissions](../concepts/permissions.md).
+- 🔒 **NRPEServer `client identity source`** defaults to `none` (previous
+  behaviour). Set to `cn` only after configuring `verify_mode = peer-cert` and a
+  `ca path` pinned to your **private** monitoring CA — the system trust store
+  would accept any public cert's CN.
+- **`[/paths]` overrides** from an older install moved to `[paths]` in
+  `boot.ini` (same section name, different file). No automatic migration — copy
+  each entry across and delete the old section.
+- 🔒 **WEB `disable admin user = true`** is a new opt-in for status-only WEB
+  exposure; existing installs keep their admin unchanged.
+- **NRPEServer** now survives a failed listener (logs an ERROR, leaves the
+  module loaded) instead of failing the whole module. Add "NRPE listener failed"
+  as a signal if you alerted on module-load failure.
+- **`insecure = true` on NRPEServer** now logs at ERROR (louder, behaviour
+  unchanged) — whitelist the message on agents intentionally run insecure.
+
+## 0.12.5
+
+- **`[/paths]` users:** copy entries into `[paths]` in `boot.ini`; the
+  settings-side section is no longer consulted. Default installs are unaffected.
+- **Custom-plugin authors:** implement the new optional `prepare_shutdown`
+  callback if your module manages sockets or background threads — `unload` is
+  now a last-resort teardown.
+- 🔒 **Monitoring-only WEB deployments:** `disable admin user = true` under
+  `[/settings/WEB/server]` suppresses the built-in admin even on first boot;
+  define your own read-only users (or a tightly scoped `anonymous` role).
+
+## 0.12.4
+
+- 🔒 **Icinga `check_nscp_api`** works again after upgrade with no config
+  change. For a non-stock probe, set `[/settings/WEB/server] legacy query auth
+  user agents` to a substring of its User-Agent. For the strict 0.12.3 behaviour
+  (no query-string credentials at all), set that key to empty.
+
+## 0.12.3
+
+1. 🔒 **Audit `allowed hosts`** on every node — empty values now reject everything.
+2. 🔒 **`check_nt` (NSClientServer)** now defaults to `ssl = true`; set
+   `ssl = false` explicitly if your clients don't speak TLS.
+3. 🔒 **Replace clients** that call `/auth/token` or `/auth/logout` with the
+   `/api/v2/login` flow, and any that pass `?TOKEN=` / `?__TOKEN=` in the query
+   string with a header-based token.
+4. **Scheduler cron expressions** on non-UTC hosts shift to local time — update
+   them or set `[/settings/scheduler] timezone = utc`.
+5. **Review `check_service` / `check_process` / `check_files` filters** that
+   relied on the old (now corrected) behaviours.
+6. Restart and review the log for new "refused alias" / "rejected connection"
+   warnings — configurations that were previously silently accepted.
+
+## 0.11.33
+
+- No configuration migration required (new `proxy` keys are opt-in). The
+  `check_files` fixes change a few corner cases: `max-depth=0` now scans the top
+  directory (#730); missing paths return UNKNOWN (#613); junction loops are not
+  double-counted (#605); empty results return OK instead of UNKNOWN (#717).
+  Review alerting that relied on the old corner-case behaviour.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,8 +31,11 @@ nav:
       - Permissions: concepts/permissions.md
   - Setup:
       - Installation: setup/installing.md
+      - Upgrading: setup/upgrading.md
       - Securing NSClient++: setup/securing.md
       - Web Interface: setup/web-interface.md
+  - Security:
+      - Security notices: security/notices.md
   - Monitoring Scenarios:
       - Overview: scenarios/index.md
       - Windows Server Health: scenarios/windows-server-health.md


### PR DESCRIPTION
Adds two durable docs pages that mirror the security- and upgrade-relevant content that currently only lives in GitHub release notes, plus a CLAUDE.md convention to keep them fed.

Closes #1410 — the collected upgrade-notes document requested there is `docs/docs/setup/upgrading.md`.

## Pages
- **`docs/docs/security/notices.md`** — running record of advisories (CVE/GHSA) and no-CVE hardening changes. Seeded with the two published CVEs (CVE-2025-34078, CVE-2025-34079). Complements the GitHub Security Advisories tab, which only shows *published* advisories and so misses hardening changes.
- **`docs/docs/setup/upgrading.md`** — per-release operator actions, newest first, aggregated from the release notes of `0.11.33`..`0.16.1`, with security-relevant items flagged 🔒. This is the upgrade-notes document requested in #1410.

Both wired into the mkdocs nav (`Setup → Upgrading`, new top-level `Security → Security notices`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)