### PR TITLE
Expand host name placeholders in attachment paths and [/includes]

### DIFF
--- a/docs/docs/concepts/settings.md
+++ b/docs/docs/concepts/settings.md
@@ -221,7 +221,10 @@ An attachment target and an included file are paths, so they take path tokens (`
 `${exe-path}`, ...) as well. The two kinds of placeholder share a syntax but not a vocabulary: the
 host name placeholders in this table are resolved first, and everything else is left to the path
 tokens. Only the copy being opened is expanded - the placeholder stays in the configuration file,
-which is the point.
+which is the point. When the substituted value lands in a local path (an attachment target, an
+included file) it is additionally reduced to the characters a legal host name can contain, so a
+host name outside the operator's control cannot carry a path separator or a `..` into a path the
+agent reads or writes.
 
 > **New in 0.17:** `${hostname}`, `${hostname_lc}` and `${hostname_uc}`, and host name placeholders
 > in attachment targets and in `[/includes]` (issue

--- a/docs/docs/concepts/settings.md
+++ b/docs/docs/concepts/settings.md
@@ -29,6 +29,14 @@ You can include any number of files registry or other stores. and they will be i
 parent child relationship.
 Important to note here is that the first found key will be used. So parents will override children.
 
+An included file may be named with a [host name placeholder](#host-name-placeholders), which is how
+one configuration rolled out to many machines pulls in a per-host file:
+
+```ini
+[/includes]
+client = ${host}-nsclient.ini
+```
+
 And example of this:
 
 * nsclient.ini:
@@ -144,6 +152,15 @@ Adding a script:
 scripts/myscript.bat = http://www.myserver.com/myscript.bat
 ```
 
+The key is where the file is written and the value is where it is fetched from. Both sides take
+the [host name placeholders](#host-name-placeholders) below, and the key additionally takes the
+usual path tokens, so one configuration can give every agent in a fleet its own file:
+
+```ini
+[/attachments]
+${shared-path}/${host}-nsclient.ini = https://nsclient.mydom.local/nsclient/hosts/${host}-nsclient.ini
+```
+
 #### Query parameters
 
 The url may carry a query string, which is passed on to the server unchanged.
@@ -166,9 +183,9 @@ yourself is not encoded twice.
 
 #### Host name placeholders
 
-The url may contain the same host name placeholders the submit clients (NRDP, Graphite, Syslog and
-friends) accept, so a single `boot.ini` can be rolled out to an entire fleet and each agent asks for
-its own configuration:
+A settings url may contain the same host name placeholders the submit clients (NRDP, Graphite,
+Syslog and friends) accept, so a single `boot.ini` can be rolled out to an entire fleet and each
+agent asks for its own configuration:
 
 ```ini
 [settings]
@@ -190,8 +207,29 @@ expanded before percent-encoding, so a host name containing a character that nee
 escaped rather than corrupting the request. The cache file name is derived from the expanded url,
 so each host caches its own configuration.
 
-> **New in 0.17:** `${hostname}`, `${hostname_lc}` and `${hostname_uc}`. The other placeholders
-> already existed for the submit clients; this makes them available in settings urls too.
+The same placeholders are resolved in three more places, so a per-host configuration does not stop
+at the settings url:
+
+| Where | Example |
+|---|---|
+| A settings url | `[settings] 1 = http://cfgsrv/hosts/${host}.ini` |
+| An attachment's source url | `[/attachments] scripts/local.bat = https://cfgsrv/${host}.bat` |
+| An attachment's target path | `[/attachments] ${shared-path}/${host}.ini = https://cfgsrv/${host}.ini` |
+| An included file | `[/includes] client = ${host}-nsclient.ini` |
+
+An attachment target and an included file are paths, so they take path tokens (`${shared-path}`,
+`${exe-path}`, ...) as well. The two kinds of placeholder share a syntax but not a vocabulary: the
+host name placeholders in this table are resolved first, and everything else is left to the path
+tokens. Only the copy being opened is expanded - the placeholder stays in the configuration file,
+which is the point.
+
+> **New in 0.17:** `${hostname}`, `${hostname_lc}` and `${hostname_uc}`, and host name placeholders
+> in attachment targets and in `[/includes]` (issue
+> [#458](https://github.com/mickem/nscp/issues/458)). The other placeholders already existed for the
+> submit clients; this makes them available across the settings subsystem too. Note that an unknown
+> `${...}` token in a path is not an error: it resolves to the installation directory. A `${host}`
+> written in one of these places before this release therefore did not fail, it silently produced a
+> path with the installation directory embedded in it.
 
 If the query carries a credential (`?token=...`), note that it is still sent in clear text unless
 the url is `https://`. NSClient++ keeps query parameters out of its own log and out of the settings

--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -92,6 +92,28 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### Host name placeholders are sanitized before they land in a local path
+
+**Fixed in:** next · **Severity:** Low
+
+With host name placeholders now resolving in attachment target paths and in
+`[/includes]` (issue [#458](https://github.com/mickem/nscp/issues/458)), the
+system host name is substituted into paths the agent reads and writes with its
+service privileges (typically root / SYSTEM). The host name is not fully under
+the operator's control — DHCP can set it on some systems, as can any local
+privileged process — so a hostile value such as `../../etc/cron.d/evil` must
+not be able to redirect where an attachment is written or which file an
+include opens. Values substituted into a path are therefore reduced to the
+characters a legal RFC-952 host name can contain (letters, digits, `.`, `-`,
+plus `_`): anything else becomes `_`, and a dots-only value (`.`/`..`) becomes
+`_`. A legitimate host name comes through unchanged; settings urls and the
+submit clients' host name specs are not affected, since there the value never
+names a local file. The same expansion pass no longer aborts settings boot if
+`gethostname()` itself fails — the placeholders are then left unresolved.
+
+**What to do:** nothing required. Only a host name that is not a legal host
+name resolves differently, and only in attachment targets and `[/includes]`.
+
 ### Settings values for sensitive keys are redacted on read
 
 **Fixed in:** 0.16.2 · **Severity:** Medium · **Reported by:** [yagust](https://github.com/yagust)

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -14,6 +14,17 @@ page tracks those in one place. Full per-release detail lives in each
 
 ## next
 
+- **`${host}` and friends now resolve in attachment paths and in
+  `[/includes]`.** Host name placeholders were only expanded in settings urls
+  and in the url an attachment is fetched from, not in the path it is written
+  to nor in an included file name. An unknown `${...}` token in a path is not
+  an error - it resolves to the installation directory - so a configuration
+  such as `[/attachments] ${shared-path}/${host}.ini = ...` did not fail, it
+  quietly wrote one file with the installation directory in its name. Those
+  paths now name the host, which changes where such a file lands: check any
+  `${host}`, `${hostname}` or `${domain}` you already have under
+  `[/attachments]` or `[/includes]`, and remove the workaround if you scripted
+  around this. Configurations without a host name placeholder are unaffected.
 - **Syslog submission works again, so a configured syslog server will start
   receiving traffic.** `SyslogClient` read its connection settings from the
   wrong place, so the target's address, port, facility, severity and templates

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -14,7 +14,7 @@ page tracks those in one place. Full per-release detail lives in each
 
 ## next
 
-- **`${host}` and friends now resolve in attachment paths and in
+- 🔒 **`${host}` and friends now resolve in attachment paths and in
   `[/includes]`.** Host name placeholders were only expanded in settings urls
   and in the url an attachment is fetched from, not in the path it is written
   to nor in an included file name. An unknown `${...}` token in a path is not
@@ -25,6 +25,13 @@ page tracks those in one place. Full per-release detail lives in each
   `${host}`, `${hostname}` or `${domain}` you already have under
   `[/attachments]` or `[/includes]`, and remove the workaround if you scripted
   around this. Configurations without a host name placeholder are unaffected.
+  When the substitution lands in a local path, the value is sanitized to the
+  characters a legal host name can contain (see the
+  [security notice](../security/notices.md#host-name-placeholders-are-sanitized-before-they-land-in-a-local-path)).
+  Like `nscp settings --switch`, `nscp settings --migrate-to` (and the REST
+  migrate) now keeps a placeholder you pass it as-is in `boot.ini` while
+  migrating into the expanded per-host file, so the template survives on a
+  fleet-managed machine.
 - **Syslog submission works again, so a configured syslog server will start
   receiving traffic.** `SyslogClient` read its connection settings from the
   wrong place, so the target's address, port, facility, severity and templates

--- a/include/net/socket/socket_helpers.cpp
+++ b/include/net/socket/socket_helpers.cpp
@@ -29,27 +29,67 @@ namespace ip = boost::asio::ip;
 
 std::list<std::string> socket_helpers::connection_info::validate() const { return validate_ssl(); }
 
-std::string socket_helpers::expand_hostname_placeholders(std::string spec) {
-  // Nothing to resolve, and asking the OS for its host name is not free: a
-  // settings context or an attachment path usually has no placeholder at all.
-  if (spec.find("${") == std::string::npos) return spec;
-  std::string host_name = ip::host_name();
+namespace {
+std::string keep_verbatim(std::string value) { return value; }
+
+// One host name placeholder substitution pass; `prep` is applied to every
+// value before it is spliced in (identity for a host name spec, the path
+// sanitizer for a string that ends up on the file system).
+std::string expand_placeholders_with(std::string spec, std::string (*prep)(std::string)) {
+  // Nothing to resolve, and asking the OS for its host name is not free (and
+  // can even throw): a settings context or an attachment path usually has no
+  // host name placeholder at all. Every token starts with ${host or ${domain,
+  // so this also skips a spec that only carries path tokens (${shared-path}).
+  if (spec.find("${host") == std::string::npos && spec.find("${domain") == std::string::npos) return spec;
+  std::string host_name;
+  try {
+    host_name = ip::host_name();
+  } catch (const std::exception &) {
+    // No host name to substitute with. Leave the placeholders alone rather
+    // than let a failing gethostname() abort settings boot - the callers all
+    // have a defined answer for an unresolved token.
+    return spec;
+  }
 
   // The full name exactly as the system reports it. ${host} stops at the first
   // '.', so without this there is no way to get the fqdn from inside a template
   // - only by setting the whole spec to "auto", which a template cannot do.
-  str::utils::replace(spec, "${hostname_uc}", boost::algorithm::to_upper_copy(host_name));
-  str::utils::replace(spec, "${hostname_lc}", boost::algorithm::to_lower_copy(host_name));
-  str::utils::replace(spec, "${hostname}", host_name);
+  str::utils::replace(spec, "${hostname_uc}", prep(boost::algorithm::to_upper_copy(host_name)));
+  str::utils::replace(spec, "${hostname_lc}", prep(boost::algorithm::to_lower_copy(host_name)));
+  str::utils::replace(spec, "${hostname}", prep(host_name));
 
   const str::utils::token dn = str::utils::getToken(host_name, '.');
-  str::utils::replace(spec, "${host}", dn.first);
-  str::utils::replace(spec, "${domain}", dn.second);
-  str::utils::replace(spec, "${host_uc}", boost::algorithm::to_upper_copy(dn.first));
-  str::utils::replace(spec, "${domain_uc}", boost::algorithm::to_upper_copy(dn.second));
-  str::utils::replace(spec, "${host_lc}", boost::algorithm::to_lower_copy(dn.first));
-  str::utils::replace(spec, "${domain_lc}", boost::algorithm::to_lower_copy(dn.second));
+  str::utils::replace(spec, "${host}", prep(dn.first));
+  str::utils::replace(spec, "${domain}", prep(dn.second));
+  str::utils::replace(spec, "${host_uc}", prep(boost::algorithm::to_upper_copy(dn.first)));
+  str::utils::replace(spec, "${domain_uc}", prep(boost::algorithm::to_upper_copy(dn.second)));
+  str::utils::replace(spec, "${host_lc}", prep(boost::algorithm::to_lower_copy(dn.first)));
+  str::utils::replace(spec, "${domain_lc}", prep(boost::algorithm::to_lower_copy(dn.second)));
   return spec;
+}
+}  // namespace
+
+std::string socket_helpers::sanitize_path_component(std::string value) {
+  // gethostname() is not fully under the operator's control - DHCP can set it
+  // on some systems - so a value substituted into a local path must not be
+  // able to smuggle in a separator or a ".." component. A real host name is
+  // RFC-952 material (letters, digits, '-', '.' between labels), so mapping
+  // everything else to '_' cannot change a legitimate setup.
+  bool only_dots = !value.empty();
+  for (char &c : value) {
+    const bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '_' || c == '-';
+    if (!ok) c = '_';
+    if (c != '.') only_dots = false;
+  }
+  // "." or ".." as a whole component is a path, not a name.
+  if (only_dots) return "_";
+  return value;
+}
+
+std::string socket_helpers::expand_hostname_placeholders(std::string spec) { return expand_placeholders_with(std::move(spec), keep_verbatim); }
+
+std::string socket_helpers::expand_hostname_placeholders_in_path(std::string spec) {
+  return expand_placeholders_with(std::move(spec), &socket_helpers::sanitize_path_component);
 }
 
 std::string socket_helpers::expand_hostname(std::string spec) {

--- a/include/net/socket/socket_helpers.cpp
+++ b/include/net/socket/socket_helpers.cpp
@@ -29,11 +29,11 @@ namespace ip = boost::asio::ip;
 
 std::list<std::string> socket_helpers::connection_info::validate() const { return validate_ssl(); }
 
-std::string socket_helpers::expand_hostname(std::string spec) {
+std::string socket_helpers::expand_hostname_placeholders(std::string spec) {
+  // Nothing to resolve, and asking the OS for its host name is not free: a
+  // settings context or an attachment path usually has no placeholder at all.
+  if (spec.find("${") == std::string::npos) return spec;
   std::string host_name = ip::host_name();
-  if (spec == "auto") return host_name;
-  if (spec == "auto-lc") return boost::algorithm::to_lower_copy(host_name);
-  if (spec == "auto-uc") return boost::algorithm::to_upper_copy(host_name);
 
   // The full name exactly as the system reports it. ${host} stops at the first
   // '.', so without this there is no way to get the fqdn from inside a template
@@ -50,6 +50,16 @@ std::string socket_helpers::expand_hostname(std::string spec) {
   str::utils::replace(spec, "${host_lc}", boost::algorithm::to_lower_copy(dn.first));
   str::utils::replace(spec, "${domain_lc}", boost::algorithm::to_lower_copy(dn.second));
   return spec;
+}
+
+std::string socket_helpers::expand_hostname(std::string spec) {
+  // The "auto" shorthands reinterpret the whole spec, so they only apply where
+  // the string *is* a host name - not to the strings which merely contain a
+  // placeholder (a settings context, an attachment target).
+  if (spec == "auto") return ip::host_name();
+  if (spec == "auto-lc") return boost::algorithm::to_lower_copy(ip::host_name());
+  if (spec == "auto-uc") return boost::algorithm::to_upper_copy(ip::host_name());
+  return expand_hostname_placeholders(std::move(spec));
 }
 void socket_helpers::validate_certificate(const std::string &certificate, std::list<std::string> &list) {
 #ifdef USE_SSL

--- a/include/net/socket/socket_helpers.hpp
+++ b/include/net/socket/socket_helpers.hpp
@@ -78,6 +78,21 @@ void validate_certificate(const std::string& certificate, std::list<std::string>
 // as a whole (see the "auto" shorthands in expand_hostname).
 std::string expand_hostname_placeholders(std::string spec);
 
+// The same substitution, but every substituted value is first passed through
+// sanitize_path_component. Use this - not the plain variant - whenever the
+// result names something on the local file system (an attachment target, a
+// settings context): the host name is not fully under the operator's control
+// (DHCP can set it on some systems), and a value carrying '/', '\' or a
+// dots-only component must not be able to redirect a path the agent reads or
+// writes with its (typically root/SYSTEM) privileges.
+std::string expand_hostname_placeholders_in_path(std::string spec);
+
+// Reduce `value` to characters safe inside a single path component: letters,
+// digits, '.', '_' and '-' pass, anything else becomes '_', and a value that
+// is nothing but dots ("." / "..") becomes "_". A legal RFC-952 host name
+// comes through unchanged.
+std::string sanitize_path_component(std::string value);
+
 // Resolve a hostname spec used by the various submit-clients.
 //   "auto"     -> system host name as-is
 //   "auto-lc"  -> system host name, lower-cased

--- a/include/net/socket/socket_helpers.hpp
+++ b/include/net/socket/socket_helpers.hpp
@@ -66,14 +66,23 @@ std::string format_subject_cn_only(void* x509);
 #endif
 void validate_certificate(const std::string& certificate, std::list<std::string>& list);
 
+// Substitute the host name placeholders in `spec`: ${hostname}, ${hostname_lc}
+// and ${hostname_uc} are the system host name as reported; ${host}, ${domain},
+// ${host_lc}, ${host_uc}, ${domain_lc} and ${domain_uc} are substituted from it
+// after splitting on the first '.' into host and domain. Other text is
+// preserved.
+//
+// This is the half of expand_hostname which is safe to apply to a string that
+// is not a host name spec - a settings context or an attachment path, say -
+// since it only ever replaces a placeholder and never reinterprets the string
+// as a whole (see the "auto" shorthands in expand_hostname).
+std::string expand_hostname_placeholders(std::string spec);
+
 // Resolve a hostname spec used by the various submit-clients.
 //   "auto"     -> system host name as-is
 //   "auto-lc"  -> system host name, lower-cased
 //   "auto-uc"  -> system host name, upper-cased
-//   anything else: ${hostname}, ${hostname_lc} and ${hostname_uc} are the
-//   system host name as reported; ${host}, ${domain}, ${host_lc}, ${host_uc},
-//   ${domain_lc} and ${domain_uc} are substituted from it after splitting on
-//   the first '.' into host and domain. Other text is preserved.
+//   anything else: expand_hostname_placeholders above.
 std::string expand_hostname(std::string spec);
 
 class socket_exception : public std::exception {

--- a/include/net/socket/socket_helpers_test.cpp
+++ b/include/net/socket/socket_helpers_test.cpp
@@ -363,6 +363,48 @@ TEST(ExpandHostnamePlaceholders, MixedWithAPathToken) {
   EXPECT_EQ(out, "${shared-path}/" + host + "-nsclient.ini");
 }
 
+// =============================================================================
+// expand_hostname_placeholders_in_path / sanitize_path_component
+//
+// The variant for values that land on the local file system. The host name is
+// not fully under the operator's control (DHCP can set it on some systems), so
+// what gets substituted into an attachment target or a settings context must
+// not be able to carry a path separator or a dots-only component.
+// =============================================================================
+
+TEST(SanitizePathComponent, LeavesALegalHostNameAlone) {
+  EXPECT_EQ(socket_helpers::sanitize_path_component("my-host"), "my-host");
+  EXPECT_EQ(socket_helpers::sanitize_path_component("MY-HOST.example.com"), "MY-HOST.example.com");
+  EXPECT_EQ(socket_helpers::sanitize_path_component("srv_01"), "srv_01");
+  EXPECT_EQ(socket_helpers::sanitize_path_component(""), "");
+}
+
+TEST(SanitizePathComponent, MapsSeparatorsAndFriendsToUnderscore) {
+  EXPECT_EQ(socket_helpers::sanitize_path_component("a/b"), "a_b");
+  EXPECT_EQ(socket_helpers::sanitize_path_component("a\\b"), "a_b");
+  EXPECT_EQ(socket_helpers::sanitize_path_component("../../etc/cron.d/evil"), ".._.._etc_cron.d_evil");
+  EXPECT_EQ(socket_helpers::sanitize_path_component("a:b?c"), "a_b_c");
+}
+
+TEST(SanitizePathComponent, ADotsOnlyValueIsNotAPathComponent) {
+  EXPECT_EQ(socket_helpers::sanitize_path_component("."), "_");
+  EXPECT_EQ(socket_helpers::sanitize_path_component(".."), "_");
+  // ...but dots inside a name are just dots.
+  EXPECT_EQ(socket_helpers::sanitize_path_component("a..b"), "a..b");
+}
+
+TEST(ExpandHostnamePlaceholdersInPath, AgreesWithThePlainVariantForARealHostName) {
+  // A real system host name is RFC-952 material, so on any sane machine the
+  // two variants answer the same - the sanitizer only bites on a hostile name.
+  const std::string spec = "${shared-path}/${host}-nsclient.ini|${hostname}|${domain_uc}";
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders_in_path(spec), socket_helpers::expand_hostname_placeholders(spec));
+}
+
+TEST(ExpandHostnamePlaceholdersInPath, LeavesNonHostTokensAndShorthandsAlone) {
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders_in_path("${shared-path}/nsclient.ini"), "${shared-path}/nsclient.ini");
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders_in_path("auto"), "auto");
+}
+
 #ifdef USE_SSL
 // =============================================================================
 // SSL-specific: get_verify_mode

--- a/include/net/socket/socket_helpers_test.cpp
+++ b/include/net/socket/socket_helpers_test.cpp
@@ -7,6 +7,7 @@
 #include <boost/asio/ip/host_name.hpp>
 #include <net/socket/server.hpp>
 #include <net/socket/socket_helpers.hpp>
+#include <str/utils.hpp>
 #include <string>
 
 // =============================================================================
@@ -320,6 +321,46 @@ TEST(ExpandHostname, CasePlaceholdersAreExpanded) {
   // placeholders are substituted away.
   std::string out = socket_helpers::expand_hostname("${host_lc}|${host_uc}|${domain_lc}|${domain_uc}|${domain}");
   EXPECT_EQ(out.find("${"), std::string::npos);
+}
+
+// =============================================================================
+// expand_hostname_placeholders
+//
+// The half of expand_hostname which is applied to strings that are not host
+// name specs - settings contexts and attachment paths (issue #458). It must
+// substitute exactly what expand_hostname substitutes and nothing more.
+// =============================================================================
+
+TEST(ExpandHostnamePlaceholders, SubstitutesTheSamePlaceholders) {
+  const std::string spec = "${hostname}|${host}|${domain}|${hostname_lc}|${host_uc}|${domain_lc}";
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders(spec), socket_helpers::expand_hostname(spec));
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders(spec).find("${"), std::string::npos);
+}
+
+TEST(ExpandHostnamePlaceholders, LeavesTheAutoShorthandsAlone) {
+  // The whole reason this is a separate entry point: a settings context or an
+  // attachment path named "auto" is a name, not a request for the host name.
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders("auto"), "auto");
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders("auto-lc"), "auto-lc");
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders("auto-uc"), "auto-uc");
+  // ...while expand_hostname still resolves them for the submit clients.
+  EXPECT_EQ(socket_helpers::expand_hostname("auto"), boost::asio::ip::host_name());
+}
+
+TEST(ExpandHostnamePlaceholders, PassesThroughWhatHasNoPlaceholder) {
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders(""), "");
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders("ini:///etc/nsclient/nsclient.ini"), "ini:///etc/nsclient/nsclient.ini");
+  // A path token is not ours to resolve - it belongs to the path manager, and
+  // has to survive this pass untouched.
+  EXPECT_EQ(socket_helpers::expand_hostname_placeholders("${shared-path}/nsclient.ini"), "${shared-path}/nsclient.ini");
+}
+
+TEST(ExpandHostnamePlaceholders, MixedWithAPathToken) {
+  // The #458 case: the two kinds of placeholder share a syntax and a string,
+  // and each pass must leave the other's tokens for it.
+  const std::string out = socket_helpers::expand_hostname_placeholders("${shared-path}/${host}-nsclient.ini");
+  const std::string host = str::utils::getToken(boost::asio::ip::host_name(), '.').first;
+  EXPECT_EQ(out, "${shared-path}/" + host + "-nsclient.ini");
 }
 
 #ifdef USE_SSL

--- a/include/settings/impl/settings_http.hpp
+++ b/include/settings/impl/settings_http.hpp
@@ -69,8 +69,13 @@ class settings_http : public settings::settings_interface_impl {
   // and an unknown token silently expands to the installation directory rather
   // than failing, so the attachment landed in one shared file with a mangled
   // name instead of a per-host one.
+  //
+  // The substituted values are sanitized (the _in_path variant): the target is
+  // written to with the service's privileges, and the host name - which DHCP
+  // can set on some systems - must not be able to smuggle a separator or a
+  // ".." into it.
   static std::string resolve_attachment_target(settings_core *core, const std::string &key) {
-    return core->expand_path(socket_helpers::expand_hostname_placeholders(key));
+    return core->expand_path(socket_helpers::expand_hostname_placeholders_in_path(key));
   }
 
   settings_http(settings::settings_core *core, std::string alias, std::string context) : settings::settings_interface_impl(core, alias, context) {

--- a/include/settings/impl/settings_http.hpp
+++ b/include/settings/impl/settings_http.hpp
@@ -56,6 +56,23 @@ class settings_http : public settings::settings_interface_impl {
   // name that needs escaping gets escaped rather than corrupting the request.
   static net::url parse_settings_url(const std::string &url) { return net::parse(socket_helpers::expand_hostname(url)); }
 
+  // Local path an attachment is written to, from the key it is declared under.
+  // Both kinds of placeholder are resolved, host name first and path tokens
+  // afterwards, so one fleet-wide configuration can give every agent its own
+  // file (issue #458):
+  //
+  //   [/attachments]
+  //   ${shared-path}/${host}-nsclient.ini = https://cfgsrv/hosts/${host}.ini
+  //
+  // The url on the right goes through parse_settings_url and has taken host
+  // name placeholders since 0.16.1; without this the path on the left did not,
+  // and an unknown token silently expands to the installation directory rather
+  // than failing, so the attachment landed in one shared file with a mangled
+  // name instead of a per-host one.
+  static std::string resolve_attachment_target(settings_core *core, const std::string &key) {
+    return core->expand_path(socket_helpers::expand_hostname_placeholders(key));
+  }
+
   settings_http(settings::settings_core *core, std::string alias, std::string context) : settings::settings_interface_impl(core, alias, context) {
     remote_url = parse_settings_url(utf8::cvt<std::string>(context));
     boost::filesystem::path path = core->expand_path(CACHE_FOLDER);
@@ -364,7 +381,7 @@ class settings_http : public settings::settings_interface_impl {
     if (!child) return;
     string_list keys = child->get_keys("/attachments");
     for (const std::string &k : keys) {
-      std::string target = get_core()->expand_path(k);
+      std::string target = resolve_attachment_target(get_core(), k);
       op_string str = child->get_string("/attachments", k);
       if (!str) continue;
       net::url source = parse_settings_url(*str);

--- a/include/settings/impl/settings_http_test.cpp
+++ b/include/settings/impl/settings_http_test.cpp
@@ -8,6 +8,7 @@
 #include <future>
 #include <settings/impl/settings_http.hpp>
 #include <settings/test_helpers.hpp>
+#include <str/utils.hpp>
 #include <thread>
 
 using settings_test::mock_settings_core;
@@ -386,4 +387,57 @@ TEST(settings_http, resolve_cache_file_handles_url_without_a_file_name) {
   EXPECT_NE(resolved, cache.path());
   EXPECT_EQ(resolved.parent_path(), cache.path());
   EXPECT_EQ(resolved.filename().string().find("cached.ini"), 0u);
+}
+
+// --- issue #458: host name placeholders in attachment targets ---------------
+
+namespace {
+// A core whose expand_path behaves like the real path manager for the one
+// token these tests care about, so the assertions show which pass resolved
+// which placeholder.
+class attachment_core : public mock_settings_core {
+ public:
+  std::string expand_path(std::string key) override {
+    str::utils::replace(key, "${shared-path}", "/etc/nsclient");
+    return key;
+  }
+};
+}  // namespace
+
+TEST(settings_http, attachment_target_expands_host_name_placeholders) {
+  // The reported case: one configuration served to a whole fleet, each agent
+  // writing its own file. Before this the ${host} token reached the path
+  // manager, which has no answer for it and hands back the installation
+  // directory - so every agent wrote the same mangled name.
+  attachment_core core;
+  const std::string host = str::utils::getToken(boost::asio::ip::host_name(), '.').first;
+
+  EXPECT_EQ(settings::settings_http::resolve_attachment_target(&core, "${shared-path}/${host}-nsclient.ini"),
+            "/etc/nsclient/" + host + "-nsclient.ini");
+}
+
+TEST(settings_http, attachment_target_expands_the_full_host_name) {
+  attachment_core core;
+  EXPECT_EQ(settings::settings_http::resolve_attachment_target(&core, "${shared-path}/${hostname}.ini"),
+            "/etc/nsclient/" + boost::asio::ip::host_name() + ".ini");
+}
+
+TEST(settings_http, attachment_target_without_a_placeholder_is_unchanged) {
+  // Attachments have always been declared as plain paths; those must resolve
+  // exactly as before.
+  attachment_core core;
+  EXPECT_EQ(settings::settings_http::resolve_attachment_target(&core, "scripts/myscript.bat"), "scripts/myscript.bat");
+  EXPECT_EQ(settings::settings_http::resolve_attachment_target(&core, "${shared-path}/scripts/myscript.bat"), "/etc/nsclient/scripts/myscript.bat");
+}
+
+TEST(settings_http, attachment_target_and_source_agree_on_the_host) {
+  // Both halves of an attachment line have to name the same host, or the file
+  // an agent downloads is not the file it writes.
+  attachment_core core;
+  const std::string target = settings::settings_http::resolve_attachment_target(&core, "${shared-path}/${host}.ini");
+  const net::url source = settings::settings_http::parse_settings_url("https://cfgsrv/hosts/${host}.ini");
+
+  const std::string host = str::utils::getToken(boost::asio::ip::host_name(), '.').first;
+  EXPECT_EQ(target, "/etc/nsclient/" + host + ".ini");
+  EXPECT_EQ(source.path, "/hosts/" + host + ".ini");
 }

--- a/libs/settings_manager/settings_handler_impl.hpp
+++ b/libs/settings_manager/settings_handler_impl.hpp
@@ -73,16 +73,27 @@ class settings_handler_impl : public settings_core {
   instance_ptr get_no_wait();
   void update_defaults();
   void remove_defaults();
-  void migrate(instance_ptr from, instance_ptr to) {
+  // primary_context is what set_primary stores in boot.ini. It is passed
+  // separately from `to` because an instance's context is the *expanded* one
+  // (create_instance resolves host name placeholders so it can open the per-
+  // host file), and storing that would bake this host's name into a boot.ini
+  // meant for every machine (issue #458): the callers which still have the
+  // context as the operator wrote it hand that in, placeholder intact, and
+  // set_primary resolves the protocol aliases itself.
+  void migrate(instance_ptr from, instance_ptr to, const std::string &primary_context) {
     if (!from || !to) throw new settings_exception(__FILE__, __LINE__, "Source or target is null");
     from->save_to(to);
-    set_primary(to->get_context());
+    set_primary(primary_context);
+  }
+  void migrate(instance_ptr from, instance_ptr to) {
+    if (!to) throw new settings_exception(__FILE__, __LINE__, "Source or target is null");
+    migrate(from, to, to->get_context());
   }
   void migrate_to(instance_ptr to) { migrate(get(), to); }
   void migrate_from(instance_ptr from) { migrate(from, get()); }
   void migrate_to(std::string alias, std::string to) {
     instance_ptr i = create_instance(alias, to);
-    migrate_to(i);
+    migrate(get(), i, to);
   }
   void migrate_from(std::string alias, std::string from) {
     instance_ptr i = create_instance(alias, from);
@@ -91,7 +102,7 @@ class settings_handler_impl : public settings_core {
   void migrate(std::string alias_from, std::string from, std::string alias_to, std::string to) {
     instance_ptr ifrom = create_instance(alias_from, from);
     instance_ptr ito = create_instance(alias_to, to);
-    migrate(ifrom, ito);
+    migrate(ifrom, ito, to);
   }
 
   //////////////////////////////////////////////////////////////////////////

--- a/libs/settings_manager/settings_manager_impl.cpp
+++ b/libs/settings_manager/settings_manager_impl.cpp
@@ -89,11 +89,14 @@ std::string NSCSettingsImpl::expand_context(const std::string &key) {
   //
   // Note this deliberately does not go through expand_hostname: its "auto"
   // shorthands would rewrite a context which merely happens to be named auto.
+  // And it is the sanitizing _in_path variant, since a context names a file
+  // this process opens: the host name is not fully under the operator's
+  // control, and must not be able to smuggle a separator or ".." into it.
   //
   // Anything which *stores* a context (set_primary rewriting boot.ini) must use
   // expand_context_alias instead, or the placeholder is replaced by this host's
   // name in the file - the opposite of what a fleet-wide boot.ini is for.
-  return socket_helpers::expand_hostname_placeholders(expand_context_alias(key));
+  return socket_helpers::expand_hostname_placeholders_in_path(expand_context_alias(key));
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/libs/settings_manager/settings_manager_impl.cpp
+++ b/libs/settings_manager/settings_manager_impl.cpp
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <file_helpers.hpp>
+#include <net/socket/socket_helpers.hpp>
 #include <nscp/path_defaults.hpp>
 #include <settings/client/settings_proxy.hpp>
 #include <str/format.hpp>
@@ -64,7 +65,7 @@ std::string NSCSettingsImpl::find_file(std::string file, std::string fallback) {
 }
 std::string NSCSettingsImpl::expand_path(std::string file) { return provider_->expand_path(file); }
 
-std::string NSCSettingsImpl::expand_context(const std::string &key) {
+std::string NSCSettingsImpl::expand_context_alias(const std::string &key) {
 #ifdef WIN32
   if (key == "old") return DEFAULT_CONF_OLD_LOCATION;
   if (key == "registry" || key == "reg") return DEFAULT_CONF_REG_LOCATION;
@@ -72,6 +73,27 @@ std::string NSCSettingsImpl::expand_context(const std::string &key) {
   if (key == "ini") return DEFAULT_CONF_INI_LOCATION;
   if (key == "dummy") return "dummy://";
   return key;
+}
+
+std::string NSCSettingsImpl::expand_context(const std::string &key) {
+  // Host name placeholders, so an included file can be per host (issue #458):
+  //
+  //   [/includes]
+  //   client = ${host}-nsclient.ini
+  //
+  // This is the same expansion http(s) settings urls take, and it happens here
+  // rather than in the ini backend so every store which chains children -
+  // [/includes] in an ini file or in the registry, and the [settings] entries
+  // in boot.ini - resolves a context the same way. The stored string keeps its
+  // placeholder: only the context we are about to open is expanded.
+  //
+  // Note this deliberately does not go through expand_hostname: its "auto"
+  // shorthands would rewrite a context which merely happens to be named auto.
+  //
+  // Anything which *stores* a context (set_primary rewriting boot.ini) must use
+  // expand_context_alias instead, or the placeholder is replaced by this host's
+  // name in the file - the opposite of what a fleet-wide boot.ini is for.
+  return socket_helpers::expand_hostname_placeholders(expand_context_alias(key));
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -249,10 +271,15 @@ void NSCSettingsImpl::set_primary(std::string key) {
   std::list<std::string> order;
   CSimpleIni boot_conf;
   boot_conf.LoadFile(boot_.string().c_str());
+  // Every entry read here is written back below, so only the protocol aliases
+  // are resolved: a host name placeholder has to survive being reordered, or
+  // switching context once would bake this host's name into a boot.ini meant
+  // for every machine (issue #458).
+  key = expand_context_alias(key);
   for (int i = 0; i < 20; i++) {
     std::string v = utf8::cvt<std::string>(boot_conf.GetValue(L"settings", utf8::cvt<std::wstring>(str::xtos(i)).c_str(), L""));
     if (!v.empty()) {
-      order.push_back(expand_context(v));
+      order.push_back(expand_context_alias(v));
       boot_conf.SetValue(L"settings", utf8::cvt<std::wstring>(str::xtos(i)).c_str(), L"");
     }
   }

--- a/libs/settings_manager/settings_manager_impl.h
+++ b/libs/settings_manager/settings_manager_impl.h
@@ -89,6 +89,10 @@ class NSCSettingsImpl : public settings::settings_handler_impl {
   std::string find_file(std::string file, std::string fallback = "");
   std::string expand_path(std::string file);
   std::string expand_context(const std::string &key);
+  // The protocol aliases only ("ini", "dummy", ...), without the host name
+  // placeholders expand_context resolves. Use this wherever the result is
+  // written back to a configuration file rather than opened.
+  static std::string expand_context_alias(const std::string &key);
 
   settings::instance_raw_ptr create_instance(std::string alias, std::string key);
   void change_context(const std::string &file);

--- a/libs/settings_manager/settings_manager_impl_test.cpp
+++ b/libs/settings_manager/settings_manager_impl_test.cpp
@@ -16,11 +16,13 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <boost/asio/ip/host_name.hpp>
 #include <boost/filesystem.hpp>
 #include <fstream>
 #include <map>
 #include <memory>
 #include <settings/test_helpers.hpp>
+#include <str/utils.hpp>
 #include <string>
 #include <vector>
 
@@ -118,6 +120,45 @@ TEST(SettingsManagerExpandContext, UnknownKeyPassesThrough) {
   // Anything not recognised - including fully-formed URLs - should round-trip.
   EXPECT_EQ(impl.expand_context("ini://D:/somewhere.ini"), "ini://D:/somewhere.ini");
   EXPECT_EQ(impl.expand_context(""), "");
+}
+
+// --- issue #458: host name placeholders in a settings context ---------------
+
+TEST(SettingsManagerExpandContext, ExpandsHostNamePlaceholders) {
+  settings_test::temp_dir dir;
+  const auto boot_ini = dir.file("boot.ini");
+  recording_provider p(boot_ini.string());
+  settings_manager::NSCSettingsImpl impl(&p);
+
+  // What [/includes] hands to create_instance, so one shared configuration can
+  // pull in a per-host file.
+  const std::string host = str::utils::getToken(boost::asio::ip::host_name(), '.').first;
+  EXPECT_EQ(impl.expand_context("${host}-nsclient.ini"), host + "-nsclient.ini");
+  EXPECT_EQ(impl.expand_context("${hostname}.ini"), boost::asio::ip::host_name() + ".ini");
+  EXPECT_EQ(impl.expand_context("ini://${shared-path}/${host}.ini"), "ini://${shared-path}/" + host + ".ini");
+}
+
+TEST(SettingsManagerExpandContext, LeavesPathTokensToThePathManager) {
+  settings_test::temp_dir dir;
+  const auto boot_ini = dir.file("boot.ini");
+  recording_provider p(boot_ini.string());
+  settings_manager::NSCSettingsImpl impl(&p);
+
+  // The two kinds of placeholder share a syntax; this pass must not consume
+  // a token that expand_path is going to resolve later.
+  EXPECT_EQ(impl.expand_context("ini://${shared-path}/nsclient.ini"), "ini://${shared-path}/nsclient.ini");
+}
+
+TEST(SettingsManagerExpandContext, DoesNotResolveTheAutoShorthand) {
+  settings_test::temp_dir dir;
+  const auto boot_ini = dir.file("boot.ini");
+  recording_provider p(boot_ini.string());
+  settings_manager::NSCSettingsImpl impl(&p);
+
+  // A context named "auto" is a name. Only the submit clients' host name specs
+  // give "auto" its other meaning, which is why this does not go through
+  // expand_hostname.
+  EXPECT_EQ(impl.expand_context("auto"), "auto");
 }
 
 #ifdef WIN32
@@ -895,6 +936,59 @@ TEST_F(SettingsHandlerTest, ContextExistsIsAlwaysTrueForDummyAndHttp) {
 
 TEST_F(SettingsHandlerTest, CreateInstanceThrowsForAnUnknownProtocol) {
   EXPECT_THROW(impl_->create_instance("master", "gopher://localhost/settings"), settings::settings_exception);
+}
+
+// --- issue #458: a stored context keeps its placeholder ---------------------
+
+TEST_F(SettingsManagerBootTest, SwitchingContextKeepsAPlaceholderInBootIni) {
+  // set_primary reorders boot.ini and writes every entry back. The whole point
+  // of a placeholder is that the same boot.ini works on every machine, so it
+  // has to survive the round trip - expanding it here would replace the
+  // template with the name of whichever host happened to switch context.
+  settings_test::write_file(boot_ini_, "[settings]\n1=ini://${host}-nsclient.ini\n2=dummy\n");
+  ASSERT_TRUE(settings_manager::init_settings(provider_.get(), "dummy"));
+
+  settings_manager::set_boot_ini_primary("dummy");
+
+  const std::string after = settings_test::read_file(boot_ini_);
+  EXPECT_NE(after.find("ini://${host}-nsclient.ini"), std::string::npos) << after;
+  EXPECT_EQ(after.find(str::utils::getToken(boost::asio::ip::host_name(), '.').first + "-nsclient.ini"), std::string::npos) << after;
+}
+
+// --- issue #458: a per-host [/includes] entry -------------------------------
+
+TEST_F(SettingsContextTest, AContextWithAHostPlaceholderResolvesToThePerHostFile) {
+  // The end of the chain [/includes] walks: the ini backend hands the value it
+  // read straight to create_instance/context_exists, so expanding the
+  // placeholder there is what makes
+  //
+  //   [/includes]
+  //   client = ${host}-nsclient.ini
+  //
+  // open this host's file. Without it the token reached the path manager,
+  // which has no answer for it and substitutes the installation directory.
+  settings_test::temp_dir dir;
+  const std::string host = str::utils::getToken(boost::asio::ip::host_name(), '.').first;
+  settings_test::write_file(dir.file(host + "-nsclient.ini"), "[/settings]\nkey = value\n");
+
+  const std::string context = ini_context(dir.path() / "${host}-nsclient.ini");
+  EXPECT_TRUE(impl_->context_exists(context));
+
+  const settings::instance_raw_ptr instance = impl_->create_instance("client", context);
+  ASSERT_TRUE(static_cast<bool>(instance));
+  EXPECT_EQ(instance->get_type(), "ini");
+  // get_info() names the file that was actually opened.
+  EXPECT_NE(instance->get_info().find(host + "-nsclient.ini"), std::string::npos) << instance->get_info();
+  EXPECT_EQ(instance->get_info().find("${host}"), std::string::npos) << instance->get_info();
+}
+
+TEST_F(SettingsContextTest, AContextWithoutAPlaceholderIsUnaffected) {
+  settings_test::temp_dir dir;
+  const boost::filesystem::path file = dir.file("plain.ini");
+  settings_test::write_file(file, "");
+
+  EXPECT_TRUE(impl_->context_exists(ini_context(file)));
+  EXPECT_FALSE(impl_->context_exists(ini_context(dir.path() / "${host}-plain.ini")));
 }
 
 TEST_F(SettingsContextTest, CreateInstanceBuildsTheBackendTheContextNames) {

--- a/libs/settings_manager/settings_manager_impl_test.cpp
+++ b/libs/settings_manager/settings_manager_impl_test.cpp
@@ -955,6 +955,30 @@ TEST_F(SettingsManagerBootTest, SwitchingContextKeepsAPlaceholderInBootIni) {
   EXPECT_EQ(after.find(str::utils::getToken(boost::asio::ip::host_name(), '.').first + "-nsclient.ini"), std::string::npos) << after;
 }
 
+TEST_F(SettingsManagerBootTest, MigratingToAContextKeepsItsPlaceholderInBootIni) {
+  // The other way a context gets stored: migrate ends in set_primary too, but
+  // the instance it migrates into carries the *expanded* context, because
+  // create_instance resolves the placeholder to open the per-host file. What
+  // lands in boot.ini has to be the context as the operator wrote it - or
+  // `nscp settings --migrate-to 'ini://${host}.ini'` on one machine would bake
+  // that machine's name into a boot.ini meant for the whole fleet, while
+  // --switch with the same argument keeps the template.
+  settings_test::write_file(boot_ini_, "[settings]\n1=dummy\n");
+  ASSERT_TRUE(settings_manager::init_settings(provider_.get(), "dummy"));
+
+  settings_test::temp_dir dir;
+  const std::string host = str::utils::getToken(boost::asio::ip::host_name(), '.').first;
+  // INISettings resolves its context against an existing file, so the per-host
+  // file the expanded context names has to be there first.
+  settings_test::write_file(dir.file(host + "-migrated.ini"), "");
+
+  settings_manager::get_core()->migrate_to("master", ini_context(dir.path() / "${host}-migrated.ini"));
+
+  const std::string after = settings_test::read_file(boot_ini_);
+  EXPECT_NE(after.find("${host}-migrated.ini"), std::string::npos) << after;
+  EXPECT_EQ(after.find(host + "-migrated.ini"), std::string::npos) << after;
+}
+
 // --- issue #458: a per-host [/includes] entry -------------------------------
 
 TEST_F(SettingsContextTest, AContextWithAHostPlaceholderResolvesToThePerHostFile) {

--- a/service/settings_client.cpp
+++ b/service/settings_client.cpp
@@ -241,7 +241,11 @@ int nsclient_core::settings_client::generate(std::string target) {
   }
 }
 
-void nsclient_core::settings_client::switch_context(std::string context) { get_core()->set_primary(expand_context(context)); }
+// The context is handed over unexpanded: set_primary writes it to boot.ini, and
+// a host name placeholder the operator typed is a template for the whole fleet,
+// not a request to store this host's name (issue #458). set_primary resolves
+// the protocol aliases itself.
+void nsclient_core::settings_client::switch_context(std::string context) { get_core()->set_primary(context); }
 
 int nsclient_core::settings_client::set(std::string path, std::string key, std::string val) {
   get_core()->get()->set_string(path, key, val);

--- a/service/settings_client.cpp
+++ b/service/settings_client.cpp
@@ -65,7 +65,8 @@ void nsclient_core::settings_client::terminate() {
 int nsclient_core::settings_client::migrate_from(std::string src) {
   try {
     debug_msg(__FILE__, __LINE__, "Migrating from: " + expand_context(src));
-    get_core()->migrate_from("master", expand_context(src));
+    // Handed over as written: create_instance expands what it opens itself.
+    get_core()->migrate_from("master", src);
     return 1;
   } catch (settings::settings_exception &e) {
     error_msg(__FILE__, __LINE__, "Failed to initialize settings: " + utf8::utf8_from_native(e.what()));
@@ -77,7 +78,12 @@ int nsclient_core::settings_client::migrate_from(std::string src) {
 int nsclient_core::settings_client::migrate_to(std::string target) {
   try {
     debug_msg(__FILE__, __LINE__, "Migrating to: " + expand_context(target));
-    get_core()->migrate_to("master", expand_context(target));
+    // Handed over as written, like --switch: migrate_to ends in set_primary,
+    // which writes the context to boot.ini, and a host name placeholder the
+    // operator typed is a template for the whole fleet - expanding it first
+    // would store this host's name instead (issue #458). create_instance
+    // expands what it opens itself.
+    get_core()->migrate_to("master", target);
     return 1;
   } catch (const settings::settings_exception &e) {
     error_msg(e.file(), e.line(), "Failed to initialize settings: " + utf8::utf8_from_native(e.what()));

--- a/tests/settings-host-placeholders.test.ts
+++ b/tests/settings-host-placeholders.test.ts
@@ -1,0 +1,157 @@
+/**
+ * End-to-end test of host name placeholder expansion in the settings
+ * subsystem (issue #458): one fleet-wide configuration, served over http,
+ * gives every agent its own per-host config file and check script.
+ *
+ * The local bootstrap ini includes a fleet-wide ini from a fake config
+ * server. The fleet ini attaches a per-host configuration file — target path
+ * and source url both named with ${host} — and includes that file. The
+ * per-host file in turn attaches a per-host check script and defines an
+ * external script command that runs it.
+ *
+ * Convergence deliberately takes two boots: the http store resolves its
+ * include chain from the freshly downloaded config before it fetches the
+ * attachments, so the per-host file dropped by boot one is only picked up as
+ * an include on boot two — which then also sees the script attachment the
+ * per-host file declares, downloads it, and can run the command.
+ *
+ * Before the fix, ${host} in an attachment target or an included file name
+ * fell through to the path manager, where an unknown token silently expands
+ * to the installation path: the attachment was written under a mangled name
+ * and the include never matched anything.
+ */
+import http from "http";
+import { AddressInfo } from "net";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(180_000);
+
+const onWindows = process.platform === "win32";
+// ${host} expands to the OS host name up to the first dot, case preserved —
+// the same gethostname() node's os.hostname() reports.
+const host = os.hostname().split(".")[0];
+
+describe("settings host name placeholders (issue #458)", () => {
+  let nscp: NscpInstance;
+  let workDir: string;
+  let server: http.Server;
+  let baseUrl: string;
+  const requests: string[] = [];
+
+  const ext = onWindows ? "bat" : "sh";
+  const marker = `fleet-greeting-for-${host}`;
+  const scriptBody = onWindows
+    ? `@echo off\r\necho OK: ${marker}\r\n`
+    : `#!/bin/sh\necho "OK: ${marker}"\n`;
+
+  const perHostFile = () => path.join(workDir, `${host}-nsclient.ini`);
+  const scriptFile = () => path.join(workDir, `${host}-hello.${ext}`);
+
+  // Server-side content; built in beforeAll once baseUrl/workDir are known.
+  let fleetIni: string;
+  let perHostIni: string;
+
+  beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nscp-hostcfg-"));
+    // ${shared-path} is where the fleet config drops the per-host files, so
+    // point it into the sandbox.
+    nscp = new NscpInstance({ workDir, pathOverrides: { "shared-path": workDir } });
+
+    server = http.createServer((req, res) => {
+      const url = decodeURIComponent(req.url ?? "/");
+      requests.push(url);
+      const serve = (body: string) => {
+        res.writeHead(200, { "Content-Type": "text/plain" });
+        res.end(body);
+      };
+      if (url === "/conf/fleet.ini") return serve(fleetIni);
+      if (url === `/hosts/${host}-nsclient.ini`) return serve(perHostIni);
+      if (url === `/scripts/${host}-hello.${ext}`) return serve(scriptBody);
+      res.writeHead(404);
+      res.end("not found");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+
+    // The fleet-wide file, identical for every host in the fleet. Attachment
+    // target and include mix both placeholder vocabularies: the host pass has
+    // to resolve ${host} and leave ${shared-path} to the path manager.
+    fleetIni = [
+      "[/attachments]",
+      "${shared-path}/${host}-nsclient.ini = " + baseUrl + "/hosts/${host}-nsclient.ini",
+      "",
+      "[/includes]",
+      "client = ini://${shared-path}/${host}-nsclient.ini",
+      "",
+    ].join("\n");
+
+    // The per-host file: attaches this host's check script and wires it up as
+    // an external script command. The command uses the resolved absolute path
+    // (unquoted: a temp dir has no spaces on any platform we run on).
+    const runner = onWindows ? `cmd /c ${scriptFile()}` : `/bin/sh ${scriptFile()}`;
+    perHostIni = [
+      "[/attachments]",
+      "${shared-path}/${host}-hello." + ext + " = " + baseUrl + "/scripts/${host}-hello." + ext,
+      "",
+      "[/settings/external scripts/scripts]",
+      `check_fleet_host = ${runner}`,
+      "",
+    ].join("\n");
+
+    // Local bootstrap: everything else comes from the config server.
+    fs.writeFileSync(nscp.settingsFile, `[/includes]\nfleet = ${baseUrl}/conf/fleet.ini\n`);
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  /** One-shot boot + query over the client-query path (no web server needed). */
+  async function queryFleetHost() {
+    return nscp.run(
+      ["client", "--module", "CheckExternalScripts", "--boot", "--query", "check_fleet_host"],
+      { allowFailure: true },
+    );
+  }
+
+  it("first boot downloads the per-host config under this host's name", async () => {
+    // The query itself is expected to fail on this boot (the include chain
+    // was resolved before the attachment landed); it is only run to boot the
+    // settings subsystem once.
+    await queryFleetHost();
+
+    // The attachment target ${shared-path}/${host}-nsclient.ini resolved both
+    // kinds of token: the file is here, byte for byte, under OUR host name...
+    expect(fs.readFileSync(perHostFile(), "utf8")).toBe(perHostIni);
+
+    // ...and it is the only *-nsclient.ini in the folder. Before the fix the
+    // unresolved ${host} token silently expanded to the installation path and
+    // the attachment was written under a mangled name instead.
+    const strays = fs
+      .readdirSync(workDir)
+      .filter((f) => f.endsWith("-nsclient.ini") && f !== `${host}-nsclient.ini`);
+    expect(strays).toEqual([]);
+
+    // The attachment source url asked the server for this host's file by name,
+    // and no request ever went out with an unexpanded placeholder.
+    expect(requests).toContain(`/hosts/${host}-nsclient.ini`);
+    expect(requests.filter((u) => u.includes("${"))).toEqual([]);
+  });
+
+  it("second boot includes the per-host config, downloads its script and runs it", async () => {
+    const r = await queryFleetHost();
+    const out = r.all ?? `${r.stdout}\n${r.stderr}`;
+
+    // The included per-host file is live: the command it defines resolved,
+    // the script it attaches was fetched from the server and executed.
+    // (Client-query output is the raw message, no status-word prefix.)
+    expect(out).toContain(marker);
+    expect(r.exitCode).toBe(0);
+
+    expect(requests).toContain(`/scripts/${host}-hello.${ext}`);
+    expect(fs.readFileSync(scriptFile(), "utf8")).toBe(scriptBody);
+  });
+});


### PR DESCRIPTION
Fixes #458.

## The problem

A settings url has taken `${host}` and friends since 0.16.1, which is what lets one `boot.ini` serve a whole fleet. The rest of the settings subsystem never followed. Of the configuration in the issue:

```ini
[/attachments]
${shared-path}/${host}-nsclient.ini = https://cfgsrv/hosts/${host}-nsclient.ini

[/includes]
client = ${host}-nsclient.ini
```

only the url on the right of the attachment was expanded. `fetch_attachments` sends the two halves of that line down different paths — the value through `parse_settings_url` (host names), the key through `expand_path` (path tokens only) — and an included file name goes to the path manager as well, by way of `create_instance`.

Neither knows `${host}`, and an unknown token in a path is deliberately not an error: `get_path_for_key` falls back to the installation directory so a typo cannot expand to an empty, root-relative path. So this never failed. It quietly wrote one shared file with the installation directory embedded in its name, and included a file nobody had.

## The change

- **Attachment targets.** `fetch_attachments` runs the key through the host name pass before handing it to the path manager, so a target takes both kinds of token. The two vocabularies share a syntax but not a namespace, so each pass leaves the other's tokens alone.
- **Settings contexts.** `expand_context` does the same, which covers `[/includes]` in an ini file and in the registry as well as the `[settings]` entries in `boot.ini` — every store that chains children resolves a context through this one function.
- **A new entry point.** The substitution is split out of `expand_hostname` as `expand_hostname_placeholders`, so these callers get the `${...}` replacement without the `auto` / `auto-lc` / `auto-uc` shorthands. Those reinterpret the whole string, which is right for a submit client's host name spec and wrong for a settings context or a file that happens to be named `auto`. `expand_hostname` keeps its existing behaviour and now delegates.

## Stored contexts keep their placeholder

This is the part worth reviewing. `set_primary` reads every `[settings]` entry out of `boot.ini` and writes them all back to reorder them. Expanding there would replace the fleet-wide template with the name of whichever host happened to switch context — the exact opposite of the point — so that path resolves the protocol aliases only, via a new `expand_context_alias`. `nscp settings --switch` likewise hands its argument over untouched and lets `set_primary` normalise it. There is a regression test that fails if either reverts.

`boot()`, `create_instance` and `context_exists` read rather than store, so they take the full expansion.

## Review follow-up (second commit)

A review of the first commit found two issues, fixed in the follow-up commit:

- **Migrate stored the expanded context.** `migrate()` set the primary from `to->get_context()`, and an instance's context is the *expanded* one (that is how `create_instance` opens the per-host file). So while `--switch` kept `${host}` intact, `nscp settings --migrate-to 'ini://${host}.ini'`, the REST migrate and `change_context` baked this host's name into boot.ini — and `change_context`, which reaches `set_primary` twice, left both spellings behind. The context as the caller wrote it is now threaded through `migrate()` to `set_primary`, and the settings client hands its argument over unexpanded like `--switch` does. Regression test alongside the `--switch` one.
- **Host name tokens are sanitized before they land in a path.** The host name is not fully under the operator's control (DHCP can set it on some systems), and with `${host}` now resolving in attachment targets and includes, a value carrying `/`, `\` or `..` could redirect a path the agent reads or writes with service privileges. Attachment targets and settings contexts go through a new `expand_hostname_placeholders_in_path`, which maps anything a legal RFC-952 host name cannot contain to `_` (and a dots-only value to `_`); a legitimate name comes through unchanged, and settings urls / submit clients keep the verbatim substitution. Documented as a hardening note under `docs/docs/security/notices.md`, linked 🔒 from the upgrading entry.

The same pass also stops calling `gethostname()` for strings that only carry path tokens, and no longer lets a failing `gethostname()` throw out of settings boot.

## Testing

No CI-equivalent full build was available in this environment (no Boost/protobuf toolchain configured), so the affected translation units were compiled and their suites run directly against system Boost + GTest:

| Suite | Result |
|---|---|
| `socket_helpers_test` | 44 passed (39 + 5 new) |
| `settings_http_test` | 25 passed |
| `settings_manager_test` | 80 passed (79 + 1 new) |
| `settings_test` (value / interface / dummy / ini) | 134 passed |

New cases: `expand_hostname_placeholders` substitutes exactly what `expand_hostname` does and leaves the `auto` shorthands alone; attachment targets resolve both token kinds and agree with the source url on which host they name; a context with a placeholder opens the per-host file (asserted through `context_exists` and `create_instance`, i.e. the chain `[/includes]` actually walks); `boot.ini` keeps its literal `${host}` across a context switch **and across a migrate**; and `sanitize_path_component` / the `_in_path` variant agree with the plain substitution for a legal host name while mapping separators and dots-only values to `_`.

`settings_client.cpp` could not be compiled here (it needs generated protobuf headers); the changes to it are the removal of two calls on `std::string` arguments.

## Docs

- `docs/docs/concepts/settings.md` — a table of the four places placeholders now resolve, an example on the attachments section, a pointer from the include section, and a note on the path sanitization.
- `docs/docs/setup/upgrading.md` — an entry under `## next`, now marked 🔒 and linking the new hardening note in `docs/docs/security/notices.md`. This changes where an existing `${host}` attachment lands, and the old behaviour was silent, so anyone who tried this and worked around it should look.

The new note follows the file's existing "New in 0.17" convention. Worth flagging separately: the two notes already in that file say 0.17 for the settings-url placeholders and the query-parameter change, but `git tag --contains` puts both in 0.16.1. Left alone here rather than widening this diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FJjw8FDELHJKWLf3tZUXNe)_