### PR TITLE
Coverage reporting, and the six defects it found

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -18,6 +18,11 @@ jobs:
     uses: ./.github/workflows/tests-sanitizers.yml
     with:
       version: ${{ needs.get-version.outputs.version }}
+  coverage:
+    needs: get-version
+    uses: ./.github/workflows/tests-coverage.yml
+    with:
+      version: ${{ needs.get-version.outputs.version }}
   build-server-x64:
     needs: [get-version, create-test-bundle]
     uses: ./.github/workflows/build-windows.yml

--- a/.github/workflows/tests-coverage.yml
+++ b/.github/workflows/tests-coverage.yml
@@ -1,0 +1,151 @@
+name: Coverage (unit + integration)
+
+# Builds NSClient++ on Linux with gcov instrumentation (NSCP_COVERAGE=ON), runs
+# both the C++ unit tests (ctest) and the tests/ jest integration suite against
+# the same instrumented tree, and publishes an HTML + Cobertura coverage report
+# as a build artifact.
+#
+# The integration numbers are the interesting half: the jest harness spawns the
+# instrumented `nscp` and lets it dlopen the instrumented modules, so the report
+# covers real command dispatch and REST argument handling, not just the pure
+# logic the unit tests reach.
+#
+# Local reproduction (one command):
+#   tools/coverage/run.sh
+# or a single suite:
+#   SUITES=unit tools/coverage/run.sh
+#
+# This job is informational - it does not gate the build. Add
+# `--fail-under-line N` to the final gcovr call in tools/coverage/run.sh if you
+# ever want it to.
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        type: string
+        description: 'Version to build'
+        required: true
+        default: '0.0.0'
+  # Also runnable on its own, so a coverage report can be pulled for a branch
+  # without waiting for a full main build.
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: 'Version to build'
+        required: false
+        default: '0.0.0'
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:24.04
+
+    steps:
+    - name: Install dependencies
+      run: |
+        apt-get update
+        DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          git curl unzip cmake build-essential python3-pip pkg-config \
+          libboost-all-dev libgtest-dev libgmock-dev \
+          protobuf-compiler libprotobuf-dev \
+          openssl libssl-dev libcrypto++-dev \
+          liblua5.4-dev libdbus-1-dev \
+          libzip-dev libtinyxml2-dev libmariadb-dev \
+          ccache zstd gcovr
+
+    - uses: actions/checkout@v6
+
+    - name: Configure ccache
+      shell: bash
+      run: |
+        # Same rationale as build-debian.yml / tests-sanitizers.yml: the
+        # instrumented -O0 build is cheap to compile but there is a lot of it.
+        if command -v ccache > /dev/null; then
+          echo "CCACHE_DIR=$GITHUB_WORKSPACE/.ccache" >> "$GITHUB_ENV"
+          echo "CCACHE_MAXSIZE=500M" >> "$GITHUB_ENV"
+          echo "CCACHE_LAUNCHER=ccache" >> "$GITHUB_ENV"
+        else
+          echo "::warning::ccache not available - building without a compiler cache"
+        fi
+
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: .ccache
+        key: ccache-coverage-ubuntu-24.04-x64-${{ github.sha }}
+        restore-keys: |
+          ccache-coverage-ubuntu-24.04-x64-
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: 20
+        cache: 'npm'
+        cache-dependency-path: web/package-lock.json
+
+    - name: Make build dir
+      run: mkdir -p tmp/nscp
+
+    - name: Setup python dependencies
+      run: |
+        pip3 install --break-system-packages -r build/python/requirements.txt 2>/dev/null || pip3 install -r build/python/requirements.txt
+
+    - name: Build web
+      working-directory: web
+      run: |
+        npm install
+        npm run build
+
+    - name: CMake configure (coverage)
+      working-directory: tmp/nscp
+      run: |
+        cmake ../.. \
+          ${CCACHE_LAUNCHER:+-DCMAKE_C_COMPILER_LAUNCHER=$CCACHE_LAUNCHER -DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_LAUNCHER} \
+          -DBUILD_VERSION=${{ inputs.version }} \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DNSCP_COVERAGE=ON \
+          -DBUILD_MODULE_CauseCrashes=OFF \
+          -DNSCP_WEB_BACKEND=beast \
+          -DNSCP_BOOST_PYTHON_VERSION=python312 \
+          -DLIBRARY_ROOT_FOLDER="$GITHUB_WORKSPACE" \
+          -DCHECK_NSCLIENT_MISSING=ON \
+          -DUSE_STATIC_RUNTIME=OFF
+
+    - name: Build
+      working-directory: tmp/nscp
+      run: |
+        if [ -n "${CCACHE_LAUNCHER:-}" ]; then ccache --zero-stats; fi
+        cmake --build . -j$(nproc)
+
+    - name: ccache statistics
+      if: always()
+      shell: bash
+      run: |
+        if [ -n "${CCACHE_LAUNCHER:-}" ]; then ccache --show-stats; fi
+
+    - name: Run unit tests and collect coverage
+      shell: bash
+      run: SKIP_BUILD=1 BUILD_DIR=tmp/nscp SUITES=unit tools/coverage/run.sh
+
+    - name: Install integration harness deps
+      working-directory: tests
+      run: npm install
+
+    - name: Run integration tests and collect coverage
+      shell: bash
+      # NSCP_SKIP_DOCKER=1: no docker daemon inside this container, so the
+      # container-backed scenarios (mysql, docker, ...) skip themselves.
+      run: SKIP_BUILD=1 BUILD_DIR=tmp/nscp SUITES=integration tools/coverage/run.sh
+
+    - name: Upload coverage report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: coverage/
+        if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,7 @@ rotate-signing-secret.ps1
 # Coverage reports written by tools/coverage/run.sh (build-coverage/ itself
 # is already covered by the build-* rule above).
 /coverage/
+# gcov scratch output: named <source>##<hash>.gcov and written into the
+# repo root while a coverage report is generated. run.sh sweeps them, but
+# a hard-killed run cannot.
+*.gcov

--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,6 @@ _build
 .fleet-machines.json
 
 rotate-signing-secret.ps1
+# Coverage reports written by tools/coverage/run.sh (build-coverage/ itself
+# is already covered by the build-* rule above).
+/coverage/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -687,6 +687,46 @@ if(
     )
 endif()
 
+# ##############################################################################
+# Coverage (gcc/clang on Linux). NSCP_COVERAGE instruments every target with
+# gcov counters so `ctest` and the tests/ integration suite can be turned into
+# an lcov/gcovr report. Off by default; the instrumentation slows the build and
+# every binary down and must never leak into a package build.
+#
+# -fprofile-update=atomic is mandatory rather than nice-to-have: nscp is
+# heavily threaded (asio io_contexts, the 1 Hz metrics collectors), and
+# non-atomic counter updates race, producing both wrong numbers and the
+# occasional corrupt .gcda.
+#
+# -O0 keeps line/branch mapping honest - with optimisation on, inlining
+# attributes coverage to whatever function the inlinee landed in.
+#
+# See tools/coverage/run.sh for the full configure -> run -> report cycle.
+# ##############################################################################
+option(NSCP_COVERAGE "Instrument the build for gcov/gcovr coverage" OFF)
+if(
+    NSCP_COVERAGE
+    AND (
+        CMAKE_COMPILER_IS_GNUCXX
+        OR CMAKE_CXX_COMPILER_ID
+            MATCHES
+            "Clang"
+    )
+)
+    message(STATUS "Enabling coverage instrumentation (gcov)")
+    set(_nscp_cov_cflags "--coverage -fprofile-update=atomic -O0 -g")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${_nscp_cov_cflags}")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${_nscp_cov_cflags}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+    set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} --coverage")
+elseif(NSCP_COVERAGE)
+    message(
+        WARNING
+        "NSCP_COVERAGE requires gcc or clang; ignoring it for this compiler"
+    )
+endif()
+
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
     message(STATUS "Added parallel build arguments")

--- a/build.md
+++ b/build.md
@@ -95,6 +95,7 @@ with `-DNSCP_CMAKE_CONFIG=<file>`).
 | `NSCP_WEB_BACKEND`          | `mongoose`       | HTTP/REST backend for `WEBServer`: `mongoose` (needs the vendored Mongoose source) or `beast` (header-only, **requires OpenSSL**). The Linux package builds use `beast`. |
 | `NSCP_BOOST_PYTHON_VERSION` | —                | Boost.Python component matching your Python, e.g. `python311`, `python312`, `python313`. Only relevant when building `PythonScript`.                                     |
 | `NSCP_SANITIZE`             | `off`            | Comma-separated sanitizer list for gcc/clang on Linux: `address`, `undefined`, `address,undefined`, `thread`. See `tools/sanitizers/run.sh`.                             |
+| `NSCP_COVERAGE`             | `OFF`            | Instrument every target with gcov counters (gcc/clang on Linux) so ctest and the `tests/` suite can be turned into a coverage report. See `tools/coverage/run.sh`.      |
 | `NSCP_BUILD_DOCS_HTML`      | `ON` on Windows, `OFF` elsewhere | Build the mkdocs HTML site as part of the default target. Only the Windows installer ships the site; elsewhere build it on demand with `cmake --build . --target build_docs_html`. |
 | `USE_STATIC_RUNTIME`        | `OFF`            | Link the C/C++ runtime statically (used by the Win32 static build).                                                                                                      |
 | `USE_SYSTEMD`               | `ON` (Linux)     | Install systemd service files in the package.                                                                                                                            |
@@ -923,6 +924,81 @@ export UBSAN_OPTIONS=suppressions=$PWD/../tools/sanitizers/ubsan-suppressions.tx
 
 See the header of `tools/sanitizers/run.sh` and
 `.github/workflows/tests-sanitizers.yml` for more variations.
+
+#### Coverage reports
+
+`-DNSCP_COVERAGE=ON` instruments every target with gcov counters. Because the
+integration harness spawns the built `nscp` and lets it `dlopen` the built
+modules, the *same* instrumented tree yields coverage for both the C++ unit
+tests and the scenario suites — the latter is the more interesting half, since
+it covers real command dispatch and REST argument parsing rather than pure
+logic in isolation.
+
+`tools/coverage/run.sh` does the whole cycle — configure, build, run, report:
+
+```bash
+# From the repo root. Builds build-coverage/, runs both suites, writes coverage/
+tools/coverage/run.sh
+
+# One suite at a time (each starts from a clean counter set):
+SUITES=unit tools/coverage/run.sh
+SUITES=integration tools/coverage/run.sh
+
+# Re-run tests in an existing tree without rebuilding:
+SKIP_BUILD=1 SUITES=integration JEST_ARGS=checkdisk tools/coverage/run.sh
+```
+
+It needs **gcovr** (`apt-get install gcovr`) and leaves this in `coverage/`:
+`html/index.html` (both suites merged, with annotated per-file source),
+one-page summaries `unit.html` and `integration.html`, and `cobertura.xml`
+for CI coverage services. Only the merged report carries per-file detail
+pages — one full set is ~80MB. Extra cmake
+`-D` flags go in `CMAKE_ARGS`, exactly as for the sanitizer runner — e.g.
+`CMAKE_ARGS="-DNSCP_WEB_BACKEND=beast"` when the vendored Mongoose source is
+absent.
+
+Generated code is excluded from the reports: the protobuf `*.pb.cc`, and the
+per-module `module.cpp` / `module.hpp` dispatch glue that CMake generates from
+each `module.json` (66 files, ~4600 lines — leaving them in cost 2.6 points of
+line coverage, and a gap in generated code isn't something you can write a test
+for). The `.json` tracefiles still contain them, though, because they carry one
+signal worth having: **a `module.cpp` at 0% means no test ever loaded that
+module**, even when its own sources are well covered by a unit test that links
+them directly — which is exactly the gap the "every new check command needs a
+`tests/` test" rule exists to close. To see that view:
+
+```bash
+gcovr --add-tracefile coverage/unit.json \
+      --filter '.*/module\.cpp$' --txt glue.txt --print-summary
+```
+
+`CauseCrashes` is not built at all for coverage (`-DBUILD_MODULE_CauseCrashes=OFF`):
+nothing exercises a module whose only job is to crash the daemon, and if
+anything did, the crash would take the unflushed gcov counters with it.
+
+Three things are worth knowing before trusting the numbers:
+
+- **Stale `.gcda` are poison.** Once the sources move on, gcov rejects the old
+  data with `stamp mismatch with notes file` and silently under-reports. The
+  script deletes every `.gcda` before each suite; if you drive gcov by hand, do
+  the same.
+- **The daemon must shut down cleanly.** gcov flushes its counters in an
+  `atexit` handler, so a SIGKILLed `nscp` contributes nothing. On Linux the
+  harness stops it with SIGTERM and `CommandClient` turns that into a graceful
+  shutdown, which is exactly what makes this work — the same property
+  LeakSanitizer depends on. On Windows the harness uses SIGKILL, and MSVC has
+  no gcov anyway; use OpenCppCoverage there.
+- **`-fprofile-update=atomic` is not optional** (the CMake option sets it).
+  nscp is heavily threaded, and non-atomic counter updates race into wrong
+  numbers and the occasional corrupt `.gcda`.
+
+The Lua acceptance tests (`lua_*_test`) are part of `ctest -R '_test$'`, so the
+unit-suite report already includes the module code paths they drive.
+
+`.github/workflows/tests-coverage.yml` runs the same two suites in CI and
+uploads `coverage/` as a build artifact. It is informational and does not gate
+the build; add `--fail-under-line N` to the final `gcovr` call in the script if
+you want it to.
 
 See `tests/README.md` for the full layout, fixture documentation and the
 per-suite table.

--- a/build/cmake/functions.cmake
+++ b/build/cmake/functions.cmake
@@ -591,6 +591,16 @@ function(NSCP_ADD_LUA_TEST _NAME _SCRIPT)
             --language lua
             --script ${_SCRIPT}
             --path-override scripts=${BUILD_TARGET_ROOT_PATH}/scripts
+            # Keep everything a module writes inside the build tree. Without
+            # this ${certificate-path} is the install location
+            # (/usr/local/lib/nsclient/security), which a developer running
+            # ctest cannot create: NRPEServer generates or validates a
+            # certificate as it loads - even with insecure=true, because the
+            # certificate setting still has its default value - so the whole
+            # module refuses to load and any test that talks to it fails.
+            # ${data-path} is the same story for writable per-machine state.
+            --path-override certificate-path=${BUILD_TARGET_ROOT_PATH}/security
+            --path-override data-path=${BUILD_TARGET_ROOT_PATH}
         # Run from the build root so ${base-path} (the external-scripts working
         # dir) makes relative script paths like "scripts/check_test.sh" resolve.
         WORKING_DIRECTORY ${BUILD_TARGET_ROOT_PATH}

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -12,6 +12,28 @@ page tracks those in one place. Full per-release detail lives in each
 
 ---
 
+## next
+
+- **`nscp settings --show` now says so when `--key` is missing.** `--show
+  --path /some/path` without a `--key` used to print nothing and exit 0; it
+  now reports `Invalid command line please use --path and --key with show`
+  and exits non-zero. A bare `--show` still describes the active
+  settings store, and `--show --path … --key …` is unchanged. Scripts that
+  relied on the silent success need the missing `--key` added.
+- **Client commands shorter than eight characters work again.** A command
+  such as `cpu` or `run` answered `Exception processing command line:
+  basic_string::substr …` instead of running, in every module built on the
+  shared client machinery (NRPE, NSCA, NRDP, Graphite, …). Remove any
+  workaround that renamed such commands to a longer alias; no configuration
+  change is needed.
+- **The settings diff no longer reports changes that were already saved.**
+  `get_changes()` — behind the REST settings `diff` endpoint and any
+  operator-facing "what am I about to save?" view — kept listing an edit for
+  the lifetime of the process after it had been written, reporting it as a
+  `modified` entry whose old value equalled its new one. Tooling that treated
+  a non-empty diff as "unsaved work pending" no longer needs to special-case
+  that; no configuration change is needed.
+
 ## 0.16.4
 
 - **Check-specific filter keywords that clashed with the generic summary

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -14,6 +14,13 @@ page tracks those in one place. Full per-release detail lives in each
 
 ## next
 
+- **Syslog submission works again, so a configured syslog server will start
+  receiving traffic.** `SyslogClient` read its connection settings from the
+  wrong place, so the target's address, port, facility, severity and templates
+  were all ignored: the agent logged `Undefined facility:` and sent nothing.
+  Broken since 0.4.3 (2015). If you have a syslog target configured, check it
+  still points where you want before upgrading - it has not been delivering,
+  and it will now. `CheckMKClient` had the same defect on its query path.
 - **`nscp settings --show` now says so when `--key` is missing.** `--show
   --path /some/path` without a `--key` used to print nothing and exit 0; it
   now reports `Invalid command line please use --path and --key with show`

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -21,6 +21,12 @@ page tracks those in one place. Full per-release detail lives in each
   Broken since 0.4.3 (2015). If you have a syslog target configured, check it
   still points where you want before upgrading - it has not been delivering,
   and it will now. `CheckMKClient` had the same defect on its query path.
+- **SMTP notifications now announce this host in EHLO instead of
+  `localhost`.** The sender's host name was read from the wrong place, so it
+  was always empty and the EHLO fell back to `localhost`. If your mail server
+  applies HELO/EHLO policy (SPF checks, or a rule that rejects `localhost`),
+  the agent will now identify itself properly - set `ehlo-hostname` on the
+  target if you need a specific name.
 - **`nscp settings --show` now says so when `--key` is missing.** `--show
   --path /some/path` without a `--key` used to print nothing and exit 0; it
   now reports `Invalid command line please use --path and --key with show`

--- a/include/client/command_line_parser.cpp
+++ b/include/client/command_line_parser.cpp
@@ -292,7 +292,12 @@ void client::configuration::i_do_query(destination_container &s, destination_con
       custom_command = true;
       // TODO: Build argument vector here!
     }
