### PR TITLE
ci: disable automatic Chocolatey publishing on release

### DIFF
--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -1,15 +1,20 @@
 name: Publish to Chocolatey
 
 # Builds a Chocolatey package that wraps the signed MSI and pushes it to
-# https://community.chocolatey.org/ whenever a non-draft, non-prerelease
-# release is published.
+# https://community.chocolatey.org/.
+#
+# NOTE: automatic publishing on release is DISABLED for now — we ran into
+# issues getting the package onboarded on chocolatey.org. The workflow can
+# still be run manually (workflow_dispatch, defaults to dry-run) or via
+# workflow_call; restore the release trigger below once onboarding is sorted:
+#
+#   release:
+#     types: [published]
 
 permissions:
   contents: read
 
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Publishing to chocolatey.org is not working yet - we ran into issues getting the package onboarded - so drop the `release: published` trigger to stop the workflow from running (and failing) on every release. Manual runs via workflow_dispatch (dry-run by default) and workflow_call remain available for testing; the trigger to restore once onboarding is sorted is kept as a comment in the workflow.

Assisted-by: Claude Code:claude-fable-5