### PR TITLE
docs(upgrading): add 0.16.3 entry for the check_nt client fix

### DIFF
--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -12,6 +12,15 @@ page tracks those in one place. Full per-release detail lives in each
 
 ---
 
+## 0.16.3
+
+- **`check_nt` (NSClientServer) answers the real nagios-plugins client again.**
+  Requests without a trailing newline used to hang until the client timed out
+  (`No data was received from host!`) — broken since 0.12.2. Remove any
+  client-side timeout/retry workarounds; no configuration change is needed.
+  If you expose this legacy endpoint, see the new guidance on securing it
+  (password, `allowed hosts` and the `allow` command list).
+
 ## 0.16.2
 
 - 🔒 **Sensitive settings values are redacted on read.** The REST settings


### PR DESCRIPTION
0.16.3 is a small bugfix release cut from main; the only behaviour-visible change for operators is that the legacy check_nt server answers the real nagios-plugins client again (requests without a trailing newline no longer hang), so record that in the upgrading page per the release process.

Assisted-by: Claude Code:claude-fable-5