### PR TITLE
Security hardening: redact sensitive settings on read; flag the legacy WEB permission

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -52,4 +52,43 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
-_No hardening notices recorded yet._
+### Settings values for sensitive keys are redacted on read
+
+**Fixed in:** 0.16.2 · **Severity:** Medium · **Reported by:** [yagust](https://github.com/yagust)
+
+The settings read paths — `GET /api/v2/settings/...`,
+`GET /api/v2/settings/descriptions/...`, and the `nscp settings --list` /
+`--show` CLI — returned values for keys registered sensitive (via
+`add_password` / `is_sensitive_key`) in clear text, while the settings `diff`
+endpoint already masked them. They now return `***` for sensitive keys, to
+match `diff`; internal reads a module makes of its own configuration are
+unaffected. This is a defense-in-depth / consistency change, not an
+authorization boundary: the values remain stored in plaintext in
+`nsclient.ini` (shared with the legacy NRPE/NSCA/NSClient protocols) and are
+readable by any principal with write or execute privilege regardless.
+
+**What to do:** nothing required. Tooling that read a secret back out of
+`GET /api/v2/settings/...` now receives `***` for keys registered sensitive.
+
+### The `legacy` WEB permission is flagged and no longer seeded by default
+
+**Fixed in:** 0.16.2 · **Severity:** Medium · **Reported by:** [yagust](https://github.com/yagust)
+
+The `legacy` WEB grant unlocks the deprecated `POST /query.pb` and
+`GET /query/{name}` endpoints, which dispatch through the same command registry
+as the versioned `/api/v2/queries` API — so a token holding the `legacy`
+permission can run any registered check or command (including any configured
+`CheckExternalScripts` command) even without `queries.execute`. This is
+intended compatibility behaviour for clients that predate the versioned API,
+but it was under-documented and more powerful than the role name suggests.
+
+The built-in `legacy` role is no longer seeded on fresh installs; NSClient++
+now logs a `SECURITY` warning at startup — and from `nscp web add-role` /
+`add-user` — for any role whose grant includes the `legacy` token (so a custom
+role such as `reporting = legacy,login.get` is flagged too); and the capability
+is documented in the securing guide.
+
+**What to do:** existing installs are unaffected (the role stays in their
+config and keeps working). Only grant `legacy` to trusted legacy systems that
+cannot use the versioned `/api/v2/queries` endpoints; see
+[Securing NSClient++](../setup/securing.md).

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -141,6 +141,15 @@ Options:
       scrapes.
     * `client` — adds query listing; needed for the legacy `check_nscp_api` integration.
     * `full` — admin (settings, modules, scripts). Avoid for monitoring callers.
+    * `legacy` — `legacy,login.get`. **Dangerous — do not use for normal clients.** It unlocks the deprecated
+      `POST /query.pb` and `GET /query/{name}` endpoints, which dispatch through the same command registry as the
+      versioned query API. A `legacy`-only token can therefore run **any** registered check or command — including any
+      configured `CheckExternalScripts` command, which can amount to arbitrary command execution — even though it lacks
+      `queries.execute`. The danger is the **`legacy` grant token itself**, not the role name: any role whose grant
+      string includes `legacy` (a custom role such as `reporting = legacy,login.get`, not just the built-in one) is
+      equally powerful, and NSClient++ logs a `SECURITY` warning at startup for each such role. Grant `legacy` only to a
+      specific, trusted legacy system that cannot be upgraded, and constrain it with a
+      [permission policy](#permission-policy). See the warning on the [Web interface](web-interface.md) page.
 * `--grant`: Additional grants beyond the role (see `add-role` to define new roles).
 
 Move the per-user passwords into the credential manager rather than leaving them in the INI; see the Passwords section

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -12,6 +12,23 @@ page tracks those in one place. Full per-release detail lives in each
 
 ---
 
+## 0.16.2
+
+- 🔒 **Sensitive settings values are redacted on read.** The REST settings
+  read endpoints (`GET /api/v2/settings/...`, `/descriptions`) and
+  `nscp settings --list` / `--show` now return `***` for keys registered
+  sensitive, matching the `diff` endpoint. No action required; tooling that
+  read such a value back now receives `***`. See
+  [Security notices](../security/notices.md).
+- 🔒 **The built-in `legacy` WEB role is no longer seeded on fresh installs,**
+  and any role granting the `legacy` permission now triggers a `SECURITY`
+  warning at startup (and from `nscp web add-role` / `add-user`). Existing
+  installs are unaffected — the role stays in their config. The `legacy` grant
+  unlocks the deprecated `/query.pb` and `/query/{name}` query-dispatch
+  endpoints, so a token with it can run any registered check/command; only
+  grant it to trusted legacy systems. See
+  [Security notices](../security/notices.md).
+
 ## 0.16.1
 
 - **RHEL/SUSE:** workaround `ca=` arguments can be dropped — `${ca-path}` now

--- a/docs/docs/setup/web-interface.md
+++ b/docs/docs/setup/web-interface.md
@@ -54,7 +54,6 @@ What this does is add the following configuration:
 
 ```ini
 [/settings/WEB/server/roles]
-legacy = legacy,login.get
 client = public,info.get,info.get.version,queries.list,queries.get,queries.execute,login.get,modules.list
 full = *
 view = *
@@ -72,6 +71,36 @@ WEBServer = enabled
 [/settings/WEB/server]
 port = 8443
 ```
+
+<!-- @formatter:off -->
+!!! danger "The `legacy` role is powerful — only for legacy integrations"
+    The `legacy` role (`legacy,login.get`) exists so that old clients which
+    predate the versioned REST API can still run checks, through the
+    deprecated `POST /query.pb` and `GET /query/{name}` endpoints. Those
+    endpoints dispatch through the **same command registry** as the modern
+    `GET /api/v2/queries/{name}/commands/execute` API, so a token holding only
+    the `legacy` grant can run **any** check or command registered on the
+    agent — including any `CheckExternalScripts` command an operator has
+    configured, which can be equivalent to arbitrary command execution.
+
+    What matters is the **`legacy` grant token**, not the role name: any role
+    whose grant string includes `legacy` — the built-in role, or a custom one
+    such as `cucumber = legacy,login.get` — unlocks these endpoints and is
+    exactly as powerful. Because the routes are gated by that coarse grant
+    rather than by `queries.execute`, such a role is **more capable than its
+    name suggests** and is not restricted relative to `client` / `monitoring`
+    for running checks.
+
+    Do **not** grant `legacy` to a normal user or monitoring server: modern
+    clients should use the `monitoring` or `client` role and the versioned
+    `/api/v2/queries/...` endpoints. Grant `legacy` only for a specific,
+    trusted legacy system that genuinely cannot be upgraded, and pair it with
+    the [permission policy](../concepts/permissions.md) to restrict which
+    commands it may run. A normal install grants this permission to no role
+    (the built-in `legacy` role is no longer created by default) and never
+    exposes those endpoints. NSClient++ logs a `SECURITY` warning at startup
+    for any role that grants `legacy`.
+<!-- @formatter:on -->
 
 Next up we need top restart NSClient++: 
 

--- a/libs/protobuf/settings.proto
+++ b/libs/protobuf/settings.proto
@@ -51,6 +51,11 @@ message SettingsRequestMessage {
 			bool recursive = 2;
 			bool include_keys = 6;
 			string default_value = 7;
+			// When set, values for keys registered sensitive (add_password /
+			// is_sensitive_key) are returned as "***". Opt-in so internal
+			// self-reads (modules loading their own secrets) still get the
+			// real value; the REST read endpoints set it, nothing else does.
+			bool redact_sensitive = 8;
 		};
 		message Update {
 			Node node = 1;
@@ -64,6 +69,8 @@ message SettingsRequestMessage {
 			bool fetch_samples = 5;
 			bool fetch_templates = 7;
 			bool descriptions = 6;
+			// See Query.redact_sensitive: mask values for sensitive keys.
+			bool redact_sensitive = 8;
 		};
 		message Control {
 			Command command = 1;

--- a/modules/WEBServer/WEBServer.cpp
+++ b/modules/WEBServer/WEBServer.cpp
@@ -75,6 +75,25 @@ class WEBServerLogger : public WebLogger {
   }
 };
 
+namespace {
+// True if a WEB role's comma-separated grant string confers the bare `legacy`
+// permission - the token the deprecated /query.pb and /query/{name}
+// query-dispatch routes check for. What matters is the permission, not the
+// role name: a custom role (e.g. `cucumber = legacy,login.get`) that includes
+// this grant is exactly as powerful as the built-in `legacy` role. We match
+// the literal token and deliberately not `*`, because a wildcard role
+// (`full`) is self-evidently all-powerful and does not need this warning.
+bool grant_confers_legacy(const std::string &grant) {
+  for (const std::string &g : str::utils::split<std::list<std::string> >(grant, ",")) {
+    const std::size_t b = g.find_first_not_of(" \t");
+    if (b == std::string::npos) continue;
+    const std::size_t e = g.find_last_not_of(" \t");
+    if (g.compare(b, e - b + 1, "legacy") == 0) return true;
+  }
+  return false;
+}
+}  // namespace
+
 WEBServer::WEBServer() : simple_plugin(), session(new session_manager_interface()), events_(new event_store()), last_log_index(0) {}
 WEBServer::~WEBServer() = default;
 
@@ -196,7 +215,13 @@ bool WEBServer::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   // RCE-equivalent). Operators who want to expose the console must grant
   // `console.exec` explicitly, normally only under the `full` role (which is
   // already a wildcard).
-  ensure_role(roles, settings, role_path, "legacy", "legacy,login.get", "legacy API");
+  // `legacy` is registered but NOT seeded (seed=false): it unlocks the
+  // deprecated /query.pb and /query/{name} routes, which dispatch through the
+  // same command registry as the versioned query API, so a `legacy` token can
+  // run any registered check/command (including configured external scripts).
+  // Fresh installs should not carry it unless an operator adds it on purpose;
+  // existing installs already have it in their config and keep working.
+  ensure_role(roles, settings, role_path, "legacy", "legacy,login.get", "legacy API", false);
   ensure_role(roles, settings, role_path, "full", "*", "Full access");
   ensure_role(roles, settings, role_path, "client",
               "public,info.get,info.get.version,queries.list,queries.get,queries.execute,aliases.list,login.get,modules.list", "read only");
@@ -222,7 +247,18 @@ bool WEBServer::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
       }
       session->add_user(o->get_alias(), o->role, o->password);
     }
-    roles.for_each([this](const std::string &name, const std::string &grant) { session->add_grant(name, grant); });
+    roles.for_each([this](const std::string &name, const std::string &grant) {
+      session->add_grant(name, grant);
+      // Warn on the dangerous *permission*, not the role name: any role whose
+      // grant includes the `legacy` token unlocks the query-dispatch routes.
+      if (grant_confers_legacy(grant)) {
+        NSC_LOG_ERROR("SECURITY: WEB role '" + name +
+                      "' grants the 'legacy' permission, which unlocks the deprecated /query.pb and /query/{name} "
+                      "endpoints. Any user with this role can run ANY registered check or command (including configured "
+                      "CheckExternalScripts commands) even without 'queries.execute'. Only grant 'legacy' to roles for "
+                      "trusted legacy systems that cannot use the versioned /api/v2/queries endpoints.");
+      }
+    });
 
     socket_helpers::validate_certificate(certificate, errors);
     NSC_LOG_ERROR_LISTS(errors);
@@ -507,6 +543,27 @@ bool WEBServer::cli_add_user(const PB::Commands::ExecuteRequestMessage::Request 
       result << "WARNING: No role specified using client" << std::endl;
       role = "client";
     }
+    // Warn on the dangerous *permission*, not the role name: resolve the
+    // assigned role's grants and warn if it confers `legacy` (a custom role
+    // that includes that grant is exactly as powerful as the built-in one).
+    {
+      const std::string roles_path = "/settings/WEB/server/roles";
+      pf::settings_query rq(get_id());
+      rq.get(roles_path, role, "");
+      get_core()->settings_query(rq.request(), rq.response());
+      if (rq.validate_response()) {
+        for (const pf::settings_query::key_values &val : rq.get_query_key_response()) {
+          if (val.matches(roles_path, role) && grant_confers_legacy(val.get_string())) {
+            result << "WARNING: role '" << role
+                   << "' grants the 'legacy' permission, which unlocks the deprecated /query.pb and /query/{name} "
+                      "endpoints. A user with it can run any registered check or command (including any configured "
+                      "external scripts) even without 'queries.execute'. Only use it for a trusted legacy system that "
+                      "cannot use the versioned /api/v2/queries endpoints."
+                   << std::endl;
+          }
+        }
+      }
+    }
 
     // Hash the per-user password before persisting. The /settings/default
     // password (shared with NRPE / NSCA / NSClient) is untouched - those
@@ -596,6 +653,12 @@ bool WEBServer::cli_add_role(const PB::Commands::ExecuteRequestMessage::Request 
     result << "Role " << role << std::endl;
     for (const std::string &g : str::utils::split<std::list<std::string> >(grant, ",")) {
       result << " " << g << std::endl;
+    }
+    if (grant_confers_legacy(grant)) {
+      result << "WARNING: this role grants the 'legacy' permission, which unlocks the deprecated /query.pb and "
+                "/query/{name} endpoints. A user with it can run any registered check or command (including any "
+                "configured external scripts) even without 'queries.execute'. Only use it for trusted legacy systems."
+             << std::endl;
     }
     s.set(path, role, grant);
     s.save();
@@ -908,7 +971,7 @@ void WEBServer::add_user(const std::string &key, const std::string &arg) {
 }
 
 void WEBServer::ensure_role(role_map &roles, const nscapi::settings_helper::settings_registry &settings, const std::string &role_path, const std::string &role,
-                            const std::string &value, const std::string &reason) {
+                            const std::string &value, const std::string &reason, bool seed) {
   // Register the schema every load so the role key carries plugin attribution
   // and type info in the inventory. Without this, restarts after the first
   // boot leave the role as an unregistered raw INI entry: parse_inventory's
@@ -916,7 +979,13 @@ void WEBServer::ensure_role(role_map &roles, const nscapi::settings_helper::sett
   // service/settings_query_handler.cpp). Only the value-seeding stays gated
   // so we don't overwrite operator-customized grants.
   settings.register_key_string(role_path, role, "Role for " + reason, "Default role for " + reason, value);
-  if (!roles.contains(role)) {
+  // `seed == false` registers the schema but does not create the role on a
+  // fresh install. Used for `legacy`, which is powerful (it unlocks the
+  // deprecated /query.pb and /query/{name} query-dispatch endpoints) and
+  // should not exist unless an operator adds it deliberately. Existing
+  // installs already carry the role in their config, so `roles` contains it
+  // by the time this runs and they keep working unchanged.
+  if (seed && !roles.contains(role)) {
     roles.add(role, value);
     settings.set_static_key(role_path, role, value);
   }

--- a/modules/WEBServer/WEBServer.h
+++ b/modules/WEBServer/WEBServer.h
@@ -28,7 +28,7 @@ class WEBServer : public nscapi::impl::simple_plugin {
   bool loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode);
 
   void ensure_role(role_map &roles, const nscapi::settings_helper::settings_registry &settings, const std::string &role_path, const std::string &role,
-                   const std::string &value, const std::string &reason);
+                   const std::string &value, const std::string &reason, bool seed = true);
   void ensure_user(const nscapi::settings_helper::settings_registry &settings, const std::string &path, const std::string &user, const std::string &role,
                    const std::string &value, const std::string &reason);
 

--- a/modules/WEBServer/settings_controller.cpp
+++ b/modules/WEBServer/settings_controller.cpp
@@ -39,6 +39,8 @@ void settings_controller::get(Mongoose::Request &request, boost::smatch &what, M
   payload->mutable_query()->mutable_node()->set_path(path);
   payload->mutable_query()->set_recursive(true);
   payload->mutable_query()->set_include_keys(true);
+  // REST read: mask values for keys registered sensitive, matching /diff.
+  payload->mutable_query()->set_redact_sensitive(true);
   payload->set_plugin_id(plugin_id);
 
   std::string str_response;
@@ -85,6 +87,7 @@ void settings_controller::get_desc(Mongoose::Request &request, boost::smatch &wh
   payload_1->mutable_inventory()->set_fetch_paths(true);
   payload_1->mutable_inventory()->set_fetch_keys(true);
   payload_1->mutable_inventory()->set_fetch_samples(request.get_bool("samples", false));
+  payload_1->mutable_inventory()->set_redact_sensitive(true);
   payload_1->set_plugin_id(plugin_id);
 
   std::string str_response_1;
@@ -111,6 +114,7 @@ void settings_controller::get_desc(Mongoose::Request &request, boost::smatch &wh
     payload_2->mutable_query()->mutable_node()->set_path(path);
     payload_2->mutable_query()->set_recursive(true);
     payload_2->mutable_query()->set_include_keys(true);
+    payload_2->mutable_query()->set_redact_sensitive(true);
     payload_2->set_plugin_id(plugin_id);
 
     std::string str_response_2;

--- a/service/settings_client.cpp
+++ b/service/settings_client.cpp
@@ -187,6 +187,21 @@ int nsclient_core::settings_client::migrate_layout(const std::string &mode, cons
   }
   return -1;
 }
+namespace {
+// Mask values for keys registered sensitive (add_password / is_sensitive_key)
+// so a shared `--list` dump or an accidental `--show` does not spill secrets.
+// `--list`/`--show` are local tools, so this is defence-in-depth (the caller
+// can still read nsclient.ini), and it keeps CLI output consistent with the
+// masking the REST read paths and /diff already apply. Only keys whose module
+// registered them sensitive are masked; an unknown backend returns false.
+std::string redacted_for_display(settings::settings_core *core, const std::string &path, const std::string &key, const std::string &value) {
+  try {
+    if (core->is_sensitive_key(path, key)) return "***";
+  } catch (...) {
+  }
+  return value;
+}
+}  // namespace
 
 void nsclient_core::settings_client::dump_path(std::string root) {
   for (const std::string &path : get_core()->get()->get_sections(root)) {
@@ -198,7 +213,7 @@ void nsclient_core::settings_client::dump_path(std::string root) {
   }
   for (std::string key : get_core()->get()->get_keys(root)) {
     settings::settings_interface::op_string val = get_core()->get()->get_string(root, key);
-    if (val) std::cout << root << "." << key << "=" << *val << std::endl;
+    if (val) std::cout << root << "." << key << "=" << redacted_for_display(get_core(), root, key, *val) << std::endl;
   }
 }
 
@@ -246,7 +261,7 @@ int nsclient_core::settings_client::show(std::string path, std::string key) {
     list_settings_context_info(2, settings_manager::get_settings());
   else {
     settings::settings_interface::op_string val = get_core()->get()->get_string(path, key);
-    if (val) std::cout << *val;
+    if (val) std::cout << redacted_for_display(get_core(), path, key, *val);
   }
   return 0;
 }

--- a/service/settings_query_handler.cpp
+++ b/service/settings_query_handler.cpp
@@ -116,7 +116,7 @@ void settings_query_handler::parse_inventory(const PB::Settings::SettingsRequest
             rpp->mutable_info()->set_sample(desc.is_sample);
             rpp->mutable_info()->set_default_value(desc.default_value);
             settings::settings_interface::op_string val = settings_manager::get_settings()->get_string(path, key);
-            if (val) rpp->mutable_node()->set_value(*val);
+            if (val) rpp->mutable_node()->set_value(redact_value(path, key, *val, q.redact_sensitive()));
             settings_add_plugin_data(desc.plugins, rpp->mutable_info());
           }
           if (!plugin_id) {
@@ -133,7 +133,7 @@ void settings_query_handler::parse_inventory(const PB::Settings::SettingsRequest
                 rpp->mutable_info()->set_sample(false);
                 rpp->mutable_info()->set_default_value("");
                 settings::settings_interface::op_string val = settings_manager::get_settings()->get_string(path, key);
-                if (val) rpp->mutable_node()->set_value(*val);
+                if (val) rpp->mutable_node()->set_value(redact_value(path, key, *val, q.redact_sensitive()));
               }
             }
           }
@@ -177,7 +177,7 @@ void settings_query_handler::parse_inventory(const PB::Settings::SettingsRequest
           rpp->mutable_info()->set_sample(desc.is_sample);
           rpp->mutable_info()->set_default_value(desc.default_value);
           try {
-            rpp->mutable_node()->set_value(settings_manager::get_settings()->get_string(path, key, ""));
+            rpp->mutable_node()->set_value(redact_value(path, key, settings_manager::get_settings()->get_string(path, key, ""), q.redact_sensitive()));
           } catch (settings::settings_exception &) {
           }
           settings_add_plugin_data(desc.plugins, rpp->mutable_info());
@@ -195,7 +195,7 @@ void settings_query_handler::parse_inventory(const PB::Settings::SettingsRequest
               rpp->mutable_info()->set_advanced(true);
               rpp->mutable_info()->set_sample(false);
               settings::settings_interface::op_string val = settings_manager::get_settings()->get_string(path, key);
-              if (val) rpp->mutable_node()->set_value(*val);
+              if (val) rpp->mutable_node()->set_value(redact_value(path, key, *val, q.redact_sensitive()));
             }
           }
         }
@@ -231,8 +231,17 @@ void settings_query_handler::parse_inventory(const PB::Settings::SettingsRequest
   }
 }
 
+std::string settings_query_handler::redact_value(const std::string &path, const std::string &key, const std::string &value, bool redact) {
+  if (!redact || value.empty() || key.empty()) return value;
+  try {
+    if (settings_manager::get_core()->is_sensitive_key(path, key)) return "***";
+  } catch (...) {
+  }
+  return value;
+}
+
 void settings_query_handler::recurse_find(PB::Settings::SettingsResponseMessage::Response::Query *rpp, const std::string base_path, bool recurse,
-                                          bool fetch_keys) {
+                                          bool fetch_keys, bool redact) {
   std::string path = base_path;
   if (base_path.size() > 1 && base_path[base_path.size() - 1] == '/') {
     path = base_path.substr(0, base_path.size() - 1);
@@ -244,7 +253,7 @@ void settings_query_handler::recurse_find(PB::Settings::SettingsResponseMessage:
       node->set_path(child_path);
     }
     if (recurse) {
-      recurse_find(rpp, child_path, true, fetch_keys);
+      recurse_find(rpp, child_path, true, fetch_keys, redact);
     }
   }
   if (fetch_keys) {
@@ -252,7 +261,7 @@ void settings_query_handler::recurse_find(PB::Settings::SettingsResponseMessage:
       PB::Settings::Node *node = rpp->add_nodes();
       node->set_path(path);
       node->set_key(key);
-      node->set_value(settings_manager::get_settings()->get_string(path, key, ""));
+      node->set_value(redact_value(path, key, settings_manager::get_settings()->get_string(path, key, ""), redact));
     }
   }
 }
@@ -262,9 +271,10 @@ void settings_query_handler::parse_query(const PB::Settings::SettingsRequestMess
   rpp->mutable_node()->CopyFrom(q.node());
   if (!q.node().key().empty()) {
     std::string def = q.default_value().empty() ? "" : q.default_value();
-    rpp->mutable_node()->set_value(settings_manager::get_settings()->get_string(q.node().path(), q.node().key(), def));
+    rpp->mutable_node()->set_value(
+        redact_value(q.node().path(), q.node().key(), settings_manager::get_settings()->get_string(q.node().path(), q.node().key(), def), q.redact_sensitive()));
   } else {
-    recurse_find(rpp, q.node().path(), q.recursive(), q.include_keys());
+    recurse_find(rpp, q.node().path(), q.recursive(), q.include_keys(), q.redact_sensitive());
   }
   rp->mutable_result()->set_code(PB::Common::Result_StatusCodeType_STATUS_OK);
 }

--- a/service/settings_query_handler.hpp
+++ b/service/settings_query_handler.hpp
@@ -33,7 +33,11 @@ class settings_query_handler {
   void parse_diff(const PB::Settings::SettingsRequestMessage::Request::Diff &q, PB::Settings::SettingsResponseMessage::Response *rp);
 
  private:
-  void recurse_find(PB::Settings::SettingsResponseMessage::Response::Query *rpp, const std::string base, bool recurse, bool fetch_keys);
+  void recurse_find(PB::Settings::SettingsResponseMessage::Response::Query *rpp, const std::string base, bool recurse, bool fetch_keys, bool redact);
+  // Returns "***" for a non-empty value whose key is registered sensitive
+  // when redact is set, otherwise the value unchanged. Mirrors parse_diff's
+  // masking so every read path treats sensitive keys the same way.
+  static std::string redact_value(const std::string &path, const std::string &key, const std::string &value, bool redact);
   void settings_add_plugin_data(const std::set<unsigned int> &plugins, PB::Settings::Information *info);
   logging::logger_instance get_logger() const { return logger_; }
 };

--- a/tests/rest-settings.test.ts
+++ b/tests/rest-settings.test.ts
@@ -141,4 +141,42 @@ describe("REST settings controller", () => {
         .expect(400);
     });
   });
+
+  // /settings/default/password is registered sensitive by WEBServer
+  // (add_password) and the fixture pins it to "default-password". The read
+  // paths must mask it to "***" the way /diff already does, while leaving a
+  // non-sensitive sibling key (allowed hosts) untouched. Guards the
+  // settings.get -> plaintext-secret disclosure.
+  describe("sensitive values are redacted on read", () => {
+    it("GET masks a sensitive key but not its neighbours", async () => {
+      await request(REST_URL)
+        .get("/api/v2/settings/settings/default")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(200)
+        .then((response) => {
+          const password = response.body.find((n: { key: string }) => n.key === "password");
+          expect(password).toBeDefined();
+          expect(password.value).toEqual("***");
+          expect(password.value).not.toContain("default-password");
+
+          const hosts = response.body.find((n: { key: string }) => n.key === "allowed hosts");
+          expect(hosts).toBeDefined();
+          expect(hosts.value).toEqual("127.0.0.1,::1");
+        });
+    });
+
+    it("GET /descriptions masks a sensitive key", async () => {
+      await request(REST_URL)
+        .get("/api/v2/settings/descriptions/settings/default")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(200)
+        .then((response) => {
+          const password = response.body.find((n: { key: string }) => n.key === "password");
+          expect(password).toBeDefined();
+          expect(password.value).not.toContain("default-password");
+        });
+    });
+  });
 });

--- a/web/src/components/atoms/SettingsDialog.tsx
+++ b/web/src/components/atoms/SettingsDialog.tsx
@@ -39,12 +39,20 @@ export default function SettingsDialog({ onClose, path, keyName, value, descript
     setNewValue(value);
   }, [value]);
 
+  // Only write when the value actually changed. Re-saving an unchanged value
+  // is at best a spurious write that dirties the settings store, and — once
+  // sensitive values are returned redacted ("***") — it would clobber the real
+  // stored secret with the mask. "No change" therefore means "nothing to do".
+  const dirty = newValue !== value;
+
   const onHandleSave = async () => {
-    await saveSettings({
-      path,
-      key: keyName,
-      value: newValue,
-    }).unwrap();
+    if (dirty) {
+      await saveSettings({
+        path,
+        key: keyName,
+        value: newValue,
+      }).unwrap();
+    }
     onClose();
   };
 
@@ -80,7 +88,7 @@ export default function SettingsDialog({ onClose, path, keyName, value, descript
       </DialogContent>
       <DialogActions>
         <Button onClick={onClose}>Cancel</Button>
-        <Button onClick={onHandleSave} autoFocus>
+        <Button onClick={onHandleSave} disabled={!dirty} autoFocus>
           Update
         </Button>
       </DialogActions>


### PR DESCRIPTION
Two Medium security-hardening items, both reported by [yagust](https://github.com/yagust) and handled as defense-in-depth (advisories closed, no CVE). Consolidated into one branch since there's no embargo.

## 1. Sensitive settings values redacted on read
The settings read paths — `GET /api/v2/settings/...`, `/descriptions`, and `nscp settings --list` / `--show` — returned values for keys registered sensitive in clear text, while `diff` already masked them. They now return `***`, via an opt-in `redact_sensitive` flag the REST read endpoints set; internal reads a module makes of its own config are unaffected (so auth keeps working). The web admin edit dialog now writes only changed fields, so redaction can't overwrite a stored secret with the mask on an unedited re-save.

## 2. Legacy WEB permission flagged, no longer seeded by default
The `legacy` grant unlocks the deprecated `/query.pb` and `/query/{name}` endpoints, which dispatch through the same command registry as `/api/v2/queries` — so a token with `legacy` can run any registered check/command (including configured external scripts) without `queries.execute`. This is intended compatibility behaviour, but under-documented. The built-in `legacy` role is no longer seeded on fresh installs (existing installs unaffected), a `SECURITY` warning is logged for any role whose grant includes the `legacy` token (keyed on the permission, so custom roles are caught too; `*`/`full` is not), and the capability is documented in the securing/web-interface guides.

## Docs
Both are recorded in `docs/docs/security/notices.md` (Hardening changes) and `docs/docs/setup/upgrading.md` (Unreleased), crediting yagust.

## Verification
- Built `nscp_protobuf`, `nscp`, `WEBServer` (RelWithDebInfo) — clean.
- `rest-settings`, `rest-permissions`, `rest-log`, `rest-aliases-v2` — 40/40 pass.

Supersedes the two private-fork PRs (GHSA-3jgm-2x47-rj62 #1, GHSA-p3x6-xgqq-gj45 #1), which can be closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)