### PR TITLE
docs: restructure the upgrading page by impact and fix attribution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,8 +173,24 @@ Release notes live on GitHub and get buried over time, so two docs pages mirror
 them durably. Whenever a change introduces a **breaking change, a behaviour
 change that needs operator action, or a new/removed default**, add a
 newest-first entry to `docs/docs/setup/upgrading.md` (the same content as the
-release's `## Upgrade notes`). Whenever a change is **security-relevant** —
-including hardening handled without a CVE — also add an entry to
+release's `## Upgrade notes`). Each release there is split into `### Requires
+action`, `### Changes behaviour (no action)` and `### New and opt-in (no
+action)`: file the item by what an existing install has to *do* about it, not by
+how large the change is, and add only the headings that release actually needs.
+A new module or a setting that defaults to the old behaviour belongs under
+*New and opt-in*, however important it is. Keep an item to one change: split a
+compound entry so each half can be filed where it belongs. Start each item with
+the module, setting or command it concerns so a reader can find everything
+touching their configuration by searching for its name, and lead it with an
+area icon (🔒 security, 🔧 settings/CLI, 📊 perfdata, 📁 paths, 🧩 modules, …),
+reusing one already on the page rather than inventing another. Each item appears **once**, under the
+release that introduced the change — pre-releases included, since those get
+installed too. Do not repeat it in a later release that merely re-announced it,
+and when in doubt establish the release from the commit
+(`git log -S<setting> …`, then `git tag --contains <commit>`) rather than from
+the release notes, which have aggregated items into later releases before.
+Whenever a change is **security-relevant** — including hardening handled
+without a CVE — also add an entry to
 `docs/docs/security/notices.md` (under "Published advisories" if it carries a
 CVE/GHSA, otherwise under "Hardening changes (no CVE)"), and mark the matching
 `upgrading.md` item with a 🔒 that links to it. For an embargoed fix, add these

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -1,44 +1,41 @@
 # Upgrading
 
-What to do when upgrading NSClient++, newest release first. Most upgrades are
-in place — defaults are preserved and the default install is usually unaffected
-— but the items below change observable behaviour or want a configuration
-touch. Read the entries between the version you are on and the version you are
-moving to.
+What to do when upgrading NSClient++, newest release first. Read the entries
+between the version you are on and the version you are moving to. Most upgrades
+are in place — defaults are preserved and the default install is usually
+unaffected.
 
-Each entry carries an icon for the area it touches. 🔒 is the one that
-matters: those entries are security-relevant, and the
-[Security notices](../security/notices.md) page tracks them in one place. Full
-per-release detail lives in each
+Every release is split by how much it asks of you, so you can stop reading at
+the point where a section stops applying:
+
+| Section | What it means |
+|---|---|
+| **Requires action** | An existing install needs a change from you — a setting to add, a threshold, client or alert to review. Every item names its condition up front, so skip the ones that do not apply. |
+| **Changes behaviour (no action)** | Something observable changed, but the upgrade is in place. Read it if output, perfdata or alerting looks different afterwards. |
+| **New and opt-in (no action)** | Additions that stay off until you turn them on. Nothing breaks if you skip the section entirely. |
+
+Each item appears **once**, under the release that actually introduced it —
+including the releases marked as pre-releases, since those are installed too. A
+section is omitted when a release has nothing under it, and a release with no
+upgrade-relevant change is not listed at all. **Skipping several versions?**
+Read every *Requires action* section between your version and your target
+first — together they are the complete list of things that will not sort
+themselves out. Each item starts with the module, setting or command it
+concerns, so searching this page for the name of something you have configured
+finds everything that touches it.
+
+Each entry carries an icon for the area it touches; 🔒 is the one that matters —
+those entries are security-relevant, and where a notice exists the item links to
+it on the [Security notices](../security/notices.md) page, which tracks them in
+one place. Full per-release detail lives in each
 [GitHub release](https://github.com/mickem/nscp/releases).
 
 ---
 
 ## 0.18.1
 
-- 🔒 **Icinga API submissions now honour the configured `timeout`, and
-  credentials no longer reach the trace log.** The `IcingaClient` module's
-  HTTP calls previously waited forever — the target's `timeout` setting
-  (default 30 s) was read but never applied — so a stalled Icinga endpoint
-  could silently wedge passive-result submission; set `timeout = 0` on the
-  target if you depend on the old unbounded wait. The same pass masked
-  `password`/`token` values in the trace-level target dump (this also covers
-  the other client modules sharing that machinery) and added a log message
-  when an `https` submission runs with certificate verification disabled
-  (`verify mode` empty or `none`). See
-  [Security notices](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
-- 🔒 **Filter expressions are now bounded in length and nesting depth.** A
-  `filter` / `warning` / `critical` expression — and a `%(...)` expression
-  placeholder inside a syntax template — longer than **1024 characters** or
-  nested more than **64** parentheses deep is now rejected at parse time
-  instead of being evaluated, failing with a clear "exceeds the maximum
-  length/depth" error. The where-parser and the expression evaluator both
-  recurse with the shape of the input, so an unbounded or deeply nested
-  expression could exhaust the stack and crash the agent. Real filters are a
-  small fraction of these limits, so the default install and every normal
-  configuration are unaffected — only a pathologically large or deeply nested
-  expression is refused. See the
-  [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
+### Requires action
+
 - 🔒 **CheckExternalScripts hardening.** A hardening pass over the external
   scripts module tightened several rough edges: the `ext-scr install` argument
   lockdown now writes to the setting the module actually reads (previously it
@@ -80,33 +77,10 @@ per-release detail lives in each
   builds compiled without crypto++, where any cipher name previously
   degraded to plaintext and the server now refuses to start.
   See the [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
-- 🔒 **NSCA hardening: empty-password warning, `performance data = false`
-  honoured, wire-field validation.** Enabling NSCA encryption with an empty
-  `password` now logs an error on both ends (the password *is* the key, so an
-  empty one is a well-known key) — set the same password on both ends to
-  clear it. `NSCAServer`'s `performance data = false` now actually strips
-  perfdata from forwarded submissions (it was silently ignored). Inbound
-  host/service names are stripped of control characters and out-of-range
-  status codes are clamped to UNKNOWN. No action needed on a default install.
-  See the [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
-- 🔒 **NRDP submissions now honour `timeout` and `retry`.** Both settings were
-  parsed but never applied: a submission to a server that accepted the
-  connection and then stalled hung the submission thread forever, and failed
-  submissions were never retried. Every step of the exchange (connect, TLS
-  handshake, proxy tunnel, request, response) now runs under the configured
-  `timeout` (default 30 seconds for configured targets, 10 for one-shot
-  `nscp client` submissions), and transport failures are retried up to `retry`
-  times. Nothing to do unless your NRDP endpoint legitimately takes longer
-  than the timeout to answer — raise `timeout` on that target. The response
-  body is also capped at 5 MB, far above any real NRDP reply. See the
-  [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
-- 🔒 **A `tls version` with a trailing `+` now means "that version or later".**
-  `1.2+` (the common default) previously negotiated TLS 1.2 *only*; it now
-  also permits TLS 1.3, and `any` is accepted as the documentation always
-  claimed. This applies everywhere the setting exists: NRDP and the other
-  HTTP-based clients, the NRPE/NSCA clients and servers, and `check_tcp`.
-  No action needed; pin an exact version (`tls version = 1.2`) if a peer
-  misbehaves when TLS 1.3 is offered. See the
+- 🔒 **NSCA encryption with an empty `password` now logs an error on both
+  ends.** The password *is* the key, so an empty one is a well-known key: set
+  the same non-empty password on both ends to clear the message, or set
+  `encryption = none` if plaintext was what you wanted. See the
   [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
 - 🔒 **The Elastic module now verifies HTTPS server certificates and can
   authenticate.** `ElasticClient` previously hardcoded TLS verification off;
@@ -169,6 +143,68 @@ per-release detail lives in each
       spaces (previously only CR, LF and NUL), so check output cannot smuggle
       ANSI escape sequences into the receiver's log.
 
+### Changes behaviour (no action)
+
+- 🔒 **Icinga API submissions now honour the configured `timeout`, and
+  credentials no longer reach the trace log.** The `IcingaClient` module's
+  HTTP calls previously waited forever — the target's `timeout` setting
+  (default 30 s) was read but never applied — so a stalled Icinga endpoint
+  could silently wedge passive-result submission; set `timeout = 0` on the
+  target if you depend on the old unbounded wait. The same pass masked
+  `password`/`token` values in the trace-level target dump (this also covers
+  the other client modules sharing that machinery) and added a log message
+  when an `https` submission runs with certificate verification disabled
+  (`verify mode` empty or `none`). See
+  [Security notices](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
+- 🔒 **Filter expressions are now bounded in length and nesting depth.** A
+  `filter` / `warning` / `critical` expression — and a `%(...)` expression
+  placeholder inside a syntax template — longer than **1024 characters** or
+  nested more than **64** parentheses deep is now rejected at parse time
+  instead of being evaluated, failing with a clear "exceeds the maximum
+  length/depth" error. The where-parser and the expression evaluator both
+  recurse with the shape of the input, so an unbounded or deeply nested
+  expression could exhaust the stack and crash the agent. Real filters are a
+  small fraction of these limits, so the default install and every normal
+  configuration are unaffected — only a pathologically large or deeply nested
+  expression is refused. See the
+  [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
+- 🔒 **NSCA: `performance data = false` is honoured, and inbound fields are
+  validated.** `NSCAServer`'s `performance data = false` now actually strips
+  perfdata from forwarded submissions (it was silently ignored); inbound
+  host/service names are stripped of control characters, and out-of-range
+  status codes are clamped to UNKNOWN. No action needed on a default install.
+  See the [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
+- 🔒 **NRDP submissions now honour `timeout` and `retry`.** Both settings were
+  parsed but never applied: a submission to a server that accepted the
+  connection and then stalled hung the submission thread forever, and failed
+  submissions were never retried. Every step of the exchange (connect, TLS
+  handshake, proxy tunnel, request, response) now runs under the configured
+  `timeout` (default 30 seconds for configured targets, 10 for one-shot
+  `nscp client` submissions), and transport failures are retried up to `retry`
+  times. Nothing to do unless your NRDP endpoint legitimately takes longer
+  than the timeout to answer — raise `timeout` on that target. The response
+  body is also capped at 5 MB, far above any real NRDP reply. See the
+  [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
+- 🔒 **A `tls version` with a trailing `+` now means "that version or later".**
+  `1.2+` (the common default) previously negotiated TLS 1.2 *only*; it now
+  also permits TLS 1.3, and `any` is accepted as the documentation always
+  claimed. This applies everywhere the setting exists: NRDP and the other
+  HTTP-based clients, the NRPE/NSCA clients and servers, and `check_tcp`.
+  No action needed; pin an exact version (`tls version = 1.2`) if a peer
+  misbehaves when TLS 1.3 is offered. See the
+  [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
+- 🔒 ✉️ **SMTP: a server's reply text is scrubbed and bounded before it reaches
+  the log.** Replies quoted into the agent log and the submit response are
+  reduced to printable US-ASCII, a multi-line reply is joined into one log
+  line, and an oversized one is truncated — a hostile relay could otherwise
+  aim terminal escapes at whoever tails the log, or forge extra log lines. How
+  much a server can make the client buffer is capped as well (64 KB per line,
+  100 lines), so a peer that never terminates a line now fails the submission
+  instead of exhausting memory inside the timeout window. Two stricter checks
+  ride along: the reply to `STARTTLS` must be exactly `220`, and AUTH
+  credentials containing a NUL byte are refused before connecting. Nothing to
+  do; a relay whose replies carry non-ASCII text will show `?` in their place.
+  See the [security notice](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
 - ⏱️ **The Graphite `timeout` is now enforced — as a budget for the whole
   submission.** It was doubly dead before: the value the operator configured
   never reached the connection (the lookup read a map the well-known `timeout`
@@ -181,6 +217,12 @@ per-release detail lives in each
   previously completed by quietly taking longer will now fail at the
   configured value; raise `timeout` on targets talking to a slow relay. See
   [Security notices](../security/notices.md#security-hardening-across-the-clients-scripts-and-filter-framework).
+- 🔊 **Graphite: a failed metrics submission is logged instead of being
+  dropped.** The metrics flush discarded the send result, so a failure — now
+  including the submission timeout above — was invisible and metrics simply
+  stopped arriving. It is logged at error level naming the target and the
+  reason (`Failed to submit metrics to <target>: …`). If you alert on the
+  agent log, expect that line from a Graphite target that cannot be reached.
 - 🧹 **The Graphite `retry` setting is not honoured and is no longer read.**
   The module always made exactly one attempt per submission; reading the value
   made it look otherwise, and a retry loop would multiply the worst-case time
@@ -189,9 +231,9 @@ per-release detail lives in each
   still appear in the GraphiteClient reference, but `GraphiteClient` does not
   act on them. Mirrors the SMTP `retry` change in 0.18.0.
 
----
-
 ## 0.18.0
+
+### Requires action
 
 - 💥 **`check_nscp` is now a filter check, and it can see crash reports again.**
   Crash reporting itself has always worked — the agent has archived crash
@@ -240,7 +282,6 @@ per-release detail lives in each
   `"crit=crash_age < 7d"`) if you only care about recent crashes, or clean the
   folder out. Crash reports remain a Windows-only concept; on Linux there is no
   crash handler, so `crashes` is always 0.
-
 - 📤 **`check_and_forward` now actually submits the result.** The command ran the
   wrapped check, answered `Message submitted` and delivered nothing: the
   submission was built in a form the channels could not read, so NSCA, NRDP,
@@ -268,38 +309,6 @@ per-release detail lives in each
     command now reports that failure instead of `Message submitted` — including
     when only one channel of a comma list (`channel=NSCA,GRAPHITE`) fails,
     which previously was silently reported as success.
-
-- ⚙️ **A reload now loads modules enabled in an included file since the last one.**
-  An `[/includes]` file is read once when the configuration is loaded and served
-  from memory after that, so a module switched on in one — most importantly
-  `fleet.ini`, which the fleet sync rewrites whenever a bundle changes — was not
-  actually loaded until the service next restarted. Nothing said so: the file on
-  disk was right and a fleet host reported itself in sync, while the module
-  quietly did nothing. The visible case was a fleet bundle turning on
-  `NRDPClient` and `Scheduler` to start passive submissions, which then never
-  arrived. A reload now re-reads the included files first, so settings changed
-  in them take effect and newly enabled modules are loaded; modules already
-  running are left alone. Two things are unchanged: a module *disabled* since
-  the last load keeps running until the service restarts, and `[/modules]` in
-  the main `nsclient.ini` is still only read at startup.
-- 📅 **New: run scheduled checks on demand with `run_schedules`.** After editing
-  `nsclient.ini` you no longer have to wait out the interval to see the new
-  result on the monitoring server — `nscp client --boot --query run_schedules`
-  (optionally `--argument schedule=<alias>`) runs the configured schedules now
-  and submits their results on their normal channel. It is a regular check
-  command, so it also works over NRPE, REST and in `nscp test`. Nothing changes
-  for existing configurations; the timers are untouched. See
-  [Passive monitoring → Step 6](../scenarios/passive-monitoring-nsca.md#step-6-send-a-result-without-waiting-for-the-interval).
-- 🚫 **A denied check is no longer submitted as a passive result.** The permission
-  layer answers a denied query as a *successful* query carrying an UNKNOWN
-  "Permission denied" payload, and both `run_schedules` and `check_and_forward`
-  forwarded that to the monitoring server — overwriting the last real result
-  for that service while telling the caller it had succeeded. Both now refuse
-  with `Permission denied: not allowed to run <command>, nothing was
-  submitted` and touch no channel. If you restrict what a REST or NRPE identity
-  may run, expect the denial as an error where you previously saw a stale
-  UNKNOWN appear on the server. See
-  [Permissions](../concepts/permissions.md).
 - 🔧 **`settings --update --add-defaults --use-samples` now writes the sample
   objects.** The flag was parsed and never read, so it behaved exactly like the
   plain invocation. It now writes the registered `/sample` sections, and
@@ -308,15 +317,6 @@ per-release detail lives in each
   output is byte-for-byte what it was. If you have scripted
   `--add-defaults --use-samples` expecting today's (sample-free) output, drop
   the flag.
-- 💬 **`nscp client --query <cmd>` no longer appends "No module was specified…".**
-  The line was appended to every result when no `--module` was named. Scripts
-  that stripped or matched it can stop; naming a module is unchanged.
-- 🔧 **Settings writes work again when `[/includes]` names a directory.** Saving
-  handed the directory path to the INI writer, and the resulting "Is a
-  directory" error aborted the whole save — so `nscp settings --set` and the
-  web UI failed *and the main file was never written*. Directory includes are
-  read-only by nature and are now skipped when saving. If you worked around
-  this by removing a directory include, you can put it back.
 - 🔒 **NRDP HTTPS submissions now verify the server certificate by default on
   the `nscp client`/REST path.** Previously an `https://` submission made that
   way with no `verify mode` set trusted any certificate silently (configured
@@ -356,6 +356,45 @@ per-release detail lives in each
   one-shot command line, or a default target — falls back to the same bundle,
   resolved once at module load, so no submission path is left on OpenSSL's
   built-in verify paths by accident.
+- 🔒 **WEB: a script or module name that begins with `-` is now rejected.**
+  Rename it; interior dashes are fine. The legacy `POST /auth/logout` route
+  now enforces `allowed hosts` like the rest of the API as well, so a caller
+  outside the perimeter gets 403. See the [security notice](../security/notices.md#web-server-security-hardening).
+
+### Changes behaviour (no action)
+
+- ⚙️ **A reload now loads modules enabled in an included file since the last one.**
+  An `[/includes]` file is read once when the configuration is loaded and served
+  from memory after that, so a module switched on in one — most importantly
+  `fleet.ini`, which the fleet sync rewrites whenever a bundle changes — was not
+  actually loaded until the service next restarted. Nothing said so: the file on
+  disk was right and a fleet host reported itself in sync, while the module
+  quietly did nothing. The visible case was a fleet bundle turning on
+  `NRDPClient` and `Scheduler` to start passive submissions, which then never
+  arrived. A reload now re-reads the included files first, so settings changed
+  in them take effect and newly enabled modules are loaded; modules already
+  running are left alone. Two things are unchanged: a module *disabled* since
+  the last load keeps running until the service restarts, and `[/modules]` in
+  the main `nsclient.ini` is still only read at startup.
+- 🚫 **A denied check is no longer submitted as a passive result.** The permission
+  layer answers a denied query as a *successful* query carrying an UNKNOWN
+  "Permission denied" payload, and both `run_schedules` and `check_and_forward`
+  forwarded that to the monitoring server — overwriting the last real result
+  for that service while telling the caller it had succeeded. Both now refuse
+  with `Permission denied: not allowed to run <command>, nothing was
+  submitted` and touch no channel. If you restrict what a REST or NRPE identity
+  may run, expect the denial as an error where you previously saw a stale
+  UNKNOWN appear on the server. See
+  [Permissions](../concepts/permissions.md).
+- 💬 **`nscp client --query <cmd>` no longer appends "No module was specified…".**
+  The line was appended to every result when no `--module` was named. Scripts
+  that stripped or matched it can stop; naming a module is unchanged.
+- 🔧 **Settings writes work again when `[/includes]` names a directory.** Saving
+  handed the directory path to the INI writer, and the resulting "Is a
+  directory" error aborted the whole save — so `nscp settings --set` and the
+  web UI failed *and the main file was never written*. Directory includes are
+  read-only by nature and are now skipped when saving. If you worked around
+  this by removing a directory include, you can put it back.
 - 🔒 **SMTP client security hardening.** The same pass closed a set of
   trust gaps in `SMTPClient`: data pipelined into the STARTTLS greeting is
   refused rather than trusted as post-handshake input, the EHLO name is
@@ -376,35 +415,23 @@ per-release detail lives in each
   made it look otherwise. `retry`/`retries` are registered for every client
   module centrally, so they still appear in the SMTPClient reference, but
   `SMTPClient` does not act on them.
-
----
-
-- 🔒 **NRPE hardening: a new `expose version` setting, and the metachar
-  guard now also checks decoded input.** Nothing to do on a default install.
-  Two things are worth knowing. `NRPEServer` gained `expose version` (default
-  `true`, which keeps the legacy banner `check_nrpe` expects); set it to
-  `false` to answer the unauthenticated `_NRPE_CHECK` ping with a generic
-  message instead of the exact build. And `allow nasty characters = false` now
-  re-checks the *decoded* command and arguments, not just the raw wire bytes —
-  with a non-UTF-8 `encoding` set, a multi-byte sequence could previously
-  decode into a metacharacter that was never literally on the wire, so a
-  request the guard was always meant to block may now be rejected. Separately,
-  `nscp nrpe install` reads the stored `verify mode` again instead of silently
-  resetting it on a re-run.
-  See the [security notice](../security/notices.md#nrpe-decoded-argument-metachar-guard-optional-version-banner-and-consistency-fixes).
-- 🔒 **WEB server security hardening.** A review of the `WEBServer`
-  module produced several defense-in-depth fixes (session tokens now come from
-  the OpenSSL CSPRNG, cookie-name matching requires a name boundary, the
-  installer refuses an HTTPS→HTTP redirect, and the `legacy` grant's startup
-  warning now names `/settings/query.pb`). The default install needs no
-  action. Two changes touch observable behaviour: a script or module **name
-  that begins with `-` is now rejected** (rename it; interior dashes are
-  fine), and the legacy **`POST /auth/logout` route now enforces `allowed
-  hosts`** like the rest of the API (a caller outside the perimeter gets 403).
-  A third only bites on a broken system: if the OpenSSL CSPRNG fails, the
-  server now **refuses to issue a session token** (HTTP 500, logged as
-  `SECURITY:`) rather than falling back to a weaker generator.
-  See the [security notice](../security/notices.md#web-server-security-hardening).
+- 🔒 **NRPEServer's metachar guard now also checks decoded input.** `allow
+  nasty characters = false` re-checks the *decoded* command and arguments, not
+  just the raw wire bytes — with a non-UTF-8 `encoding` set, a multi-byte
+  sequence could previously decode into a metacharacter that was never
+  literally on the wire, so a request the guard was always meant to block may
+  now be rejected. Separately, `nscp nrpe install` reads the stored `verify
+  mode` again instead of silently resetting it on a re-run. Nothing to do on a
+  default install. See the [security notice](../security/notices.md#nrpe-decoded-argument-metachar-guard-optional-version-banner-and-consistency-fixes).
+- 🔒 **WEB server security hardening.** A review of the `WEBServer` module
+  produced several defense-in-depth fixes: session tokens now come from the
+  OpenSSL CSPRNG, cookie-name matching requires a name boundary, the installer
+  refuses an HTTPS→HTTP redirect, and the `legacy` grant's startup warning now
+  names `/settings/query.pb`. The default install needs no action. One change
+  only bites on a broken system: if the OpenSSL CSPRNG fails, the server now
+  refuses to issue a session token (HTTP 500, logged as `SECURITY:`) rather
+  than falling back to a weaker generator. See the
+  [security notice](../security/notices.md#web-server-security-hardening).
 - 🔒 **The bundled OpenSSL is updated from 3.5.4 to 3.5.8** in the Windows
   builds, picking up the fixes from four upstream security releases on the
   3.5 LTS line. The most relevant fix for NSClient++ is
@@ -416,7 +443,109 @@ per-release detail lives in each
   distribution's OpenSSL and are unaffected. See
   [Security notices](../security/notices.md).
 
+### New and opt-in (no action)
+
+- 📅 **New: run scheduled checks on demand with `run_schedules`.** After editing
+  `nsclient.ini` you no longer have to wait out the interval to see the new
+  result on the monitoring server — `nscp client --boot --query run_schedules`
+  (optionally `--argument schedule=<alias>`) runs the configured schedules now
+  and submits their results on their normal channel. It is a regular check
+  command, so it also works over NRPE, REST and in `nscp test`. Nothing changes
+  for existing configurations; the timers are untouched. See
+  [Passive monitoring → Step 6](../scenarios/passive-monitoring-nsca.md#step-6-send-a-result-without-waiting-for-the-interval).
+- 🔒 **NRPEServer `expose version`** — a new setting, default `true`, which
+  keeps the legacy banner `check_nrpe` expects. Set it to `false` to answer the
+  unauthenticated `_NRPE_CHECK` ping with a generic message instead of the exact
+  build. See the [security notice](../security/notices.md#nrpe-decoded-argument-metachar-guard-optional-version-banner-and-consistency-fixes).
+
 ## 0.17.0
+
+### Requires action
+
+- 🔒 **`${host}` and friends now resolve in attachment paths and in
+  `[/includes]`.** Host name placeholders were only expanded in settings urls
+  and in the url an attachment is fetched from, not in the path it is written
+  to nor in an included file name. An unknown `${...}` token in a path is not
+  an error - it resolves to the installation directory - so a configuration
+  such as `[/attachments] ${shared-path}/${host}.ini = ...` did not fail, it
+  quietly wrote one file with the installation directory in its name. Those
+  paths now name the host, which changes where such a file lands: check any
+  `${host}`, `${hostname}` or `${domain}` you already have under
+  `[/attachments]` or `[/includes]`, and remove the workaround if you scripted
+  around this. Configurations without a host name placeholder are unaffected.
+  When the substitution lands in a local path, the value is sanitized to the
+  characters a legal host name can contain (see the
+  [security notice](../security/notices.md#host-name-placeholders-are-sanitized-before-they-land-in-a-local-path)).
+  Like `nscp settings --switch`, `nscp settings --migrate-to` (and the REST
+  migrate) now keeps a placeholder you pass it as-is in `boot.ini` while
+  migrating into the expanded per-host file, so the template survives on a
+  fleet-managed machine.
+- 🔢 **An unknown unit in `format_bytes()` is now reported instead of rendering
+  nonsense.** `format_bytes(used, 'gb')` used to render `1.27055e-10` because
+  the unit comparison was case sensitive, and any misspelled unit rendered
+  `value/1024^7`. Lowercase units now work, and a unit that names nothing (say
+  `'ZB'`) makes the check report `Filter processing failed: format_bytes
+  failed: Unknown byte unit: ZB`. A syntax string with such a typo returns
+  UNKNOWN rather than a quietly wrong number - fix the unit, or the check will
+  stay UNKNOWN.
+- 📊 **A `unit:` in `perf-config` that names no unit no longer divides the metric
+  by 1024⁷.** An unrecognised unit now leaves the value alone. If a graph of
+  yours has been flat at a near-zero value, check the `unit:` spelling in its
+  `perf-config`: the metric will jump to its real magnitude on upgrade.
+- 📊 **`perf-config`'s `unit:` now converts plain byte series instead of
+  relabelling them.** On series that are byte counts but do not auto-scale
+  (most byte keywords outside `check_drivesize`), `unit:KB` used to change the
+  label only, shipping `=1536KB` for a value of 1536 *bytes* - a metric off by
+  the unit ratio to any consumer that trusts the label. The value and the
+  warn/crit bounds now convert into the requested unit, matching what the
+  auto-scaling series always did. A dashboard that compensated for the
+  mislabelling will see the metric drop by that ratio on upgrade. Series not
+  measured in bytes (`ms`, `%`, `s`, ...) and explicit `minimum:`/`maximum:`
+  overrides are unaffected, and a `unit:` that names no byte unit still only
+  changes the label.
+- 🪟 **`check_pending_reboot`'s default message now names the pending-since
+  time.** When the reboot was queued by Component Based Servicing or Windows
+  Update, the message gains a suffix: `Reboot required: Windows Update` became
+  `Reboot required: Windows Update (pending since 2026-08-16 09:41:12)`.
+  Notification pipelines that match the exact message text (an anchored regex,
+  a string equality) need their pattern relaxed; thresholds, states and
+  existing keywords are unchanged.
+- 🔢 **Filter comparisons between a text keyword and a bare number are now
+  numeric.** A string-typed keyword compared against an unquoted number used
+  to order *lexically* — `filter=value > 90` on `filter_perf` matched
+  `value=100` as false ("100" sorts before "90") — or, with the operands
+  reversed (`90 > value`), failed to evaluate at all. Both now compare as
+  numbers, whichever side the keyword is on: the row's text is parsed per
+  record, and a value that is not a number simply never matches (the check
+  logs one warning naming the value; the result stays a certain
+  non-match, not UNKNOWN). This applies to keywords such as
+  `value`/`warn`/`crit`/`min`/`max` (`filter_perf`, `render_perf`),
+  `speed` (`check_network`), `string_value` (`check_registry_value`) and the
+  `column()` function (`check_logfile`). **Quoted** literals keep the lexical
+  comparison — `version < '8'` still orders as text — as do `like`, `regexp`
+  and `in`, keyword-specific converters (`state = 'running'`,
+  `age > 30m`), and the `= 'unknown'` / `= 'never'` sentinels for optional
+  values. Review any filter that deliberately relied on text ordering
+  against a bare number: quote the number to keep the old behaviour.
+- 📊 **`filter_perf`/`render_perf`/`xform_perf`: the `max` and `min` filter
+  keywords were swapped.** `max` read the perf-data *minimum* bound and
+  `min` the *maximum*. They now read the bounds they name — a filter that
+  compensated for the swap needs the two names exchanged back.
+- 📨 **Syslog submission works again, so a configured syslog server will start
+  receiving traffic.** `SyslogClient` read its connection settings from the
+  wrong place, so the target's address, port, facility, severity and templates
+  were all ignored: the agent logged `Undefined facility:` and sent nothing.
+  Broken since 0.4.3 (2015). If you have a syslog target configured, check it
+  still points where you want before upgrading - it has not been delivering,
+  and it will now. `CheckMKClient` had the same defect on its query path.
+- 🔧 **`nscp settings --show` now says so when `--key` is missing.** `--show
+  --path /some/path` without a `--key` used to print nothing and exit 0; it
+  now reports `Invalid command line please use --path and --key with show`
+  and exits non-zero. A bare `--show` still describes the active
+  settings store, and `--show --path … --key …` is unchanged. Scripts that
+  relied on the silent success need the missing `--key` added.
+
+### Changes behaviour (no action)
 
 - 🏷️ **Check-specific filter keywords that clashed with the generic summary
   keywords are renamed.** A handful of checks registered their own keyword
@@ -463,24 +592,39 @@ per-release detail lives in each
       unchanged (the renames keep their original perf suffixes, and
       `check_connections`' default perf-config intentionally still uses the
       alias for series continuity).
-- 🔒 **`${host}` and friends now resolve in attachment paths and in
-  `[/includes]`.** Host name placeholders were only expanded in settings urls
-  and in the url an attachment is fetched from, not in the path it is written
-  to nor in an included file name. An unknown `${...}` token in a path is not
-  an error - it resolves to the installation directory - so a configuration
-  such as `[/attachments] ${shared-path}/${host}.ini = ...` did not fail, it
-  quietly wrote one file with the installation directory in its name. Those
-  paths now name the host, which changes where such a file lands: check any
-  `${host}`, `${hostname}` or `${domain}` you already have under
-  `[/attachments]` or `[/includes]`, and remove the workaround if you scripted
-  around this. Configurations without a host name placeholder are unaffected.
-  When the substitution lands in a local path, the value is sanitized to the
-  characters a legal host name can contain (see the
-  [security notice](../security/notices.md#host-name-placeholders-are-sanitized-before-they-land-in-a-local-path)).
-  Like `nscp settings --switch`, `nscp settings --migrate-to` (and the REST
-  migrate) now keeps a placeholder you pass it as-is in `boot.ini` while
-  migrating into the expanded per-host file, so the template survives on a
-  fleet-managed machine.
+- 🧩 **Errors raised while a template renders are now reported.** A function that
+  failed inside `detail-syntax` or `top-syntax` used to leave the placeholder
+  empty and say nothing; the check now returns UNKNOWN with `Filter processing
+  failed: …`. This surfaces template mistakes that have been silently producing
+  incomplete messages.
+- 🔢 **Fractional numbers in thresholds are no longer truncated or rounded.**
+  `count > 2.5` used to evaluate as `count > 3` (the literal was rounded
+  into the counter's integer domain); unit literals lost their fraction
+  entirely, so `working_set > 1.5g` meant 1g and `uptime < 2.5h` meant 2h.
+  Fractions now mean what they say. Whole-number thresholds are unchanged;
+  only expressions that already used a decimal point can behave differently.
+- ✉️ **SMTP notifications now announce this host in EHLO instead of
+  `localhost`.** The sender's host name was read from the wrong place, so it
+  was always empty and the EHLO fell back to `localhost`. If your mail server
+  applies HELO/EHLO policy (SPF checks, or a rule that rejects `localhost`),
+  the agent will now identify itself properly - set `ehlo-hostname` on the
+  target if you need a specific name.
+- 💬 **Client commands shorter than eight characters work again.** A command
+  such as `cpu` or `run` answered `Exception processing command line:
+  basic_string::substr …` instead of running, in every module built on the
+  shared client machinery (NRPE, NSCA, NRDP, Graphite, …). Remove any
+  workaround that renamed such commands to a longer alias; no configuration
+  change is needed.
+- 🔧 **The settings diff no longer reports changes that were already saved.**
+  `get_changes()` — behind the REST settings `diff` endpoint and any
+  operator-facing "what am I about to save?" view — kept listing an edit for
+  the lifetime of the process after it had been written, reporting it as a
+  `modified` entry whose old value equalled its new one. Tooling that treated
+  a non-empty diff as "unsaved work pending" no longer needs to special-case
+  that; no configuration change is needed.
+
+### New and opt-in (no action)
+
 - 🔢 **Check messages can now be told how to render their numbers.** Every filter
   check gained four options - `decimals`, `byte-unit`, `decimal-separator` and
   `thousands-separator` - so `check_drivesize` can report
@@ -502,101 +646,10 @@ per-release detail lives in each
   rendering scientific (`1.23457e+07`). A pipeline that matches float text in
   the message may need its pattern relaxed when you first set one of these
   options; leave all four unset and the message is byte-for-byte unchanged.
-- 🔢 **An unknown unit in `format_bytes()` is now reported instead of rendering
-  nonsense.** `format_bytes(used, 'gb')` used to render `1.27055e-10` because
-  the unit comparison was case sensitive, and any misspelled unit rendered
-  `value/1024^7`. Lowercase units now work, and a unit that names nothing (say
-  `'ZB'`) makes the check report `Filter processing failed: format_bytes
-  failed: Unknown byte unit: ZB`. A syntax string with such a typo returns
-  UNKNOWN rather than a quietly wrong number - fix the unit, or the check will
-  stay UNKNOWN.
-- 📊 **A `unit:` in `perf-config` that names no unit no longer divides the metric
-  by 1024⁷.** An unrecognised unit now leaves the value alone. If a graph of
-  yours has been flat at a near-zero value, check the `unit:` spelling in its
-  `perf-config`: the metric will jump to its real magnitude on upgrade.
-- 📊 **`perf-config`'s `unit:` now converts plain byte series instead of
-  relabelling them.** On series that are byte counts but do not auto-scale
-  (most byte keywords outside `check_drivesize`), `unit:KB` used to change the
-  label only, shipping `=1536KB` for a value of 1536 *bytes* - a metric off by
-  the unit ratio to any consumer that trusts the label. The value and the
-  warn/crit bounds now convert into the requested unit, matching what the
-  auto-scaling series always did. A dashboard that compensated for the
-  mislabelling will see the metric drop by that ratio on upgrade. Series not
-  measured in bytes (`ms`, `%`, `s`, ...) and explicit `minimum:`/`maximum:`
-  overrides are unaffected, and a `unit:` that names no byte unit still only
-  changes the label.
-- 🧩 **Errors raised while a template renders are now reported.** A function that
-  failed inside `detail-syntax` or `top-syntax` used to leave the placeholder
-  empty and say nothing; the check now returns UNKNOWN with `Filter processing
-  failed: …`. This surfaces template mistakes that have been silently producing
-  incomplete messages.
-- 🪟 **`check_pending_reboot`'s default message now names the pending-since
-  time.** When the reboot was queued by Component Based Servicing or Windows
-  Update, the message gains a suffix: `Reboot required: Windows Update` became
-  `Reboot required: Windows Update (pending since 2026-08-16 09:41:12)`.
-  Notification pipelines that match the exact message text (an anchored regex,
-  a string equality) need their pattern relaxed; thresholds, states and
-  existing keywords are unchanged.
-- 🔢 **Filter comparisons between a text keyword and a bare number are now
-  numeric.** A string-typed keyword compared against an unquoted number used
-  to order *lexically* — `filter=value > 90` on `filter_perf` matched
-  `value=100` as false ("100" sorts before "90") — or, with the operands
-  reversed (`90 > value`), failed to evaluate at all. Both now compare as
-  numbers, whichever side the keyword is on: the row's text is parsed per
-  record, and a value that is not a number simply never matches (the check
-  logs one warning naming the value; the result stays a certain
-  non-match, not UNKNOWN). This applies to keywords such as
-  `value`/`warn`/`crit`/`min`/`max` (`filter_perf`, `render_perf`),
-  `speed` (`check_network`), `string_value` (`check_registry_value`) and the
-  `column()` function (`check_logfile`). **Quoted** literals keep the lexical
-  comparison — `version < '8'` still orders as text — as do `like`, `regexp`
-  and `in`, keyword-specific converters (`state = 'running'`,
-  `age > 30m`), and the `= 'unknown'` / `= 'never'` sentinels for optional
-  values. Review any filter that deliberately relied on text ordering
-  against a bare number: quote the number to keep the old behaviour.
-- 🔢 **Fractional numbers in thresholds are no longer truncated or rounded.**
-  `count > 2.5` used to evaluate as `count > 3` (the literal was rounded
-  into the counter's integer domain); unit literals lost their fraction
-  entirely, so `working_set > 1.5g` meant 1g and `uptime < 2.5h` meant 2h.
-  Fractions now mean what they say. Whole-number thresholds are unchanged;
-  only expressions that already used a decimal point can behave differently.
-- 📊 **`filter_perf`/`render_perf`/`xform_perf`: the `max` and `min` filter
-  keywords were swapped.** `max` read the perf-data *minimum* bound and
-  `min` the *maximum*. They now read the bounds they name — a filter that
-  compensated for the swap needs the two names exchanged back.
-- 📨 **Syslog submission works again, so a configured syslog server will start
-  receiving traffic.** `SyslogClient` read its connection settings from the
-  wrong place, so the target's address, port, facility, severity and templates
-  were all ignored: the agent logged `Undefined facility:` and sent nothing.
-  Broken since 0.4.3 (2015). If you have a syslog target configured, check it
-  still points where you want before upgrading - it has not been delivering,
-  and it will now. `CheckMKClient` had the same defect on its query path.
-- ✉️ **SMTP notifications now announce this host in EHLO instead of
-  `localhost`.** The sender's host name was read from the wrong place, so it
-  was always empty and the EHLO fell back to `localhost`. If your mail server
-  applies HELO/EHLO policy (SPF checks, or a rule that rejects `localhost`),
-  the agent will now identify itself properly - set `ehlo-hostname` on the
-  target if you need a specific name.
-- 🔧 **`nscp settings --show` now says so when `--key` is missing.** `--show
-  --path /some/path` without a `--key` used to print nothing and exit 0; it
-  now reports `Invalid command line please use --path and --key with show`
-  and exits non-zero. A bare `--show` still describes the active
-  settings store, and `--show --path … --key …` is unchanged. Scripts that
-  relied on the silent success need the missing `--key` added.
-- 💬 **Client commands shorter than eight characters work again.** A command
-  such as `cpu` or `run` answered `Exception processing command line:
-  basic_string::substr …` instead of running, in every module built on the
-  shared client machinery (NRPE, NSCA, NRDP, Graphite, …). Remove any
-  workaround that renamed such commands to a longer alias; no configuration
-  change is needed.
-- 🔧 **The settings diff no longer reports changes that were already saved.**
-  `get_changes()` — behind the REST settings `diff` endpoint and any
-  operator-facing "what am I about to save?" view — kept listing an edit for
-  the lifetime of the process after it had been written, reporting it as a
-  `modified` entry whose old value equalled its new one. Tooling that treated
-  a non-empty diff as "unsaved work pending" no longer needs to special-case
-  that; no configuration change is needed.
+
 ## 0.16.4
+
+### Changes behaviour (no action)
 
 - 🔒 **The bundled Mongoose web server is upgraded to 7.23,** fixing two
   critical (CVSS 9.1) HTTP request-smuggling vulnerabilities in its HTTP
@@ -610,6 +663,8 @@ per-release detail lives in each
 
 ## 0.16.3
 
+### Changes behaviour (no action)
+
 - 🔌 **`check_nt` (NSClientServer) answers the real nagios-plugins client again.**
   Requests without a trailing newline used to hang until the client timed out
   (`No data was received from host!`) — broken since 0.12.2. Remove any
@@ -619,115 +674,362 @@ per-release detail lives in each
 
 ## 0.16.2
 
-- 🔒 **Sensitive settings values are redacted on read.** The REST settings
-  read endpoints (`GET /api/v2/settings/...`, `/descriptions`) and
-  `nscp settings --list` / `--show` now return `***` for keys registered
-  sensitive, matching the `diff` endpoint. No action required; tooling that
-  read such a value back now receives `***`. See
-  [Security notices](../security/notices.md).
-- 🔒 **The built-in `legacy` WEB role is no longer seeded on fresh installs,**
-  and any role granting the `legacy` permission now triggers a `SECURITY`
-  warning at startup (and from `nscp web add-role` / `add-user`). Existing
-  installs are unaffected — the role stays in their config. The `legacy` grant
-  unlocks the deprecated `/query.pb` and `/query/{name}` query-dispatch
-  endpoints, so a token with it can run any registered check/command; only
-  grant it to trusted legacy systems. See
+### Requires action
+
+- 🔒 **WEB `legacy` permission** — if a role in your configuration grants
+  `legacy`, startup now logs a `SECURITY` warning (as do `nscp web add-role` /
+  `add-user`). That grant unlocks the deprecated `/query.pb` and
+  `/query/{name}` endpoints, so a token holding it can run any registered check
+  or command: keep it only for trusted systems that cannot use
+  `/api/v2/queries`, and drop it elsewhere. Existing installs are otherwise
+  unaffected — the role stays and keeps working; fresh installs no longer seed
+  it. See [Security notices](../security/notices.md).
+
+### Changes behaviour (no action)
+
+- 🔒 **Settings reads redact sensitive values.** `GET /api/v2/settings/...`,
+  `/descriptions` and `nscp settings --list` / `--show` return `***` for keys
+  registered sensitive, matching the `diff` endpoint. Tooling that read such a
+  value back out now receives `***`. See
   [Security notices](../security/notices.md).
 
 ## 0.16.1
 
-- 🐧 **RHEL/SUSE:** workaround `ca=` arguments can be dropped — `${ca-path}` now
-  resolves on its own (the explicit form still works). Packagers cross-building
-  for another distribution should set `-DCONFIG_CA_PATH=`.
-- 📄 **`check_logfile`** is unchanged unless you opt in to `bookmark` / `max-lines`.
-  Adopting `bookmark` is a trade-off: a line is consumed when the check runs
-  (not when its result is submitted) and positions are saved on clean shutdown,
-  so a crash re-reports the backlog. Prefer an explicit bookmark name for a
-  check whose filter changes often.
+### Requires action
+
+- 🏷️ **`${hostname}` in settings URLs is now expanded.** It used to be left in
+  place as literal text; it is now expanded everywhere `expand_hostname` is
+  used, including the submit clients' `hostname`. Check any configuration that
+  relied on the literal.
+- 📚 **Building from source** — the HTML docs on non-Windows now need
+  `-DNSCP_BUILD_DOCS_HTML=ON` (or the `build_docs_html` target). Packagers
+  cross-building for another distribution should set `-DCONFIG_CA_PATH=`.
+
+### Changes behaviour (no action)
+
+- 🐧 **`${ca-path}` resolves on its own on RHEL/SUSE**, so workaround `ca=`
+  arguments can be dropped. Naming a bundle explicitly still works.
 - 🔧 **Settings URLs with a query string now send it.** A server that relied on
-  receiving the bare path will now see the parameters. The offline-boot cache
-  file is migrated to the query-aware name once on first start.
-- 🏷️ **`${hostname}` in an existing config changes meaning** — it is now expanded
-  everywhere `expand_hostname` is used (including submit clients' `hostname`),
-  where it used to be left as literal text.
-- ⏱️ **`run on startup` is off by default** so the default install is unaffected;
-  if you enable it for the `default` schedule use `startup window` to avoid a
-  thundering herd.
-- 📚 **Building the HTML docs on non-Windows** now needs `-DNSCP_BUILD_DOCS_HTML=ON`.
+  receiving the bare path will see the parameters. The offline-boot cache file
+  is migrated to the query-aware name once, on first start.
+
+### New and opt-in (no action)
+
+- 📄 **`check_logfile` `bookmark` / `max-lines`** — a check with neither reads the
+  whole file exactly as before and never touches a stored position. Adopting
+  `bookmark` is a trade-off: a line is consumed when the check runs, not when
+  its result is submitted, and positions are saved on clean shutdown, so a crash
+  re-reports the backlog. Prefer an explicit bookmark name for a check whose
+  filter changes often — an automatic name covers the expressions, so editing
+  the filter starts a new position.
+- ⏱️ **`run on startup`** is off by default. Turning it on for the `default`
+  schedule enables it fleet-wide; use `startup window` to spread the resulting
+  submissions.
+
+## 0.16.0
+
+### Requires action
+
+- 🔢 **Filter expressions testing the old `-1` sentinels.** A keyword that has no
+  value no longer parks `-1` in itself: it reports *no value*, and every numeric
+  comparison against it is false — including `=`, `!=`, `in` and `not in`, the
+  way SQL treats NULL. Rewrite such expressions as a presence test on the string
+  form:
+
+  | Command | Keywords | Presence test |
+  |---|---|---|
+  | `check_ping` | `jitter`, `ttl` | `jitter = 'unknown'` |
+  | `check_ntp_offset` | `jitter` | `jitter = 'unknown'` |
+  | `check_tcp`, `check_http` | `ssl_expiry_days` | `ssl_expiry_days = 'no certificate'` |
+  | `check_disk_health` | `total`, `free`, `used`, `user_free`, `free_pct`, `used_pct` | `free_pct = 'no space data'` |
+
+  Two thresholds get better as a result: `critical=ssl_expiry_days < 30` is now
+  safe on a plain connection, and `free_pct < 10` no longer fires on
+  `check_disk_health` rows that have no filesystem behind them. Sentinels
+  elsewhere are untouched — `check_process`'s `uid` still reports `-1` on
+  synthetic rows.
+- 🔧 **`check_docker` `host=` only accepts a local endpoint** — a named pipe or an
+  absolute socket path. A configuration pointing at a remote or UNC endpoint is
+  refused.
+- 🔧 **CheckDocker requires Docker API 1.41 or newer** (the pinned `/v1.40` prefix
+  is gone). Any daemon from Docker 20.10 onwards qualifies.
+
+### Changes behaviour (no action)
+
+- 📊 **`check_disk_health` and `check_disk_io` perfdata series are renamed.**
+  `free_pct`, `queue_length` and `percent_disk_time` carry their own label
+  suffixes instead of sharing the bare drive label, so Graphite and InfluxDB see
+  new series — the old collapsed series held the wrong metric anyway. Icinga
+  shows two correctly named entries where it showed two under one name.
+- 📊 **Perfdata is omitted for values that were not measured** rather than plotted
+  as `-1`, so those series appear and disappear instead of carrying a fake
+  floor.
+
+### New and opt-in (no action)
+
+- 🧩 **CheckMySQL** — a new module for MySQL, MariaDB and Percona servers, not
+  loaded by default. It is built wherever MariaDB Connector/C is available; the
+  Windows installer ships it as its own feature (`MySQLPlugin`, which bundles
+  the Connector/C library), installed by default and removable from the feature
+  tree or with `REMOVE=MySQLPlugin`.
+
+## 0.15.0
+
+### Requires action
+
+- 🔧 **`check_process delta=true` requires the `process cpu` collector setting.**
+  With the collector off the check returns UNKNOWN naming the setting, instead
+  of sleeping one second inside the check. With it on, memory and handle fields
+  report absolute values in delta mode rather than 1-second differences.
+  Installs that do not use `delta=true` are unaffected.
+
+### New and opt-in (no action)
+
+- 🧩 **CheckMSSQL** — a new optional module, not loaded by default. Enable it and
+  see the *Monitoring a SQL Server host* scenario in the docs.
 
 ## 0.14.1
 
-- ⚖️ **Licence change:** now distributed as **Apache-2.0 OR GPL-2.0-only** — a
-  clarification/relicensing with no code or runtime behaviour change. Review it
-  if your organisation tracks bundled-software licences.
-- 📊 **CheckNet perfdata is on by default.** If you added perfdata manually,
-  make sure you are not now emitting it twice.
+### Requires action
+
+- 📊 **CheckNet emits perfdata by default.** Network checks produce performance
+  data without an explicit `perf` syntax: if you were adding it manually, check
+  you are not now emitting it twice. Graphs that showed nothing start
+  populating.
+- ⚖️ **Licence change** — NSClient++ is distributed as **Apache-2.0 OR
+  GPL-2.0-only**. A clarification/relicensing with no code or runtime change;
+  review it only if your organisation tracks the licence of bundled software.
+
+### Changes behaviour (no action)
+
 - ☑️ **Boolean check arguments** (`option=true` / `option=false`) now work from the
-  CLI as well as REST; bare-flag usage is unchanged.
-- 🔒 **`CheckSecurity` is not loaded by default.** Enable it before using its
-  checks (`nscp settings --active-module CheckSecurity`). Windows-only checks
-  return UNKNOWN elsewhere.
+  CLI as well as over REST. Bare-flag usage is unchanged.
+
+### New and opt-in (no action)
+
+- 🔒 **CheckSecurity** — a new module, not loaded by default. Enable it before
+  using its checks (`nscp settings --active-module CheckSecurity`). Its
+  Windows-only checks return UNKNOWN on other platforms rather than erroring.
+
+## 0.14.0
+
+### Requires action
+
+- 🐧 **Linux `check_service` targets systemd.** Match units by unit name
+  (e.g. `service=ssh`) and use `state`, `active`, `sub_state` and `preset` in
+  thresholds; the default expression keeps *disabled* units OK. Rewrite rules
+  written against the old behaviour.
+- 🐧 **Linux `check_process` reports delta CPU** — usage between samples rather
+  than lifetime CPU. Review CPU thresholds that assumed the old semantics.
+
+### Changes behaviour (no action)
+
+- 🐧 **Linux disk I/O needs one collector sample.** The first `check_disk_io` /
+  `check_disk_health` query immediately after startup may return UNKNOWN
+  ("collector still initializing") — normal in one-shot testing, invisible with
+  a running service.
+- 🔒 **`check_tcp` / `check_http` take a boolean `ssl`.** Enable TLS with
+  `ssl=true`; to verify certificates set `verify=peer` and provide a `ca=`
+  bundle. The default remains `verify=none`.
+
+## 0.13.0
+
+Linux users and anyone running the web server in cleartext should read this
+section; a normal Windows MSI upgrade is unaffected.
+
+### Requires action
+
+- 🔒 **The web server refuses to run unencrypted.** Provide a certificate
+  (`certificate = …`), or opt in explicitly if you intentionally run cleartext
+  behind a TLS-terminating proxy or on an isolated network:
+
+  ```ini
+  [/settings/WEB/server]
+  allow insecure = true
+  ```
+
+  With neither, it logs an error and does not start the listener.
+- 🐧 **The web UI is a separate download on Linux (`.deb` / `.rpm`).** Run
+  `sudo nscp web install-ui` after installing the package to fetch the matching
+  UI bundle (`nscp web ui-status` / `uninstall-ui` manage it). Until then the
+  web port serves a built-in placeholder; the REST API and every listener work
+  without it. The Windows MSI still bundles the UI inline.
+- 📁 **Building for a custom location** — the Linux layout follows the FHS and the
+  install prefix (daemon `/usr/sbin/nscp`, modules and private libs under
+  `/usr/lib/nsclient`, config `/etc/nsclient`, state and logs under `/var`).
+  Patching hardcoded paths is no longer needed: pass `-DCMAKE_INSTALL_PREFIX`
+  and the standard `CMAKE_INSTALL_*DIR` knobs. To point an installed daemon at a
+  `boot.ini` elsewhere, use
+  `nscp service --run --path-override boot-conf=/etc/nsclient/boot.ini`.
 
 ## 0.12.6
 
-- 🔒 **New permission policy layer, disabled by default.** Existing installs
-  behave exactly as before until an operator sets
-  `/settings/permissions/enabled = true`. If you opt in: per-command rules apply
-  to **queries only** (exec is gated by the separate `allow exec` boolean, which
-  defaults `true`); roll out with `log allows = true` first to inventory real
-  traffic. See [Permissions](../concepts/permissions.md).
-- 🔒 **NRPEServer `client identity source`** defaults to `none` (previous
-  behaviour). Set to `cn` only after configuring `verify_mode = peer-cert` and a
-  `ca path` pinned to your **private** monitoring CA — the system trust store
-  would accept any public cert's CN.
-- 📁 **`[/paths]` overrides** from an older install moved to `[paths]` in
-  `boot.ini` (same section name, different file). No automatic migration — copy
-  each entry across and delete the old section.
-- 🔒 **WEB `disable admin user = true`** is a new opt-in for status-only WEB
-  exposure; existing installs keep their admin unchanged.
-- 🔌 **NRPEServer** now survives a failed listener (logs an ERROR, leaves the
-  module loaded) instead of failing the whole module. Add "NRPE listener failed"
-  as a signal if you alerted on module-load failure.
-- 🔊 **`insecure = true` on NRPEServer** now logs at ERROR (louder, behaviour
-  unchanged) — whitelist the message on agents intentionally run insecure.
+### Requires action
+
+- 🔒 **`cache allowed hosts` is a real boolean now.** It used to be parsed as a
+  string with surprising truthiness: change `yes` / `on` to `true`. Numeric
+  `1` / `0` still work.
+- 🔌 **NRPEServer survives a failed listener** (bad bind address, port in use): it
+  logs an ERROR and stays loaded with no active listener instead of failing the
+  whole module, so you can reconfigure and reload without restarting the
+  service. If you alerted on "module load failed", add "NRPE listener failed" as
+  a separate signal.
+
+### Changes behaviour (no action)
+
+- 📊 **Nagios range syntax in performance data** is additive — plain numbers still
+  parse as before. Only consumers that special-cased NSClient++'s old output may
+  need adjusting.
+
+### New and opt-in (no action)
+
+- 🔒 **Permission policy layer** — a new system, disabled by default. Existing
+  installs behave exactly as before until an operator sets
+  `/settings/permissions/enabled = true`. If you opt in: per-command rules under
+  `/settings/permissions/policies` apply to **queries only** — exec is gated by
+  the separate `allow exec` boolean, which defaults `true`, so enabling the
+  policy does not silently break the WEB scripts UI, lua/python
+  `core:simple_exec(...)` or CLI exec. Roll out with `log allows = true` first to
+  inventory real traffic. See [Permissions](../concepts/permissions.md).
+- 🔒 **NRPEServer `client identity source`** — a new setting defaulting to
+  `none`, which is the previous behaviour (subject is bare `NRPEServer`). Set it
+  to `cn` only for per-cert principals, and only after configuring
+  `verify_mode = peer-cert` and a `ca path` pinned to your **private**
+  monitoring CA — the system trust store would accept any public cert's CN. The
+  module refuses to start with a clear error if `cn` is set without those.
 
 ## 0.12.5
 
-- 📁 **`[/paths]` users:** copy entries into `[paths]` in `boot.ini`; the
-  settings-side section is no longer consulted. Default installs are unaffected.
-- 🧩 **Custom-plugin authors:** implement the new optional `prepare_shutdown`
-  callback if your module manages sockets or background threads — `unload` is
-  now a last-resort teardown.
-- 🔒 **Monitoring-only WEB deployments:** `disable admin user = true` under
-  `[/settings/WEB/server]` suppresses the built-in admin even on first boot;
-  define your own read-only users (or a tightly scoped `anonymous` role).
+### Requires action
+
+- 📁 **`[/paths]` users** — copy the entries into a `[paths]` section in `boot.ini`
+  (same section name, different file, next to `nscp.exe`) and delete the old
+  section from `nsclient.ini`. There is no automatic migration and the
+  settings-side section is no longer consulted. The default install does not use
+  `[/paths]` and is unaffected.
+- 🧩 **Custom-plugin authors** — implement the new optional `prepare_shutdown`
+  callback if your module manages sockets or background threads. `unload` is now
+  a last-resort teardown rather than the place where listeners get stopped.
+
+### New and opt-in (no action)
+
+- 🔒 **WEB `disable admin user = true`** — suppresses the built-in admin even on
+  first boot, for monitoring-only exposure of the WEB UI; define your own
+  read-only users, or a tightly scoped `anonymous` role. Existing installs keep
+  their admin and work unchanged.
 
 ## 0.12.4
 
-- 🔒 **Icinga `check_nscp_api`** works again after upgrade with no config
-  change. For a non-stock probe, set `[/settings/WEB/server] legacy query auth
-  user agents` to a substring of its User-Agent. For the strict 0.12.3 behaviour
-  (no query-string credentials at all), set that key to empty.
+### Changes behaviour (no action)
 
-## 0.12.3
+- 🔒 **Icinga `check_nscp_api` works again** after the upgrade, with no config
+  change. For a non-stock probe with a different binary name, set
+  `[/settings/WEB/server] legacy query auth user agents` to a substring of its
+  User-Agent (or to plain `Icinga` to broaden the match). For the strictest
+  behaviour — no query-string credentials at all — set that key to empty.
 
-1. 🔒 **Audit `allowed hosts`** on every node — empty values now reject everything.
-2. 🔒 **`check_nt` (NSClientServer)** now defaults to `ssl = true`; set
-   `ssl = false` explicitly if your clients don't speak TLS.
-3. 🔒 **Replace clients** that call `/auth/token` or `/auth/logout` with the
-   `/api/v2/login` flow, and any that pass `?TOKEN=` / `?__TOKEN=` in the query
-   string with a header-based token.
-4. **Scheduler cron expressions** on non-UTC hosts shift to local time — update
-   them or set `[/settings/scheduler] timezone = utc`.
-5. **Review `check_service` / `check_process` / `check_files` filters** that
-   relied on the old (now corrected) behaviours.
-6. Restart and review the log for new "refused alias" / "rejected connection"
-   warnings — configurations that were previously silently accepted.
+## 0.12.2
+
+### Requires action
+
+- 🔒 **`allowed hosts` is fail-closed.** An empty value used to mean "allow any
+  source" and now rejects every connection, with the reason logged. Audit it on
+  every node; to genuinely accept any source, say so explicitly:
+
+  ```ini
+  allowed hosts = 0.0.0.0/0,::/0
+  ```
+
+- 📅 **Scheduler cron expressions evaluate in local time** (#570), matching
+  standard cron semantics — `40 15 * * *` now fires at 15:40 host-local instead
+  of 15:40 UTC. Update the expressions, or restore the old reference clock with
+  `[/settings/scheduler] timezone = utc`. Any POSIX TZ string is accepted; IANA
+  names such as `Europe/Stockholm` are **not** — an unparseable value falls back
+  to UTC and shows as `UTC?` in timezone labels.
+- 🔒 **`check_nt` (NSClientServer) defaults to `ssl = true`.** The listener still
+  starts with TLS off, but logs a warning at startup and another when a password
+  is configured. Set `ssl = false` explicitly in `[/settings/NSClient/server]`
+  if your clients do not speak TLS — and prefer NRPE or NSCA-ng.
+- 🔒 **`check_nt`: the literal password `None` no longer authenticates.** A
+  client sending `None` used to be accepted when no server password was
+  configured; an empty server password now rejects every request. Configure a
+  password, or move to a modern protocol.
+- 🔒 **Passwords and tokens are no longer accepted in the query string** of GET
+  queries — move them to a header. (The `/auth/token` and `/auth/logout`
+  endpoints themselves still exist, behind the WEB `legacy` permission; see
+  0.16.2.)
+- 🔒 **Outbound SSL connections verify the certificate hostname** whenever
+  `verify_mode` includes `peer`. A peer certificate whose CN/SAN does not match
+  the host the client connects to is now rejected, where it used to pass on a
+  valid chain alone. Re-issue certificates that are reached under a name they do
+  not carry, or connect using the name in the certificate.
+
+### Changes behaviour (no action)
+
+- 🔒 **NRPEServer logs an ERROR at startup when `insecure = true`** — it names
+  the loss of server authentication ("Clients have no way to authenticate this
+  server, traffic can be MITMed"). Nothing else changes for that listener, but
+  the message will show up in dashboards that alert on ERROR: whitelist it on
+  agents deliberately run insecure. The insecure cipher preset also stops
+  allowing anonymous (ADH) suites, which legacy `check_nrpe` does not need.
+
+## 0.12.1
+
+### Changes behaviour (no action)
+
+- 🔧 **`check_service`: `delayed` is reported only for auto-start services**
+  (#362). A filter matching `start_type = 'delayed'` no longer picks up
+  `Manual`, `Boot`, `System` or `Disabled` services. To alert on "not running
+  and not disabled", write
+  `start_type IN ('auto','delayed','boot','system') AND state != 'running'`.
+- 🏷️ **`check_service`: `${desc}` returns the real display name** instead of the
+  literal `TODO` (#456). Backends that matched on `TODO` need a different
+  signal.
+- 📊 **`check_service`: `perf-syntax=none` actually suppresses perfdata** (#681),
+  where it used to be ignored and emit empty-aliased entries.
+
+## 0.12.0
+
+### Requires action
+
+- 🔢 **Mixed `warn=` / `crit=` expressions now evaluate when nothing matches.** An
+  empty result set used to be skipped and return OK; object-bound variables now
+  default to `false` and summary variables hold their final values, so
+  `crit = state = 'stopped' OR count = 0` becomes CRITICAL on an empty set. Add
+  a `count > 0 AND …` guard if a config relied on "empty means OK".
+- 🧩 **Module authors:** `http::request` and `http::response` are distinct types,
+  headers are stored case-insensitively and chunked decoding is transparent.
+  Out-of-tree modules built against the old shared request/response type need a
+  small adjustment to compile.
+
+### Changes behaviour (no action)
+
+- 🔢 **`warn=` / `crit=` no longer fire mid-iteration on running counts.** The
+  verdict is computed against the final counts, so a config tuned against the
+  old early-fire behaves differently — `crit = state = 'hung' OR count < 5` used
+  to trip on the first row.
+- 🔧 **Realtime `check_process` matches `process=` case-insensitively**, like the
+  active path always did (#587, #552). A rule that deliberately matched one
+  casing now matches both.
 
 ## 0.11.33
 
-- ✅ No configuration migration required (new `proxy` keys are opt-in). The
-  `check_files` fixes change a few corner cases: `max-depth=0` now scans the top
-  directory (#730); missing paths return UNKNOWN (#613); junction loops are not
-  double-counted (#605); empty results return OK instead of UNKNOWN (#717).
-  Review alerting that relied on the old corner-case behaviour.
+### Changes behaviour (no action)
+
+- 📄 **`check_files` corner cases are fixed**: `max-depth=0` scans the top
+  directory instead of returning empty (#730); missing paths return UNKNOWN
+  instead of OK/empty (#613); junction loops are no longer double-counted
+  (#605); legacy `CheckFiles` calls that returned UNKNOWN on empty results now
+  return OK (#717). Review alerting that relied on any of these.
+
+### New and opt-in (no action)
+
+- 🔧 **Proxy support** — the new `proxy` and `no-proxy` keys and the `[proxy]`
+  section in `boot.ini` are opt-in. No configuration migration is required.
+
+## 0.11.32
+
+### Changes behaviour (no action)
+
+- 📚 **The documentation tree was reorganised**, so bookmarks and deep links into
+  the old structure may no longer resolve.


### PR DESCRIPTION
Follow-up to #1410.

## Why

Every item of a release sits in one flat bullet list, so a mandatory action, a behaviour change nobody has to act on and a purely opt-in addition all look alike. That is hardest on the two readers the page exists for: an operator jumping several versions, who wants only the things that will not fix themselves, and anyone handing the page to an assistant, which cannot tell which items apply to a given configuration without re-deriving all of it from the source.

## What changed

Each release is split into **Requires action**, **Changes behaviour (no action)** and **New and opt-in (no action)**; empty sections are omitted, so a release that asks nothing of you is visibly short. Each item starts with the module, setting or command it concerns, so searching the page for a name you have configured finds everything that touches it.

I established the introducing release for every item from the commits (`git log -S…`, then `git tag --contains`) rather than from the release notes, which surfaced a set of attribution problems:

| Problem | Fix |
|---|---|
| 0.11.32, 0.12.0, 0.12.1, 0.12.2, 0.13.0, 0.14.0, 0.15.0, 0.16.0 have upgrade-relevant changes but no section | added, with the items placed by commit |
| Everything under 0.12.3 belongs to 0.12.0-0.12.2 (0.12.3 has 19 commits and no upgrade-relevant change of its own) | 0.12.3 removed, items moved to the release that introduced them |
| `[/paths]` → `boot.ini` and `disable admin user` listed under both 0.12.5 and 0.12.6 | kept in 0.12.5 (`fbdfe257`, `cccc14e4`); 0.12.6 only renamed the `--path-override` CLI flag (`a37bb258`) |
| The web-server-refuses-cleartext / `install-ui` / FHS-layout items are 0.13.0 (`82094007`, `c1ae115d`, `2a945286`), re-announced in 0.14.0 | listed once, under 0.13.0 |
| Setting name given as `cache allowed host` | it is `cache allowed hosts`, plural (`socket_settings_helper.hpp:98`) |
| "Replace clients that call `/auth/token` or `/auth/logout`" | both endpoints still exist (`legacy_controller.cpp:28-30`), behind the WEB `legacy` permission. The 0.12.2 change (`340b8db1`) is that passwords and tokens are no longer accepted in the query string |
| Items that never made it onto the page | recovered, e.g. the `check_nt` literal `None` password no longer authenticating (`6fcb6e44`), `cache allowed hosts` becoming a real boolean (`b3337534`), Nagios range syntax in perfdata (`86da6b5b`), and the mixed `warn=`/`crit=` evaluation changes (`24ffb992`, `dd8024ae`) |

Pre-releases get their own sections rather than being folded into the next stable one: people do install them, and folding is what put 0.12.0-0.12.2 under 0.12.3 in the first place.

`CLAUDE.md` documents the section split, and asks for the introducing release to be established from the commit when in doubt.

## One open question

**`insecure = true` on NRPEServer logging at ERROR** is in the 0.12.6 release notes, but I could not place it: no commit in `0.12.5..0.12.6` touches the log level, and the message in `include/net/socket/connection.hpp:306` has been `log_error` since 0.4.3.147. I left it off rather than file it under a release I could not confirm — happy to add it wherever it belongs.