-    if (command.substr(0, 8) == "forward_" || command.substr(command.size() - 8, 8) == "_forward") {
+    // Prefix and suffix both select forwarding. Test the suffix with
+    // ends_with: command.size() - 8 underflows for a shorter name and the
+    // substr then throws, which the catch at the bottom turns into an
+    // "Exception processing command line" answer for every command under
+    // eight characters.
+    if (boost::algorithm::starts_with(command, "forward_") || boost::algorithm::ends_with(command, "_forward")) {
       for (const PB::Commands::QueryRequestMessage::Request &p : request.payload()) {
         if (p.arguments_size() > 0) {
           for (const std::string &a : p.arguments()) {
@@ -311,8 +316,7 @@ void client::configuration::i_do_query(destination_container &s, destination_con
     } else {
       po::options_description desc = create_descriptor(command, s, d);
       payload_builder builder;
-      std::string x = command.substr(command.size() - 6, 6);
-      if (command.substr(0, 6) == "check_" || command.substr(command.size() - 6, 6) == "_query") {
+      if (boost::algorithm::starts_with(command, "check_") || boost::algorithm::ends_with(command, "_query")) {
         builder.set_type(payload_builder::type_query);
         desc.add(add_query_options(s, d, builder));
       } else if (command.substr(0, 5) == "exec_") {
@@ -456,7 +460,7 @@ bool client::configuration::i_do_exec(destination_container &s, destination_cont
       } else if (command.substr(0, 5) == "exec_") {
         builder.set_type(payload_builder::type_exec);
         desc.add(add_exec_options(s, d, builder));
-      } else if (command.substr(0, 7) == "submit_" || command.substr(command.size() - 7, 7) == "_submit") {
+      } else if (boost::algorithm::starts_with(command, "submit_") || boost::algorithm::ends_with(command, "_submit")) {
         builder.set_type(payload_builder::type_submit);
         desc.add(add_submit_options(s, d, builder));
       } else {

--- a/include/client/command_line_parser_test.cpp
+++ b/include/client/command_line_parser_test.cpp
@@ -1,0 +1,544 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for include/client/command_line_parser.cpp - the machinery every
+// outbound client module (NRPEClient, NSCAClient, ...) shares.
+//
+// client::configuration is what turns an incoming query/exec/submit request
+// into a call on the module's handler: it picks the target, expands command
+// aliases, builds the payload from the request's own arguments and decides
+// whether a command is a query, an exec, a submit or a plain forward. All of
+// that is driven here through a recording handler, so the assertions are
+// about the dispatch decisions rather than any particular protocol.
+
+#include <gtest/gtest.h>
+
+#include <boost/program_options.hpp>
+#include <client/command_line_parser.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace po = boost::program_options;
+
+namespace {
+
+// Handler that records what it was asked to do and answers with whatever the
+// test set up. The real ones talk to a remote host over NRPE/NSCA/HTTP.
+class recording_handler : public client::handler_interface {
+ public:
+  bool query_result = true;
+  bool submit_result = true;
+  bool exec_result = true;
+  bool metrics_result = true;
+
+  int query_calls = 0;
+  int submit_calls = 0;
+  int exec_calls = 0;
+  int metrics_calls = 0;
+
+  client::destination_container last_target;
+  client::destination_container last_sender;
+  PB::Commands::QueryRequestMessage last_query;
+  PB::Commands::SubmitRequestMessage last_submit;
+  PB::Commands::ExecuteRequestMessage last_exec;
+
+  bool query(client::destination_container sender, client::destination_container target, const PB::Commands::QueryRequestMessage &request_message,
+             PB::Commands::QueryResponseMessage &response_message) override {
+    query_calls++;
+    last_sender = sender;
+    last_target = target;
+    last_query = request_message;
+    if (!query_result) return false;
+    PB::Commands::QueryResponseMessage::Response *payload = response_message.add_payload();
+    payload->set_command("handled");
+    payload->set_result(PB::Common::ResultCode::OK);
+    payload->add_lines()->set_message("from the handler");
+    return true;
+  }
+
+  bool submit(client::destination_container sender, client::destination_container target, const PB::Commands::SubmitRequestMessage &request_message,
+              PB::Commands::SubmitResponseMessage &response_message) override {
+    submit_calls++;
+    last_sender = sender;
+    last_target = target;
+    last_submit = request_message;
+    if (!submit_result) return false;
+    PB::Commands::SubmitResponseMessage::Response *payload = response_message.add_payload();
+    payload->set_command("handled");
+    payload->mutable_result()->set_code(PB::Common::Result_StatusCodeType_STATUS_OK);
+    return true;
+  }
+
+  bool exec(client::destination_container sender, client::destination_container target, const PB::Commands::ExecuteRequestMessage &request_message,
+            PB::Commands::ExecuteResponseMessage &response_message) override {
+    exec_calls++;
+    last_sender = sender;
+    last_target = target;
+    last_exec = request_message;
+    if (!exec_result) return false;
+    PB::Commands::ExecuteResponseMessage::Response *payload = response_message.add_payload();
+    payload->set_command("handled");
+    payload->set_result(PB::Common::ResultCode::OK);
+    payload->set_message("from the handler");
+    return true;
+  }
+
+  bool metrics(client::destination_container sender, client::destination_container target, const PB::Metrics::MetricsMessage &request_message) override {
+    metrics_calls++;
+    last_sender = sender;
+    last_target = target;
+    return metrics_result;
+  }
+};
+
+// The reader is where a module adds its own options (--password, --ssl, ...).
+// Nothing here needs module-specific options, so it adds none.
+struct null_reader : client::options_reader_interface {
+  void process(po::options_description &, client::destination_container &, client::destination_container &) override {}
+  object_instance create(std::string alias, std::string path) override {
+    return std::make_shared<nscapi::settings_objects::object_instance_interface>(alias, path);
+  }
+  object_instance clone(object_instance parent, std::string alias, std::string path) override {
+    return std::make_shared<nscapi::settings_objects::object_instance_interface>(parent, alias, path);
+  }
+};
+
+// A configuration wired to the two fakes above, plus the handles a test needs
+// to poke at them.
+struct fixture {
+  std::shared_ptr<recording_handler> handler = std::make_shared<recording_handler>();
+  std::shared_ptr<null_reader> reader = std::make_shared<null_reader>();
+  client::configuration config{"test client", handler, reader};
+
+  fixture() { config.set_path("/settings/test/targets"); }
+
+  // Install a target object the way reading settings would have.
+  void add_target(const std::string &alias, const std::map<std::string, std::string> &options) {
+    auto obj = std::make_shared<nscapi::settings_objects::object_instance_interface>(alias, "/settings/test/targets");
+    for (const auto &o : options) obj->set_property_string(o.first, o.second);
+    config.targets.objects[alias] = obj;
+  }
+
+  // Build a one-payload query request for `command` with `arguments`.
+  static PB::Commands::QueryRequestMessage query_request(const std::string &command, const std::vector<std::string> &arguments = {},
+                                                         const std::string &recipient = "") {
+    PB::Commands::QueryRequestMessage request;
+    if (!recipient.empty()) request.mutable_header()->set_recipient_id(recipient);
+    PB::Commands::QueryRequestMessage::Request *payload = request.add_payload();
+    payload->set_command(command);
+    for (const std::string &a : arguments) payload->add_arguments(a);
+    return request;
+  }
+};
+
+// First line of the first payload - where both the handler's answer and any
+// error message end up.
+std::string first_message(const PB::Commands::QueryResponseMessage &response) {
+  if (response.payload_size() == 0) return "<no payload>";
+  const PB::Commands::QueryResponseMessage::Response &payload = response.payload(0);
+  if (payload.lines_size() == 0) return "<no lines>";
+  return payload.lines(0).message();
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// destination_container - the bag of connection settings every handler reads.
+// Its setters translate a handful of well-known keys into structured fields
+// and let everything else through as free-form data.
+// ---------------------------------------------------------------------------
+
+TEST(destination_container, well_known_keys_become_structured_fields) {
+  client::destination_container d;
+  d.set_string_data("host", "server.example.com");
+  d.set_string_data("port", "5666");
+  d.set_string_data("timeout", "42");
+  d.set_string_data("retry", "7");
+
+  EXPECT_EQ(d.get_host(), "server.example.com");
+  EXPECT_EQ(d.address.port, 5666u);
+  EXPECT_EQ(d.timeout, 42);
+  EXPECT_EQ(d.retry, 7);
+  EXPECT_FALSE(d.has_data("host")) << "translated, not stored as free-form data";
+}
+
+TEST(destination_container, unknown_keys_are_kept_as_data) {
+  client::destination_container d;
+  d.set_string_data("password", "secret");
+
+  EXPECT_TRUE(d.has_data("password"));
+  EXPECT_EQ(d.get_string_data("password"), "secret");
+  EXPECT_EQ(d.get_string_data("missing", "fallback"), "fallback");
+}
+
+TEST(destination_container, address_sets_protocol_host_and_port_at_once) {
+  client::destination_container d;
+  d.set_string_data("address", "nrpe://server.example.com:5667");
+
+  EXPECT_TRUE(d.has_protocol());
+  EXPECT_EQ(d.get_protocol(), "nrpe");
+  EXPECT_EQ(d.get_host(), "server.example.com");
+  EXPECT_EQ(d.address.port, 5667u);
+}
+
+TEST(destination_container, garbage_numbers_fall_back_to_the_previous_value) {
+  // to_int swallows the parse error: a bad timeout in a config file must not
+  // take the whole client down.
+  client::destination_container d;
+  d.set_string_data("timeout", "not-a-number");
+  EXPECT_EQ(d.timeout, 10) << "the default is kept";
+
+  d.set_string_data("timeout", "");
+  EXPECT_EQ(d.timeout, 10) << "and so is an empty value";
+}
+
+TEST(destination_container, booleans_only_accept_the_documented_spellings) {
+  EXPECT_TRUE(client::destination_container::to_bool("true"));
+  EXPECT_TRUE(client::destination_container::to_bool("True"));
+  EXPECT_TRUE(client::destination_container::to_bool("1"));
+  EXPECT_FALSE(client::destination_container::to_bool("yes")) << "not a documented spelling";
+  EXPECT_FALSE(client::destination_container::to_bool("false"));
+  EXPECT_TRUE(client::destination_container::to_bool("", true)) << "empty falls back to the default";
+}
+
+TEST(destination_container, a_host_from_the_request_header_is_applied) {
+  PB::Common::Host host;
+  host.set_id("primary");
+  host.set_address("nrpe://from-header:1234");
+  PB::Common::KeyValue *kvp = host.add_metadata();
+  kvp->set_key("password");
+  kvp->set_value("from-header");
+
+  client::destination_container d;
+  d.apply_host(host);
+
+  EXPECT_EQ(d.get_host(), "from-header");
+  EXPECT_EQ(d.address.port, 1234u);
+  EXPECT_EQ(d.get_string_data("password"), "from-header");
+}
+
+// ---------------------------------------------------------------------------
+// Command aliases. `nscp settings --set /settings/NRPE/client/targets ...`
+// style configuration registers an alias plus a fixed argument list.
+// ---------------------------------------------------------------------------
+
+TEST(client_configuration, add_command_splits_the_command_from_its_arguments) {
+  fixture f;
+
+  const std::string key = f.config.add_command("check_alias", "check_cpu warn=10 crit=20");
+
+  EXPECT_EQ(key, "check_alias");
+  ASSERT_EQ(f.config.commands.count("check_alias"), 1u);
+  EXPECT_EQ(f.config.commands["check_alias"].command, "check_cpu");
+  EXPECT_EQ(f.config.commands["check_alias"].arguments.size(), 2u);
+}
+
+TEST(client_configuration, add_command_lower_cases_the_alias) {
+  // Command lookup is done on the lower-cased name, so the key has to match.
+  fixture f;
+
+  const std::string key = f.config.add_command("CHECK_Alias", "check_cpu");
+
+  EXPECT_EQ(key, "check_alias");
+  EXPECT_EQ(f.config.commands.count("check_alias"), 1u);
+}
+
+TEST(client_configuration, add_command_keeps_quoted_arguments_together) {
+  fixture f;
+
+  f.config.add_command("check_alias", "check_cpu \"filter=core = 'total'\"");
+
+  ASSERT_EQ(f.config.commands["check_alias"].arguments.size(), 1u);
+  EXPECT_EQ(f.config.commands["check_alias"].arguments.front(), "filter=core = 'total'");
+}
+
+// ---------------------------------------------------------------------------
+// Target selection.
+// ---------------------------------------------------------------------------
+
+TEST(client_configuration, get_target_uses_the_named_target) {
+  fixture f;
+  f.add_target("primary", {{"address", "nrpe://primary.example.com:5666"}, {"password", "p"}});
+
+  const client::destination_container d = f.config.get_target("primary");
+
+  EXPECT_EQ(d.get_host(), "primary.example.com");
+}
+
+TEST(client_configuration, get_target_falls_back_to_default) {
+  // An unknown target is not an error: the default target's settings apply.
+  fixture f;
+  f.add_target("default", {{"address", "nrpe://fallback.example.com:5666"}});
+
+  const client::destination_container d = f.config.get_target("nobody-configured-this");
+
+  EXPECT_EQ(d.get_host(), "fallback.example.com");
+}
+
+TEST(client_configuration, get_target_without_any_configuration_is_empty) {
+  fixture f;
+
+  const client::destination_container d = f.config.get_target("anything");
+
+  EXPECT_TRUE(d.get_host().empty());
+}
+
+TEST(client_configuration, get_sender_comes_from_the_configured_sender) {
+  fixture f;
+  f.config.set_sender("nsca://sender.example.com:5667");
+
+  const client::destination_container s = f.config.get_sender();
+
+  EXPECT_EQ(s.get_host(), "sender.example.com");
+  EXPECT_EQ(s.address.port, 5667u);
+}
+
+// ---------------------------------------------------------------------------
+// do_query: which handler call a command shape maps to.
+// ---------------------------------------------------------------------------
+
+TEST(client_query, a_check_command_is_sent_to_the_handler) {
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_cpu", {"--command", "check_cpu"}), response);
+
+  EXPECT_EQ(f.handler->query_calls, 1);
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_EQ(first_message(response), "from the handler");
+}
+
+TEST(client_query, the_command_and_arguments_reach_the_handler) {
+  // The payload the handler receives is rebuilt from the request's own
+  // arguments (--command / --argument), not forwarded verbatim.
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_remote", {"--command", "check_cpu", "--argument", "warn=10"}), response);
+
+  ASSERT_EQ(f.handler->last_query.payload_size(), 1);
+  EXPECT_EQ(f.handler->last_query.payload(0).command(), "check_cpu");
+  ASSERT_EQ(f.handler->last_query.payload(0).arguments_size(), 1);
+  EXPECT_EQ(f.handler->last_query.payload(0).arguments(0), "warn=10");
+}
+
+TEST(client_query, a_failing_handler_is_reported_as_failed) {
+  fixture f;
+  f.handler->query_result = false;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_cpu"), response);
+
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_EQ(response.payload(0).result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_EQ(first_message(response), "check_cpu failed");
+}
+
+TEST(client_query, an_unrecognised_command_shape_is_reported_as_not_found) {
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("wibble_wobble"), response);
+
+  EXPECT_EQ(f.handler->query_calls, 0);
+  EXPECT_EQ(first_message(response), "wibble_wobble not found");
+}
+
+TEST(client_query, a_short_command_name_is_reported_as_not_found) {
+  // Regression: the prefix/suffix tests used to index from command.size() - 8,
+  // which underflows for anything shorter than the suffix. Every command under
+  // eight characters came back as "Exception processing command line:
+  // basic_string::substr" instead of an answer.
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("cpu"), response);
+
+  EXPECT_EQ(first_message(response), "cpu not found");
+}
+
+TEST(client_query, a_short_check_command_still_reaches_the_handler) {
+  // The other half of the same defect: "check_" is six characters, so a query
+  // named check_x is long enough for the prefix test but too short for the
+  // "_forward" suffix test that runs first.
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_x"), response);
+
+  EXPECT_EQ(f.handler->query_calls, 1);
+  EXPECT_EQ(first_message(response), "from the handler");
+}
+
+TEST(client_query, a_query_suffix_is_recognised_as_well_as_the_check_prefix) {
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("cpu_query"), response);
+
+  EXPECT_EQ(f.handler->query_calls, 1);
+}
+
+TEST(client_query, a_forward_command_hands_the_request_over_untouched) {
+  // Forwarding is the pass-through mode: the request goes to the remote
+  // system as-is rather than being rebuilt from parsed options.
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("forward_check", {"whatever=1"}), response);
+
+  ASSERT_EQ(f.handler->query_calls, 1);
+  ASSERT_EQ(f.handler->last_query.payload_size(), 1);
+  EXPECT_EQ(f.handler->last_query.payload(0).command(), "forward_check");
+  ASSERT_EQ(f.handler->last_query.payload(0).arguments_size(), 1);
+  EXPECT_EQ(f.handler->last_query.payload(0).arguments(0), "whatever=1");
+}
+
+TEST(client_query, a_forward_suffix_forwards_too) {
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_forward", {"whatever=1"}), response);
+
+  ASSERT_EQ(f.handler->query_calls, 1);
+  EXPECT_EQ(f.handler->last_query.payload(0).command(), "check_forward");
+}
+
+TEST(client_query, help_pb_on_a_forward_command_is_answered_locally) {
+  // A forwarding command cannot describe its arguments, so it answers the
+  // introspection request itself instead of asking the remote system.
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("forward_check", {"help-pb"}), response);
+
+  EXPECT_EQ(f.handler->query_calls, 0) << "answered without going to the handler";
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_FALSE(response.payload(0).data().empty());
+}
+
+TEST(client_query, an_alias_is_expanded_to_the_command_it_names) {
+  fixture f;
+  f.config.add_command("my_alias", "forward_check");
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("my_alias"), response);
+
+  EXPECT_EQ(f.handler->query_calls, 1) << "the alias resolved to a forwarding command";
+}
+
+TEST(client_query, each_recipient_in_a_list_gets_its_own_call) {
+  fixture f;
+  f.add_target("first", {{"address", "nrpe://first.example.com:5666"}});
+  f.add_target("second", {{"address", "nrpe://second.example.com:5666"}});
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_cpu", {}, "first,second"), response);
+
+  EXPECT_EQ(f.handler->query_calls, 2);
+  EXPECT_EQ(response.payload_size(), 2);
+}
+
+TEST(client_query, the_target_settings_reach_the_handler) {
+  fixture f;
+  f.add_target("primary", {{"address", "nrpe://primary.example.com:5666"}, {"password", "secret"}});
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_cpu", {}, "primary"), response);
+
+  EXPECT_EQ(f.handler->last_target.get_host(), "primary.example.com");
+  EXPECT_EQ(f.handler->last_target.get_string_data("password"), "secret");
+}
+
+TEST(client_query, command_line_options_override_the_target) {
+  // -H on the command line beats whatever the configured target says.
+  fixture f;
+  f.add_target("default", {{"address", "nrpe://configured.example.com:5666"}});
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_cpu", {"--host", "override.example.com", "--timeout", "99"}), response);
+
+  EXPECT_EQ(f.handler->last_target.get_host(), "override.example.com");
+  EXPECT_EQ(f.handler->last_target.timeout, 99);
+}
+
+TEST(client_query, an_unknown_option_is_reported_rather_than_sent) {
+  fixture f;
+  PB::Commands::QueryResponseMessage response;
+
+  f.config.do_query(fixture::query_request("check_cpu", {"--no-such-option"}), response);
+
+  EXPECT_EQ(f.handler->query_calls, 0);
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_NE(response.payload(0).result(), PB::Common::ResultCode::OK);
+}
+
+// ---------------------------------------------------------------------------
+// do_exec / do_submit / do_metrics.
+// ---------------------------------------------------------------------------
+
+TEST(client_exec, an_exec_command_is_sent_to_the_handler) {
+  fixture f;
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteRequestMessage::Request *payload = request.add_payload();
+  payload->set_command("exec_something");
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_TRUE(f.config.do_exec(request, response, ""));
+
+  EXPECT_EQ(f.handler->exec_calls, 1);
+}
+
+TEST(client_exec, an_unknown_exec_command_does_not_reach_the_handler) {
+  fixture f;
+  PB::Commands::ExecuteRequestMessage request;
+  request.add_payload()->set_command("wibble_wobble");
+  PB::Commands::ExecuteResponseMessage response;
+
+  f.config.do_exec(request, response, "");
+
+  EXPECT_EQ(f.handler->exec_calls, 0);
+}
+
+TEST(client_exec, a_short_exec_command_does_not_blow_up) {
+  // Same underflow as the query path: "_submit" is seven characters, so an
+  // exec command shorter than that used to answer with the substr exception
+  // rather than saying it did not recognise the command.
+  fixture f;
+  PB::Commands::ExecuteRequestMessage request;
+  request.add_payload()->set_command("run");
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(f.config.do_exec(request, response, ""));
+
+  EXPECT_EQ(f.handler->exec_calls, 0);
+  ASSERT_GE(response.payload_size(), 1);
+  EXPECT_EQ(response.payload(0).message(), "Module does not know of any command called: run");
+}
+
+TEST(client_submit, a_submit_command_is_sent_to_the_handler) {
+  fixture f;
+  PB::Commands::SubmitRequestMessage request;
+  request.mutable_header()->set_command("submit_result");
+  PB::Commands::QueryResponseMessage::Response *payload = request.add_payload();
+  payload->set_command("check_cpu");
+  payload->set_result(PB::Common::ResultCode::OK);
+  PB::Commands::SubmitResponseMessage response;
+
+  f.config.do_submit(request, response);
+
+  EXPECT_EQ(f.handler->submit_calls, 1);
+}
+
+TEST(client_metrics, metrics_are_sent_to_every_configured_target) {
+  fixture f;
+  f.add_target("default", {{"address", "nsca://metrics.example.com:5667"}});
+  PB::Metrics::MetricsMessage request;
+  request.add_payload();
+
+  f.config.do_metrics(request);
+
+  EXPECT_EQ(f.handler->metrics_calls, 1);
+  EXPECT_EQ(f.handler->last_target.get_host(), "metrics.example.com");
+}

--- a/include/nscapi/nscapi_program_options.cpp
+++ b/include/nscapi/nscapi_program_options.cpp
@@ -179,7 +179,7 @@ void nscapi::program_options::format_description(std::ostream &os, const std::st
   }  // paragraphs
 }
 
-std::string nscapi::program_options::strip_default_value(const std::string &arg) {
+std::string nscapi::program_options::extract_default_value(const std::string &arg) {
   // boost's format_parameter() renders the value slot as one of:
   //   "arg"               plain value
   //   "arg (=D)"          with default D
@@ -199,7 +199,7 @@ namespace {
 // "0"/"1"; translate to "false"/"true" so help texts and the generated docs
 // show the value the user would actually pass (x=true).
 std::string format_default_value(const po::option_description &op) {
-  std::string value = nscapi::program_options::strip_default_value(op.format_parameter());
+  std::string value = nscapi::program_options::extract_default_value(op.format_parameter());
   if (dynamic_cast<const po::typed_value<bool> *>(op.semantic().get()) != nullptr) {
     if (value == "0") return "false";
     if (value == "1") return "true";

--- a/include/nscapi/nscapi_program_options.hpp
+++ b/include/nscapi/nscapi_program_options.hpp
@@ -92,7 +92,7 @@ void format_paragraph(std::ostream &os, std::string par, std::size_t indent, std
 
 void format_description(std::ostream &os, const std::string &desc, std::size_t first_column_width, unsigned line_length);
 
-std::string strip_default_value(const std::string &arg);
+std::string extract_default_value(const std::string &arg);
 
 std::string help(const po::options_description &desc, const std::string &extra_info = "");
 

--- a/include/nscapi/nscapi_program_options_test.cpp
+++ b/include/nscapi/nscapi_program_options_test.cpp
@@ -114,7 +114,7 @@ TEST(program_options_kvp, handles_no_arguments) {
 }
 
 //////////////////////////////////////////////////////////////////////////
-// strip_default_value
+// extract_default_value
 //
 // Turns boost's format_parameter() rendering back into a bare default, for
 // the help/CSV/show-default output.
@@ -125,14 +125,14 @@ TEST(program_options_default_value, a_value_without_a_default_has_none) {
   desc.add_options()("plain", po::value<std::string>(), "d");
 
   EXPECT_EQ("arg", desc.options()[0]->format_parameter()) << "guards the assumption the code below strips";
-  EXPECT_EQ("", npo::strip_default_value(desc.options()[0]->format_parameter()));
+  EXPECT_EQ("", npo::extract_default_value(desc.options()[0]->format_parameter()));
 }
 
 TEST(program_options_default_value, strips_the_boost_decoration) {
   po::options_description desc;
   desc.add_options()("with-default", po::value<std::string>()->default_value("ok"), "d");
 
-  EXPECT_EQ("ok", npo::strip_default_value(desc.options()[0]->format_parameter()));
+  EXPECT_EQ("ok", npo::extract_default_value(desc.options()[0]->format_parameter()));
 }
 
 TEST(program_options_default_value, strips_an_implicit_value) {
@@ -141,15 +141,15 @@ TEST(program_options_default_value, strips_an_implicit_value) {
   po::options_description desc;
   desc.add_options()("flag", po::value<bool>()->implicit_value(true)->default_value(false), "d");
 
-  const std::string stripped = npo::strip_default_value(desc.options()[0]->format_parameter());
+  const std::string stripped = npo::extract_default_value(desc.options()[0]->format_parameter());
   EXPECT_EQ(std::string::npos, stripped.find("arg")) << "no boost decoration may survive, got: " << stripped;
   EXPECT_EQ(std::string::npos, stripped.find('[')) << "no boost decoration may survive, got: " << stripped;
 }
 
 TEST(program_options_default_value, input_without_a_default_has_none) {
-  EXPECT_EQ("", npo::strip_default_value("arg"));
-  EXPECT_EQ("", npo::strip_default_value("x"));
-  EXPECT_EQ("", npo::strip_default_value(""));
+  EXPECT_EQ("", npo::extract_default_value("arg"));
+  EXPECT_EQ("", npo::extract_default_value("x"));
+  EXPECT_EQ("", npo::extract_default_value(""));
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/include/nscapi/nscapi_program_options_test.cpp
+++ b/include/nscapi/nscapi_program_options_test.cpp
@@ -146,9 +146,9 @@ TEST(program_options_default_value, strips_an_implicit_value) {
   EXPECT_EQ(std::string::npos, stripped.find('[')) << "no boost decoration may survive, got: " << stripped;
 }
 
-TEST(program_options_default_value, passes_short_input_through) {
+TEST(program_options_default_value, input_without_a_default_has_none) {
   EXPECT_EQ("", npo::strip_default_value("arg"));
-  EXPECT_EQ("x", npo::strip_default_value("x"));
+  EXPECT_EQ("", npo::strip_default_value("x"));
   EXPECT_EQ("", npo::strip_default_value(""));
 }
 

--- a/include/nscapi/nscapi_program_options_test.cpp
+++ b/include/nscapi/nscapi_program_options_test.cpp
@@ -1,0 +1,334 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include <nscapi/nscapi_program_options.hpp>
+
+#include <gtest/gtest.h>
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace po = boost::program_options;
+namespace npo = nscapi::program_options;
+
+namespace {
+
+//////////////////////////////////////////////////////////////////////////
+// option_parser_kvp
+//
+// This is the parser that makes REST work: over REST a check argument
+// arrives as the single token "key=value", whereas the CLI hands us
+// "--key" and "value" as two tokens. Everything below pins the single
+// token form, since that is the one that only breaks in production.
+//////////////////////////////////////////////////////////////////////////
+
+std::vector<po::option> parse_kvp(std::vector<std::string> args, const std::string &break_at = "") {
+  return npo::option_parser_kvp(args, break_at);
+}
+
+TEST(program_options_kvp, splits_key_value_token) {
+  const std::vector<po::option> result = parse_kvp({"warning", "critical=load>5"});
+
+  ASSERT_EQ(2u, result.size());
+  EXPECT_EQ("warning", result[0].string_key);
+  EXPECT_TRUE(result[0].value.empty()) << "a token without '=' carries no value";
+  EXPECT_EQ("critical", result[1].string_key);
+  ASSERT_EQ(1u, result[1].value.size());
+  EXPECT_EQ("load>5", result[1].value[0]);
+}
+
+TEST(program_options_kvp, splits_on_the_first_equals_only) {
+  // Filters routinely contain '=', e.g. filter=name='foo'. Splitting on the
+  // last (or every) '=' would truncate them.
+  const std::vector<po::option> result = parse_kvp({"filter=name='a=b'"});
+
+  ASSERT_EQ(1u, result.size());
+  EXPECT_EQ("filter", result[0].string_key);
+  ASSERT_EQ(1u, result[0].value.size());
+  EXPECT_EQ("name='a=b'", result[0].value[0]);
+}
+
+TEST(program_options_kvp, keeps_an_empty_value_as_a_value) {
+  // "key=" must stay distinct from a bare "key": the former explicitly sets
+  // the option to the empty string, the latter does not set it at all.
+  const std::vector<po::option> result = parse_kvp({"empty-syntax="});
+
+  ASSERT_EQ(1u, result.size());
+  EXPECT_EQ("empty-syntax", result[0].string_key);
+  ASSERT_EQ(1u, result[0].value.size());
+  EXPECT_EQ("", result[0].value[0]);
+}
+
+TEST(program_options_kvp, records_the_original_token) {
+  const std::vector<po::option> result = parse_kvp({"warning=load>5"});
+
+  ASSERT_EQ(1u, result.size());
+  ASSERT_EQ(1u, result[0].original_tokens.size());
+  EXPECT_EQ("warning=load>5", result[0].original_tokens[0]);
+}
+
+TEST(program_options_kvp, break_at_swallows_the_remaining_tokens) {
+  // Used to hand everything after a marker to a wrapped command verbatim.
+  const std::vector<po::option> result = parse_kvp({"target=host", "--", "-x", "raw=arg"}, "--");
+
+  ASSERT_EQ(2u, result.size());
+  EXPECT_EQ("target", result[0].string_key);
+  EXPECT_EQ("--", result[1].string_key);
+  ASSERT_EQ(2u, result[1].value.size());
+  EXPECT_EQ("-x", result[1].value[0]);
+  EXPECT_EQ("raw=arg", result[1].value[1]) << "tokens after the break are not split on '='";
+}
+
+TEST(program_options_kvp, break_at_only_matches_a_bare_token) {
+  // "--=x" contains '=' so it is a key/value pair, not the break marker.
+  const std::vector<po::option> result = parse_kvp({"--=x", "after"}, "--");
+
+  ASSERT_EQ(2u, result.size());
+  EXPECT_EQ("--", result[0].string_key);
+  ASSERT_EQ(1u, result[0].value.size());
+  EXPECT_EQ("x", result[0].value[0]);
+  EXPECT_EQ("after", result[1].string_key) << "parsing must continue past a non-break token";
+}
+
+TEST(program_options_kvp, empty_break_at_never_breaks) {
+  const std::vector<po::option> result = parse_kvp({"a", "b"});
+
+  ASSERT_EQ(2u, result.size());
+  EXPECT_EQ("a", result[0].string_key);
+  EXPECT_EQ("b", result[1].string_key);
+}
+
+TEST(program_options_kvp, consumes_the_input) {
+  // The caller passes a mutable vector and boost::program_options relies on
+  // the parser having taken ownership of everything it handled.
+  std::vector<std::string> args = {"a=1", "b=2"};
+  const std::vector<po::option> result = npo::option_parser_kvp(args, "");
+
+  EXPECT_EQ(2u, result.size());
+  EXPECT_TRUE(args.empty());
+}
+
+TEST(program_options_kvp, handles_no_arguments) {
+  EXPECT_TRUE(parse_kvp({}).empty());
+}
+
+//////////////////////////////////////////////////////////////////////////
+// strip_default_value
+//
+// Turns boost's format_parameter() rendering back into a bare default, for
+// the help/CSV/show-default output.
+//////////////////////////////////////////////////////////////////////////
+
+TEST(program_options_default_value, a_value_without_a_default_has_none) {
+  po::options_description desc;
+  desc.add_options()("plain", po::value<std::string>(), "d");
+
+  EXPECT_EQ("arg", desc.options()[0]->format_parameter()) << "guards the assumption the code below strips";
+  EXPECT_EQ("", npo::strip_default_value(desc.options()[0]->format_parameter()));
+}
+
+TEST(program_options_default_value, strips_the_boost_decoration) {
+  po::options_description desc;
+  desc.add_options()("with-default", po::value<std::string>()->default_value("ok"), "d");
+
+  EXPECT_EQ("ok", npo::strip_default_value(desc.options()[0]->format_parameter()));
+}
+
+TEST(program_options_default_value, strips_an_implicit_value) {
+  // The shape every boolean check option uses: implicit_value(true) so REST
+  // can pass "x=true", default_value(false) so the flag is off by default.
+  po::options_description desc;
+  desc.add_options()("flag", po::value<bool>()->implicit_value(true)->default_value(false), "d");
+
+  const std::string stripped = npo::strip_default_value(desc.options()[0]->format_parameter());
+  EXPECT_EQ(std::string::npos, stripped.find("arg")) << "no boost decoration may survive, got: " << stripped;
+  EXPECT_EQ(std::string::npos, stripped.find('[')) << "no boost decoration may survive, got: " << stripped;
+}
+
+TEST(program_options_default_value, passes_short_input_through) {
+  EXPECT_EQ("", npo::strip_default_value("arg"));
+  EXPECT_EQ("x", npo::strip_default_value("x"));
+  EXPECT_EQ("", npo::strip_default_value(""));
+}
+
+//////////////////////////////////////////////////////////////////////////
+// make_csv / help_csv
+//
+// help_csv output is consumed as CSV by the docs build, so quoting matters.
+//////////////////////////////////////////////////////////////////////////
+
+TEST(program_options_csv, leaves_a_plain_value_unquoted) {
+  EXPECT_EQ("plain", npo::make_csv("plain"));
+}
+
+TEST(program_options_csv, quotes_a_value_containing_a_separator) {
+  EXPECT_EQ("\"a,b\"", npo::make_csv("a,b"));
+}
+
+TEST(program_options_csv, escapes_and_quotes_embedded_quotes) {
+  EXPECT_EQ("\"say \\\"hi\\\"\"", npo::make_csv("say \"hi\""));
+}
+
+TEST(program_options_csv, escapes_newlines_so_a_row_stays_one_line) {
+  // A raw newline would split the record in two and corrupt every later column.
+  const std::string csv = npo::make_csv("first\nsecond");
+  EXPECT_EQ(std::string::npos, csv.find('\n'));
+  EXPECT_EQ("first\\nsecond", csv);
+}
+
+TEST(program_options_csv, renders_one_row_per_option) {
+  po::options_description desc;
+  desc.add_options()("flag", "a flag")("value", po::value<std::string>()->default_value("5"), "a value");
+
+  const std::string csv = npo::help_csv(desc, "");
+
+  EXPECT_EQ("flag,false,,a flag\nvalue,true,5,a value\n", csv);
+}
+
+//////////////////////////////////////////////////////////////////////////
+// help_show_default
+//////////////////////////////////////////////////////////////////////////
+
+TEST(program_options_show_default, lists_only_options_that_have_a_default) {
+  po::options_description desc;
+  desc.add_options()("flag", "no value at all")("no-default", po::value<std::string>(), "value, no default")(
+      "with-default", po::value<std::string>()->default_value("42"), "value with default");
+
+  const std::string shown = npo::help_show_default(desc);
+
+  EXPECT_EQ("\"with-default=42\" ", shown);
+}
+
+//////////////////////////////////////////////////////////////////////////
+// format_paragraph / format_description
+//
+// The wrapping used by every `--help` rendering.
+//////////////////////////////////////////////////////////////////////////
+
+TEST(program_options_format, leaves_a_short_paragraph_alone) {
+  std::stringstream ss;
+  npo::format_paragraph(ss, "short", 4, 40);
+
+  EXPECT_EQ("short", ss.str());
+}
+
+TEST(program_options_format, wraps_a_long_paragraph_and_indents_continuations) {
+  std::stringstream ss;
+  npo::format_paragraph(ss, "aaaa bbbb cccc dddd eeee ffff gggg hhhh", 4, 20);
+
+  const std::string out = ss.str();
+  ASSERT_NE(std::string::npos, out.find('\n')) << "expected wrapping, got: " << out;
+  // Every continuation line is padded to the indent.
+  std::stringstream lines(out);
+  std::string line;
+  bool first = true;
+  while (std::getline(lines, line)) {
+    if (!first) {
+      EXPECT_EQ("    ", line.substr(0, 4)) << "continuation not indented: " << line;
+    }
+    EXPECT_LE(line.size(), 20u) << "line exceeds the requested width: " << line;
+    first = false;
+  }
+}
+
+TEST(program_options_format, description_keeps_explicit_newlines_as_paragraphs) {
+  // Check descriptions use "\n" to separate a summary from its detail; that
+  // break has to survive into the help output.
+  std::stringstream ss;
+  npo::format_description(ss, "first\nsecond", 2, 40);
+
+  const std::string out = ss.str();
+  ASSERT_NE(std::string::npos, out.find('\n'));
+  EXPECT_EQ("first", out.substr(0, out.find('\n')));
+  EXPECT_NE(std::string::npos, out.find("second"));
+}
+
+//////////////////////////////////////////////////////////////////////////
+// help
+//////////////////////////////////////////////////////////////////////////
+
+TEST(program_options_help, renders_options_with_their_defaults) {
+  po::options_description desc;
+  desc.add_options()("flag", "a flag")("value", po::value<std::string>()->default_value("5"), "a value");
+
+  const std::string text = npo::help(desc, "");
+
+  EXPECT_NE(std::string::npos, text.find("flag")) << text;
+  EXPECT_NE(std::string::npos, text.find("value=ARG")) << "an option taking an argument is shown as such: " << text;
+  EXPECT_EQ(std::string::npos, text.find("flag=ARG")) << "a flag takes no argument: " << text;
+  EXPECT_NE(std::string::npos, text.find("Default value: value=5")) << text;
+}
+
+TEST(program_options_help, prefixes_extra_info) {
+  po::options_description desc;
+  desc.add_options()("flag", "a flag");
+
+  const std::string text = npo::help(desc, "something went wrong");
+
+  EXPECT_EQ(0u, text.find("something went wrong\n")) << text;
+}
+
+TEST(program_options_help, handles_an_option_longer_than_the_column) {
+  // Long names push the description onto its own line; the branch is easy to
+  // get wrong (it underflows an unsigned pad count if mishandled).
+  po::options_description desc;
+  desc.add_options()("an-extremely-long-option-name-that-exceeds-the-column", po::value<std::string>(), "described");
+
+  const std::string text = npo::help(desc, "");
+
+  EXPECT_NE(std::string::npos, text.find("an-extremely-long-option-name-that-exceeds-the-column")) << text;
+  EXPECT_NE(std::string::npos, text.find("described")) << text;
+}
+
+//////////////////////////////////////////////////////////////////////////
+// add_standard_filter
+//
+// Every modern_filter check gets its options from here, so the aliases and
+// the defaults are effectively public API.
+//////////////////////////////////////////////////////////////////////////
+
+TEST(program_options_standard_filter, registers_the_documented_options) {
+  po::options_description desc;
+  npo::standard_filter_config filter;
+  npo::add_standard_filter(desc, filter, "top", "top-keys", "detail", "keys");
+
+  for (const char *name : {"filter", "warning", "warn", "critical", "crit", "ok", "top-syntax", "ok-syntax", "detail-syntax", "empty-syntax", "empty-state"}) {
+    EXPECT_TRUE(desc.find_nothrow(name, false) != nullptr) << "missing option: " << name;
+  }
+}
+
+TEST(program_options_standard_filter, applies_the_supplied_and_builtin_defaults) {
+  po::options_description desc;
+  npo::standard_filter_config filter;
+  npo::add_standard_filter(desc, filter, "top", "top-keys", "detail", "keys");
+
+  po::variables_map vm;
+  std::vector<std::string> args;
+  po::store(po::command_line_parser(args).options(desc).run(), vm);
+  po::notify(vm);
+
+  EXPECT_EQ("top", filter.syntax_top);
+  EXPECT_EQ("detail", filter.syntax_detail);
+  EXPECT_EQ("ok", filter.empty_state);
+  EXPECT_EQ("%(status): Nothing found...", filter.syntax_empty);
+}
+
+TEST(program_options_standard_filter, warn_and_crit_are_aliases) {
+  // Documented shorthand; both spellings write the same field, so a check
+  // behaves identically however the user spelled it.
+  po::options_description desc;
+  npo::standard_filter_config filter;
+  npo::add_standard_filter(desc, filter, "top", "top-keys", "detail", "keys");
+
+  po::variables_map vm;
+  std::vector<std::string> args = {"warn=w>1", "crit=c>2"};
+  po::store(po::command_line_parser(args).options(desc).extra_style_parser([](std::vector<std::string> &a) { return npo::option_parser_kvp(a, ""); }).run(),
+            vm);
+  po::notify(vm);
+
+  EXPECT_EQ("w>1", filter.warn_string);
+  EXPECT_EQ("c>2", filter.crit_string);
+}
+
+}  // namespace

--- a/include/settings/impl/settings_http_test.cpp
+++ b/include/settings/impl/settings_http_test.cpp
@@ -84,6 +84,25 @@ class loopback_http {
 
 std::string http_url(unsigned short port, const std::string &path = "/settings.ini") { return "http://127.0.0.1:" + std::to_string(port) + path; }
 
+// A port on 127.0.0.1 that nothing listens on, obtained by binding an
+// ephemeral port and closing it again. The tests below need a download to
+// *fail*, and the obvious way to spell that - some low fixed port such as 1 -
+// is not portable: on WSL2 a connect to an arbitrary unbound fixed port is
+// swallowed rather than refused, and the three tests using it each sat in the
+// TCP connect timeout for over two minutes. A port the kernel has just handed
+// out and taken back is known-free to the local stack, so the connect is
+// refused immediately.
+unsigned short closed_port() {
+  boost::asio::io_context io;
+  tcp::acceptor probe(io, {tcp::v4(), 0});
+  const unsigned short port = probe.local_endpoint().port();
+  probe.close();
+  return port;
+}
+
+std::string unreachable_url(const std::string &path) { return "http://127.0.0.1:" + std::to_string(closed_port()) + path; }
+
+
 }  // namespace
 
 TEST(settings_http, type_is_http) {
@@ -310,9 +329,9 @@ TEST(settings_http, migrates_the_pre_460_cache_file_to_the_new_name) {
   settings_test::write_file(cache.path() / "nsclient.php", cached_ini);
 
   http_test_core core(cache.path());
-  // Port 1 has no listener, so the download fails and only the migrated file
+  // Nothing listens on that port, so the download fails and only the migrated file
   // can satisfy cache_remote_file's fallback.
-  settings::settings_http s(&core, "test", "http://127.0.0.1:1/nsclient.php?RootFolder=myhost");
+  settings::settings_http s(&core, "test", unreachable_url("/nsclient.php?RootFolder=myhost"));
 
   net::url u;
   u.path = "/nsclient.php";
@@ -327,7 +346,7 @@ TEST(settings_http, migrates_the_pre_460_cache_file_to_the_new_name) {
 TEST(settings_http, migration_does_not_clobber_an_existing_cache_file) {
   temp_dir cache;
   http_test_core core(cache.path());
-  settings::settings_http s(&core, "test", "http://127.0.0.1:1/nsclient.php?RootFolder=myhost");
+  settings::settings_http s(&core, "test", unreachable_url("/nsclient.php?RootFolder=myhost"));
 
   net::url u;
   u.path = "/nsclient.php";
@@ -345,7 +364,7 @@ TEST(settings_http, migration_does_not_clobber_an_existing_cache_file) {
 TEST(settings_http, no_migration_for_a_url_without_a_query) {
   temp_dir cache;
   http_test_core core(cache.path());
-  settings::settings_http s(&core, "test", "http://127.0.0.1:1/nsclient.php");
+  settings::settings_http s(&core, "test", unreachable_url("/nsclient.php"));
 
   net::url u;
   u.path = "/nsclient.php";

--- a/include/settings/impl/settings_ini.hpp
+++ b/include/settings/impl/settings_ini.hpp
@@ -320,6 +320,14 @@ class INISettings : public settings_interface_impl {
       ini.GetAllKeys(ePath.pItem, keys);
       for (const CSimpleIni::Entry &eKey : keys) {
         std::string key = utf8::cvt<std::string>(eKey.pItem);
+        // FIXME: this never reports anything against the production core.
+        // get_registered_key returns boost::none for an unknown key
+        // (settings_handler_impl) and only throws when it cannot take the
+        // registry lock, so the catch below is dead and `nscp settings
+        // --validate` cannot flag a mistyped key. Testing the optional
+        // instead is the fix, but it also starts reporting every key of
+        // every module that is not currently loaded, so it needs its own
+        // change with a decision about that output.
         try {
           get_core()->get_registered_key(path, key);
         } catch (const settings_exception &) {

--- a/include/settings/impl/settings_ini.hpp
+++ b/include/settings/impl/settings_ini.hpp
@@ -74,6 +74,15 @@ class INISettings : public settings_interface_impl {
     return ini.GetValue(utf8::cvt<std::wstring>(key.first).c_str(), utf8::cvt<std::wstring>(key.second).c_str()) != nullptr;
   }
 
+  // FIXME: this treats an existing but empty section as missing.
+  // CSimpleIni::GetSectionSize returns -1 when the section is not there and 0
+  // when it is there without any keys, so the test should be `>= 0`. As it
+  // stands, a section that exists in the file with no keys under it reads as
+  // absent: has_section() says false and get_changes() keeps reporting it as
+  // path_added even after a save. Not changed here because has_section() has
+  // no production callers today and the correction widens what
+  // get_real_sections()/get_changes() consider real - it wants its own change
+  // with coverage for the empty-section case.
   bool has_real_path(std::string path) override { return ini.GetSectionSize(utf8::cvt<std::wstring>(path).c_str()) > 0; }
 
   static std::string render_comment(const boost::optional<settings_core::key_description> &desc) {

--- a/include/settings/impl/settings_ini_test.cpp
+++ b/include/settings/impl/settings_ini_test.cpp
@@ -642,3 +642,44 @@ TEST(settings_ini, get_local_sections_includes_values_set_but_not_yet_saved) {
   const auto sections = s.get_local_sections("");
   EXPECT_NE(std::find(sections.begin(), sections.end(), "/pending"), sections.end());
 }
+
+// The pending-change bookkeeping lives in settings_interface_impl, but it is
+// only correct if the backend really did take the write. These two run the
+// same scenarios as settings_interface_impl_test through the ini backend and
+// an actual file on disk.
+TEST(settings_ini, get_changes_is_empty_after_a_save) {
+  temp_dir dir;
+  auto file = dir.file("changes.ini");
+  write_file(file, "; nothing here\n");
+  mock_settings_core core;
+  settings::INISettings s(&core, "test", ini_context(file));
+  s.set_string("/section", "key", "value");
+  ASSERT_FALSE(s.get_changes().empty()) << "the edit is pending before the save";
+
+  s.save(false);
+
+  EXPECT_TRUE(s.get_changes().empty()) << "and settled once written";
+  EXPECT_NE(settings_test::read_file(file).find("value"), std::string::npos);
+  // The cleanup must not cost us the section or the value.
+  auto v = s.get_string("/section", "key");
+  ASSERT_TRUE(v.has_value());
+  EXPECT_EQ(*v, "value");
+  const auto sections = s.get_local_sections("");
+  EXPECT_NE(std::find(sections.begin(), sections.end(), "/section"), sections.end());
+}
+
+TEST(settings_ini, get_changes_is_empty_after_a_deletion_is_saved) {
+  temp_dir dir;
+  auto file = dir.file("changes_del.ini");
+  write_file(file, "[/section]\nkey = doomed\n");
+  mock_settings_core core;
+  settings::INISettings s(&core, "test", ini_context(file));
+  s.remove_key("/section", "key");
+  ASSERT_FALSE(s.get_changes().empty());
+
+  s.save(false);
+
+  EXPECT_TRUE(s.get_changes().empty());
+  EXPECT_EQ(settings_test::read_file(file).find("doomed"), std::string::npos);
+  EXPECT_FALSE(s.get_string("/section", "key").has_value()) << "and it stays gone for readers";
+}

--- a/include/settings/settings_interface_impl.hpp
+++ b/include/settings/settings_interface_impl.hpp
@@ -559,22 +559,42 @@ class settings_interface_impl : public settings_interface {
         set_real_path(path);
       }
     }
-    // Everything above is now in the backend, so nothing here is pending any
-    // more. Without this the entries stay dirty for the lifetime of the store
-    // and get_changes() keeps reporting edits that were already written - as a
-    // `modified` entry whose old_value equals its new_value, since the key now
-    // exists in the backend and no longer reads as an addition.
+    // Everything above was handed to the backend, so drop the pending markers
+    // the backend now agrees with. Without this the entries stay dirty for the
+    // lifetime of the store and get_changes() keeps reporting edits that were
+    // already written - as a `modified` entry whose old_value equals its
+    // new_value, since the key now exists in the backend and no longer reads
+    // as an addition.
     //
-    // Only the pending markers are dropped. settings_cache_ keeps its values
-    // because it is also the read cache; the delete and path caches exist
-    // purely to mask/augment backend reads until a save, and the backend now
-    // agrees with them.
+    // Only the pending markers are dropped, and each one is verified against
+    // the backend rather than assumed persisted: a store that discards writes
+    // (settings_dummy backs `nscp unit` and one-shot client runs) answers
+    // has_real_path() with false, and for it path_cache_ IS the section store
+    // - clearing it unconditionally made every section written before save()
+    // vanish from get_sections(), which silently dropped all of the
+    // Scheduler's enumerated schedules in the python unit tests.
+    // settings_cache_ keeps its values because it is also the read cache.
     for (cache_type::iterator it = settings_cache_.begin(); it != settings_cache_.end(); ++it) {
-      it->second.make_clean();
+      if (has_real_key(it->first)) it->second.make_clean();
     }
-    settings_delete_cache_.clear();
-    settings_delete_path_cache_.clear();
-    path_cache_.clear();
+    for (path_delete_cache_type::iterator it = settings_delete_cache_.begin(); it != settings_delete_cache_.end();) {
+      if (!has_real_key(*it))
+        it = settings_delete_cache_.erase(it);
+      else
+        ++it;
+    }
+    for (path_cache_type::iterator it = settings_delete_path_cache_.begin(); it != settings_delete_path_cache_.end();) {
+      if (!has_real_path(*it))
+        it = settings_delete_path_cache_.erase(it);
+      else
+        ++it;
+    }
+    for (path_cache_type::iterator it = path_cache_.begin(); it != path_cache_.end();) {
+      if (has_real_path(*it))
+        it = path_cache_.erase(it);
+      else
+        ++it;
+    }
     for (instance_raw_ptr &child : children_) {
       child->save(re_save_all);
     }

--- a/include/settings/settings_interface_impl.hpp
+++ b/include/settings/settings_interface_impl.hpp
@@ -433,6 +433,13 @@ class settings_interface_impl : public settings_interface {
   virtual bool has_key(std::string path, std::string key) {
     MUTEX_GUARD();
     settings_core::key_path_type lookup(path, key);
+    // Honor staged deletions, the same way getter() and get_keys() do. Without
+    // this, a key removed but not yet saved still reads as present here while
+    // every read path says it is gone - and a caller that checks before
+    // reading (settings_handler_impl::update_defaults does) takes the
+    // key-exists branch only to get nothing back from get_string().
+    if (settings_delete_cache_.find(cache_key_type(path, key)) != settings_delete_cache_.end()) return false;
+    if (settings_delete_path_cache_.find(path) != settings_delete_path_cache_.end()) return false;
     cache_type::const_iterator cit = settings_cache_.find(lookup);
     if (cit != settings_cache_.end()) return true;
     if (has_real_key(lookup)) {

--- a/include/settings/settings_interface_impl.hpp
+++ b/include/settings/settings_interface_impl.hpp
@@ -46,6 +46,7 @@ class settings_interface_impl : public settings_interface {
     conainer() : is_dirty_(false) {}
 
     void make_dirty() { is_dirty_ = true; }
+    void make_clean() { is_dirty_ = false; }
 
     bool is_dirty() const { return is_dirty_; }
     std::string get_string() const {
@@ -551,6 +552,22 @@ class settings_interface_impl : public settings_interface {
         set_real_path(path);
       }
     }
+    // Everything above is now in the backend, so nothing here is pending any
+    // more. Without this the entries stay dirty for the lifetime of the store
+    // and get_changes() keeps reporting edits that were already written - as a
+    // `modified` entry whose old_value equals its new_value, since the key now
+    // exists in the backend and no longer reads as an addition.
+    //
+    // Only the pending markers are dropped. settings_cache_ keeps its values
+    // because it is also the read cache; the delete and path caches exist
+    // purely to mask/augment backend reads until a save, and the backend now
+    // agrees with them.
+    for (cache_type::iterator it = settings_cache_.begin(); it != settings_cache_.end(); ++it) {
+      it->second.make_clean();
+    }
+    settings_delete_cache_.clear();
+    settings_delete_path_cache_.clear();
+    path_cache_.clear();
     for (instance_raw_ptr &child : children_) {
       child->save(re_save_all);
     }

--- a/include/settings/settings_interface_impl_test.cpp
+++ b/include/settings/settings_interface_impl_test.cpp
@@ -697,3 +697,39 @@ TEST(settings_interface_impl, get_changes_includes_child_store_changes) {
   EXPECT_NE(nullptr, find_change(changes, "/parent-section", "key", kind::added));
   EXPECT_NE(nullptr, find_change(changes, "/child-section", "key", kind::added)) << "child changes must not be invisible";
 }
+
+TEST(settings_interface_impl, has_key_honors_a_staged_deletion) {
+  // getter() and get_keys() both mask a key that has been removed but not yet
+  // saved. has_key() has to agree with them, or a caller that checks before
+  // reading (update_defaults does exactly that) sees a key it cannot read.
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_values[pk("/section", "key")] = "doomed";
+  b.remove_key("/section", "key");
+
+  EXPECT_FALSE(b.has_key("/section", "key"));
+  EXPECT_FALSE(b.get_string("/section", "key").has_value()) << "and the read path agrees";
+}
+
+TEST(settings_interface_impl, has_key_honors_a_staged_path_deletion) {
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_values[pk("/section", "key")] = "doomed";
+  b.persisted_paths.insert("/section");
+  b.remove_path("/section");
+
+  EXPECT_FALSE(b.has_key("/section", "key"));
+  EXPECT_FALSE(b.get_string("/section", "key").has_value());
+}
+
+TEST(settings_interface_impl, has_key_finds_a_key_set_again_after_a_deletion) {
+  // The un-delete path: setting the key again clears the pending delete, so
+  // it must read as present once more.
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_values[pk("/section", "key")] = "doomed";
+  b.remove_key("/section", "key");
+  b.set_string("/section", "key", "reborn");
+
+  EXPECT_TRUE(b.has_key("/section", "key"));
+}

--- a/include/settings/settings_interface_impl_test.cpp
+++ b/include/settings/settings_interface_impl_test.cpp
@@ -498,3 +498,153 @@ TEST(settings_interface_impl, to_string_includes_info) {
   memory_backend b(&core, "test", "memory://");
   EXPECT_NE(b.to_string().find("memory backend"), std::string::npos);
 }
+
+// ============================================================================
+// get_changes: the pending change-set an operator sees before saving
+// ============================================================================
+
+namespace {
+using kind = settings::settings_interface::change_entry::change_kind;
+
+// A core that hands out real backends, so the child-store recursion in
+// get_changes() can be exercised (production uses this for included files).
+class chaining_core : public mock_settings_core {
+ public:
+  // Kept alive here because add_child() stores a raw-pointer-like handle.
+  std::list<std::shared_ptr<memory_backend>> children;
+
+  settings::instance_raw_ptr create_instance(std::string alias, std::string context) override {
+    auto child = std::make_shared<memory_backend>(this, alias, context);
+    children.push_back(child);
+    return child;
+  }
+};
+}  // namespace
+
+TEST(settings_interface_impl, get_changes_is_empty_for_a_clean_store) {
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_values[{"/section", "key"}] = "value";
+  b.persisted_paths.insert("/section");
+
+  // Reading must not manufacture a pending change.
+  EXPECT_TRUE(b.get_string("/section", "key").has_value());
+  EXPECT_TRUE(b.get_changes().empty());
+}
+
+TEST(settings_interface_impl, get_changes_reports_an_unknown_key_as_added) {
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.set_string("/section", "key", "value");
+
+  const auto changes = b.get_changes();
+  const auto *c = find_change(changes, "/section", "key", kind::added);
+  ASSERT_NE(nullptr, c);
+  EXPECT_EQ("value", c->new_value);
+  EXPECT_EQ("", c->old_value) << "there is no previous value to report";
+}
+
+TEST(settings_interface_impl, get_changes_reports_an_overwritten_key_as_modified) {
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_values[{"/section", "key"}] = "before";
+  b.persisted_paths.insert("/section");
+  b.set_string("/section", "key", "after");
+
+  const auto changes = b.get_changes();
+  const auto *c = find_change(changes, "/section", "key", kind::modified);
+  ASSERT_NE(nullptr, c);
+  EXPECT_EQ("before", c->old_value);
+  EXPECT_EQ("after", c->new_value);
+  EXPECT_EQ(nullptr, find_change(changes, "/section", "key", kind::added)) << "an overwrite is not also an addition";
+}
+
+TEST(settings_interface_impl, get_changes_reports_a_removed_key_with_its_old_value) {
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_values[{"/section", "key"}] = "doomed";
+  b.persisted_paths.insert("/section");
+  b.remove_key("/section", "key");
+
+  const auto changes = b.get_changes();
+  const auto *c = find_change(changes, "/section", "key", kind::removed);
+  ASSERT_NE(nullptr, c);
+  EXPECT_EQ("doomed", c->old_value) << "an operator needs to see what is about to be lost";
+}
+
+TEST(settings_interface_impl, get_changes_reports_a_removed_path) {
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_paths.insert("/dead");
+  b.remove_path("/dead");
+
+  const auto *c = find_change(b.get_changes(), "/dead", "", kind::path_removed);
+  ASSERT_NE(nullptr, c);
+}
+
+TEST(settings_interface_impl, get_changes_reports_a_new_path_as_added) {
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.add_path("/brand-new");
+
+  const auto *c = find_change(b.get_changes(), "/brand-new", "", kind::path_added);
+  ASSERT_NE(nullptr, c);
+}
+
+TEST(settings_interface_impl, get_changes_ignores_a_path_that_already_exists) {
+  // add_path on an existing section is a no-op as far as the operator is
+  // concerned; reporting it would make every save look like a change.
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_paths.insert("/already-there");
+  b.add_path("/already-there");
+
+  EXPECT_EQ(nullptr, find_change(b.get_changes(), "/already-there", "", kind::path_added));
+}
+
+TEST(settings_interface_impl, get_changes_still_reports_a_saved_change_as_pending) {
+  // CHARACTERIZATION TEST - this pins current behaviour, which is wrong.
+  //
+  // save() writes the cache out to the backend and clears the *core* dirty
+  // flag, but it never clears the per-entry dirty flags, the delete caches or
+  // the path cache. get_changes() keys off those per-entry flags, so a change
+  // stays "pending" for the lifetime of the store even after it was written.
+  //
+  // Worse, the entry changes shape: before the save it is reported as `added`
+  // (no such key in the backend), afterwards the key does exist, so it is
+  // reported as `modified` with old_value == new_value - a change that claims
+  // to alter nothing. Anything driving an operator-facing diff off
+  // get_changes() shows already-saved edits as outstanding.
+  //
+  // The fix belongs in save() (mark entries clean and drop the delete/path
+  // caches once written). When that lands, this test should be replaced with
+  // the obvious one: get_changes() is empty after a save.
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.set_string("/section", "key", "value");
+  ASSERT_NE(nullptr, find_change(b.get_changes(), "/section", "key", kind::added));
+
+  b.save(false);
+  ASSERT_EQ("value", b.persisted_values[pk("/section", "key")]) << "the value really was written";
+
+  const auto after = b.get_changes();
+  const auto *c = find_change(after, "/section", "key", kind::modified);
+  ASSERT_NE(nullptr, c) << "documenting the defect: the saved change is still reported";
+  EXPECT_EQ(c->old_value, c->new_value) << "and it reports a no-op modification";
+}
+
+TEST(settings_interface_impl, get_changes_includes_child_store_changes) {
+  // Included config files are child stores; their pending edits belong in the
+  // same change-set or an operator saves without seeing them.
+  chaining_core core;
+  memory_backend parent(&core, "parent", "memory://parent");
+  auto child = std::static_pointer_cast<memory_backend>(parent.add_child("child", "memory://child"));
+  ASSERT_TRUE(static_cast<bool>(child));
+
+  parent.set_string("/parent-section", "key", "parent-value");
+  child->set_string("/child-section", "key", "child-value");
+
+  const auto changes = parent.get_changes();
+  EXPECT_NE(nullptr, find_change(changes, "/parent-section", "key", kind::added));
+  EXPECT_NE(nullptr, find_change(changes, "/child-section", "key", kind::added)) << "child changes must not be invisible";
+}

--- a/include/settings/settings_interface_impl_test.cpp
+++ b/include/settings/settings_interface_impl_test.cpp
@@ -602,35 +602,84 @@ TEST(settings_interface_impl, get_changes_ignores_a_path_that_already_exists) {
   EXPECT_EQ(nullptr, find_change(b.get_changes(), "/already-there", "", kind::path_added));
 }
 
-TEST(settings_interface_impl, get_changes_still_reports_a_saved_change_as_pending) {
-  // CHARACTERIZATION TEST - this pins current behaviour, which is wrong.
-  //
-  // save() writes the cache out to the backend and clears the *core* dirty
-  // flag, but it never clears the per-entry dirty flags, the delete caches or
-  // the path cache. get_changes() keys off those per-entry flags, so a change
-  // stays "pending" for the lifetime of the store even after it was written.
-  //
-  // Worse, the entry changes shape: before the save it is reported as `added`
-  // (no such key in the backend), afterwards the key does exist, so it is
-  // reported as `modified` with old_value == new_value - a change that claims
-  // to alter nothing. Anything driving an operator-facing diff off
-  // get_changes() shows already-saved edits as outstanding.
-  //
-  // The fix belongs in save() (mark entries clean and drop the delete/path
-  // caches once written). When that lands, this test should be replaced with
-  // the obvious one: get_changes() is empty after a save.
+TEST(settings_interface_impl, get_changes_is_empty_once_saved) {
+  // save() must drop the pending markers, not just write the values. When it
+  // did not, the entry stayed dirty for the lifetime of the store and was
+  // re-reported on every call - as a `modified` entry whose old_value equalled
+  // its new_value, because the key now existed in the backend and no longer
+  // read as an addition. Anything driving an operator-facing diff off
+  // get_changes() showed already-saved edits as outstanding.
   mock_settings_core core;
   memory_backend b(&core, "test", "memory://");
   b.set_string("/section", "key", "value");
   ASSERT_NE(nullptr, find_change(b.get_changes(), "/section", "key", kind::added));
 
   b.save(false);
-  ASSERT_EQ("value", b.persisted_values[pk("/section", "key")]) << "the value really was written";
 
-  const auto after = b.get_changes();
-  const auto *c = find_change(after, "/section", "key", kind::modified);
-  ASSERT_NE(nullptr, c) << "documenting the defect: the saved change is still reported";
-  EXPECT_EQ(c->old_value, c->new_value) << "and it reports a no-op modification";
+  ASSERT_EQ("value", b.persisted_values[pk("/section", "key")]) << "the value really was written";
+  EXPECT_TRUE(b.get_changes().empty()) << "a saved change is no longer pending";
+}
+
+TEST(settings_interface_impl, get_changes_is_empty_once_a_deletion_is_saved) {
+  // Same for the delete caches: a removal that has been applied to the backend
+  // is no longer a pending change.
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_values[pk("/section", "key")] = "doomed";
+  b.persisted_paths.insert("/section");
+  b.persisted_paths.insert("/dead");
+  b.remove_key("/section", "key");
+  b.remove_path("/dead");
+  ASSERT_EQ(2u, b.get_changes().size());
+
+  b.save(false);
+
+  EXPECT_TRUE(b.get_changes().empty());
+  EXPECT_EQ(0u, b.persisted_values.count(pk("/section", "key")));
+  EXPECT_EQ(0u, b.persisted_paths.count("/dead"));
+}
+
+TEST(settings_interface_impl, a_saved_value_is_still_readable) {
+  // Guards the narrow scope of the cleanup above: clearing the pending markers
+  // must not clear the cached values with them, or every save would push reads
+  // back to the backend (and reads of never-persisted defaults would break).
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.set_string("/section", "key", "value");
+  b.add_path("/section");
+  b.save(false);
+
+  auto v = b.get_string("/section", "key");
+  ASSERT_TRUE(v.has_value());
+  EXPECT_EQ("value", *v);
+  EXPECT_TRUE(b.has_section("/section"));
+}
+
+TEST(settings_interface_impl, a_saved_deletion_stays_deleted_for_readers) {
+  // The delete caches mask backend reads until a save; once cleared, the
+  // backend itself must be the thing that says the key is gone.
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.persisted_values[pk("/section", "key")] = "doomed";
+  b.persisted_paths.insert("/section");
+  b.remove_key("/section", "key");
+  b.save(false);
+
+  EXPECT_FALSE(b.get_string("/section", "key").has_value());
+}
+
+TEST(settings_interface_impl, save_after_save_is_a_no_op) {
+  // A second save with nothing changed in between must not rewrite anything;
+  // the backends skip non-dirty values, which only works if save() cleaned up.
+  mock_settings_core core;
+  memory_backend b(&core, "test", "memory://");
+  b.set_string("/section", "key", "value");
+  b.save(false);
+
+  b.persisted_values.erase(pk("/section", "key"));
+  b.save(false);
+
+  EXPECT_EQ(0u, b.persisted_values.count(pk("/section", "key"))) << "nothing was pending, so nothing should have been written";
 }
 
 TEST(settings_interface_impl, get_changes_includes_child_store_changes) {

--- a/libs/plugin_api/nscapi_program_options_test.cpp
+++ b/libs/plugin_api/nscapi_program_options_test.cpp
@@ -7,24 +7,24 @@
 
 namespace po = boost::program_options;
 
-TEST(nscapiProgramOptionsTest, strip_default_value_plain) {
-  EXPECT_EQ("", nscapi::program_options::strip_default_value("arg"));
+TEST(nscapiProgramOptionsTest, extract_default_value_plain) {
+  EXPECT_EQ("", nscapi::program_options::extract_default_value("arg"));
 }
 
-TEST(nscapiProgramOptionsTest, strip_default_value_default) {
-  EXPECT_EQ("10", nscapi::program_options::strip_default_value("arg (=10)"));
-  EXPECT_EQ("%(status): Nothing found...", nscapi::program_options::strip_default_value("arg (=%(status): Nothing found...)"));
+TEST(nscapiProgramOptionsTest, extract_default_value_default) {
+  EXPECT_EQ("10", nscapi::program_options::extract_default_value("arg (=10)"));
+  EXPECT_EQ("%(status): Nothing found...", nscapi::program_options::extract_default_value("arg (=%(status): Nothing found...)"));
 }
 
-TEST(nscapiProgramOptionsTest, strip_default_value_implicit) {
-  EXPECT_EQ("true", nscapi::program_options::strip_default_value("[=arg(=true)]"));
+TEST(nscapiProgramOptionsTest, extract_default_value_implicit) {
+  EXPECT_EQ("true", nscapi::program_options::extract_default_value("[=arg(=true)]"));
 }
 
-TEST(nscapiProgramOptionsTest, strip_default_value_implicit_and_default) {
+TEST(nscapiProgramOptionsTest, extract_default_value_implicit_and_default) {
   // The bool convention implicit_value(true)->default_value(false) formats as
   // "[=arg(=1)] (=0)"; the default is the part to surface.
-  EXPECT_EQ("0", nscapi::program_options::strip_default_value("[=arg(=1)] (=0)"));
-  EXPECT_EQ("1", nscapi::program_options::strip_default_value("[=arg(=1)] (=1)"));
+  EXPECT_EQ("0", nscapi::program_options::extract_default_value("[=arg(=1)] (=0)"));
+  EXPECT_EQ("1", nscapi::program_options::extract_default_value("[=arg(=1)] (=1)"));
 }
 
 namespace {

--- a/libs/settings_manager/settings_handler_impl.cpp
+++ b/libs/settings_manager/settings_handler_impl.cpp
@@ -73,7 +73,12 @@ void settings::settings_handler_impl::destroy_all_instances() {
 
 void settings::settings_handler_impl::house_keeping() {
   boost::unique_lock<boost::timed_mutex> mutex(instance_mutex_, boost::get_system_time() + boost::posix_time::seconds(5));
-  if (!mutex.owns_lock()) throw settings_exception(__FILE__, __LINE__, "destroy_all_instances Failed to get mutex, cant get access settings");
+  if (!mutex.owns_lock()) throw settings_exception(__FILE__, __LINE__, "house_keeping Failed to get mutex, cant get access settings");
+  // The scheduler calls this on a timer (scheduler::handle_settings), so it
+  // can fire before boot() installs an instance or after shutdown destroyed
+  // it. Dereferencing then is a null crash; the scheduler thread catches
+  // exceptions, so report it the way every sibling here does.
+  if (!instance_) throw settings_exception(__FILE__, __LINE__, "Failed initialize settings instance");
   instance_->house_keeping();
 }
 

--- a/libs/settings_manager/settings_manager_impl_test.cpp
+++ b/libs/settings_manager/settings_manager_impl_test.cpp
@@ -603,4 +603,311 @@ TEST_F(SettingsHandlerTest, SetInstanceMakesGetReturn) {
   ASSERT_TRUE(static_cast<bool>(inst));
 }
 
+// ===========================================================================
+// update_defaults / remove_defaults
+//
+// These two are what `nscp settings --add-defaults` and `--remove-defaults`
+// do to a live store: the first materialises every registered non-advanced
+// key at its default value, the second strips back out whatever still sits at
+// that default. Together they decide what a shipped nsclient.ini looks like,
+// and the half that matters most is the one that leaves an operator's own
+// value alone.
+//
+// Backed by a real INI store in a temp dir rather than the dummy backend -
+// dummy discards everything written to it, which would make every assertion
+// below vacuously true.
+// ===========================================================================
+
+// recording_provider answers every expand_path() with its boot.ini, which is
+// what the boot() tests need but breaks anything that resolves a real path:
+// INISettings runs its file name through the same hook, so loading, saving
+// and context_exists() would all end up looking at the boot.ini instead.
+class passthrough_provider : public recording_provider {
+ public:
+  passthrough_provider() : recording_provider("") {}
+  std::string expand_path(std::string file) override { return file; }
+};
+
+// Build an "ini:///<absolute path>" context - three slashes so net::parse
+// leaves the host empty and hands the whole absolute path to url.path.
+std::string ini_context(const boost::filesystem::path &p) {
+  std::string s = p.generic_string();
+  if (!s.empty() && s.front() == '/') s.erase(0, 1);
+  return "ini:///" + s;
+}
+
+class SettingsDefaultsTest : public SettingsHandlerTest {
+ protected:
+  settings_test::temp_dir store_dir_;
+  std::unique_ptr<passthrough_provider> store_provider_;
+
+  void SetUp() override {
+    store_provider_ = std::make_unique<passthrough_provider>();
+    impl_ = std::make_unique<settings_manager::NSCSettingsImpl>(store_provider_.get());
+    // INISettings resolves its context against an existing file (see the note
+    // in settings_ini_test), so the file has to be there before we point at
+    // it - empty is fine.
+    const boost::filesystem::path file = store_dir_.file("store.ini");
+    settings_test::write_file(file, "");
+    impl_->set_instance("master", ini_context(file));
+  }
+};
+
+// Same provider, no store: for the context-dispatch tests, which resolve
+// paths but never open an instance.
+class SettingsContextTest : public SettingsHandlerTest {
+ protected:
+  std::unique_ptr<passthrough_provider> path_provider_;
+
+  void SetUp() override {
+    path_provider_ = std::make_unique<passthrough_provider>();
+    impl_ = std::make_unique<settings_manager::NSCSettingsImpl>(path_provider_.get());
+  }
+};
+
+TEST_F(SettingsDefaultsTest, UpdateDefaultsMaterialisesRegisteredKeys) {
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "k", "string", "", "", "the-default", false, false, true);
+
+  impl_->update_defaults();
+
+  EXPECT_EQ(impl_->get()->get_string("/sec", "k", ""), "the-default");
+}
+
+TEST_F(SettingsDefaultsTest, UpdateDefaultsSkipsAdvancedKeys) {
+  // "advanced" is the flag that keeps rarely-touched keys out of a fresh ini.
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "k", "string", "", "", "the-default", /*advanced=*/true, false, true);
+
+  impl_->update_defaults();
+
+  EXPECT_FALSE(impl_->get()->has_key("/sec", "k"));
+}
+
+TEST_F(SettingsDefaultsTest, UpdateDefaultsLeavesAnOperatorsValueAlone) {
+  // The whole point of the has_key branch: --add-defaults must not reset
+  // configuration somebody deliberately changed.
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "k", "string", "", "", "the-default", false, false, true);
+  impl_->get()->set_string("/sec", "k", "operator-value");
+
+  impl_->update_defaults();
+
+  EXPECT_EQ(impl_->get()->get_string("/sec", "k", ""), "operator-value");
+}
+
+TEST_F(SettingsDefaultsTest, UpdateDefaultsCreatesRegisteredSectionsWithoutKeys) {
+  impl_->register_path(0xffff, "/empty-sec", "S", "", false, false, true);
+
+  impl_->update_defaults();
+
+  EXPECT_TRUE(impl_->get()->has_section("/empty-sec"));
+}
+
+TEST_F(SettingsDefaultsTest, UpdateDefaultsIgnoresSamplePaths) {
+  // Sample sections document what a config could look like; writing them into
+  // the live store would enable configuration nobody asked for.
+  impl_->register_path(0xffff, "/sample", "S", "", false, /*is_sample=*/true, true);
+  impl_->register_key(0xffff, "/sample", "k", "string", "", "", "d", false, /*is_sample=*/true, true);
+
+  impl_->update_defaults();
+
+  EXPECT_FALSE(impl_->get()->has_key("/sample", "k"));
+}
+
+TEST_F(SettingsDefaultsTest, RemoveDefaultsDropsKeysLeftAtTheirDefault) {
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "k", "string", "", "", "the-default", false, false, true);
+  impl_->get()->set_string("/sec", "k", "the-default");
+
+  impl_->remove_defaults();
+
+  EXPECT_FALSE(impl_->get()->has_key("/sec", "k"));
+}
+
+TEST_F(SettingsDefaultsTest, RemoveDefaultsKeepsCustomisedKeys) {
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "k", "string", "", "", "the-default", false, false, true);
+  impl_->get()->set_string("/sec", "k", "operator-value");
+
+  impl_->remove_defaults();
+
+  EXPECT_EQ(impl_->get()->get_string("/sec", "k", ""), "operator-value");
+}
+
+TEST_F(SettingsDefaultsTest, RemoveDefaultsDropsTheSectionOnceItIsEmpty) {
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "k", "string", "", "", "the-default", false, false, true);
+  impl_->get()->set_string("/sec", "k", "the-default");
+
+  impl_->remove_defaults();
+
+  EXPECT_FALSE(impl_->get()->has_section("/sec"));
+}
+
+TEST_F(SettingsDefaultsTest, RemoveDefaultsKeepsASectionThatStillHasKeys) {
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "default-key", "string", "", "", "the-default", false, false, true);
+  impl_->register_key(0xffff, "/sec", "custom-key", "string", "", "", "the-default", false, false, true);
+  impl_->get()->set_string("/sec", "default-key", "the-default");
+  impl_->get()->set_string("/sec", "custom-key", "operator-value");
+
+  impl_->remove_defaults();
+
+  EXPECT_TRUE(impl_->get()->has_section("/sec"));
+  EXPECT_EQ(impl_->get()->get_string("/sec", "custom-key", ""), "operator-value");
+}
+
+TEST_F(SettingsDefaultsTest, DefaultsRoundTripLeavesNothingBehind) {
+  // Adding every default and then removing every default should land back on
+  // the store we started with.
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "k", "string", "", "", "the-default", false, false, true);
+
+  impl_->update_defaults();
+  impl_->remove_defaults();
+
+  EXPECT_FALSE(impl_->get()->has_key("/sec", "k"));
+  EXPECT_FALSE(impl_->get()->has_section("/sec"));
+}
+
+// ---------------------------------------------------------------------------
+// Instance-backed accessors. Each of these dereferences the settings instance,
+// so the interesting case is what they do before boot() installs one.
+// ---------------------------------------------------------------------------
+
+TEST_F(SettingsHandlerTest, HouseKeepingThrowsBeforeAnInstanceExists) {
+  // scheduler::handle_settings drives this on a timer, which can fire before
+  // boot() has installed an instance or after shutdown destroyed it. It used
+  // to dereference the null instance; the scheduler thread catches exceptions
+  // but cannot catch a segfault.
+  EXPECT_THROW(impl_->house_keeping(), settings::settings_exception);
+}
+
+TEST_F(SettingsHandlerTest, HouseKeepingRunsOnALiveInstance) {
+  impl_->set_instance("master", "dummy");
+  EXPECT_NO_THROW(impl_->house_keeping());
+}
+
+TEST_F(SettingsHandlerTest, SupportsUpdatesThrowsBeforeAnInstanceExists) { EXPECT_THROW(impl_->supports_updates(), settings::settings_exception); }
+
+TEST_F(SettingsHandlerTest, SupportsUpdatesFollowsTheBackend) {
+  // The dummy backend swallows writes, so it must report itself read-only.
+  impl_->set_instance("master", "dummy");
+  EXPECT_FALSE(impl_->supports_updates());
+}
+
+TEST_F(SettingsDefaultsTest, SupportsUpdatesIsTrueForAnIniStore) { EXPECT_TRUE(impl_->supports_updates()); }
+
+// validate() is what `nscp settings --validate` reports. It has to run against
+// configuration read from disk: writing a key through the store auto-registers
+// its section as "in flight" (settings_interface_impl::setter does), so a
+// section created in the same process is never unregistered by the time
+// validate() looks.
+TEST_F(SettingsContextTest, ValidateReportsSectionsNobodyRegistered) {
+  settings_test::temp_dir dir;
+  const boost::filesystem::path file = dir.file("stray.ini");
+  settings_test::write_file(file, "[/nobody-registered-this]\nk = v\n");
+  impl_->set_instance("master", ini_context(file));
+
+  EXPECT_FALSE(impl_->validate().empty());
+}
+
+TEST_F(SettingsContextTest, ValidateIsQuietForRegisteredConfiguration) {
+  settings_test::temp_dir dir;
+  const boost::filesystem::path file = dir.file("known.ini");
+  settings_test::write_file(file, "[/sec]\nk = v\n");
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->register_key(0xffff, "/sec", "k", "string", "", "", "", false, false, true);
+  impl_->set_instance("master", ini_context(file));
+
+  EXPECT_TRUE(impl_->validate().empty());
+}
+
+TEST_F(SettingsContextTest, ValidateDoesNotFlagUnregisteredKeys) {
+  // CHARACTERIZATION TEST - this pins current behaviour, which is wrong.
+  //
+  // settings_ini::validate() spots an unregistered key by catching an
+  // exception out of get_registered_key(). The production core does not throw
+  // for an unknown key, it returns boost::none (settings_handler_impl), so
+  // that half of --validate never fires and a typo in a key name is reported
+  // by nothing. Only the test core in test_helpers.hpp throws, which is why
+  // settings_ini_test's own validate test sees the errors this one cannot.
+  //
+  // See the FIXME in settings_ini.hpp: the fix is to test the optional rather
+  // than wait for an exception, but it widens what --validate prints (every
+  // key of every module that is not currently loaded), so it wants its own
+  // change.
+  settings_test::temp_dir dir;
+  const boost::filesystem::path file = dir.file("typo.ini");
+  settings_test::write_file(file, "[/sec]\nunregistered-key = v\n");
+  impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
+  impl_->set_instance("master", ini_context(file));
+
+  EXPECT_TRUE(impl_->validate().empty()) << "documenting the defect: the unknown key is not reported";
+}
+
+TEST_F(SettingsDefaultsTest, UseSensitiveKeysDefaultsToFalse) { EXPECT_FALSE(impl_->use_sensitive_keys()); }
+
+TEST_F(SettingsDefaultsTest, UseSensitiveKeysFollowsTheSetting) {
+  // Turning this on is what redirects passwords into the Windows credential
+  // manager instead of writing them into the ini in clear text.
+  impl_->get()->set_string("/settings", "use credential manager", "true");
+  EXPECT_TRUE(impl_->use_sensitive_keys());
+}
+
+// ---------------------------------------------------------------------------
+// Context dispatch: which backend a context string selects, whether it can be
+// edited, and whether it is already there. get_context/--migrate-to and the
+// settings web UI all branch on these.
+// ---------------------------------------------------------------------------
+
+TEST_F(SettingsHandlerTest, SupportsEditAcceptsAnEmptyContext) {
+  // Empty means "whatever is configured", which the caller resolves later.
+  EXPECT_TRUE(impl_->supports_edit(""));
+}
+
+TEST_F(SettingsHandlerTest, SupportsEditIsTrueForIni) { EXPECT_TRUE(impl_->supports_edit("ini:///tmp/whatever.ini")); }
+
+TEST_F(SettingsHandlerTest, SupportsEditIsFalseForReadOnlyBackends) {
+  EXPECT_FALSE(impl_->supports_edit("dummy"));
+  EXPECT_FALSE(impl_->supports_edit("http://localhost/settings"));
+  EXPECT_FALSE(impl_->supports_edit("https://localhost/settings"));
+}
+
+TEST_F(SettingsHandlerTest, SupportsEditIsFalseForAnUnknownProtocol) { EXPECT_FALSE(impl_->supports_edit("gopher://localhost/settings")); }
+
+TEST_F(SettingsContextTest, ContextExistsFollowsTheFileForIni) {
+  settings_test::temp_dir dir;
+  const boost::filesystem::path file = dir.file("there.ini");
+  settings_test::write_file(file, "");
+
+  EXPECT_TRUE(impl_->context_exists(ini_context(file)));
+  EXPECT_FALSE(impl_->context_exists(ini_context(file) + ".missing"));
+}
+
+TEST_F(SettingsHandlerTest, ContextExistsIsAlwaysTrueForDummyAndHttp) {
+  // Neither has anything to check up front: dummy has no storage at all and
+  // an http store is only reachable once the daemon is running.
+  EXPECT_TRUE(impl_->context_exists("dummy"));
+  EXPECT_TRUE(impl_->context_exists("http://localhost/settings"));
+}
+
+TEST_F(SettingsHandlerTest, CreateInstanceThrowsForAnUnknownProtocol) {
+  EXPECT_THROW(impl_->create_instance("master", "gopher://localhost/settings"), settings::settings_exception);
+}
+
+TEST_F(SettingsContextTest, CreateInstanceBuildsTheBackendTheContextNames) {
+  const settings::instance_raw_ptr dummy = impl_->create_instance("master", "dummy");
+  ASSERT_TRUE(static_cast<bool>(dummy));
+  EXPECT_EQ(dummy->get_type(), "dummy");
+
+  settings_test::temp_dir dir;
+  const boost::filesystem::path file = dir.file("ctx.ini");
+  settings_test::write_file(file, "");
+  const settings::instance_raw_ptr ini = impl_->create_instance("master", ini_context(file));
+  ASSERT_TRUE(static_cast<bool>(ini));
+  EXPECT_EQ(ini->get_type(), "ini");
+}
+
 }  // namespace

--- a/modules/CheckDisk/CMakeLists.txt
+++ b/modules/CheckDisk/CMakeLists.txt
@@ -192,6 +192,20 @@ else()
             check_mount.cpp
             check_mount_test.cpp
             check_single_file.cpp
+            # The Windows-only checks: their data acquisition is #ifdef'd out
+            # here (query() returns nothing), but the keyword registry, the
+            # flag/status decoding and the rendering are ordinary C++ that the
+            # win32 build shares - and it was going untested on this platform
+            # only because the test target it lived in is if(WIN32).
+            check_shadowcopy.cpp
+            check_shadowcopy_test.cpp
+            check_share.cpp
+            check_share_test.cpp
+            check_storagepool.cpp
+            check_storagepool_test.cpp
+            check_uncpath.cpp
+            check_uncpath_test.cpp
+            check_windows_checks_unix_test.cpp
             collector_thread.cpp
             collector_thread_test.cpp
             file_finder_unix.cpp

--- a/modules/CheckDisk/check_windows_checks_unix_test.cpp
+++ b/modules/CheckDisk/check_windows_checks_unix_test.cpp
@@ -1,0 +1,213 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// The check bodies of the four Windows-oriented CheckDisk commands, exercised
+// on Unix.
+//
+// Only their data acquisition is Windows-specific: check_share,
+// check_storagepool and check_shadowcopy compile a query() that returns
+// nothing here, and check_uncpath has a real Unix implementation over statvfs.
+// Everything the command does around that - option parsing, the keyword
+// registry, threshold evaluation, the empty-state contract and the rendering -
+// is the same code the win32 build runs, and none of it was covered on this
+// platform because the tests for these files live in a target that only exists
+// under if(WIN32).
+//
+// So: drive the commands themselves. On a machine with no shares, no storage
+// pools and no shadow copies (every Unix machine), what these three must do is
+// report the documented empty state rather than fail - which is also exactly
+// what a Windows box without Storage Spaces or VSS does.
+//
+// nscapi::plugin_singleton is defined once for this target in
+// check_disk_unix_test.cpp.
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <string>
+#include <vector>
+
+#include "check_shadowcopy.hpp"
+#include "check_share.hpp"
+#include "check_storagepool.hpp"
+#include "check_uncpath.hpp"
+
+namespace {
+
+std::string join_lines(const PB::Commands::QueryResponseMessage::Response &r) {
+  std::string out;
+  for (int i = 0; i < r.lines_size(); ++i) {
+    if (!out.empty()) out += "\n";
+    out += r.lines(i).message();
+  }
+  return out;
+}
+
+// Perf labels the check emitted, in order.
+std::vector<std::string> perf_labels(const PB::Commands::QueryResponseMessage::Response &r) {
+  std::vector<std::string> out;
+  for (int i = 0; i < r.lines_size(); ++i) {
+    for (const auto &p : r.lines(i).perf()) out.push_back(p.alias());
+  }
+  return out;
+}
+
+PB::Commands::QueryRequestMessage::Request request_for(const std::string &command, const std::vector<std::string> &args) {
+  PB::Commands::QueryRequestMessage::Request request;
+  request.set_command(command);
+  for (const std::string &a : args) request.add_arguments(a);
+  return request;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// check_share / check_storagepool / check_shadowcopy - the no-data contract.
+// ---------------------------------------------------------------------------
+
+TEST(ShareCommand, NoSharesIsOkAndSaysSo) {
+  PB::Commands::QueryResponseMessage::Response response;
+  share_check::check::check_share(request_for("check_share", {}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  EXPECT_NE(join_lines(response).find("No shares"), std::string::npos) << join_lines(response);
+}
+
+TEST(ShareCommand, EmptyStateIsUserConfigurable) {
+  // An operator who considers "no shares at all" a problem can say so, and the
+  // empty-state has to be honoured rather than hard-coded to OK.
+  PB::Commands::QueryResponseMessage::Response response;
+  share_check::check::check_share(request_for("check_share", {"empty-state=critical"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL) << join_lines(response);
+}
+
+TEST(ShareCommand, ARequiredShareThatDoesNotExistIsReported) {
+  // Required mode emits a row per requested share whether or not it exists, so
+  // a missing one can be alerted on. With no shares present the row is the
+  // "missing" one, and the default critical expression (exists = 0) trips.
+  PB::Commands::QueryResponseMessage::Response response;
+  share_check::check::check_share(request_for("check_share", {"share=NoSuchShare"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL) << join_lines(response);
+  EXPECT_NE(join_lines(response).find("NoSuchShare"), std::string::npos) << join_lines(response);
+}
+
+TEST(ShareCommand, ABadFilterIsRejectedRatherThanIgnored) {
+  PB::Commands::QueryResponseMessage::Response response;
+  share_check::check::check_share(request_for("check_share", {"filter=no such keyword > 1"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+}
+
+TEST(StoragePoolCommand, NoPoolsIsOkAndSaysSo) {
+  // A machine without Storage Spaces is not a fault: the check must not go
+  // critical just because there are no pools.
+  PB::Commands::QueryResponseMessage::Response response;
+  storagepool_check::check::check_storagepool(request_for("check_storagepool", {}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  EXPECT_NE(join_lines(response).find("No storage pools found"), std::string::npos) << join_lines(response);
+}
+
+TEST(StoragePoolCommand, EmptyStateIsUserConfigurable) {
+  PB::Commands::QueryResponseMessage::Response response;
+  storagepool_check::check::check_storagepool(request_for("check_storagepool", {"empty-state=warning"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::WARNING) << join_lines(response);
+}
+
+TEST(StoragePoolCommand, ABadFilterIsRejectedRatherThanIgnored) {
+  PB::Commands::QueryResponseMessage::Response response;
+  storagepool_check::check::check_storagepool(request_for("check_storagepool", {"filter=no such keyword > 1"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+}
+
+TEST(ShadowCopyCommand, NoShadowCopiesIsOkAndSaysSo) {
+  PB::Commands::QueryResponseMessage::Response response;
+  shadowcopy_check::check::check_shadowcopy(request_for("check_shadowcopy", {}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  EXPECT_NE(join_lines(response).find("No shadow copies found"), std::string::npos) << join_lines(response);
+}
+
+TEST(ShadowCopyCommand, EmptyStateIsUserConfigurable) {
+  // Documented in the samples: a volume that is supposed to have snapshots can
+  // be alerted on with empty-state=critical.
+  PB::Commands::QueryResponseMessage::Response response;
+  shadowcopy_check::check::check_shadowcopy(request_for("check_shadowcopy", {"empty-state=critical"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL) << join_lines(response);
+}
+
+// ---------------------------------------------------------------------------
+// check_uncpath - a real query on this platform (statvfs), so the whole
+// command runs end to end.
+// ---------------------------------------------------------------------------
+
+TEST(UncPathCommand, WithoutAPathItSaysWhichArgumentIsMissing) {
+  PB::Commands::QueryResponseMessage::Response response;
+  uncpath_check::check::check_uncpath(request_for("check_uncpath", {}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+  EXPECT_NE(join_lines(response).find("No path specified"), std::string::npos) << join_lines(response);
+}
+
+TEST(UncPathCommand, AnExistingPathIsReportedWithItsSizes) {
+  // On Unix the query is a statvfs of an already-mounted path; the root
+  // filesystem is the one path every machine running this has.
+  PB::Commands::QueryResponseMessage::Response response;
+  uncpath_check::check::check_uncpath(request_for("check_uncpath", {"path=/", "warning=used_pct > 100", "critical=used_pct > 100"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  EXPECT_NE(join_lines(response).find('/'), std::string::npos) << join_lines(response);
+}
+
+TEST(UncPathCommand, EachMetricGetsItsOwnPerfSeries) {
+  // Perf series follow the keywords the thresholds reference. The suffixes
+  // exist so that two of them do not collapse onto the shared ${path} alias -
+  // without them a graph shows one series for two different numbers.
+  PB::Commands::QueryResponseMessage::Response response;
+  uncpath_check::check::check_uncpath(request_for("check_uncpath", {"path=/", "warning=used_pct > 100 or free < 0", "critical=used_pct > 100"}), &response);
+
+  const std::vector<std::string> labels = perf_labels(response);
+  ASSERT_EQ(labels.size(), 2u) << join_lines(response);
+  EXPECT_NE(labels[0], labels[1]) << "both metrics landed on one series";
+  for (const std::string &suffix : {"_free", "_used_pct"}) {
+    bool found = false;
+    for (const std::string &l : labels) {
+      if (l.size() >= suffix.size() && l.compare(l.size() - suffix.size(), suffix.size(), suffix) == 0) found = true;
+    }
+    EXPECT_TRUE(found) << "no perf series ending in " << suffix;
+  }
+}
+
+TEST(UncPathCommand, AThresholdOnUsedSpaceTrips) {
+  // used_pct is always >= 0, so this is the deterministic way to prove the
+  // threshold reaches the data rather than testing the host's actual fullness.
+  PB::Commands::QueryResponseMessage::Response response;
+  uncpath_check::check::check_uncpath(request_for("check_uncpath", {"path=/", "critical=used_pct >= 0"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL) << join_lines(response);
+}
+
+TEST(UncPathCommand, APathThatCannotBeQueriedIsAnError) {
+  PB::Commands::QueryResponseMessage::Response response;
+  const boost::filesystem::path missing = boost::filesystem::temp_directory_path() / "nscp-no-such-path-for-uncpath-test";
+  ASSERT_FALSE(boost::filesystem::exists(missing));
+  uncpath_check::check::check_uncpath(request_for("check_uncpath", {"path=" + missing.string()}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+  EXPECT_NE(join_lines(response).find(missing.string()), std::string::npos) << join_lines(response);
+}
+
+TEST(UncPathCommand, SeveralPathsAreEachReported) {
+  PB::Commands::QueryResponseMessage::Response response;
+  uncpath_check::check::check_uncpath(
+      request_for("check_uncpath", {"path=/", "path=/tmp", "warning=used_pct > 100", "critical=used_pct > 100", "detail-syntax=${path}"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  const std::string message = join_lines(response);
+  EXPECT_NE(message.find("/tmp"), std::string::npos) << message;
+}

--- a/modules/CheckMKClient/check_mk_client.hpp
+++ b/modules/CheckMKClient/check_mk_client.hpp
@@ -55,7 +55,9 @@ struct check_mk_client_handler : public client::handler_interface {
   bool query(client::destination_container sender, client::destination_container target, const PB::Commands::QueryRequestMessage &request_message,
              PB::Commands::QueryResponseMessage &response_message) {
     const ::PB::Common::Header &request_header = request_message.header();
-    check_mk_client::connection_data con(sender, target);
+    // (target, sender), matching the ctor: the target's settings decide
+    // where to connect, not the sender's.
+    check_mk_client::connection_data con(target, sender);
 
     nscapi::protobuf::functions::make_return_header(response_message.mutable_header(), request_header);
 

--- a/modules/IcingaClient/icinga_client_test.cpp
+++ b/modules/IcingaClient/icinga_client_test.cpp
@@ -1,0 +1,328 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for the Icinga 2 client's connection settings and its submissions.
+//
+// icinga.cpp (the JSON body and the response parsing) already has a suite;
+// this covers icinga_client.hpp, which had none: connection_data, which turns
+// a target's settings into an API endpoint, and submit(), which posts a check
+// result to /v1/actions/process-check-result and turns the answer back into a
+// submit response.
+//
+// The request is captured from a loopback HTTP server, so what is asserted is
+// the API call Icinga would receive - the path, the credentials and the body.
+
+#include <client/command_line_parser.hpp>
+
+#include "icinga_client.hpp"
+
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+#include <cstdlib>
+#include <future>
+#include <map>
+#include <string>
+#include <thread>
+
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+using boost::asio::ip::tcp;
+
+client::destination_container target_with(const std::map<std::string, std::string> &options) {
+  client::destination_container d;
+  for (const auto &o : options) d.set_string_data(o.first, o.second);
+  return d;
+}
+
+// Accepts one connection, keeps the request, and answers with a caller-chosen
+// status and body.
+class loopback_icinga_api {
+ public:
+  explicit loopback_icinga_api(std::string response_body = R"({"results":[{"code":200,"status":"Successfully processed check result"}]})",
+                               const int status = 200)
+      : body_to_send_(std::move(response_body)), status_(status) {
+    std::promise<unsigned short> p;
+    std::future<unsigned short> f = p.get_future();
+    thread_ = std::thread([this, prom = std::move(p)]() mutable {
+      try {
+        boost::asio::io_context io;
+        tcp::acceptor acceptor(io, {tcp::v4(), 0});
+        prom.set_value(acceptor.local_endpoint().port());
+        tcp::socket socket(io);
+        acceptor.accept(socket);
+
+        boost::asio::streambuf buffer;
+        boost::system::error_code ec;
+        boost::asio::read_until(socket, buffer, "\r\n\r\n", ec);
+        const std::string received((std::istreambuf_iterator<char>(&buffer)), std::istreambuf_iterator<char>());
+        const std::string::size_type split = received.find("\r\n\r\n");
+        headers_ = split == std::string::npos ? received : received.substr(0, split);
+        std::string body = split == std::string::npos ? std::string() : received.substr(split + 4);
+
+        std::size_t expected = 0;
+        const std::string::size_type cl = headers_.find("Content-Length:");
+        if (cl != std::string::npos) expected = std::strtoul(headers_.c_str() + cl + 15, nullptr, 10);
+        while (body.size() < expected && !ec) {
+          char chunk[4096];
+          const std::size_t n = socket.read_some(boost::asio::buffer(chunk), ec);
+          if (!ec) body.append(chunk, n);
+        }
+        request_body_ = body;
+
+        const std::string response = "HTTP/1.1 " + std::to_string(status_) + " x\r\nContent-Type: application/json\r\nContent-Length: " +
+                                     std::to_string(body_to_send_.size()) + "\r\n\r\n" + body_to_send_;
+        boost::asio::write(socket, boost::asio::buffer(response), ec);
+      } catch (...) {
+      }
+    });
+    port_ = f.get();
+  }
+
+  ~loopback_icinga_api() {
+    if (thread_.joinable()) thread_.join();
+  }
+
+  unsigned short port() const { return port_; }
+  std::string request_body() {
+    if (thread_.joinable()) thread_.join();
+    return request_body_;
+  }
+  std::string headers() {
+    if (thread_.joinable()) thread_.join();
+    return headers_;
+  }
+
+ private:
+  std::string body_to_send_;
+  int status_;
+  unsigned short port_ = 0;
+  std::string headers_;
+  std::string request_body_;
+  std::thread thread_;
+};
+
+// Submit one result, and hand back the response payload so the caller can
+// check how the API's answer was interpreted.
+PB::Commands::SubmitResponseMessage submit_one(loopback_icinga_api &api, const std::string &alias, const PB::Common::ResultCode result,
+                                               const std::string &message, std::map<std::string, std::string> extra = {}) {
+  PB::Commands::SubmitRequestMessage request;
+  PB::Commands::QueryResponseMessage::Response *payload = request.add_payload();
+  payload->set_command("check_something");
+  if (!alias.empty()) payload->set_alias(alias);
+  payload->set_result(result);
+  payload->add_lines()->set_message(message);
+
+  extra["address"] = "http://127.0.0.1:" + std::to_string(api.port());
+  if (extra.find("username") == extra.end()) extra["username"] = "root";
+  if (extra.find("password") == extra.end()) extra["password"] = "icinga";
+
+  client::destination_container sender;
+  sender.set_host("monitored-host");
+
+  PB::Commands::SubmitResponseMessage response;
+  icinga_client::icinga_client_handler handler;
+  handler.submit(sender, target_with(extra), request, response);
+  return response;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// connection_data
+// ---------------------------------------------------------------------------
+
+TEST(IcingaConnectionData, DefaultsToHttpsOnTheApiPort) {
+  const icinga_client::connection_data con(target_with({{"address", "icinga.example.com"}}), client::destination_container());
+
+  EXPECT_EQ(con.protocol, "https") << "Icinga 2's API is https-only in practice";
+  EXPECT_EQ(con.get_port(), "5665");
+}
+
+TEST(IcingaConnectionData, PlainHttpIsHonouredForATestSetup) {
+  const icinga_client::connection_data con(target_with({{"address", "http://icinga.example.com"}}), client::destination_container());
+
+  EXPECT_EQ(con.protocol, "http");
+  EXPECT_EQ(con.get_port(), "5665");
+}
+
+TEST(IcingaConnectionData, AnExplicitPortWins) {
+  const icinga_client::connection_data con(target_with({{"address", "https://icinga.example.com:8443"}}), client::destination_container());
+
+  EXPECT_EQ(con.get_port(), "8443");
+}
+
+TEST(IcingaConnectionData, CarriesTheApiCredentials) {
+  const icinga_client::connection_data con(target_with({{"address", "https://h"}, {"username", "root"}, {"password", "s3cret"}}),
+                                           client::destination_container());
+
+  EXPECT_EQ(con.username, "root");
+  EXPECT_EQ(con.password, "s3cret");
+}
+
+TEST(IcingaConnectionData, TlsVersionDefaultsToOneThree) {
+  const icinga_client::connection_data con(target_with({{"address", "https://h"}}), client::destination_container());
+
+  EXPECT_EQ(con.tls_version, "1.3");
+}
+
+TEST(IcingaConnectionData, ObjectTemplatesAndEnsureFlagAreRead) {
+  const icinga_client::connection_data con(target_with({{"address", "https://h"},
+                                                        {"ensure_objects", "true"},
+                                                        {"host_template", "generic-host"},
+                                                        {"service_template", "generic-service"},
+                                                        {"check_command", "dummy"}}),
+                                           client::destination_container());
+
+  EXPECT_TRUE(con.ensure_objects);
+  EXPECT_EQ(con.host_template, "generic-host");
+  EXPECT_EQ(con.service_template, "generic-service");
+  EXPECT_EQ(con.check_command, "dummy");
+}
+
+TEST(IcingaConnectionData, TheSenderNamesTheHostAndTheCheckSource) {
+  client::destination_container sender;
+  sender.set_host("monitored-host");
+
+  const icinga_client::connection_data con(target_with({{"address", "https://h"}}), sender);
+
+  EXPECT_EQ(con.sender_hostname, "monitored-host");
+  EXPECT_EQ(con.check_source, "monitored-host") << "check_source defaults to whoever is reporting";
+}
+
+TEST(IcingaConnectionData, AnExplicitCheckSourceIsKept) {
+  client::destination_container sender;
+  sender.set_host("monitored-host");
+
+  const icinga_client::connection_data con(target_with({{"address", "https://h"}, {"check_source", "nscp-agent"}}), sender);
+
+  EXPECT_EQ(con.check_source, "nscp-agent");
+}
+
+TEST(IcingaConnectionData, WithoutASenderTheLocalHostNameIsUsed) {
+  // submit_icinga from the CLI has no sender, and Icinga rejects a check
+  // result with an empty host, so something has to fill it in.
+  const icinga_client::connection_data con(target_with({{"address", "https://h"}}), client::destination_container());
+
+  EXPECT_FALSE(con.sender_hostname.empty());
+  EXPECT_EQ(con.sender_hostname, boost::asio::ip::host_name());
+}
+
+// ---------------------------------------------------------------------------
+// submit - the API call Icinga receives.
+// ---------------------------------------------------------------------------
+
+TEST(IcingaSubmit, PostsAProcessCheckResultAction) {
+  loopback_icinga_api api;
+
+  submit_one(api, "disk", PB::Common::ResultCode::WARNING, "running low");
+
+  EXPECT_NE(api.headers().find("POST /v1/actions/process-check-result"), std::string::npos) << api.headers();
+  // Icinga only answers json, and the API requires the client to say so.
+  EXPECT_NE(api.headers().find("Accept: application/json"), std::string::npos) << api.headers();
+}
+
+TEST(IcingaSubmit, AuthenticatesWithTheConfiguredCredentials) {
+  loopback_icinga_api api;
+
+  submit_one(api, "disk", PB::Common::ResultCode::OK, "fine");
+
+  // root:icinga
+  EXPECT_NE(api.headers().find("Authorization: Basic cm9vdDppY2luZ2E="), std::string::npos) << api.headers();
+}
+
+TEST(IcingaSubmit, AServiceResultFiltersOnHostAndService) {
+  loopback_icinga_api api;
+
+  submit_one(api, "disk", PB::Common::ResultCode::WARNING, "running low");
+
+  const std::string body = api.request_body();
+  EXPECT_NE(body.find("\"type\":\"Service\""), std::string::npos) << body;
+  EXPECT_NE(body.find("host.name==\\\"monitored-host\\\""), std::string::npos) << body;
+  EXPECT_NE(body.find("service.name==\\\"disk\\\""), std::string::npos) << body;
+  EXPECT_NE(body.find("\"exit_status\":1"), std::string::npos) << body;
+}
+
+TEST(IcingaSubmit, TheHostCheckAliasFiltersOnTheHostAlone) {
+  loopback_icinga_api api;
+
+  submit_one(api, "host_check", PB::Common::ResultCode::CRITICAL, "host is down");
+
+  const std::string body = api.request_body();
+  EXPECT_NE(body.find("\"type\":\"Host\""), std::string::npos) << body;
+  EXPECT_EQ(body.find("service.name"), std::string::npos) << body;
+  // A host is UP or DOWN: CRITICAL maps onto DOWN (1), not the service's 2.
+  EXPECT_NE(body.find("\"exit_status\":1"), std::string::npos) << body;
+}
+
+TEST(IcingaSubmit, PerfdataIsSplitOutOfThePluginOutput) {
+  loopback_icinga_api api;
+
+  submit_one(api, "disk", PB::Common::ResultCode::OK, "all good|'used'=42%;80;90");
+
+  const std::string body = api.request_body();
+  EXPECT_NE(body.find("\"performance_data\""), std::string::npos) << body;
+  EXPECT_NE(body.find("'used'=42%;80;90"), std::string::npos) << body;
+  // The perfdata must not be left in the human-readable output as well.
+  EXPECT_NE(body.find("\"plugin_output\":\"all good\""), std::string::npos) << body;
+}
+
+TEST(IcingaSubmit, ASuccessfulSubmissionIsReportedAsGood) {
+  loopback_icinga_api api;
+
+  const PB::Commands::SubmitResponseMessage response = submit_one(api, "disk", PB::Common::ResultCode::OK, "fine");
+
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_EQ(response.payload(0).result().code(), PB::Common::Result_StatusCodeType_STATUS_OK);
+  EXPECT_NE(response.payload(0).result().message().find("Successfully processed"), std::string::npos) << response.payload(0).result().message();
+}
+
+TEST(IcingaSubmit, AnApiErrorIsReportedRatherThanSwallowed) {
+  // A submission that Icinga rejected must not look like a delivery.
+  loopback_icinga_api api(R"({"results":[{"code":404,"status":"No objects found."}]})", 404);
+
+  const PB::Commands::SubmitResponseMessage response = submit_one(api, "disk", PB::Common::ResultCode::OK, "fine");
+
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_EQ(response.payload(0).result().code(), PB::Common::Result_StatusCodeType_STATUS_ERROR);
+  EXPECT_NE(response.payload(0).result().message().find("No objects found"), std::string::npos) << response.payload(0).result().message();
+}
+
+TEST(IcingaSubmit, AnUnreachableApiIsReportedAsAnError) {
+  // Nothing is listening on a port the kernel has just handed back.
+  boost::asio::io_context io;
+  tcp::acceptor probe(io, {tcp::v4(), 0});
+  const unsigned short closed = probe.local_endpoint().port();
+  probe.close();
+
+  PB::Commands::SubmitRequestMessage request;
+  PB::Commands::QueryResponseMessage::Response *payload = request.add_payload();
+  payload->set_command("check_something");
+  payload->set_result(PB::Common::ResultCode::OK);
+  payload->add_lines()->set_message("fine");
+
+  PB::Commands::SubmitResponseMessage response;
+  icinga_client::icinga_client_handler handler;
+  handler.submit(client::destination_container(), target_with({{"address", "http://127.0.0.1:" + std::to_string(closed)}}), request, response);
+
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_EQ(response.payload(0).result().code(), PB::Common::Result_StatusCodeType_STATUS_ERROR);
+}
+
+TEST(IcingaSubmit, QueryAndExecAreNotSupported) {
+  icinga_client::icinga_client_handler handler;
+  const client::destination_container empty;
+
+  PB::Commands::QueryRequestMessage query_request;
+  PB::Commands::QueryResponseMessage query_response;
+  EXPECT_FALSE(handler.query(empty, empty, query_request, query_response));
+
+  PB::Commands::ExecuteRequestMessage exec_request;
+  PB::Commands::ExecuteResponseMessage exec_response;
+  EXPECT_FALSE(handler.exec(empty, empty, exec_request, exec_response));
+
+  PB::Metrics::MetricsMessage metrics;
+  EXPECT_FALSE(handler.metrics(empty, empty, metrics));
+}

--- a/modules/NRDPClient/CMakeLists.txt
+++ b/modules/NRDPClient/CMakeLists.txt
@@ -78,12 +78,23 @@ NSCP_CREATE_TEST(
     nrdp_test
     SOURCES
         nrdp_test.cpp
+        nrdp_client_test.cpp
         nrdp.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_INCLUDEDIR}/bytes/base64.c
+        ${NSCP_CLIENT_CPP}
         ${TINYXML2_SRCS}
         ${NSCP_INCLUDEDIR}/str/utf8.cpp
     LIBRARIES
         GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
         ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        # nrdp_client.hpp posts through net/http/client.hpp, whose transport is
+        # TLS-capable, so the test links the same OpenSSL the module does.
+        ${EXTRA_LIBS}
         ${TINYXML2_EXTRA_LIBS}
     INCLUDES
         ${NSCP_INCLUDEDIR}

--- a/modules/NRDPClient/nrdp_client.hpp
+++ b/modules/NRDPClient/nrdp_client.hpp
@@ -50,7 +50,11 @@ struct connection_data : socket_helpers::connection_info {
     proxy_url = arguments.get_string_data("proxy");
     no_proxy_str = arguments.get_string_data("no proxy");
 
-    if (sender.has_data("host")) sender_hostname = sender.get_string_data("host");
+    // get_host(), not get_string_data("host"): destination_container routes
+    // the well-known "host" key into a typed field rather than the free-form
+    // data map, so the map lookup never found it and the trace line below
+    // always named an empty sender.
+    sender_hostname = sender.get_host();
   }
 
   /// Build proxy_config from the URL and no-proxy string stored in this object.

--- a/modules/NRDPClient/nrdp_client_test.cpp
+++ b/modules/NRDPClient/nrdp_client_test.cpp
@@ -1,0 +1,284 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for the NRDP client's connection settings and what it posts.
+//
+// nrdp.cpp (the XML rendering) already has a suite; this covers the half that
+// did not: connection_data, which turns a target's settings into a URL, and
+// submit(), which decides whether a result is a host check or a service check
+// and posts the form NRDP expects. A mistake in either is invisible until a
+// monitoring server quietly stops seeing results.
+//
+// The POST is captured from a loopback HTTP server rather than asserted
+// against an internal builder, because the form fields are the contract.
+
+#include <client/command_line_parser.hpp>
+
+#include "nrdp_client.hpp"
+
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+#include <cstdlib>
+#include <future>
+#include <map>
+#include <string>
+#include <thread>
+
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+using boost::asio::ip::tcp;
+
+client::destination_container target_with(const std::map<std::string, std::string> &options) {
+  client::destination_container d;
+  for (const auto &o : options) d.set_string_data(o.first, o.second);
+  return d;
+}
+
+// Accepts one connection, keeps the request, answers with a canned NRDP
+// response. Single-accept because a submit makes exactly one request, and a
+// server waiting for a second would hang the suite on teardown.
+class loopback_nrdp_server {
+ public:
+  loopback_nrdp_server() {
+    std::promise<unsigned short> p;
+    std::future<unsigned short> f = p.get_future();
+    thread_ = std::thread([this, prom = std::move(p)]() mutable {
+      try {
+        boost::asio::io_context io;
+        tcp::acceptor acceptor(io, {tcp::v4(), 0});
+        prom.set_value(acceptor.local_endpoint().port());
+        tcp::socket socket(io);
+        acceptor.accept(socket);
+
+        boost::asio::streambuf buffer;
+        boost::system::error_code ec;
+        boost::asio::read_until(socket, buffer, "\r\n\r\n", ec);
+        const std::string received((std::istreambuf_iterator<char>(&buffer)), std::istreambuf_iterator<char>());
+
+        const std::string::size_type split = received.find("\r\n\r\n");
+        headers_ = split == std::string::npos ? received : received.substr(0, split);
+        std::string body = split == std::string::npos ? std::string() : received.substr(split + 4);
+
+        // The rest of the body, if the headers arrived without it.
+        std::size_t expected = 0;
+        const std::string::size_type cl = headers_.find("Content-Length:");
+        if (cl != std::string::npos) expected = std::strtoul(headers_.c_str() + cl + 15, nullptr, 10);
+        while (body.size() < expected && !ec) {
+          char chunk[4096];
+          const std::size_t n = socket.read_some(boost::asio::buffer(chunk), ec);
+          if (!ec) body.append(chunk, n);
+        }
+        body_ = body;
+
+        const std::string payload = "<result><status>0</status><message>OK</message></result>";
+        const std::string response = "HTTP/1.1 200 OK\r\nContent-Type: text/xml\r\nContent-Length: " + std::to_string(payload.size()) + "\r\n\r\n" + payload;
+        boost::asio::write(socket, boost::asio::buffer(response), ec);
+      } catch (...) {
+      }
+    });
+    port_ = f.get();
+  }
+
+  ~loopback_nrdp_server() {
+    if (thread_.joinable()) thread_.join();
+  }
+
+  unsigned short port() const { return port_; }
+
+  // Both join the server thread, so call them after the submit returns.
+  std::string body() {
+    if (thread_.joinable()) thread_.join();
+    return body_;
+  }
+  std::string headers() {
+    if (thread_.joinable()) thread_.join();
+    return headers_;
+  }
+
+ private:
+  unsigned short port_ = 0;
+  std::string headers_;
+  std::string body_;
+  std::thread thread_;
+};
+
+// Submit one result to the loopback server and return the POST body.
+std::string submit_one(loopback_nrdp_server &server, const std::string &alias, const PB::Common::ResultCode result, const std::string &message,
+                       const std::string &token = "s3cret") {
+  PB::Commands::SubmitRequestMessage request;
+  PB::Commands::QueryResponseMessage::Response *payload = request.add_payload();
+  payload->set_command("check_something");
+  if (!alias.empty()) payload->set_alias(alias);
+  payload->set_result(result);
+  payload->add_lines()->set_message(message);
+
+  client::destination_container sender;
+  sender.set_string_data("host", "monitored-host");
+
+  PB::Commands::SubmitResponseMessage response;
+  nrdp_client::nrdp_client_handler handler;
+  handler.submit(sender, target_with({{"address", "http://127.0.0.1:" + std::to_string(server.port()) + "/nrdp/server/"}, {"token", token}}), request, response);
+  return server.body();
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// connection_data - a target's settings become a URL.
+// ---------------------------------------------------------------------------
+
+TEST(NrdpConnectionData, DefaultsToHttpOnPortEightyAtTheNrdpPath) {
+  const nrdp_client::connection_data con(target_with({{"address", "nagios.example.com"}}), client::destination_container());
+
+  EXPECT_EQ(con.protocol, "http");
+  EXPECT_EQ(con.get_port(), "80");
+  EXPECT_EQ(con.path, "/nrdp/server/") << "the default NRDP endpoint path";
+}
+
+TEST(NrdpConnectionData, HttpsDefaultsToPort443) {
+  const nrdp_client::connection_data con(target_with({{"address", "https://nagios.example.com"}}), client::destination_container());
+
+  EXPECT_EQ(con.protocol, "https");
+  EXPECT_EQ(con.get_port(), "443");
+}
+
+TEST(NrdpConnectionData, AnExplicitPortAndPathWin) {
+  const nrdp_client::connection_data con(target_with({{"address", "https://nagios.example.com:8443/custom/nrdp/"}}), client::destination_container());
+
+  EXPECT_EQ(con.get_port(), "8443");
+  EXPECT_EQ(con.path, "/custom/nrdp/");
+}
+
+TEST(NrdpConnectionData, AnUnknownProtocolIsTreatedAsPlainHttp) {
+  // Anything that is not https falls back to http rather than being passed to
+  // the http client as a scheme it cannot use.
+  const nrdp_client::connection_data con(target_with({{"address", "gopher://nagios.example.com"}}), client::destination_container());
+
+  EXPECT_EQ(con.protocol, "http");
+  EXPECT_EQ(con.get_port(), "80");
+}
+
+TEST(NrdpConnectionData, CarriesTheTokenAndTlsSettings) {
+  const nrdp_client::connection_data con(
+      target_with({{"address", "https://h"}, {"token", "s3cret"}, {"tls version", "1.3"}, {"verify mode", "none"}, {"ca", "/etc/ca.pem"}}),
+      client::destination_container());
+
+  EXPECT_EQ(con.token, "s3cret");
+  EXPECT_EQ(con.tls_version, "1.3");
+  EXPECT_EQ(con.verify_mode, "none");
+  EXPECT_EQ(con.ca, "/etc/ca.pem");
+}
+
+TEST(NrdpConnectionData, TlsVersionDefaultsToTwelveOrLater) {
+  // Not a cosmetic default: it is what keeps the client off TLS 1.0/1.1 when
+  // the target says nothing.
+  const nrdp_client::connection_data con(target_with({{"address", "https://h"}}), client::destination_container());
+
+  EXPECT_EQ(con.tls_version, "1.2+");
+}
+
+TEST(NrdpConnectionData, TakesTheSenderHostnameFromTheSender) {
+  // Only used in the trace line, but an empty one there is worse than useless
+  // when a submit has gone to the wrong place.
+  client::destination_container sender;
+  sender.set_string_data("host", "reporting-host");
+
+  const nrdp_client::connection_data con(target_with({{"address", "h"}}), sender);
+
+  EXPECT_EQ(con.sender_hostname, "reporting-host");
+  EXPECT_NE(con.to_string().find("reporting-host"), std::string::npos) << con.to_string();
+}
+
+// ---------------------------------------------------------------------------
+// build_proxy_config - the no-proxy list is operator-typed, so it is parsed
+// leniently.
+// ---------------------------------------------------------------------------
+
+TEST(NrdpProxyConfig, SplitsAndTrimsTheNoProxyList) {
+  const nrdp_client::connection_data con(target_with({{"address", "h"}, {"proxy", "http://proxy:3128"}, {"no proxy", "localhost, .internal ,10.0.0.1"}}),
+                                         client::destination_container());
+
+  const http::proxy_config proxy = con.build_proxy_config();
+
+  ASSERT_EQ(proxy.no_proxy.size(), 3u);
+  EXPECT_EQ(proxy.no_proxy[0], "localhost");
+  EXPECT_EQ(proxy.no_proxy[1], ".internal") << "surrounding spaces are not part of the host";
+  EXPECT_EQ(proxy.no_proxy[2], "10.0.0.1");
+}
+
+TEST(NrdpProxyConfig, AnEmptyNoProxyListIsNoEntries) {
+  const nrdp_client::connection_data con(target_with({{"address", "h"}, {"proxy", "http://proxy:3128"}}), client::destination_container());
+
+  EXPECT_TRUE(con.build_proxy_config().no_proxy.empty());
+}
+
+// ---------------------------------------------------------------------------
+// submit - the form NRDP expects.
+// ---------------------------------------------------------------------------
+
+TEST(NrdpSubmit, PostsTheSubmitcheckCommandWithTheToken) {
+  loopback_nrdp_server server;
+
+  const std::string body = submit_one(server, "disk", PB::Common::ResultCode::OK, "all good");
+
+  EXPECT_NE(body.find("cmd=submitcheck"), std::string::npos) << body;
+  EXPECT_NE(body.find("token=s3cret"), std::string::npos) << body;
+  EXPECT_NE(body.find("XMLDATA="), std::string::npos) << body;
+}
+
+TEST(NrdpSubmit, PostsToTheConfiguredPath) {
+  loopback_nrdp_server server;
+
+  submit_one(server, "disk", PB::Common::ResultCode::OK, "all good");
+
+  EXPECT_NE(server.headers().find("POST /nrdp/server/"), std::string::npos) << server.headers();
+}
+
+TEST(NrdpSubmit, ARegularResultIsReportedAsAServiceCheck) {
+  loopback_nrdp_server server;
+
+  const std::string body = submit_one(server, "disk", PB::Common::ResultCode::WARNING, "running low");
+
+  // The XML is form-encoded, so look for the encoded markers.
+  EXPECT_NE(body.find("servicename"), std::string::npos) << body;
+  EXPECT_NE(body.find("disk"), std::string::npos) << body;
+}
+
+TEST(NrdpSubmit, TheAliasHostCheckIsReportedAsAHostCheck) {
+  // "host_check" is the documented alias that turns a result into a host
+  // check; NRDP tells the two apart by whether servicename is present.
+  loopback_nrdp_server server;
+
+  const std::string body = submit_one(server, "host_check", PB::Common::ResultCode::CRITICAL, "host is down");
+
+  EXPECT_EQ(body.find("servicename"), std::string::npos) << body;
+  EXPECT_NE(body.find("checkresult"), std::string::npos) << body;
+}
+
+TEST(NrdpSubmit, ACommandWithoutAnAliasIsNamedAfterTheCommand) {
+  loopback_nrdp_server server;
+
+  const std::string body = submit_one(server, "", PB::Common::ResultCode::OK, "fine");
+
+  EXPECT_NE(body.find("check_something"), std::string::npos) << body;
+}
+
+TEST(NrdpSubmit, OnlySubmitIsSupported) {
+  // NRDP is a one-way result feed: there is nothing to query or execute.
+  nrdp_client::nrdp_client_handler handler;
+  const client::destination_container empty;
+
+  PB::Commands::QueryRequestMessage query_request;
+  PB::Commands::QueryResponseMessage query_response;
+  EXPECT_FALSE(handler.query(empty, empty, query_request, query_response));
+
+  PB::Commands::ExecuteRequestMessage exec_request;
+  PB::Commands::ExecuteResponseMessage exec_response;
+  EXPECT_FALSE(handler.exec(empty, empty, exec_request, exec_response));
+
+  PB::Metrics::MetricsMessage metrics;
+  EXPECT_FALSE(handler.metrics(empty, empty, metrics));
+}

--- a/modules/NSCPClient/CMakeLists.txt
+++ b/modules/NSCPClient/CMakeLists.txt
@@ -56,3 +56,23 @@ target_link_libraries(
 )
 include(${BUILD_CMAKE_FOLDER}/module.cmake)
 source_group("Socket" REGULAR_EXPRESSION .*include/socket/.*)
+
+# Where a forwarded check goes, and whether that link is encrypted.
+NSCP_CREATE_TEST(
+    nscp_client_test
+    SOURCES
+        nscp_client_test.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_INCLUDEDIR}/bytes/base64.c
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/NSCPClient/nscp_client_test.cpp
+++ b/modules/NSCPClient/nscp_client_test.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for the NSCP (agent-to-agent) client's connection settings.
+//
+// This is the client that talks to another NSClient++ over its own protocol,
+// so the settings decide both where a check is forwarded and whether that link
+// is encrypted and verified. The protocol half needs a second agent and is
+// covered by the integration suite.
+
+// nscp_client.hpp expects its includer to have pulled in the client machinery
+// and the logging macros already (NSCPClient.cpp does).
+#include <client/command_line_parser.hpp>
+#include <nscapi/macros.hpp>
+#include <nscapi/nscapi_helper_singleton.hpp>
+
+#include "nscp_client.hpp"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <memory>
+#include <string>
+
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+// connection_data expands ${...} in certificate paths through the handler.
+struct test_handler : socket_helpers::client::client_handler {
+  void log_debug(std::string, int, std::string) const override {}
+  void log_error(std::string, int, std::string) const override {}
+  std::string expand_path(std::string path) override { return "/expanded" + path; }
+};
+
+client::destination_container target_with(const std::map<std::string, std::string> &options) {
+  client::destination_container d;
+  for (const auto &o : options) d.set_string_data(o.first, o.second);
+  return d;
+}
+
+nscp_client::connection_data connection_for(const std::map<std::string, std::string> &options) {
+  return nscp_client::connection_data(client::destination_container(), target_with(options), std::make_shared<test_handler>());
+}
+
+}  // namespace
+
+TEST(NscpConnectionData, DefaultsToTheAgentsOwnPortAndQueryPath) {
+  const nscp_client::connection_data con = connection_for({{"address", "agent.example.com"}});
+
+  EXPECT_EQ(con.get_port(), "8443");
+  EXPECT_EQ(con.path, "/query.pb");
+}
+
+TEST(NscpConnectionData, AnExplicitPortAndPathWin) {
+  const nscp_client::connection_data con = connection_for({{"address", "agent.example.com:9443"}, {"path", "/custom.pb"}});
+
+  EXPECT_EQ(con.get_port(), "9443");
+  EXPECT_EQ(con.path, "/custom.pb");
+}
+
+TEST(NscpConnectionData, TakesTheTimeoutAndRetryFromTheTarget) {
+  // Read from the container's typed fields, which is where
+  // destination_container actually puts these two - the other clients look
+  // them up in the data map and therefore never see them.
+  client::destination_container target = target_with({{"address", "h"}});
+  target.set_string_data("timeout", "5");
+  target.set_string_data("retry", "1");
+
+  const nscp_client::connection_data con(client::destination_container(), target, std::make_shared<test_handler>());
+
+  EXPECT_EQ(con.timeout, 5);
+  EXPECT_EQ(con.retry, 1);
+}
+
+TEST(NscpConnectionData, CipherAndVerifyDefaultsAreTheDocumentedOnes) {
+  const nscp_client::connection_data con = connection_for({{"address", "h"}});
+
+  EXPECT_EQ(con.ssl.allowed_ciphers, "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH") << "the cipher list that excludes anonymous and export suites";
+  EXPECT_EQ(con.ssl.verify_mode, "none");
+  EXPECT_EQ(con.ssl.certificate_key_format, "PEM");
+}
+
+TEST(NscpConnectionData, TlsMaterialIsCarriedAndPathsExpanded) {
+  const nscp_client::connection_data con =
+      connection_for({{"address", "h"}, {"certificate key", "${certificate-path}/key.pem"}, {"ca", "/etc/ca.pem"}, {"verify mode", "peer-cert"}});
+
+  EXPECT_EQ(con.ssl.certificate_key, "/expanded${certificate-path}/key.pem") << "the handler resolves ${...} tokens";
+  EXPECT_EQ(con.ssl.ca_path, "/etc/ca.pem");
+  EXPECT_EQ(con.ssl.verify_mode, "peer-cert");
+}
+
+TEST(NscpConnectionData, SslHasTheFinalWordOverNoSsl) {
+  // Two spellings, one inverted, applied in order: "no ssl" then "ssl".
+  EXPECT_TRUE(connection_for({{"address", "h"}, {"no ssl", "false"}}).ssl.enabled);
+  EXPECT_FALSE(connection_for({{"address", "h"}, {"no ssl", "true"}}).ssl.enabled);
+  EXPECT_TRUE(connection_for({{"address", "h"}, {"no ssl", "true"}, {"ssl", "true"}}).ssl.enabled);
+  EXPECT_FALSE(connection_for({{"address", "h"}, {"no ssl", "false"}, {"ssl", "false"}}).ssl.enabled);
+}
+
+TEST(NscpConnectionData, DescribesItselfWithoutLeakingThePassword) {
+  // This is emitted at trace level on every operation, and historically leaked
+  // the shared secret into operator debug logs.
+  const std::string described = connection_for({{"address", "agent.example.com"}, {"password", "s3cret"}}).to_string();
+
+  EXPECT_NE(described.find("agent.example.com"), std::string::npos) << described;
+  EXPECT_EQ(described.find("s3cret"), std::string::npos) << "the password reached the trace line: " << described;
+  EXPECT_NE(described.find("<set>"), std::string::npos) << "but whether one is configured is still visible: " << described;
+}
+
+TEST(NscpConnectionData, AnAbsentPasswordIsShownAsUnset) {
+  const std::string described = connection_for({{"address", "h"}}).to_string();
+
+  EXPECT_NE(described.find("<unset>"), std::string::npos) << described;
+}

--- a/modules/SMTPClient/CMakeLists.txt
+++ b/modules/SMTPClient/CMakeLists.txt
@@ -82,3 +82,22 @@ NSCP_CREATE_TEST(
     INCLUDES
         ${NSCP_INCLUDEDIR}
 )
+
+# The connection settings, separately from smtp.cpp's protocol suite.
+NSCP_CREATE_TEST(
+    smtp_client_test
+    SOURCES
+        smtp_client_test.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/SMTPClient/smtp_client.hpp
+++ b/modules/SMTPClient/smtp_client.hpp
@@ -49,9 +49,12 @@ struct connection_data : socket_helpers::connection_info {
     subject_template = arguments.get_string_data("subject");
     template_string = arguments.get_string_data("template");
 
-    if (sender_container.has_data("host")) {
-      sender_hostname = sender_container.get_string_data("host");
-    }
+    // get_host(), not the data map: destination_container routes the
+    // well-known "host" key into a typed field, so the map lookup never found
+    // it - which left the EHLO name below falling back to "localhost" instead
+    // of naming this agent.
+    sender_hostname = sender_container.get_host();
+    if (sender_hostname.empty()) sender_hostname = sender_container.get_string_data("host");
     canonical_name = arguments.get_string_data("ehlo-hostname");
   }
 

--- a/modules/SMTPClient/smtp_client_test.cpp
+++ b/modules/SMTPClient/smtp_client_test.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for the SMTP client's connection settings.
+//
+// smtp.cpp (the protocol itself) has its own suite; this covers the settings
+// that decide who the agent talks to and how: the submission port, the
+// security mode, the credentials, and the name it announces in EHLO. The
+// message templates live here too, since a target that renders an empty
+// subject is a target whose mail gets filed as spam.
+
+// smtp_client.hpp expects its includer to have pulled in the client
+// machinery and the logging macros already (SMTPClient.cpp does).
+#include <client/command_line_parser.hpp>
+#include <nscapi/macros.hpp>
+#include <nscapi/nscapi_helper_singleton.hpp>
+
+#include "smtp_client.hpp"
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+client::destination_container target_with(const std::map<std::string, std::string> &options) {
+  client::destination_container d;
+  for (const auto &o : options) d.set_string_data(o.first, o.second);
+  return d;
+}
+
+smtp_client::connection_data connection_for(const std::map<std::string, std::string> &options,
+                                            const client::destination_container &sender = client::destination_container()) {
+  return smtp_client::connection_data(target_with(options), sender);
+}
+
+}  // namespace
+
+TEST(SmtpConnectionData, DefaultsToTheSubmissionPort) {
+  // 587 (submission), not 25 (relay): the agent authenticates and submits.
+  EXPECT_EQ(connection_for({{"address", "mail.example.com"}}).get_port(), "587");
+}
+
+TEST(SmtpConnectionData, AnExplicitPortWins) {
+  EXPECT_EQ(connection_for({{"address", "mail.example.com:2525"}}).get_port(), "2525");
+}
+
+TEST(SmtpConnectionData, DefaultsToStarttls) {
+  // Silently sending mail in clear because the target did not name a mode
+  // would be the wrong default.
+  EXPECT_EQ(connection_for({{"address", "h"}}).security, "starttls");
+}
+
+TEST(SmtpConnectionData, AnExplicitSecurityModeIsKept) {
+  EXPECT_EQ(connection_for({{"address", "h"}, {"security", "none"}}).security, "none");
+  EXPECT_EQ(connection_for({{"address", "h"}, {"security", "ssl"}}).security, "ssl");
+}
+
+TEST(SmtpConnectionData, CertificateVerificationIsOnUnlessWaived) {
+  EXPECT_FALSE(connection_for({{"address", "h"}}).insecure_skip_verify);
+  EXPECT_TRUE(connection_for({{"address", "h"}, {"insecure-skip-verify", "true"}}).insecure_skip_verify);
+}
+
+TEST(SmtpConnectionData, CarriesTheCredentialsAndEnvelope) {
+  const smtp_client::connection_data con = connection_for({{"address", "h"},
+                                                           {"username", "agent"},
+                                                           {"password", "s3cret"},
+                                                           {"sender", "nscp@example.com"},
+                                                           {"recipient", "ops@example.com"},
+                                                           {"subject", "%status%: %alias%"},
+                                                           {"template", "%message%"}});
+
+  EXPECT_EQ(con.username, "agent");
+  EXPECT_EQ(con.password, "s3cret");
+  EXPECT_EQ(con.sender, "nscp@example.com");
+  EXPECT_EQ(con.recipient_str, "ops@example.com");
+  EXPECT_EQ(con.subject_template, "%status%: %alias%");
+  EXPECT_EQ(con.template_string, "%message%");
+}
+
+TEST(SmtpConnectionData, TheEhloNameComesFromTheSenderWhenNotConfigured) {
+  // Regression: the sender's host name was read from the free-form data map,
+  // where destination_container never puts it, so this stayed empty and the
+  // EHLO fell back to "localhost" - which some servers reject outright.
+  client::destination_container sender;
+  sender.set_host("agent-host");
+
+  const smtp_client::connection_data con = connection_for({{"address", "h"}}, sender);
+
+  EXPECT_EQ(con.sender_hostname, "agent-host");
+}
+
+TEST(SmtpConnectionData, AnExplicitEhloHostnameWins) {
+  client::destination_container sender;
+  sender.set_host("agent-host");
+
+  const smtp_client::connection_data con = connection_for({{"address", "h"}, {"ehlo-hostname", "mail-gw.example.com"}}, sender);
+
+  EXPECT_EQ(con.canonical_name, "mail-gw.example.com");
+  EXPECT_EQ(con.sender_hostname, "agent-host") << "the sender is still recorded";
+}
+
+TEST(SmtpConnectionData, DescribesItselfWithoutLeakingThePassword) {
+  // to_string() is emitted on every operation at trace level.
+  const std::string described = connection_for({{"address", "mail.example.com"}, {"username", "agent"}, {"password", "s3cret"}}).to_string();
+
+  EXPECT_NE(described.find("mail.example.com"), std::string::npos) << described;
+  EXPECT_EQ(described.find("s3cret"), std::string::npos) << "the password must never reach a log: " << described;
+}

--- a/modules/SyslogClient/CMakeLists.txt
+++ b/modules/SyslogClient/CMakeLists.txt
@@ -38,3 +38,23 @@ target_link_libraries(
     ${NSCP_DEF_PLUGIN_LIB}
 )
 include(${BUILD_CMAKE_FOLDER}/module.cmake)
+
+# The payload construction (connection_data, the RFC 3164 priority tables and
+# what submit() puts on the wire) is ordinary C++ with a UDP socket at the end,
+# so it is unit-testable on every platform.
+NSCP_CREATE_TEST(
+    syslog_client_test
+    SOURCES
+        syslog_client_test.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/SyslogClient/syslog_client.hpp
+++ b/modules/SyslogClient/syslog_client.hpp
@@ -114,7 +114,11 @@ struct syslog_client_handler : public client::handler_interface {
   bool submit(client::destination_container sender, client::destination_container target, const PB::Commands::SubmitRequestMessage &request_message,
               PB::Commands::SubmitResponseMessage &response_message) {
     const PB::Common::Header &request_header = request_message.header();
-    connection_data con(sender, target);
+    // (target, sender): the first argument is the target's settings - the
+    // address, facility, severity and templates the operator configured.
+    // Passing them the other way round read every one of them from the
+    // sender container, which carries none of them.
+    connection_data con(target, sender);
 
     nscapi::protobuf::functions::make_return_header(response_message.mutable_header(), request_header);
 

--- a/modules/SyslogClient/syslog_client_test.cpp
+++ b/modules/SyslogClient/syslog_client_test.cpp
@@ -1,0 +1,307 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for the syslog client's payload construction.
+//
+// Two halves, both untested until now. The first is connection_data, which
+// turns the target's settings into typed connection info plus the RFC 3164
+// priority tables - a wrong default here points an agent at the wrong port or
+// files everything under the wrong facility, quietly. The second is what
+// submit() actually puts on the wire: one datagram per check result, with the
+// priority chosen from that result's status, the templates expanded, and any
+// newline in the check output neutralised so a result cannot forge extra
+// syslog records.
+//
+// The datagrams are read back from a real loopback UDP socket rather than
+// asserted against a refactored-out builder: the wire format is the contract,
+// and syslog is connectionless so there is nothing to stand up.
+
+// syslog_client.hpp expects its includer to have pulled in the client
+// machinery already (SyslogClient.cpp does); include it here too.
+#include <client/command_line_parser.hpp>
+
+#include "syslog_client.hpp"
+
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+#include <map>
+#include <string>
+#include <vector>
+
+// Normally provided by NSC_WRAP_DLL(); the module's logging macros need it.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+using boost::asio::ip::udp;
+
+client::destination_container target_with(const std::map<std::string, std::string> &options) {
+  client::destination_container d;
+  for (const auto &o : options) d.set_string_data(o.first, o.second);
+  return d;
+}
+
+// A bound UDP socket on an ephemeral port, and the datagrams it received.
+class syslog_sink {
+ public:
+  syslog_sink() : socket_(io_, udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0)) {}
+
+  unsigned short port() const { return socket_.local_endpoint().port(); }
+
+  // Read whatever has arrived. Everything is local and already sent by the
+  // time submit() returns, so a short poll is enough - but never block the
+  // suite if a datagram is missing.
+  std::vector<std::string> drain(const std::size_t expected) {
+    std::vector<std::string> out;
+    socket_.non_blocking(true);
+    for (int attempt = 0; attempt < 200 && out.size() < expected; attempt++) {
+      char buffer[4096];
+      boost::system::error_code ec;
+      const std::size_t len = socket_.receive(boost::asio::buffer(buffer), 0, ec);
+      if (!ec) {
+        out.emplace_back(buffer, len);
+        continue;
+      }
+      boost::asio::steady_timer timer(io_, boost::asio::chrono::milliseconds(5));
+      timer.wait();
+    }
+    return out;
+  }
+
+ private:
+  boost::asio::io_context io_;
+  udp::socket socket_;
+};
+
+// Submit one check result to a syslog sink and hand back the datagrams.
+std::vector<std::string> submit_to(syslog_sink &sink, const PB::Common::ResultCode result, const std::string &message,
+                                   std::map<std::string, std::string> options = {}) {
+  options["address"] = "127.0.0.1";
+  options["port"] = std::to_string(sink.port());
+  if (options.find("facility") == options.end()) options["facility"] = "kernel";
+  if (options.find("severity") == options.end()) options["severity"] = "error";
+  if (options.find("tag template") == options.end()) options["tag template"] = "nscp";
+  if (options.find("message template") == options.end()) options["message template"] = "%message%";
+
+  PB::Commands::SubmitRequestMessage request;
+  PB::Commands::QueryResponseMessage::Response *payload = request.add_payload();
+  payload->set_command("check_test");
+  payload->set_result(result);
+  payload->add_lines()->set_message(message);
+
+  PB::Commands::SubmitResponseMessage response;
+  syslog_client::syslog_client_handler handler;
+  handler.submit(client::destination_container(), target_with(options), request, response);
+  return sink.drain(1);
+}
+
+// The <PRI> prefix of a syslog line, without the angle brackets.
+int priority_of(const std::string &datagram) {
+  const std::string::size_type end = datagram.find('>');
+  if (datagram.empty() || datagram[0] != '<' || end == std::string::npos) return -1;
+  return std::stoi(datagram.substr(1, end - 1));
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// connection_data - settings in, connection info out.
+// ---------------------------------------------------------------------------
+
+TEST(SyslogConnectionData, DefaultsToTheSyslogPortAndSaneRetries) {
+  const syslog_client::connection_data con(target_with({{"address", "syslog.example.com"}}), client::destination_container());
+
+  EXPECT_EQ(con.get_port(), "514");
+  EXPECT_EQ(con.timeout, 30);
+  EXPECT_EQ(con.retry, 3);
+}
+
+TEST(SyslogConnectionData, TakesThePortFromTheTarget) {
+  const syslog_client::connection_data con(target_with({{"address", "syslog.example.com"}, {"port", "1514"}}), client::destination_container());
+
+  EXPECT_EQ(con.get_port(), "1514");
+}
+
+TEST(SyslogConnectionData, AConfiguredTimeoutDoesNotReachTheConnection) {
+  // CHARACTERIZATION TEST - this pins current behaviour, which is wrong.
+  //
+  // connection_data reads `arguments.get_int_data("timeout", 30)`, which looks
+  // in the container's free-form data map. But destination_container routes the
+  // well-known keys "timeout" and "retry" into typed *fields* instead of that
+  // map (set_string_data), so the lookup never finds them and the default wins
+  // no matter what the operator configured.
+  //
+  // Harmless here - syslog is UDP and never uses the value for anything but a
+  // debug line - but the same expression appears in NSCAClient, IcingaClient
+  // and CollectdClient, where it is the socket timeout. Fixing it means
+  // choosing what an unset timeout should be: the container defaults to 10,
+  // these clients document 30.
+  const syslog_client::connection_data con(target_with({{"address", "h"}, {"timeout", "5"}, {"retry", "1"}}), client::destination_container());
+
+  EXPECT_EQ(con.timeout, 30) << "documenting the defect: the configured 5 was ignored";
+  EXPECT_EQ(con.retry, 3) << "documenting the defect: the configured 1 was ignored";
+}
+
+TEST(SyslogConnectionData, CarriesTheTemplatesAndSeverities) {
+  const syslog_client::connection_data con(target_with({{"address", "h"},
+                                                        {"severity", "error"},
+                                                        {"facility", "daemon"},
+                                                        {"tag template", "my-tag"},
+                                                        {"message template", "prefix %message%"},
+                                                        {"ok severity", "informational"},
+                                                        {"warning severity", "warning"},
+                                                        {"critical severity", "critical"},
+                                                        {"unknown severity", "notice"}}),
+                                           client::destination_container());
+
+  EXPECT_EQ(con.severity, "error");
+  EXPECT_EQ(con.facility, "daemon");
+  EXPECT_EQ(con.tag_syntax, "my-tag");
+  EXPECT_EQ(con.message_syntax, "prefix %message%");
+  EXPECT_EQ(con.ok_severity, "informational");
+  EXPECT_EQ(con.crit_severity, "critical");
+  // to_string() is what the debug log prints when a submit misbehaves; it has
+  // to name the endpoint and both templates or the log is useless.
+  const std::string described = con.to_string();
+  EXPECT_NE(described.find("my-tag"), std::string::npos) << described;
+  EXPECT_NE(described.find("prefix %message%"), std::string::npos) << described;
+}
+
+// ---------------------------------------------------------------------------
+// parse_priority - RFC 3164 says PRI = facility * 8 + severity.
+// ---------------------------------------------------------------------------
+
+TEST(SyslogPriority, IsFacilityTimesEightPlusSeverity) {
+  syslog_client::connection_data con(target_with({{"address", "h"}}), client::destination_container());
+
+  EXPECT_EQ(con.parse_priority("emergency", "kernel"), "<0>");    // 0 * 8 + 0
+  EXPECT_EQ(con.parse_priority("debug", "kernel"), "<7>");        // 0 * 8 + 7
+  EXPECT_EQ(con.parse_priority("emergency", "user"), "<8>");      // 1 * 8 + 0
+  EXPECT_EQ(con.parse_priority("error", "local0"), "<131>");      // 16 * 8 + 3
+  EXPECT_EQ(con.parse_priority("debug", "local7"), "<191>");      // 23 * 8 + 7
+}
+
+TEST(SyslogPriority, AnUnknownNameFallsBackToZero) {
+  // Both halves come from operator configuration, so a typo must not send a
+  // random priority - it degrades to <0> and logs.
+  syslog_client::connection_data con(target_with({{"address", "h"}}), client::destination_container());
+
+  EXPECT_EQ(con.parse_priority("error", "no-such-facility"), "<0>");
+  EXPECT_EQ(con.parse_priority("no-such-severity", "kernel"), "<0>");
+}
+
+TEST(SyslogPriority, ClockResolvesToFifteenBecauseTheNameIsRegisteredTwice) {
+  // CHARACTERIZATION TEST - the table sets facilities["clock"] twice, to 9 and
+  // then to 15, so the second wins and facility 9 has no name at all. RFC 3164
+  // does list both 9 ("clock daemon") and 15 ("clock daemon" again), so the
+  // duplicate is in the spec too - but an operator who wants 9 cannot ask for
+  // it. Pinned rather than changed: renaming either entry changes what an
+  // existing `facility = clock` configuration puts on the wire.
+  syslog_client::connection_data con(target_with({{"address", "h"}}), client::destination_container());
+
+  EXPECT_EQ(con.parse_priority("emergency", "clock"), "<120>");  // 15 * 8, not 9 * 8
+}
+
+// ---------------------------------------------------------------------------
+// submit - what actually goes on the wire.
+// ---------------------------------------------------------------------------
+
+TEST(SyslogSubmit, SendsOneDatagramCarryingTheCheckOutput) {
+  syslog_sink sink;
+
+  const std::vector<std::string> sent = submit_to(sink, PB::Common::ResultCode::OK, "everything is fine");
+
+  ASSERT_EQ(sent.size(), 1u);
+  EXPECT_NE(sent[0].find("everything is fine"), std::string::npos) << sent[0];
+  EXPECT_NE(sent[0].find("nscp"), std::string::npos) << "the tag template is missing: " << sent[0];
+}
+
+TEST(SyslogSubmit, TheSeverityFollowsTheCheckResult) {
+  // This is the mapping an operator configures per status; getting it wrong
+  // means a CRITICAL check arriving as debug and never paging anyone.
+  syslog_sink sink;
+  const std::map<std::string, std::string> severities = {
+      {"ok severity", "informational"}, {"warning severity", "warning"}, {"critical severity", "critical"}, {"unknown severity", "notice"}};
+
+  // facility kernel (0), so the priority is the severity number itself.
+  EXPECT_EQ(priority_of(submit_to(sink, PB::Common::ResultCode::OK, "m", severities).at(0)), 6);
+  EXPECT_EQ(priority_of(submit_to(sink, PB::Common::ResultCode::WARNING, "m", severities).at(0)), 4);
+  EXPECT_EQ(priority_of(submit_to(sink, PB::Common::ResultCode::CRITICAL, "m", severities).at(0)), 2);
+  EXPECT_EQ(priority_of(submit_to(sink, PB::Common::ResultCode::UNKNOWN, "m", severities).at(0)), 5);
+}
+
+TEST(SyslogSubmit, ExpandsTheTagAndMessageTemplates) {
+  syslog_sink sink;
+
+  const std::vector<std::string> sent =
+      submit_to(sink, PB::Common::ResultCode::OK, "the output", {{"tag template", "tag[%message%]"}, {"message template", "msg=%message%"}});
+
+  ASSERT_EQ(sent.size(), 1u);
+  // %message% expands to the check's own output - the status word is not part
+  // of it, since the priority already carries the status.
+  EXPECT_NE(sent[0].find("tag[the output]"), std::string::npos) << sent[0];
+  EXPECT_NE(sent[0].find("msg=the output"), std::string::npos) << sent[0];
+}
+
+TEST(SyslogSubmit, ANewlineInTheCheckOutputCannotForgeASecondRecord) {
+  // Log injection: a check whose output contains CR/LF would otherwise split
+  // into two syslog records, letting a monitored process write arbitrary
+  // entries - including ones that look like they came from something else.
+  syslog_sink sink;
+
+  const std::vector<std::string> sent = submit_to(sink, PB::Common::ResultCode::OK, "first line\n<0>Jan  1 00:00:00 forged: second line");
+
+  ASSERT_EQ(sent.size(), 1u) << "the output split into more than one datagram";
+  EXPECT_EQ(sent[0].find('\n'), std::string::npos) << sent[0];
+  EXPECT_EQ(sent[0].find('\r'), std::string::npos) << sent[0];
+  // The text survives, only the line breaks are neutralised.
+  EXPECT_NE(sent[0].find("first line"), std::string::npos) << sent[0];
+  EXPECT_NE(sent[0].find("forged: second line"), std::string::npos) << sent[0];
+}
+
+TEST(SyslogSubmit, EveryPayloadInABatchGetsItsOwnDatagram) {
+  syslog_sink sink;
+
+  PB::Commands::SubmitRequestMessage request;
+  for (const char *name : {"check_a", "check_b", "check_c"}) {
+    PB::Commands::QueryResponseMessage::Response *payload = request.add_payload();
+    payload->set_command(name);
+    payload->set_result(PB::Common::ResultCode::OK);
+    payload->add_lines()->set_message(std::string("output of ") + name);
+  }
+
+  PB::Commands::SubmitResponseMessage response;
+  syslog_client::syslog_client_handler handler;
+  handler.submit(client::destination_container(),
+                 target_with({{"address", "127.0.0.1"},
+                              {"port", std::to_string(sink.port())},
+                              {"facility", "kernel"},
+                              {"severity", "error"},
+                              {"tag template", "nscp"},
+                              {"message template", "%message%"}}),
+                 request, response);
+
+  const std::vector<std::string> sent = sink.drain(3);
+  ASSERT_EQ(sent.size(), 3u);
+  EXPECT_NE(sent[0].find("output of check_a"), std::string::npos) << sent[0];
+  EXPECT_NE(sent[2].find("output of check_c"), std::string::npos) << sent[2];
+}
+
+TEST(SyslogSubmit, OnlySubmitIsSupported) {
+  // The syslog protocol is one-way: there is nothing to query or execute, and
+  // the handler has to say so rather than pretend it worked.
+  syslog_client::syslog_client_handler handler;
+  const client::destination_container empty;
+
+  PB::Commands::QueryRequestMessage query_request;
+  PB::Commands::QueryResponseMessage query_response;
+  EXPECT_FALSE(handler.query(empty, empty, query_request, query_response));
+
+  PB::Commands::ExecuteRequestMessage exec_request;
+  PB::Commands::ExecuteResponseMessage exec_response;
+  EXPECT_FALSE(handler.exec(empty, empty, exec_request, exec_response));
+
+  PB::Metrics::MetricsMessage metrics;
+  EXPECT_FALSE(handler.metrics(empty, empty, metrics));
+}

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -282,6 +282,35 @@ if(WIN32)
     )
 endif()
 
+# settings_query_handler drives the process-wide settings manager, so the test
+# needs the same pieces the service links for it: the settings manager itself,
+# the plugin cache (plugin id -> name), boost::json for template registration
+# and the protobuf helpers.
+NSCP_CREATE_TEST(
+    settings_query_handler_test
+    SOURCES
+        settings_query_handler.cpp
+        settings_query_handler_test.cpp
+        plugins/plugin_cache.cpp
+        ${NSCP_INCLUDEDIR}/json/use_json.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/protobuf/functions_query.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/protobuf/functions_response.cpp
+        ${NSCP_INCLUDEDIR}/nsclient/logger/log_level.cpp
+        ${NSCP_INCLUDEDIR}/nsclient/logger/logger_helper.cpp
+        ${NSCP_INCLUDEDIR}/nsclient/logger/log_message_factory.cpp
+        ${NSCP_INCLUDEDIR}/str/utf8.cpp
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${EXTRA_LIBS}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        settings_manager
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 NSCP_CREATE_TEST(
     plugins_test
     SOURCES

--- a/service/CMakeLists.txt
+++ b/service/CMakeLists.txt
@@ -325,6 +325,7 @@ NSCP_CREATE_TEST(
         plugins/dll_plugin_test.cpp
         plugins/plugin_list_test.cpp
         plugins/zip_plugin.cpp
+        plugins/zip_plugin_test.cpp
         commands_test.cpp
         commands.hpp
         ${NSCP_INCLUDEDIR}/bytes/unzip.cpp

--- a/service/cli_parser.cpp
+++ b/service/cli_parser.cpp
@@ -332,11 +332,18 @@ int cli_parser::parse_settings(int argc, char *argv[]) {
       } else if (vm.count("list")) {
         ret = settings_cli.list(vm["path"].as<std::string>());
       } else if (vm.count("show")) {
-        if (vm.count("path") > 0 && vm.count("key") > 0)
-          ret = settings_cli.show(vm["path"].as<std::string>(), vm["key"].as<std::string>());
-        else {
+        const std::string show_path = vm["path"].as<std::string>();
+        const std::string show_key = vm["key"].as<std::string>();
+        // Neither given is meaningful - show() then describes the active
+        // store. One without the other is a typo, and used to be answered
+        // with silence and a success exit: both options carry a
+        // default_value(""), so vm.count() reports them present even when the
+        // operator never typed them and the guard below could never fire.
+        if (show_path.empty() != show_key.empty()) {
           std::cerr << "Invalid command line please use --path and --key with show" << std::endl;
           ret = -1;
+        } else {
+          ret = settings_cli.show(show_path, show_key);
         }
       } else if (vm.count("activate-module")) {
         ret = settings_cli.activate(vm["activate-module"].as<std::vector<std::string> >());

--- a/service/plugins/zip_plugin_test.cpp
+++ b/service/plugins/zip_plugin_test.cpp
@@ -1,0 +1,265 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for the zip plugin loader - the thing behind a ".zip module": an
+// archive carrying a module.json that names the scripts to install, the
+// modules they need and the commands to run once loaded.
+//
+// Everything here stops at the metadata: the constructor opens the archive and
+// parses module.json, which is where an operator's mistake (a missing file, a
+// typo in the json, a script under a name nothing can provide) turns into a
+// clear error or a silently wrong provider. Actually installing the scripts
+// needs a live plugin manager, so that half belongs to the integration suite.
+//
+// The archives are built here rather than checked in, because the interesting
+// cases are all about *what module.json says* - a fixture per variation would
+// mean a dozen opaque binaries in the tree.
+
+#include "zip_plugin.h"
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <cstdint>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace fs = boost::filesystem;
+using nsclient::core::zip_plugin;
+
+namespace {
+
+// --- a minimal zip writer ---------------------------------------------------
+//
+// STORED (uncompressed) entries only, which is all a reader needs to accept.
+// The repo has a zip *reader* (bytes::unzip, libzip or miniz depending on the
+// platform) but no writer, and pulling one of those backends into a test just
+// to lay down a few hundred bytes is more coupling than the job needs.
+
+uint32_t crc32_of(const std::string &data) {
+  uint32_t crc = 0xFFFFFFFFu;
+  for (const unsigned char c : data) {
+    crc ^= c;
+    for (int k = 0; k < 8; k++) crc = (crc >> 1) ^ (0xEDB88320u & (0u - (crc & 1u)));
+  }
+  return crc ^ 0xFFFFFFFFu;
+}
+
+void put16(std::string &out, const uint16_t v) {
+  out.push_back(static_cast<char>(v & 0xFF));
+  out.push_back(static_cast<char>((v >> 8) & 0xFF));
+}
+void put32(std::string &out, const uint32_t v) {
+  out.push_back(static_cast<char>(v & 0xFF));
+  out.push_back(static_cast<char>((v >> 8) & 0xFF));
+  out.push_back(static_cast<char>((v >> 16) & 0xFF));
+  out.push_back(static_cast<char>((v >> 24) & 0xFF));
+}
+
+struct zip_entry {
+  std::string name;
+  std::string data;
+};
+
+void write_zip(const fs::path &path, const std::vector<zip_entry> &entries) {
+  std::string body;    // local headers + data
+  std::string central; // central directory
+  for (const zip_entry &e : entries) {
+    const uint32_t crc = crc32_of(e.data);
+    const uint32_t offset = static_cast<uint32_t>(body.size());
+
+    put32(body, 0x04034b50);                                 // local file header
+    put16(body, 20);                                         // version needed
+    put16(body, 0);                                          // flags
+    put16(body, 0);                                          // method: stored
+    put16(body, 0);                                          // mod time
+    put16(body, 0);                                          // mod date
+    put32(body, crc);
+    put32(body, static_cast<uint32_t>(e.data.size()));       // compressed size
+    put32(body, static_cast<uint32_t>(e.data.size()));       // uncompressed size
+    put16(body, static_cast<uint16_t>(e.name.size()));
+    put16(body, 0);                                          // extra length
+    body += e.name;
+    body += e.data;
+
+    put32(central, 0x02014b50);                              // central directory header
+    put16(central, 20);                                      // version made by
+    put16(central, 20);                                      // version needed
+    put16(central, 0);
+    put16(central, 0);
+    put16(central, 0);
+    put16(central, 0);
+    put32(central, crc);
+    put32(central, static_cast<uint32_t>(e.data.size()));
+    put32(central, static_cast<uint32_t>(e.data.size()));
+    put16(central, static_cast<uint16_t>(e.name.size()));
+    put16(central, 0);                                       // extra
+    put16(central, 0);                                       // comment
+    put16(central, 0);                                       // disk number
+    put16(central, 0);                                       // internal attrs
+    put32(central, 0);                                       // external attrs
+    put32(central, offset);
+    central += e.name;
+  }
+
+  std::string out = body + central;
+  put32(out, 0x06054b50);                                    // end of central directory
+  put16(out, 0);                                             // this disk
+  put16(out, 0);                                             // disk with cd
+  put16(out, static_cast<uint16_t>(entries.size()));         // entries on this disk
+  put16(out, static_cast<uint16_t>(entries.size()));         // entries total
+  put32(out, static_cast<uint32_t>(central.size()));
+  put32(out, static_cast<uint32_t>(body.size()));
+  put16(out, 0);                                             // comment length
+
+  std::ofstream f(path.string().c_str(), std::ios::binary);
+  f.write(out.data(), static_cast<std::streamsize>(out.size()));
+}
+
+class ZipPluginTest : public ::testing::Test {
+ protected:
+  fs::path dir_;
+
+  void SetUp() override {
+    dir_ = fs::temp_directory_path() / fs::unique_path("nscp-zipplugin-%%%%-%%%%");
+    fs::create_directories(dir_);
+  }
+  void TearDown() override {
+    boost::system::error_code ec;
+    fs::remove_all(dir_, ec);
+  }
+
+  // Build an archive and hand back a loaded plugin for it. The paths and
+  // plugin-manager handles stay null: reading the metadata never touches them,
+  // and installing the scripts (which does) is out of scope here.
+  fs::path make_archive(const std::string &name, const std::vector<zip_entry> &entries) {
+    const fs::path path = dir_ / name;
+    write_zip(path, entries);
+    return path;
+  }
+
+  static std::unique_ptr<zip_plugin> open(const fs::path &archive) {
+    return std::make_unique<zip_plugin>(1, archive, "", nsclient::core::path_instance(), nsclient::core::plugin_mgr_instance(),
+                                        nsclient::logging::logger_instance());
+  }
+};
+
+}  // namespace
+
+TEST_F(ZipPluginTest, reads_the_name_and_description_from_module_json) {
+  const fs::path archive = make_archive("sample.zip", {{"module.json", R"({"name":"Sample","description":"A sample module"})"}});
+
+  const auto plugin = open(archive);
+
+  EXPECT_EQ(plugin->getName(), "Sample");
+  EXPECT_EQ(plugin->getDescription(), "A sample module");
+}
+
+TEST_F(ZipPluginTest, the_module_name_comes_from_the_archive_file_name) {
+  // The extracted scripts land in a folder named after the archive, so the
+  // ".zip" has to come off - otherwise every path carries it.
+  const fs::path archive = make_archive("my-module.zip", {{"module.json", R"({"name":"Sample","description":""})"}});
+
+  EXPECT_EQ(open(archive)->getModule(), "my-module");
+}
+
+TEST_F(ZipPluginTest, an_archive_without_module_json_is_rejected) {
+  const fs::path archive = make_archive("no-metadata.zip", {{"readme.txt", "nothing to see"}});
+
+  EXPECT_THROW(open(archive), nsclient::core::plugin_exception);
+}
+
+TEST_F(ZipPluginTest, a_file_that_is_not_an_archive_is_rejected) {
+  const fs::path path = dir_ / "not-a-zip.zip";
+  std::ofstream(path.string().c_str()) << "this is not a zip file";
+
+  EXPECT_THROW(open(path), nsclient::core::plugin_exception);
+}
+
+TEST_F(ZipPluginTest, a_missing_file_is_rejected) {
+  EXPECT_THROW(open(dir_ / "does-not-exist.zip"), nsclient::core::plugin_exception);
+}
+
+TEST_F(ZipPluginTest, malformed_json_is_rejected) {
+  const fs::path archive = make_archive("bad-json.zip", {{"module.json", "{not json at all"}});
+
+  EXPECT_THROW(open(archive), nsclient::core::plugin_exception);
+}
+
+TEST_F(ZipPluginTest, module_json_without_a_name_is_rejected) {
+  // as_string() on a missing key throws, and that has to surface as the
+  // module failing to load rather than as an unhandled boost::json error.
+  const fs::path archive = make_archive("no-name.zip", {{"module.json", R"({"description":"no name here"})"}});
+
+  EXPECT_THROW(open(archive), nsclient::core::plugin_exception);
+}
+
+TEST_F(ZipPluginTest, accepts_the_full_metadata_shape) {
+  // Everything module.json may carry, in the two forms a script entry takes:
+  // a bare file name, and an object naming its provider explicitly.
+  const fs::path archive = make_archive("full.zip", {{"module.json", R"({
+        "name": "Full",
+        "description": "Every key",
+        "scripts": [
+          "check_something.py",
+          "check_other.sh",
+          {"provider": "LUAScript", "script": "s.lua", "alias": "a", "command": "c"}
+        ],
+        "modules": ["CheckHelpers"],
+        "on_start": ["CheckHelpers.add --name x"]
+      })"},
+                                                     {"check_something.py", "print('hi')\n"},
+                                                     {"check_other.sh", "echo hi\n"},
+                                                     {"s.lua", "-- lua\n"}});
+
+  const auto plugin = open(archive);
+
+  EXPECT_EQ(plugin->getName(), "Full");
+  EXPECT_EQ(plugin->getDescription(), "Every key");
+}
+
+TEST_F(ZipPluginTest, a_script_entry_that_is_not_a_string_or_an_object_is_rejected) {
+  const fs::path archive = make_archive("bad-script.zip", {{"module.json", R"({"name":"X","description":"","scripts":[42]})"}});
+
+  EXPECT_THROW(open(archive), nsclient::core::plugin_exception);
+}
+
+TEST_F(ZipPluginTest, a_script_object_missing_its_keys_is_rejected) {
+  const fs::path archive = make_archive("partial-script.zip", {{"module.json", R"({"name":"X","description":"","scripts":[{"script":"s.lua"}]})"}});
+
+  EXPECT_THROW(open(archive), nsclient::core::plugin_exception);
+}
+
+TEST_F(ZipPluginTest, the_metadata_may_be_preceded_by_other_entries) {
+  // read_metadata walks the whole archive looking for module.json rather than
+  // assuming it comes first.
+  const fs::path archive = make_archive("late-metadata.zip", {{"a.txt", "first"},
+                                                              {"b.txt", "second"},
+                                                              {"module.json", R"({"name":"Late","description":"found anyway"})"}});
+
+  EXPECT_EQ(open(archive)->getName(), "Late");
+}
+
+TEST_F(ZipPluginTest, reports_a_fixed_version_and_never_claims_duplicates) {
+  const fs::path archive = make_archive("simple.zip", {{"module.json", R"({"name":"Simple","description":""})"}});
+  const auto plugin = open(archive);
+
+  EXPECT_EQ(plugin->get_version(), "1.0.0");
+  EXPECT_FALSE(plugin->is_duplicate(archive, ""));
+  EXPECT_FALSE(plugin->hasCommandHandler());
+  EXPECT_FALSE(plugin->hasNotificationHandler());
+  EXPECT_FALSE(plugin->has_on_event());
+}
+
+TEST_F(ZipPluginTest, routing_a_message_through_a_zip_module_is_an_error) {
+  // A zip module carries scripts; it has no handlers of its own, so anything
+  // that would dispatch to one has to fail loudly rather than silently drop.
+  const fs::path archive = make_archive("simple.zip", {{"module.json", R"({"name":"Simple","description":""})"}});
+  const auto plugin = open(archive);
+
+  char *new_channel = nullptr;
+  char *new_buffer = nullptr;
+  unsigned int new_len = 0;
+  EXPECT_THROW(plugin->route_message("chan", "data", 4, &new_channel, &new_buffer, &new_len), nsclient::core::plugin_exception);
+}

--- a/service/settings_query_handler_test.cpp
+++ b/service/settings_query_handler_test.cpp
@@ -1,0 +1,569 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for service/settings_query_handler.cpp - the settings API every remote
+// caller reaches: the REST settings endpoints, `nscp settings`, and any module
+// that registers or reads configuration through the plugin API all arrive
+// here as a SettingsRequestMessage.
+//
+// The handler works on the process-wide settings manager rather than an
+// injected store, so each test boots one over a throwaway INI file in a temp
+// dir and tears it down again. That is heavier than a pure unit test but it is
+// the real thing: registration, reads, writes, save/load and the diff all go
+// through the same store the daemon uses.
+
+#include "settings_query_handler.hpp"
+
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <memory>
+#include <settings/test_helpers.hpp>
+#include <string>
+
+#include "../libs/settings_manager/settings_manager_impl.h"
+
+using nsclient::core::settings_query_handler;
+
+namespace {
+
+// Minimal provider: paths are used verbatim (the tests hand out absolute temp
+// paths) and nothing is logged.
+class test_provider : public settings_manager::provider_interface {
+ public:
+  test_provider() : logger_(settings_test::make_null_logger()) {}
+  std::string expand_path(std::string file) override { return file; }
+  nsclient::logging::logger_instance get_logger() const override { return logger_; }
+  void apply_path_overrides(std::map<std::string, std::string>) override {}
+
+ private:
+  nsclient::logging::logger_instance logger_;
+};
+
+// The handler only reaches into the core for the logger and the plugin cache
+// (to turn plugin ids into names); the rest of core_interface is never touched
+// on these paths.
+class test_core : public nsclient::core::core_interface {
+ public:
+  test_core() : logger_(settings_test::make_null_logger()), plugin_cache_(new nsclient::core::plugin_cache(logger_)) {}
+
+  nsclient::logging::logger_instance get_logger() override { return logger_; }
+  nsclient::core::plugin_mgr_instance get_plugin_manager() override { return {}; }
+  nsclient::core::path_instance get_path() override { return {}; }
+  nsclient::core::plugin_cache *get_plugin_cache() override { return plugin_cache_.get(); }
+  nsclient::core::storage_manager_instance get_storage_manager() override { return {}; }
+
+ private:
+  nsclient::logging::logger_instance logger_;
+  std::unique_ptr<nsclient::core::plugin_cache> plugin_cache_;
+};
+
+class SettingsQueryTest : public ::testing::Test {
+ protected:
+  settings_test::temp_dir dir_;
+  boost::filesystem::path ini_;
+  std::unique_ptr<test_provider> provider_;
+  std::shared_ptr<test_core> core_;
+
+  void SetUp() override {
+    ini_ = dir_.file("settings.ini");
+    settings_test::write_file(ini_, "");
+    provider_ = std::make_unique<test_provider>();
+    core_ = std::make_shared<test_core>();
+    ASSERT_TRUE(settings_manager::init_settings(provider_.get(), context()));
+  }
+
+  void TearDown() override { settings_manager::destroy_settings(); }
+
+  std::string context() const {
+    std::string p = ini_.generic_string();
+    if (!p.empty() && p.front() == '/') p.erase(0, 1);
+    return "ini:///" + p;
+  }
+
+  // Run one request through the handler and hand back the response.
+  PB::Settings::SettingsResponseMessage run(const PB::Settings::SettingsRequestMessage &request) {
+    PB::Settings::SettingsResponseMessage response;
+    settings_query_handler(core_, request).parse(response);
+    return response;
+  }
+
+  // A request with a single payload; the caller fills in the action.
+  static PB::Settings::SettingsRequestMessage::Request *new_request(PB::Settings::SettingsRequestMessage &request, int plugin_id = 1234) {
+    PB::Settings::SettingsRequestMessage::Request *payload = request.add_payload();
+    payload->set_plugin_id(plugin_id);
+    return payload;
+  }
+
+  // Set a value the way a caller would: through an update request.
+  void set_value(const std::string &path, const std::string &key, const std::string &value) {
+    PB::Settings::SettingsRequestMessage request;
+    PB::Settings::SettingsRequestMessage::Request *payload = new_request(request);
+    PB::Settings::Node *node = payload->mutable_update()->mutable_node();
+    node->set_path(path);
+    node->set_key(key);
+    node->set_value(value);
+    run(request);
+  }
+
+  void register_key(const std::string &path, const std::string &key, bool sensitive = false) {
+    PB::Settings::SettingsRequestMessage request;
+    PB::Settings::SettingsRequestMessage::Request *payload = new_request(request);
+    PB::Settings::SettingsRequestMessage::Request::Registration *reg = payload->mutable_registration();
+    reg->mutable_node()->set_path(path);
+    reg->mutable_node()->set_key(key);
+    reg->mutable_info()->set_type("string");
+    reg->mutable_info()->set_title("A key");
+    reg->mutable_info()->set_description("Describes a key");
+    reg->mutable_info()->set_default_value("the-default");
+    reg->mutable_info()->set_is_sensitive(sensitive);
+    run(request);
+  }
+};
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+TEST_F(SettingsQueryTest, a_request_without_an_action_is_rejected) {
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request);
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_EQ(response.payload(0).result().message(), "Settings error: Invalid action");
+}
+
+TEST_F(SettingsQueryTest, every_payload_gets_its_own_response) {
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_status();
+  new_request(request)->mutable_status();
+
+  EXPECT_EQ(run(request).payload_size(), 2);
+}
+
+TEST_F(SettingsQueryTest, status_reports_the_store_behind_the_settings) {
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_status();
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_EQ(response.payload(0).status().type(), "ini");
+  EXPECT_FALSE(response.payload(0).status().has_changed()) << "nothing written yet";
+}
+
+TEST_F(SettingsQueryTest, status_reports_pending_changes) {
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_status();
+
+  EXPECT_TRUE(run(request).payload(0).status().has_changed());
+}
+
+// ---------------------------------------------------------------------------
+// Update and query - the read/write pair behind `nscp settings --set/--show`.
+// ---------------------------------------------------------------------------
+
+TEST_F(SettingsQueryTest, a_value_written_can_be_read_back) {
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(request)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->mutable_node()->set_key("key");
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  EXPECT_EQ(response.payload(0).query().node().value(), "value");
+}
+
+TEST_F(SettingsQueryTest, a_missing_value_comes_back_as_the_requested_default) {
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(request)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->mutable_node()->set_key("nothing-here");
+  q->set_default_value("fallback");
+
+  EXPECT_EQ(run(request).payload(0).query().node().value(), "fallback");
+}
+
+TEST_F(SettingsQueryTest, a_key_update_with_no_value_removes_the_key) {
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::Node *node = new_request(request)->mutable_update()->mutable_node();
+  node->set_path("/section");
+  node->set_key("key");
+  run(request);
+
+  PB::Settings::SettingsRequestMessage read;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(read)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->mutable_node()->set_key("key");
+  EXPECT_EQ(run(read).payload(0).query().node().value(), "");
+}
+
+TEST_F(SettingsQueryTest, an_update_with_neither_key_nor_value_removes_the_path) {
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_update()->mutable_node()->set_path("/section");
+  run(request);
+
+  PB::Settings::SettingsRequestMessage read;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(read)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->set_include_keys(true);
+  EXPECT_EQ(run(read).payload(0).query().nodes_size(), 0);
+}
+
+TEST_F(SettingsQueryTest, a_path_query_lists_the_keys_underneath_it) {
+  set_value("/section", "first", "1");
+  set_value("/section", "second", "2");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(request)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->set_include_keys(true);
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  EXPECT_EQ(response.payload(0).query().nodes_size(), 2);
+}
+
+TEST_F(SettingsQueryTest, a_recursive_query_walks_into_sub_sections) {
+  set_value("/section/child", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(request)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->set_recursive(true);
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  ASSERT_GT(response.payload(0).query().nodes_size(), 0);
+  EXPECT_EQ(response.payload(0).query().nodes(0).path(), "/section/child");
+}
+
+TEST_F(SettingsQueryTest, a_trailing_slash_on_the_queried_path_is_ignored) {
+  // recurse_find strips it; without that the child lookup would go looking
+  // under "/section//child".
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(request)->mutable_query();
+  q->mutable_node()->set_path("/section/");
+  q->set_include_keys(true);
+
+  EXPECT_EQ(run(request).payload(0).query().nodes_size(), 1);
+}
+
+TEST_F(SettingsQueryTest, a_sensitive_value_is_redacted_when_asked) {
+  register_key("/section", "password", /*sensitive=*/true);
+  set_value("/section", "password", "hunter2");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(request)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->mutable_node()->set_key("password");
+  q->set_redact_sensitive(true);
+
+  EXPECT_EQ(run(request).payload(0).query().node().value(), "***");
+}
+
+TEST_F(SettingsQueryTest, a_sensitive_value_is_returned_when_redaction_is_off) {
+  // The daemon itself has to be able to read the value it stored.
+  register_key("/section", "password", /*sensitive=*/true);
+  set_value("/section", "password", "hunter2");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(request)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->mutable_node()->set_key("password");
+
+  EXPECT_EQ(run(request).payload(0).query().node().value(), "hunter2");
+}
+
+TEST_F(SettingsQueryTest, an_ordinary_value_is_untouched_by_redaction) {
+  register_key("/section", "key");
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Query *q = new_request(request)->mutable_query();
+  q->mutable_node()->set_path("/section");
+  q->mutable_node()->set_key("key");
+  q->set_redact_sensitive(true);
+
+  EXPECT_EQ(run(request).payload(0).query().node().value(), "value");
+}
+
+// ---------------------------------------------------------------------------
+// Registration - what a module does at load time so its configuration shows up
+// in the docs, the web UI and --add-defaults.
+// ---------------------------------------------------------------------------
+
+TEST_F(SettingsQueryTest, a_registered_key_is_reported_by_the_inventory) {
+  register_key("/section", "key");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Inventory *inv = new_request(request)->mutable_inventory();
+  inv->mutable_node()->set_path("/section");
+  inv->mutable_node()->set_key("key");
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  ASSERT_EQ(response.payload(0).inventory_size(), 1);
+  EXPECT_EQ(response.payload(0).inventory(0).info().title(), "A key");
+  EXPECT_EQ(response.payload(0).inventory(0).info().type(), "string");
+}
+
+TEST_F(SettingsQueryTest, an_inventory_of_a_path_lists_its_registered_keys) {
+  register_key("/section", "key");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Inventory *inv = new_request(request)->mutable_inventory();
+  inv->mutable_node()->set_path("/section");
+  inv->set_fetch_keys(true);
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  ASSERT_GE(response.payload(0).inventory_size(), 1);
+  EXPECT_EQ(response.payload(0).inventory(0).node().key(), "key");
+  EXPECT_EQ(response.payload(0).inventory(0).info().default_value(), "the-default");
+}
+
+TEST_F(SettingsQueryTest, an_inventory_reports_keys_nobody_registered_too) {
+  // Configuration in the file that no module claims still has to be visible,
+  // otherwise the web UI silently drops whatever it does not understand.
+  set_value("/section", "stray", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Inventory *inv = new_request(request)->mutable_inventory();
+  inv->mutable_node()->set_path("/section");
+  inv->set_fetch_keys(true);
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  ASSERT_EQ(response.payload(0).inventory_size(), 1);
+  EXPECT_EQ(response.payload(0).inventory(0).node().key(), "stray");
+  EXPECT_TRUE(response.payload(0).inventory(0).info().advanced()) << "unregistered keys are reported as advanced";
+}
+
+TEST_F(SettingsQueryTest, a_registered_path_is_reported_as_a_folder) {
+  PB::Settings::SettingsRequestMessage reg_request;
+  PB::Settings::SettingsRequestMessage::Request::Registration *reg = new_request(reg_request)->mutable_registration();
+  reg->mutable_node()->set_path("/section");
+  reg->mutable_info()->set_title("A section");
+  reg->mutable_info()->set_description("Describes a section");
+  run(reg_request);
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Inventory *inv = new_request(request)->mutable_inventory();
+  inv->mutable_node()->set_path("/section");
+  inv->set_fetch_paths(true);
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  ASSERT_EQ(response.payload(0).inventory_size(), 1);
+  EXPECT_EQ(response.payload(0).inventory(0).info().type(), "folder");
+  EXPECT_EQ(response.payload(0).inventory(0).info().title(), "A section");
+}
+
+TEST_F(SettingsQueryTest, a_registered_template_is_reported_by_the_inventory) {
+  PB::Settings::SettingsRequestMessage reg_request;
+  PB::Settings::SettingsRequestMessage::Request::Registration *reg = new_request(reg_request)->mutable_registration();
+  reg->mutable_node()->set_path("/section");
+  reg->mutable_info()->set_title("A template");
+  reg->set_fields(R"({"fields": []})");
+  run(reg_request);
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Inventory *inv = new_request(request)->mutable_inventory();
+  inv->set_fetch_templates(true);
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  ASSERT_EQ(response.payload(0).inventory_size(), 1);
+  EXPECT_EQ(response.payload(0).inventory(0).info().type(), "template");
+  EXPECT_TRUE(response.payload(0).inventory(0).info().is_template());
+}
+
+TEST_F(SettingsQueryTest, malformed_template_fields_do_not_take_the_registration_down) {
+  // The payload is whatever the module handed us; bad json is logged and the
+  // rest of the template still registers.
+  PB::Settings::SettingsRequestMessage reg_request;
+  PB::Settings::SettingsRequestMessage::Request::Registration *reg = new_request(reg_request)->mutable_registration();
+  reg->mutable_node()->set_path("/section");
+  reg->mutable_info()->set_title("A template");
+  reg->set_fields("{not json");
+
+  const PB::Settings::SettingsResponseMessage response = run(reg_request);
+
+  EXPECT_EQ(response.payload(0).result().code(), PB::Common::Result_StatusCodeType_STATUS_OK);
+}
+
+// ---------------------------------------------------------------------------
+// Control - load and save.
+// ---------------------------------------------------------------------------
+
+TEST_F(SettingsQueryTest, save_writes_the_pending_changes_to_disk) {
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_control()->set_command(PB::Settings::Command::SAVE);
+  run(request);
+
+  EXPECT_NE(settings_test::read_file(ini_).find("value"), std::string::npos);
+}
+
+TEST_F(SettingsQueryTest, a_control_command_that_is_neither_load_nor_save_says_so) {
+  // RELOAD is in the protocol but the handler only implements LOAD and SAVE.
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_control()->set_command(PB::Settings::Command::RELOAD);
+
+  EXPECT_EQ(run(request).payload(0).result().message(), "Unknown command");
+}
+
+// ---------------------------------------------------------------------------
+// Diff - what an operator-facing "what am I about to save?" view is built on.
+// ---------------------------------------------------------------------------
+
+TEST_F(SettingsQueryTest, a_pending_write_shows_up_in_the_diff) {
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_diff();
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  bool found = false;
+  for (const auto &e : response.payload(0).diff().entries()) {
+    if (e.path() == "/section" && e.key() == "key") {
+      EXPECT_EQ(e.change_type(), PB::Settings::SettingsResponseMessage::Response::Diff::ADDED);
+      EXPECT_EQ(e.new_value(), "value");
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST_F(SettingsQueryTest, the_diff_is_empty_once_the_changes_are_saved) {
+  set_value("/section", "key", "value");
+
+  PB::Settings::SettingsRequestMessage save;
+  new_request(save)->mutable_control()->set_command(PB::Settings::Command::SAVE);
+  run(save);
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_diff();
+
+  EXPECT_EQ(run(request).payload(0).diff().entries_size(), 0);
+}
+
+TEST_F(SettingsQueryTest, a_diff_filter_keeps_only_the_requested_path) {
+  set_value("/wanted", "key", "value");
+  set_value("/unwanted", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_diff()->mutable_node()->set_path("/wanted");
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  for (const auto &e : response.payload(0).diff().entries()) {
+    EXPECT_EQ(e.path(), "/wanted") << "an unrelated path leaked past the filter";
+  }
+  EXPECT_GT(response.payload(0).diff().entries_size(), 0);
+}
+
+TEST_F(SettingsQueryTest, a_non_recursive_diff_filter_excludes_sub_paths) {
+  set_value("/section/child", "key", "value");
+
+  PB::Settings::SettingsRequestMessage unfiltered;
+  new_request(unfiltered)->mutable_diff();
+  ASSERT_GT(run(unfiltered).payload(0).diff().entries_size(), 0) << "the change is pending to begin with";
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_diff()->mutable_node()->set_path("/section");
+
+  EXPECT_EQ(run(request).payload(0).diff().entries_size(), 0);
+}
+
+TEST_F(SettingsQueryTest, a_recursive_diff_filter_includes_sub_paths) {
+  set_value("/section/child", "key", "value");
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Diff *diff = new_request(request)->mutable_diff();
+  diff->mutable_node()->set_path("/section");
+  diff->set_recursive(true);
+
+  EXPECT_GT(run(request).payload(0).diff().entries_size(), 0);
+}
+
+TEST_F(SettingsQueryTest, a_recursive_diff_filter_does_not_match_a_mere_prefix) {
+  // "/section" must not swallow "/section-other": the match is on path
+  // segments, not characters.
+  set_value("/section-other", "key", "value");
+
+  PB::Settings::SettingsRequestMessage unfiltered;
+  new_request(unfiltered)->mutable_diff();
+  ASSERT_GT(run(unfiltered).payload(0).diff().entries_size(), 0) << "the change is pending to begin with";
+
+  PB::Settings::SettingsRequestMessage request;
+  PB::Settings::SettingsRequestMessage::Request::Diff *diff = new_request(request)->mutable_diff();
+  diff->mutable_node()->set_path("/section");
+  diff->set_recursive(true);
+
+  EXPECT_EQ(run(request).payload(0).diff().entries_size(), 0);
+}
+
+TEST_F(SettingsQueryTest, a_sensitive_value_is_masked_in_the_diff) {
+  register_key("/section", "password", /*sensitive=*/true);
+  set_value("/section", "password", "hunter2");
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_diff();
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  bool found = false;
+  for (const auto &e : response.payload(0).diff().entries()) {
+    if (e.key() != "password") continue;
+    found = true;
+    EXPECT_TRUE(e.is_sensitive());
+    EXPECT_EQ(e.new_value(), "***");
+  }
+  EXPECT_TRUE(found);
+}
+
+TEST_F(SettingsQueryTest, a_removal_is_reported_as_removed) {
+  set_value("/section", "key", "value");
+  PB::Settings::SettingsRequestMessage save;
+  new_request(save)->mutable_control()->set_command(PB::Settings::Command::SAVE);
+  run(save);
+
+  PB::Settings::SettingsRequestMessage remove;
+  PB::Settings::Node *node = new_request(remove)->mutable_update()->mutable_node();
+  node->set_path("/section");
+  node->set_key("key");
+  run(remove);
+
+  PB::Settings::SettingsRequestMessage request;
+  new_request(request)->mutable_diff();
+
+  const PB::Settings::SettingsResponseMessage response = run(request);
+
+  bool found = false;
+  for (const auto &e : response.payload(0).diff().entries()) {
+    if (e.path() == "/section" && e.key() == "key") {
+      EXPECT_EQ(e.change_type(), PB::Settings::SettingsResponseMessage::Response::Diff::REMOVED);
+      EXPECT_EQ(e.old_value(), "value");
+      found = true;
+    }
+  }
+  EXPECT_TRUE(found);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -639,6 +639,10 @@ NSCP_CREATE_TEST(
         ${NSCP_INCLUDEDIR}/client/command_line_parser_test.cpp
         ${NSCP_CLIENT_CPP}
         ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        # Compiled in rather than taken from plugin_api: the Windows plugin_api
+        # DLL does not export the settings_helper symbols (modules compile this
+        # file into themselves via NSCP_DEF_PLUGIN_CPP for the same reason).
+        ${NSCP_INCLUDEDIR}/nscapi/settings/helper.cpp
     LIBRARIES
         GTest::gtest_main
         ${NSCP_DEF_PLUGIN_LIB}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -617,3 +617,20 @@ if(BUILD_MODULE_LUAScript)
         NSCP_ADD_LUA_TEST(lua_scheduler_test test_scheduler)
     endif()
 endif()
+
+# client::configuration is what every outbound client module (NRPEClient,
+# NSCAClient, ...) shares, so it is built from the same ${NSCP_CLIENT_CPP}
+# list those modules use rather than a copy of it.
+NSCP_CREATE_TEST(
+    client_command_line_parser_test
+    SOURCES
+        ${NSCP_INCLUDEDIR}/client/command_line_parser_test.cpp
+        ${NSCP_CLIENT_CPP}
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_THREAD_LIBRARY}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -478,10 +478,22 @@ NSCP_CREATE_TEST(
     icinga_client_test
     SOURCES
         ${CMAKE_SOURCE_DIR}/modules/IcingaClient/icinga_test.cpp
+        # icinga_client.hpp is the other half: the connection settings and the
+        # API call itself, which needs the client machinery and a TLS-capable
+        # http transport even when the test drives it over plain http.
+        ${CMAKE_SOURCE_DIR}/modules/IcingaClient/icinga_client_test.cpp
         ${CMAKE_SOURCE_DIR}/modules/IcingaClient/icinga.cpp
         ${NSCP_INCLUDEDIR}/json/use_json.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_INCLUDEDIR}/bytes/base64.c
+        ${NSCP_CLIENT_CPP}
     LIBRARIES
         GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
     INCLUDES
         ${NSCP_INCLUDEDIR}
         ${CMAKE_SOURCE_DIR}/modules/IcingaClient

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -77,6 +77,20 @@ NSCP_CREATE_TEST(
         ${NSCP_INCLUDEDIR}
 )
 NSCP_CREATE_TEST(
+    nscapi_program_options_test
+    SOURCES
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options_test.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_INCLUDEDIR}/str/utf8.cpp
+    LIBRARIES
+        GTest::gtest_main
+        nscp_protobuf
+        ${Boost_PROGRAM_OPTIONS_LIBRARY}
+        ${Boost_FILESYSTEM_LIBRARY}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+)
+NSCP_CREATE_TEST(
     str_test
     SOURCES
         ${NSCP_INCLUDEDIR}/str/format_test.cpp
@@ -490,7 +504,7 @@ if(WIN32)
 endif()
 
 NSCP_CREATE_TEST(
-    test_settings
+    settings_test
     SOURCES
         ${NSCP_INCLUDEDIR}/settings/settings_value_test.cpp
         ${NSCP_INCLUDEDIR}/settings/settings_interface_impl_test.cpp

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,6 +53,22 @@ set NSCP_BIN=C:\path\to\nscp.exe
 npm test
 ```
 
+## Coverage
+
+Because the harness spawns a real `nscp` and lets it `dlopen` the real modules,
+pointing `NSCP_BIN` at a gcov-instrumented build turns these scenarios into a
+coverage report of actual command dispatch and REST argument parsing:
+
+```sh
+SUITES=integration tools/coverage/run.sh     # from the repo root
+```
+
+That builds `build-coverage/` with `-DNSCP_COVERAGE=ON`, runs this suite against
+it and writes `coverage/integration.html`. It works because `NscpInstance.stop()`
+stops the daemon with SIGTERM rather than SIGKILL — gcov only flushes its
+counters from an `atexit` handler. See the *Coverage reports* section of
+`build.md` for the details and the caveats.
+
 ## What runs
 
 Docker-using scenarios (skipped when `NSCP_SKIP_DOCKER=1`):

--- a/tests/checksystem-commands.test.ts
+++ b/tests/checksystem-commands.test.ts
@@ -412,21 +412,29 @@ describe("CheckSystem commands", () => {
     // (default "warning"); pin it to OK so battery-less CI hosts are
     // deterministic AND the user-configurable empty-state is exercised.
     const q = await executeQuery(key, "check_battery", { "empty-state": "ok" });
+    // Which contract applies is decided by the empty-syntax message, not by
+    // hunting for a perf label: the perf counter is named after the battery
+    // (${name} - "BAT1", "BAT0", ...), so a machine that *has* one has no perf
+    // key containing "charge" and used to be mistaken for a machine without.
     if (/no battery found/i.test(messageOf(q))) {
       // No (usable) battery on this machine (typical CI/VM): zero rows match,
       // so the pinned empty-state decides the result and the empty-syntax
       // renders the informative message.
       expect(q.result).toBe(OK);
+      expect(Object.keys(perfOf(q))).toHaveLength(0);
       return;
     }
-    // A battery matched: the default thresholds reference `charge`, whose perf
-    // entry is keyed by the battery name (perf-syntax ${name}, e.g. 'system')
-    // with unit %.
+    // A battery is present: one perf counter per battery carrying its charge
+    // percent, and the detail-syntax renders "<name>: <n>% (<source>, <status>)".
     expect(q.result).toBeLessThanOrEqual(CRITICAL);
-    const charge = Object.values(perfOf(q)).find((p) => String(p.unit ?? "") === "%");
-    expect(charge).toBeDefined();
-    expect(charge!.value).toBeGreaterThanOrEqual(0);
-    expect(charge!.value).toBeLessThanOrEqual(100);
+    const perf = Object.entries(perfOf(q));
+    expect(perf.length).toBeGreaterThan(0);
+    for (const [label, entry] of perf) {
+      expect(label).not.toEqual("");
+      expect(entry.value).toBeGreaterThanOrEqual(0);
+      expect(entry.value).toBeLessThanOrEqual(100);
+    }
+    expect(messageOf(q)).toMatch(/\d+% \(/);
   });
 
   it("check_temperature reports sensors or UNKNOWN without hardware", async () => {

--- a/tests/cli-dispatch.test.ts
+++ b/tests/cli-dispatch.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Exercises the top-level command line of the real nscp binary — the dispatch
+ * layer in service/cli_parser.cpp that decides what `nscp <context> …` means.
+ *
+ * Everything below is a one-shot invocation: no server, no port, no docker.
+ * The point is the argument handling itself — which context a word selects,
+ * what an unknown one does, where --help and --version are answered, how the
+ * common options (--settings, --path-override, --define) are consumed — plus
+ * the `settings` sub-commands that read and write an INI without booting a
+ * daemon.
+ *
+ * Exit codes are asserted as they are, not as they arguably should be: `nscp
+ * help` and a bare `nscp` both exit 1 today, which is worth pinning precisely
+ * because it is the kind of thing that gets changed by accident.
+ */
+import * as fs from "fs";
+import { NscpInstance, nscp } from "@fixtures/index";
+
+jest.setTimeout(120_000);
+
+describe("nscp command line dispatch", () => {
+  it("reports its version", async () => {
+    const r = await nscp(["--version"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toMatch(/NSClient\+\+, Version: /);
+  });
+
+  it("lists the available contexts when called with no arguments", async () => {
+    const r = await nscp([], { allowFailure: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain("Usage: nscp <context>");
+    // Every handler and a sample of the client aliases.
+    for (const context of ["client", "settings", "service", "help", "unit", "enroll"]) {
+      expect(r.stdout).toContain(context);
+    }
+    expect(r.stdout).toContain("nrpe");
+  });
+
+  it("shows the option help for the help context", async () => {
+    const r = await nscp(["help"], { allowFailure: true });
+    // Asking for help exits 1 - long-standing behaviour, pinned deliberately.
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain("Allowed options");
+    expect(r.stdout).toContain("--settings");
+    expect(r.stdout).toContain("First argument has to be one of the following:");
+  });
+
+  it("rejects an unknown context by name", async () => {
+    const r = await nscp(["wibble"], { allowFailure: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("Invalid module specified: wibble");
+  });
+
+  it("insists the context comes first", async () => {
+    const r = await nscp(["--debug", "settings", "--list"], { allowFailure: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain('First option should be the "context"');
+  });
+
+  it("answers --help inside a context with that context's options", async () => {
+    const r = await nscp(["settings", "--help"], { allowFailure: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain("Allowed options (settings)");
+    // A settings-only option, proving it is not the generic screen.
+    expect(r.stdout).toContain("--validate");
+  });
+
+  it("answers --version inside a context too", async () => {
+    const r = await nscp(["settings", "--version"], { allowFailure: true });
+    expect(r.stdout).toMatch(/NSClient\+\+, version: /);
+  });
+
+  it("warns about a --path-override that is not KEY=VALUE", async () => {
+    const r = await nscp(["settings", "--path-override", "no-equals-sign", "--validate"], {
+      allowFailure: true,
+    });
+    expect(r.all).toContain("Ignoring malformed --path-override argument");
+  });
+
+  it("reports a --define it cannot parse", async () => {
+    const r = await nscp(["client", "--define", "no-colon-or-equals", "--help"], {
+      allowFailure: true,
+    });
+    // --help short-circuits before the client boots, so the only thing this
+    // asserts is that the malformed define was noticed, not that it applied.
+    expect(r.exitCode).toBe(1);
+  });
+});
+
+describe("nscp settings sub-commands", () => {
+  it("prints the settings options and the active store when given no action", async () => {
+    const instance = new NscpInstance();
+    const r = await instance.run(["settings"], { allowFailure: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toContain("Allowed options (settings)");
+    // list_settings_info names the store that would be edited.
+    expect(r.stdout).toContain("INI settings");
+  });
+
+  it("writes a value with --set and reads it back with --show", async () => {
+    const instance = new NscpInstance();
+    const set = await instance.run([
+      "settings",
+      "--path",
+      "/settings/default",
+      "--key",
+      "allowed hosts",
+      "--set",
+      "10.0.0.1",
+    ]);
+    expect(set.exitCode).toBe(0);
+    expect(fs.readFileSync(instance.settingsFile, "utf8")).toContain("10.0.0.1");
+
+    const show = await instance.run([
+      "settings",
+      "--show",
+      "--path",
+      "/settings/default",
+      "--key",
+      "allowed hosts",
+    ]);
+    expect(show.exitCode).toBe(0);
+    expect(show.stdout).toContain("10.0.0.1");
+  });
+
+  it("describes the active store for a bare --show", async () => {
+    const instance = new NscpInstance();
+    const r = await instance.run(["settings", "--show"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("INI settings");
+  });
+
+  it("refuses --show with a path but no key", async () => {
+    const instance = new NscpInstance();
+    const r = await instance.run(["settings", "--show", "--path", "/settings/default"], {
+      allowFailure: true,
+    });
+    expect(r.exitCode).not.toBe(0);
+    expect(r.stderr).toContain("Invalid command line please use --path and --key with show");
+  });
+
+  it("lists the keys under a path", async () => {
+    const instance = new NscpInstance();
+    await instance.run([
+      "settings",
+      "--path",
+      "/settings/default",
+      "--key",
+      "allowed hosts",
+      "--set",
+      "10.0.0.2",
+    ]);
+
+    const r = await instance.run(["settings", "--list", "--path", "/settings/default"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("allowed hosts=10.0.0.2");
+  });
+
+  it("validates a store nobody has broken", async () => {
+    const instance = new NscpInstance();
+    const r = await instance.run(["settings", "--validate"]);
+    expect(r.exitCode).toBe(0);
+  });
+
+  it("sorts the ini in place", async () => {
+    const instance = new NscpInstance();
+    fs.writeFileSync(instance.settingsFile, "[/zeta]\nb = 2\na = 1\n[/alpha]\nk = v\n");
+
+    const r = await instance.run(["settings", "--sort"]);
+    expect(r.exitCode).toBe(0);
+
+    const content = fs.readFileSync(instance.settingsFile, "utf8");
+    expect(content.indexOf("[/alpha]")).toBeLessThan(content.indexOf("[/zeta]"));
+    // Sorting must not lose anything.
+    expect(content).toContain("k = v");
+    expect(content).toContain("a = 1");
+    expect(content).toContain("b = 2");
+  });
+
+  it("generates a config to stdout without touching the store", async () => {
+    const instance = new NscpInstance();
+    const before = fs.readFileSync(instance.settingsFile, "utf8");
+
+    const r = await instance.run(["settings", "--generate", "stdout"], { allowFailure: true });
+    expect(r.stdout.length).toBeGreaterThan(0);
+    expect(fs.readFileSync(instance.settingsFile, "utf8")).toEqual(before);
+  });
+});
+
+describe("nscp client aliases", () => {
+  it("maps an alias to its module's client help", async () => {
+    // `nscp nrpe …` is shorthand for `nscp client --module NRPEClient …`, so
+    // the alias has to reach NRPEClient's own options.
+    const instance = new NscpInstance();
+    const r = await instance.run(["nrpe", "--help"], { allowFailure: true });
+    // NRPE-specific options, so this really did land in NRPEClient rather
+    // than printing the generic screen.
+    expect(r.all).toContain("The NRPE version to use");
+  });
+});

--- a/tests/src/nscp.ts
+++ b/tests/src/nscp.ts
@@ -414,11 +414,56 @@ export class NscpInstance {
   }
 
   /** Wait for a TCP port on localhost to start accepting connections. */
+  /**
+   * Wait until nothing is listening on `port` - i.e. until it can be bound.
+   *
+   * Every REST suite starts its agent on the same fixed port, and they run
+   * back to back. Without this a suite can start while the previous one's
+   * agent is still shutting down: the new agent logs "Failed to bind ...:
+   * Address already in use" and dies quietly, waitForPort() below is happy
+   * because *something* is accepting, and the suite then talks to the
+   * previous agent - which answers UNKNOWN for every command it has no module
+   * for, and then starts refusing connections when it finally exits. Call this
+   * before start() so the port is known to be ours.
+   */
+  async waitForPortFree(port: number, opts: { host?: string; timeoutMs?: number } = {}): Promise<void> {
+    // 0.0.0.0, the address nscp itself binds: a listener there also blocks a
+    // 127.0.0.1 bind, so checking the loopback alone would miss it.
+    const host = opts.host ?? "0.0.0.0";
+    const timeoutMs = opts.timeoutMs ?? 30_000;
+    const deadline = Date.now() + timeoutMs;
+    let lastErr: unknown;
+    for (;;) {
+      try {
+        await new Promise<void>((resolve, reject) => {
+          const probe = net.createServer();
+          probe.once("error", reject);
+          probe.listen(port, host, () => probe.close(() => resolve()));
+        });
+        return;
+      } catch (e) {
+        lastErr = e;
+        if (Date.now() >= deadline) break;
+        await new Promise((r) => setTimeout(r, 250));
+      }
+    }
+    throw new Error(
+      `Port ${host}:${port} was still in use after ${timeoutMs}ms - something else is listening ` +
+        `(a leftover nscp from an earlier run?): ${(lastErr as Error)?.message}`,
+    );
+  }
+
   async waitForPort(port: number, opts: { host?: string; timeoutMs?: number } = {}): Promise<void> {
     const host = opts.host ?? "127.0.0.1";
     const deadline = Date.now() + (opts.timeoutMs ?? 30_000);
     let lastErr: unknown;
     while (Date.now() < deadline) {
+      // A listener that could not bind never will, and waiting the full
+      // timeout only to report "did not start accepting" hides the reason.
+      const bindError = this.stdoutBuf
+        .split(/\r?\n/)
+        .find((l) => /Failed to (bind|listen)/i.test(l));
+      if (bindError) throw new Error(`nscp could not open its listener: ${bindError.trim()}`);
       try {
         await new Promise<void>((resolve, reject) => {
           const s = new net.Socket();

--- a/tests/src/queries.ts
+++ b/tests/src/queries.ts
@@ -88,6 +88,10 @@ export async function setupQueryNscp(
     ...extraSettings,
   });
 
+  // Every REST suite uses this one port and they run back to back, so make
+  // sure the previous suite's agent has let go of it before starting ours -
+  // otherwise we bind nothing and talk to a stranger.
+  await nscp.waitForPortFree(8443, { timeoutMs: 30_000 });
   nscp.start();
   await nscp.waitForPort(8443, { timeoutMs: 30_000 });
 

--- a/tests/src/rest-fixture.ts
+++ b/tests/src/rest-fixture.ts
@@ -78,6 +78,10 @@ export async function setupRestNscp(nscp: NscpInstance): Promise<void> {
     },
   });
 
+  // Every REST suite uses this one port and they run back to back, so make
+  // sure the previous suite's agent has let go of it before starting ours -
+  // otherwise we bind nothing and talk to a stranger.
+  await nscp.waitForPortFree(8443, { timeoutMs: 30_000 });
   nscp.start();
   await nscp.waitForPort(8443, { timeoutMs: 30_000 });
 }

--- a/tools/coverage/run.sh
+++ b/tools/coverage/run.sh
@@ -92,6 +92,13 @@ fi
 
 mkdir -p "$OUT_DIR"
 
+# Tracefiles left by an earlier run describe an earlier tree. The merge below
+# picks up whatever it finds in $OUT_DIR, so a stale one is not merely out of
+# date - gcovr aborts on an md5 mismatch the moment a covered source file has
+# changed since. Only the suites that run here belong in the merge (see the
+# one-suite note above), so drop the leftovers before starting.
+rm -f "$OUT_DIR/unit.json" "$OUT_DIR/integration.json"
+
 # gcovr filters shared by every report. --root is the repo, so only our own
 # sources are considered; the excludes drop the test bodies themselves,
 # generated protobuf code and the FetchContent'ed googletest under _deps.

--- a/tools/coverage/run.sh
+++ b/tools/coverage/run.sh
@@ -114,9 +114,9 @@ rm -f "$OUT_DIR/unit.json" "$OUT_DIR/integration.json"
 #   gcovr --add-tracefile coverage/unit.json \
 #         --filter '.*/module\.cpp$' --txt glue.txt --print-summary
 gcovr_common=(
-    --root .
+    --root "$ROOT"
     --gcov-executable "$GCOV"
-    "$BUILD_DIR"
+    "$BUILD_ABS"
     --exclude '.*_test\.cpp'
     --exclude '.*\.pb\.(cc|h)$'
     --exclude '.*/_deps/.*'
@@ -124,8 +124,25 @@ gcovr_common=(
     --exclude-unreachable-branches
     --exclude-throw-branches
     --gcov-ignore-parse-errors
-    -j "$JOBS"
 )
+
+# gcov writes its .gcov output into the *current* directory, named after the
+# source file. Two objects that include the same header therefore produce the
+# same file name, so gcovr's parallel workers race: one deletes the file
+# another is still reading. The visible failure is a FileNotFoundError on some
+# .gcov half way through a run - but the quiet failure is worse, because
+# --gcov-ignore-parse-errors turns a lost file into silently missing coverage,
+# and the report still looks complete. Hence no -j here (the build and the
+# test runs above still use it), and a scratch cwd below so the temporary
+# .gcov files never land in the working tree.
+run_gcovr() {
+    local workdir rc=0
+    workdir="$(mktemp -d)"
+    # `|| rc=$?` so set -e does not abort before the scratch dir is removed.
+    ( cd "$workdir" && gcovr "$@" ) || rc=$?
+    rm -rf "$workdir"
+    return $rc
+}
 
 # Applied when *rendering*, not when reading gcov, so the .json tracefiles
 # keep the generated glue and the one-liner above stays a cheap tracefile
@@ -141,10 +158,10 @@ if [ "$run_unit" = 1 ]; then
     ctest --test-dir "$BUILD_DIR" -R '_test$' --output-on-failure ${CTEST_ARGS:-} \
         || { test_status=1; echo "!!! unit tests failed - collecting coverage anyway"; }
     echo "==> Collecting unit coverage"
-    gcovr "${gcovr_common[@]}" --json "$OUT_DIR/unit.json"
-    gcovr --root . --add-tracefile "$OUT_DIR/unit.json" \
+    run_gcovr "${gcovr_common[@]}" --json "$ROOT/$OUT_DIR/unit.json"
+    run_gcovr --root "$ROOT" --add-tracefile "$ROOT/$OUT_DIR/unit.json" \
         "${gcovr_report_excludes[@]}" \
-        --html "$OUT_DIR/unit.html" \
+        --html "$ROOT/$OUT_DIR/unit.html" \
         --print-summary
 fi
 
@@ -170,23 +187,23 @@ if [ "$run_integration" = 1 ]; then
             npx jest --runInBand ${JEST_ARGS:-}
     ) || { test_status=1; echo "!!! integration tests failed - collecting coverage anyway"; }
     echo "==> Collecting integration coverage"
-    gcovr "${gcovr_common[@]}" --json "$OUT_DIR/integration.json"
-    gcovr --root . --add-tracefile "$OUT_DIR/integration.json" \
+    run_gcovr "${gcovr_common[@]}" --json "$ROOT/$OUT_DIR/integration.json"
+    run_gcovr --root "$ROOT" --add-tracefile "$ROOT/$OUT_DIR/integration.json" \
         "${gcovr_report_excludes[@]}" \
-        --html "$OUT_DIR/integration.html" \
+        --html "$ROOT/$OUT_DIR/integration.html" \
         --print-summary
 fi
 
 echo "==> Merging reports"
 merge_args=()
 for f in "$OUT_DIR/unit.json" "$OUT_DIR/integration.json"; do
-    [ -f "$f" ] && merge_args+=(--add-tracefile "$f")
+    [ -f "$f" ] && merge_args+=(--add-tracefile "$ROOT/$f")
 done
 mkdir -p "$OUT_DIR/html"
-gcovr --root . "${merge_args[@]}" \
+run_gcovr --root "$ROOT" "${merge_args[@]}" \
     "${gcovr_report_excludes[@]}" \
-    --html-details "$OUT_DIR/html/index.html" \
-    --cobertura "$OUT_DIR/cobertura.xml" \
+    --html-details "$ROOT/$OUT_DIR/html/index.html" \
+    --cobertura "$ROOT/$OUT_DIR/cobertura.xml" \
     --cobertura-pretty \
     --print-summary
 

--- a/tools/coverage/run.sh
+++ b/tools/coverage/run.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Configure, build, and run the test suites with gcov instrumentation, then
+# render lcov-style HTML + Cobertura reports.
+#
+# Usage:
+#   tools/coverage/run.sh                     # unit + integration → coverage/
+#   SUITES=unit tools/coverage/run.sh         # C++ unit tests only
+#   SUITES=integration tools/coverage/run.sh  # tests/ jest suite only
+#   BUILD_DIR=tmp/cov tools/coverage/run.sh   # custom build dir
+#   SKIP_BUILD=1 tools/coverage/run.sh        # re-run tests in an existing tree
+#   JEST_ARGS="checkdisk" tools/coverage/run.sh          # jest test pattern
+#   CTEST_ARGS="-R parsers_where_test" tools/coverage/run.sh
+#   CMAKE_ARGS="-DBUILD_MODULE_WEBServer=OFF" tools/coverage/run.sh
+#
+# Output (under coverage/):
+#   html/index.html    merged report, click through to per-file annotated source
+#   unit.html          C++ unit tests (ctest) alone, one-page summary
+#   integration.html   tests/ jest suite alone, one-page summary
+#   cobertura.xml      merged, for Codecov / CI coverage gates
+#
+# Only the merged report gets per-file detail pages - a full --html-details set
+# is ~80MB, and three of them is not something to hand a CI artifact store. For
+# annotated source of one suite alone, run just that suite: the merged report
+# then contains only its data.
+#
+# Requires gcovr (apt-get install gcovr / pip install gcovr). The gcov used
+# must match the compiler that built the tree — override with GCOV=gcov-13,
+# or GCOV="llvm-cov gcov" for a clang build.
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+ROOT="$(pwd)"
+
+BUILD_DIR="${BUILD_DIR:-build-coverage}"
+OUT_DIR="${OUT_DIR:-coverage}"
+SUITES="${SUITES:-all}"
+JOBS="${JOBS:-$(nproc)}"
+GCOV="${GCOV:-gcov}"
+
+# Exit status of the test suites, reported at the very end. A failing suite
+# must not abort the run: a report is most useful precisely when something
+# broke, and losing it to `set -e` means re-running the whole build.
+test_status=0
+
+# Absolute path to the build tree, so the jest harness (which runs from
+# tests/) can be handed a usable NSCP_BIN regardless of how BUILD_DIR was
+# spelled on the command line.
+case "$BUILD_DIR" in
+    /*) BUILD_ABS="$BUILD_DIR" ;;
+    *) BUILD_ABS="$ROOT/$BUILD_DIR" ;;
+esac
+
+run_unit=0
+run_integration=0
+case "$SUITES" in
+    all) run_unit=1; run_integration=1 ;;
+    unit) run_unit=1 ;;
+    integration) run_integration=1 ;;
+    *) echo "SUITES must be one of: all, unit, integration" >&2; exit 2 ;;
+esac
+
+command -v gcovr > /dev/null || {
+    echo "gcovr not found - install it with 'apt-get install gcovr'" >&2
+    exit 1
+}
+
+# Stale .gcda are not merely useless, they are poison: gcov refuses them with
+# "stamp mismatch with notes file" as soon as the sources have moved on, and a
+# half-refused data set silently under-reports. Wipe before every run.
+wipe_gcda() {
+    find "$BUILD_DIR" -name '*.gcda' -delete
+}
+
+if [ -z "${SKIP_BUILD:-}" ]; then
+    echo "==> Configuring $BUILD_DIR with NSCP_COVERAGE=ON"
+    # shellcheck disable=SC2206
+    EXTRA_CMAKE_ARGS=( ${CMAKE_ARGS:-} )
+    # CauseCrashes exists only to crash the daemon on demand. Nothing exercises
+    # it here, so all it contributes is a permanently 0% file dragging the
+    # totals down - and were it ever invoked, the crash would take the
+    # unflushed gcov counters with it. Listed before CMAKE_ARGS so a caller can
+    # still turn it back on with CMAKE_ARGS="-DBUILD_MODULE_CauseCrashes=ON".
+    cmake -S . -B "$BUILD_DIR" \
+        -DCMAKE_BUILD_TYPE=Debug \
+        -DNSCP_COVERAGE=ON \
+        -DBUILD_MODULE_CauseCrashes=OFF \
+        "${EXTRA_CMAKE_ARGS[@]}"
+
+    echo "==> Building (-j$JOBS)"
+    cmake --build "$BUILD_DIR" -j"$JOBS"
+fi
+
+mkdir -p "$OUT_DIR"
+
+# gcovr filters shared by every report. --root is the repo, so only our own
+# sources are considered; the excludes drop the test bodies themselves,
+# generated protobuf code and the FetchContent'ed googletest under _deps.
+#
+# module.cpp/module.hpp are the per-module dispatch/export glue that CMake
+# generates into the build tree from module.json (66 files, ~4600 lines, none
+# of them hand-written). Nobody can act on a gap in generated code by writing
+# a test for it, and leaving it in costs ~2.6 points of line coverage. But it
+# does carry one signal worth keeping in mind: a module.cpp at 0% means no
+# test ever *loaded* that module, even if its own sources are well covered by
+# a unit test that links them directly. To see that view:
+#
+#   gcovr --add-tracefile coverage/unit.json \
+#         --filter '.*/module\.cpp$' --txt glue.txt --print-summary
+gcovr_common=(
+    --root .
+    --gcov-executable "$GCOV"
+    "$BUILD_DIR"
+    --exclude '.*_test\.cpp'
+    --exclude '.*\.pb\.(cc|h)$'
+    --exclude '.*/_deps/.*'
+    --exclude '^ext/.*'
+    --exclude-unreachable-branches
+    --exclude-throw-branches
+    --gcov-ignore-parse-errors
+    -j "$JOBS"
+)
+
+# Applied when *rendering*, not when reading gcov, so the .json tracefiles
+# keep the generated glue and the one-liner above stays a cheap tracefile
+# query rather than a full re-read of the build tree.
+gcovr_report_excludes=(
+    --exclude '.*/module\.(cpp|hpp)$'
+)
+
+if [ "$run_unit" = 1 ]; then
+    echo "==> Running unit tests (ctest)"
+    wipe_gcda
+    # shellcheck disable=SC2086
+    ctest --test-dir "$BUILD_DIR" -R '_test$' --output-on-failure ${CTEST_ARGS:-} \
+        || { test_status=1; echo "!!! unit tests failed - collecting coverage anyway"; }
+    echo "==> Collecting unit coverage"
+    gcovr "${gcovr_common[@]}" --json "$OUT_DIR/unit.json"
+    gcovr --root . --add-tracefile "$OUT_DIR/unit.json" \
+        "${gcovr_report_excludes[@]}" \
+        --html "$OUT_DIR/unit.html" \
+        --print-summary
+fi
+
+if [ "$run_integration" = 1 ]; then
+    echo "==> Running integration tests (jest)"
+    wipe_gcda
+    if [ ! -d tests/node_modules ]; then
+        ( cd tests && npm ci )
+    fi
+    # The jest harness spawns $NSCP_BIN and lets the modules dlopen from the
+    # same tree, so every .so is instrumented too. It stops the daemon with
+    # SIGTERM (tests/src/nscp.ts), which CommandClient turns into a graceful
+    # shutdown - that is what lets gcov flush its counters at exit. A SIGKILL
+    # shutdown would silently produce no coverage at all.
+    #
+    # NSCP_SKIP_DOCKER=1 by default: the container-backed suites (mysql,
+    # docker, ...) need a working docker daemon. Set NSCP_SKIP_DOCKER= to
+    # include them.
+    (
+        cd tests
+        NSCP_SKIP_DOCKER="${NSCP_SKIP_DOCKER-1}" \
+        NSCP_BIN="$BUILD_ABS/nscp" \
+            npx jest --runInBand ${JEST_ARGS:-}
+    ) || { test_status=1; echo "!!! integration tests failed - collecting coverage anyway"; }
+    echo "==> Collecting integration coverage"
+    gcovr "${gcovr_common[@]}" --json "$OUT_DIR/integration.json"
+    gcovr --root . --add-tracefile "$OUT_DIR/integration.json" \
+        "${gcovr_report_excludes[@]}" \
+        --html "$OUT_DIR/integration.html" \
+        --print-summary
+fi
+
+echo "==> Merging reports"
+merge_args=()
+for f in "$OUT_DIR/unit.json" "$OUT_DIR/integration.json"; do
+    [ -f "$f" ] && merge_args+=(--add-tracefile "$f")
+done
+mkdir -p "$OUT_DIR/html"
+gcovr --root . "${merge_args[@]}" \
+    "${gcovr_report_excludes[@]}" \
+    --html-details "$OUT_DIR/html/index.html" \
+    --cobertura "$OUT_DIR/cobertura.xml" \
+    --cobertura-pretty \
+    --print-summary
+
+echo
+echo "Report: $OUT_DIR/html/index.html"
+if [ "$test_status" != 0 ]; then
+    echo "NOTE: at least one test suite failed - the report above covers only what ran." >&2
+fi
+exit "$test_status"

--- a/tools/coverage/run.sh
+++ b/tools/coverage/run.sh
@@ -126,23 +126,27 @@ gcovr_common=(
     --gcov-ignore-parse-errors
 )
 
-# gcov writes its .gcov output into the *current* directory, named after the
-# source file. Two objects that include the same header therefore produce the
-# same file name, so gcovr's parallel workers race: one deletes the file
-# another is still reading. The visible failure is a FileNotFoundError on some
-# .gcov half way through a run - but the quiet failure is worse, because
-# --gcov-ignore-parse-errors turns a lost file into silently missing coverage,
-# and the report still looks complete. Hence no -j here (the build and the
-# test runs above still use it), and a scratch cwd below so the temporary
-# .gcov files never land in the working tree.
-run_gcovr() {
-    local workdir rc=0
-    workdir="$(mktemp -d)"
-    # `|| rc=$?` so set -e does not abort before the scratch dir is removed.
-    ( cd "$workdir" && gcovr "$@" ) || rc=$?
-    rm -rf "$workdir"
-    return $rc
-}
+# gcov names its output after the source file and writes it into gcovr's
+# --root (not the current directory), so two objects that include the same
+# header produce the same path there. gcovr serialises its own workers on that
+# directory, but the guard is an in-process lock: a second gcovr over the same
+# tree knows nothing about the first, and they delete each other's files. The
+# loud failure is a FileNotFoundError part way through; the quiet one is worse,
+# because --gcov-ignore-parse-errors turns a lost file into missing coverage in
+# a report that still looks complete.
+#
+# So: hold a lock for the whole run, and read the gcov data serially. Since
+# every .gcda resolves against --root first, gcovr's own workers queue up on
+# that one directory anyway - -j buys nothing here and costs memory. The build
+# and the test runs above still use it.
+exec 9> "$OUT_DIR/.gcovr.lock"
+flock 9
+
+# A run that dies part way leaves those temporary .gcov files behind in the
+# repo (the crash that prompted the lock above left ~100 of them). gcovr
+# removes them as it goes when it finishes normally; sweep whatever is left.
+cleanup_gcov() { find "$ROOT" -maxdepth 1 -name '*.gcov' -delete 2> /dev/null || true; }
+trap cleanup_gcov EXIT
 
 # Applied when *rendering*, not when reading gcov, so the .json tracefiles
 # keep the generated glue and the one-liner above stays a cheap tracefile
@@ -158,8 +162,8 @@ if [ "$run_unit" = 1 ]; then
     ctest --test-dir "$BUILD_DIR" -R '_test$' --output-on-failure ${CTEST_ARGS:-} \
         || { test_status=1; echo "!!! unit tests failed - collecting coverage anyway"; }
     echo "==> Collecting unit coverage"
-    run_gcovr "${gcovr_common[@]}" --json "$ROOT/$OUT_DIR/unit.json"
-    run_gcovr --root "$ROOT" --add-tracefile "$ROOT/$OUT_DIR/unit.json" \
+    gcovr "${gcovr_common[@]}" --json "$ROOT/$OUT_DIR/unit.json"
+    gcovr --root "$ROOT" --add-tracefile "$ROOT/$OUT_DIR/unit.json" \
         "${gcovr_report_excludes[@]}" \
         --html "$ROOT/$OUT_DIR/unit.html" \
         --print-summary
@@ -187,8 +191,8 @@ if [ "$run_integration" = 1 ]; then
             npx jest --runInBand ${JEST_ARGS:-}
     ) || { test_status=1; echo "!!! integration tests failed - collecting coverage anyway"; }
     echo "==> Collecting integration coverage"
-    run_gcovr "${gcovr_common[@]}" --json "$ROOT/$OUT_DIR/integration.json"
-    run_gcovr --root "$ROOT" --add-tracefile "$ROOT/$OUT_DIR/integration.json" \
+    gcovr "${gcovr_common[@]}" --json "$ROOT/$OUT_DIR/integration.json"
+    gcovr --root "$ROOT" --add-tracefile "$ROOT/$OUT_DIR/integration.json" \
         "${gcovr_report_excludes[@]}" \
         --html "$ROOT/$OUT_DIR/integration.html" \
         --print-summary
@@ -200,7 +204,7 @@ for f in "$OUT_DIR/unit.json" "$OUT_DIR/integration.json"; do
     [ -f "$f" ] && merge_args+=(--add-tracefile "$ROOT/$f")
 done
 mkdir -p "$OUT_DIR/html"
-run_gcovr --root "$ROOT" "${merge_args[@]}" \
+gcovr --root "$ROOT" "${merge_args[@]}" \
     "${gcovr_report_excludes[@]}" \
     --html-details "$ROOT/$OUT_DIR/html/index.html" \
     --cobertura "$ROOT/$OUT_DIR/cobertura.xml" \


### PR DESCRIPTION
Adds gcov coverage reporting, then uses it: the low-coverage areas it pointed at turned out to be hiding six real defects, one of them a decade old.

## Coverage tooling

`-DNSCP_COVERAGE=ON` instruments every target, and `tools/coverage/run.sh` drives the whole cycle — unit suite, integration suite, merged HTML + Cobertura. Because the jest harness spawns the built `nscp` and lets it dlopen the built modules, one instrumented tree covers both layers.

Three fixes to the runner itself, all found by using it:

- **Stale tracefiles** from a previous run were merged into the current one, and gcovr aborts on an md5 mismatch as soon as a covered source has changed — after the build and both suites have already run.
- **Concurrent gcovr runs** race over `.gcov` files. gcov names its output after the source file and writes it into `--root`, and gcovr's per-directory guard is an in-process threading lock, so a second gcovr knows nothing about the first. The loud failure is a `FileNotFoundError`; the quiet one is worse, because `--gcov-ignore-parse-errors` turns a lost file into missing coverage in a report that still looks complete. That is what produced a "unit" report showing `settings_handler_impl.cpp` at 25% with its tests passing.
- Leftover `.gcov` in the repo root after a crashed run (about a hundred of them).

## Defects found

**Syslog submission has been dead since 0.4.3 (2015).** `connection_data`'s first argument is the target's settings and its second is the sender; `SyslogClient::submit` passed them the other way round, so the configured address, port, facility, severity and templates were all ignored. Against a target configured exactly as documented, the agent logs `Undefined facility:` and sends nothing. `CheckMKClient::query` had the same swap. Verified end to end against a local syslog listener: nothing before, `<6>… nscp …` after.

**Client commands shorter than eight characters could not run.** The command-shape tests indexed from `command.size() - 8`, which underflows, so `substr` threw and the catch-all turned it into `Exception processing command line: basic_string::substr…`. Affected `cpu`, `run`, and even `check_x` — long enough for `check_` but not for the `_forward` suffix test that runs first. Three sites, in every module built on the shared client machinery.

**The settings diff reported already-saved changes as pending.** `save()` wrote the values but never dropped the pending markers, so an edit stayed "pending" for the process lifetime — and changed shape from `added` to `modified` with `old_value == new_value`.

**`has_key()` ignored staged deletions**, contradicting every other read path.

**`house_keeping()` dereferenced the settings instance without a null check**, on a path the scheduler drives on a timer.

**`nscp settings --show --path X` with no `--key`** printed nothing and exited 0 — its guard tested `vm.count()` on options carrying `default_value("")`, so it could never fire.

Plus two smaller ones from the same root cause (the well-known `host` key goes to a typed field, not the data map): NRDP's trace line never named a sender, and SMTP announced itself to every mail server as `localhost` instead of the agent's hostname.

## Test fixes

Three tests were broken rather than the code:

- `check_battery` searched perfdata for a label containing "charge", but the counter is named after the battery (`BAT1`), so **every machine with a battery** took the no-battery branch and failed.
- `settings_http_test` dialled `127.0.0.1:1` expecting a refusal; WSL2 swallows connects to unbound fixed ports, so three tests sat in the TCP connect timeout — 405 seconds, passing.
- `lua_nrpe_relay_test` needed write access to `/usr/local/lib/nsclient/security`, so NRPEServer refused to load for anyone running ctest as themselves.

And one flake: every REST suite starts its agent on the same port 8443 and they run back to back, so a suite could inherit the previous one's agent — `waitForPort` only asks whether *someone* is accepting. That produced runs where the first few checks answered UNKNOWN (wrong agent) and the rest got ECONNREFUSED.

## Coverage added

| area | before | after |
|---|---|---|
| `libs/settings_manager/settings_handler_impl.cpp` | 24% | 94% |
| `service/settings_query_handler.cpp` | 23% | 70% |
| `modules/SyslogClient/syslog_client.hpp` | 0% | 95% |
| `modules/NRDPClient/nrdp_client.hpp` | 0% | 91% |
| `modules/CheckDisk/check_{share,uncpath,storagepool,shadowcopy}` | 0% | 84–98% |
| `modules/IcingaClient/icinga_client.hpp` | 0% | 69% |
| `include/client/command_line_parser.cpp` | 37% | 64% |
| `service/cli_parser.cpp` (integration) | 48% | 65% |
| `service/plugins/zip_plugin.cpp` | 0% | 53% |

Two of those were 0% only because their tests were built nowhere: the CheckDisk four live in a target gated `if(WIN32)` though only their data acquisition is Windows-specific, and `icinga_test.cpp` was in a target that omitted half the module.

## Left alone deliberately, with characterization tests

- `settings_ini::validate()` cannot report an unregistered key — it catches an exception the production core never throws. Fixing it starts reporting every key of every module that is not loaded, which is an output decision.
- `NSCAClient`, `IcingaClient` and `CollectdClient` read `timeout` from the data map, where `destination_container` never puts it, so a configured timeout is silently ignored. The fix has to choose a default: the container says 10, these clients document 30.
- `INISettings::has_real_path()` treats an existing empty section as missing.

## Verification

Unit 69/69. Integration 499 passed, 0 failed (177 skipped — docker suites). Both on Linux; the Windows-only paths are unchanged but unverified here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
