### PR TITLE
fix(wmi): stop discarding a whole WMI collection over one NULL field

### DIFF
--- a/docs/samples/CheckSystem_check_cpu_frequency_desc.md
+++ b/docs/samples/CheckSystem_check_cpu_frequency_desc.md
@@ -3,7 +3,11 @@ Reports per-CPU-socket frequency, load and hardware inventory, sourced from the
 
 There are no default warning/critical thresholds: modern CPUs legitimately clock
 far below their maximum at idle, so a `frequency_pct` default would warn on every
-idle machine. Use `load_pct` for a per-socket utilisation alert. The inventory
+idle machine. Use `load_pct` for a per-socket utilisation alert. WMI does not
+always have a load sample ready: on such a cycle `load_pct` renders as
+`no load sample`, compares false against every numeric threshold and emits no
+perfdata (it is never a fabricated `0`, which is a valid idle reading);
+`load_pct = 'no load sample'` is the presence test. The inventory
 columns (`architecture`, `l2_cache`, `l3_cache`) make the check double as the
 per-socket CPU hardware inventory; pin them to detect a re-imaged or migrated
 box (`crit=architecture != 'x64'`).

--- a/include/win/wmi/wmi_query.cpp
+++ b/include/win/wmi/wmi_query.cpp
@@ -149,16 +149,23 @@ std::string row::to_string() const {
   return ss.str();
 }
 
-long long row::get_int(const std::string &col) const {
+boost::optional<long long> row::get_int_opt(const std::string &col) const {
   const CComBSTR bCol(utf8::cvt<std::wstring>(col).c_str());
   CComVariant vValue;
-  HRESULT hr = row_obj->Get(bCol, 0, &vValue, 0, 0);
+  HRESULT hr = row_obj->Get(bCol, 0, &vValue, nullptr, nullptr);
   if (FAILED(hr)) throw wmi_exception(hr, "Failed to get value for " + col);
+  if (vValue.vt == VT_NULL || vValue.vt == VT_EMPTY) return boost::none;
   hr = vValue.ChangeType(VT_I8);
   if (SUCCEEDED(hr)) return vValue.llVal;
   hr = vValue.ChangeType(VT_UI8);
-  if (SUCCEEDED(hr)) return vValue.ullVal;
+  if (SUCCEEDED(hr)) return static_cast<long long>(vValue.ullVal);
   throw wmi_exception(hr, "Failed to convert " + col + " to number");
+}
+
+long long row::get_int(const std::string &col) const {
+  const boost::optional<long long> value = get_int_opt(col);
+  if (!value) throw wmi_exception(DISP_E_TYPEMISMATCH, col + " is NULL (use get_int_opt for optional fields)");
+  return *value;
 }
 
 bool row_enumerator::has_next() {

--- a/include/win/wmi/wmi_query.hpp
+++ b/include/win/wmi/wmi_query.hpp
@@ -7,6 +7,7 @@
 #include <atlbase.h>
 
 #include <boost/lexical_cast.hpp>
+#include <boost/optional.hpp>
 #include <error/error.hpp>
 #include <list>
 #include <string>
@@ -68,7 +69,12 @@ struct row {
 
   std::string get_string(const std::string& col) const;
   std::string to_string() const;
+  // For mandatory fields: throws when the property is NULL (WMI returns NULL
+  // for optional properties it has no sample for, e.g. Win32_Processor.LoadPercentage).
   long long get_int(const std::string& col) const;
+  // For optional fields: boost::none when the property is NULL or unset; still
+  // throws for a property that does not exist or a value that is not numeric.
+  boost::optional<long long> get_int_opt(const std::string& col) const;
 };
 
 struct row_enumerator {

--- a/include/win/wmi/wmi_query_test.cpp
+++ b/include/win/wmi/wmi_query_test.cpp
@@ -316,6 +316,58 @@ TEST_F(WmiQueryTest, RowGetInt) {
   }
 }
 
+TEST_F(WmiQueryTest, RowGetIntOptReturnsValue) {
+  if (!com_initialized_) {
+    GTEST_SKIP() << "COM not initialized";
+  }
+
+  try {
+    wmi_impl::query q("SELECT ProcessId FROM Win32_Process", "root\\cimv2", "", "");
+    auto enumerator = q.execute();
+
+    if (enumerator.has_next()) {
+      auto& row = enumerator.get_next();
+      const boost::optional<long long> pid = row.get_int_opt("ProcessId");
+      ASSERT_TRUE(pid);
+      EXPECT_GE(*pid, 0);
+    }
+  } catch (const wmi_impl::wmi_exception& ex) {
+    GTEST_SKIP() << "WMI access failed: " << ex.what();
+  }
+}
+
+// A NULL WMI value must read as "no value", not throw away the row (#1391).
+// SpawnInstance gives a deterministic NULL: every property of a freshly
+// spawned instance is VT_NULL until assigned.
+TEST_F(WmiQueryTest, NullValueIsNoneForGetIntOptAndThrowsForGetInt) {
+  if (!com_initialized_) {
+    GTEST_SKIP() << "COM not initialized";
+  }
+
+  try {
+    wmi_impl::wmi_service svc("root\\cimv2", "", "");
+    CComPtr<IWbemClassObject> cls;
+    HRESULT hr = svc.get()->GetObject(CComBSTR(L"Win32_Processor"), 0, nullptr, &cls, nullptr);
+    if (FAILED(hr)) {
+      GTEST_SKIP() << "Failed to fetch the Win32_Processor class object";
+    }
+
+    const std::list<std::string> columns;
+    wmi_impl::row row(columns);
+    ASSERT_TRUE(SUCCEEDED(cls->SpawnInstance(0, &row.row_obj)));
+
+    EXPECT_FALSE(row.get_int_opt("LoadPercentage"));
+    EXPECT_THROW(row.get_int("LoadPercentage"), wmi_impl::wmi_exception);
+    // get_string keeps its long-standing NULL contract.
+    EXPECT_EQ(row.get_string("LoadPercentage"), "<NULL>");
+    // A property that does not exist is still an error, not a none: typos in
+    // mandatory column names must keep surfacing loudly.
+    EXPECT_THROW(row.get_int_opt("NonExistentColumn12345"), wmi_impl::wmi_exception);
+  } catch (const wmi_impl::wmi_exception& ex) {
+    GTEST_SKIP() << "WMI access failed: " << ex.what();
+  }
+}
+
 TEST_F(WmiQueryTest, RowToString) {
   if (!com_initialized_) {
     GTEST_SKIP() << "COM not initialized";

--- a/modules/CheckSystem/check_cpu_frequency.cpp
+++ b/modules/CheckSystem/check_cpu_frequency.cpp
@@ -45,18 +45,6 @@ std::string architecture_to_string(const long long architecture) {
   }
 }
 
-namespace {
-// The inventory columns are absent or NULL on some platforms (VMs, older
-// Windows); read them best-effort instead of failing the whole row.
-long long get_int_or_zero(const wmi_impl::row &r, const char *col) {
-  try {
-    return r.get_int(col);
-  } catch (...) {
-    return 0;
-  }
-}
-}  // namespace
-
 void cpu_frequency::read_wmi(const wmi_impl::row &r) {
   socket_id = r.get_string("DeviceId");
   socket = r.get_string("SocketDesignation");
@@ -65,16 +53,16 @@ void cpu_frequency::read_wmi(const wmi_impl::row &r) {
   max_mhz = r.get_int("MaxClockSpeed");
   number_of_cores = r.get_int("NumberOfCores");
   number_of_logical_processors = r.get_int("NumberOfLogicalProcessors");
-  load_pct = r.get_int("LoadPercentage");
-  // L2/L3CacheSize are reported in KB.
-  l2_cache = get_int_or_zero(r, "L2CacheSize") * 1024;
-  l3_cache = get_int_or_zero(r, "L3CacheSize") * 1024;
-  try {
-    architecture = architecture_to_string(r.get_int("Architecture"));
-  } catch (...) {
-    // Cannot default to 0 here: 0 is a valid value (x86).
-    architecture = "unknown";
-  }
+  // WMI does not always have a load sample ready (#1391); 0 is a valid idle
+  // reading, so a missing sample stays absent rather than becoming a fake 0.
+  load_pct = r.get_int_opt("LoadPercentage");
+  // The inventory columns are absent or NULL on some platforms (VMs, older
+  // Windows). L2/L3CacheSize are reported in KB.
+  l2_cache = r.get_int_opt("L2CacheSize").value_or(0) * 1024;
+  l3_cache = r.get_int_opt("L3CacheSize").value_or(0) * 1024;
+  const boost::optional<long long> arch = r.get_int_opt("Architecture");
+  // Cannot default to 0 here: 0 is a valid value (x86).
+  architecture = arch ? architecture_to_string(*arch) : "unknown";
 }
 
 std::string cpu_frequency::get_l2_cache_human() const { return str::format::format_byte_units(l2_cache); }
@@ -87,7 +75,8 @@ void cpu_frequency::build_metrics(PB::Metrics::MetricsBundle *section) const {
   add_metric(section, name + ".frequency_pct", get_frequency_pct());
   add_metric(section, name + ".cores", number_of_cores);
   add_metric(section, name + ".logical_processors", number_of_logical_processors);
-  add_metric(section, name + ".load_pct", load_pct);
+  // No fabricated 0 when WMI had no load sample this cycle: absent is absent.
+  if (load_pct) add_metric(section, name + ".load_pct", *load_pct);
   add_metric(section, name + ".l2_cache", l2_cache);
   add_metric(section, name + ".l3_cache", l3_cache);
 }
@@ -138,6 +127,14 @@ struct filter_obj_handler : native_context {
 };
 typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter_type;
 
+namespace {
+// What load_pct renders as, and compares equal to, when WMI had no sample for
+// Win32_Processor.LoadPercentage this cycle (`load_pct = 'no load sample'` is
+// the presence test). A missing sample must not read as 0: 0 is a valid idle
+// reading (#1391).
+const char *no_load_sample = "no load sample";
+}  // namespace
+
 filter_obj_handler::filter_obj_handler() {
   registry_.add_string_var("name", &filter_obj::get_name, "CPU name / model string")
       .add_string_var("socket_id", &filter_obj::get_socket_id, "Socket device id (e.g. CPU0), for per-socket filtering")
@@ -149,7 +146,9 @@ filter_obj_handler::filter_obj_handler() {
       .add_int_perf("MHz", "", "_max_mhz")
       .add_int_var("frequency_pct", &filter_obj::get_frequency_pct, "Current frequency as percentage of maximum (perfdata)")
       .add_int_perf("%", "", "_frequency_pct")
-      .add_int_var("load_pct", &filter_obj::get_load_pct, "Per-socket CPU load as reported by Win32_Processor.LoadPercentage (perfdata)")
+      .add_optional_int_var(
+          "load_pct", [](const std::shared_ptr<filter_obj> &obj) { return obj->get_load_pct(); }, no_load_sample,
+          "Per-socket CPU load as reported by Win32_Processor.LoadPercentage (perfdata); 'no load sample' when WMI has no reading this cycle")
       .add_int_perf("%", "", "_load_pct")
       .add_int_var("cores", &filter_obj::get_number_of_cores, "Number of physical cores")
       .add_int_var("logical_processors", &filter_obj::get_number_of_logical_processors, "Number of logical processors (threads)")

--- a/modules/CheckSystem/check_cpu_frequency.hpp
+++ b/modules/CheckSystem/check_cpu_frequency.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <boost/optional.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <list>
 #include <nscapi/protobuf/command.hpp>
@@ -29,14 +30,17 @@ struct cpu_frequency {
   long long max_mhz;
   long long number_of_cores;
   long long number_of_logical_processors;
-  long long load_pct;
+  // WMI does not always have a LoadPercentage sample ready (the property is
+  // NULL every now and then, #1391), so absence is a real state: none means
+  // "no reading this cycle", never 0 (an idle CPU is a valid 0).
+  boost::optional<long long> load_pct;
   // Inventory columns: cache sizes in bytes (0 when the platform does not
   // report them — common on VMs) and the architecture mapped to a name.
   long long l2_cache;
   long long l3_cache;
   std::string architecture;
 
-  cpu_frequency() : current_mhz(0), max_mhz(0), number_of_cores(0), number_of_logical_processors(0), load_pct(0), l2_cache(0), l3_cache(0) {}
+  cpu_frequency() : current_mhz(0), max_mhz(0), number_of_cores(0), number_of_logical_processors(0), l2_cache(0), l3_cache(0) {}
   cpu_frequency(const cpu_frequency &other) = default;
   cpu_frequency &operator=(const cpu_frequency &other) = default;
 
@@ -50,7 +54,7 @@ struct cpu_frequency {
   long long get_max_mhz() const { return max_mhz; }
   long long get_number_of_cores() const { return number_of_cores; }
   long long get_number_of_logical_processors() const { return number_of_logical_processors; }
-  long long get_load_pct() const { return load_pct; }
+  boost::optional<long long> get_load_pct() const { return load_pct; }
   long long get_frequency_pct() const { return max_mhz == 0 ? 0 : (current_mhz * 100 / max_mhz); }
   long long get_l2_cache() const { return l2_cache; }
   long long get_l3_cache() const { return l3_cache; }

--- a/modules/CheckSystem/check_cpu_frequency_test.cpp
+++ b/modules/CheckSystem/check_cpu_frequency_test.cpp
@@ -9,6 +9,10 @@
 
 #include "check_cpu_frequency.hpp"
 
+#include <algorithm>
+#include <string>
+#include <vector>
+
 // ============================================================================
 // cpu_frequency struct tests
 // ============================================================================
@@ -20,6 +24,8 @@ TEST(CpuFrequency, DefaultConstruction) {
   EXPECT_EQ(c.max_mhz, 0);
   EXPECT_EQ(c.number_of_cores, 0);
   EXPECT_EQ(c.number_of_logical_processors, 0);
+  // No load sample is "absent", never a fake 0 (#1391).
+  EXPECT_FALSE(c.load_pct);
 }
 
 TEST(CpuFrequency, Accessors) {
@@ -108,12 +114,29 @@ TEST(CpuFrequency, BuildMetrics) {
   c.max_mhz = 4500;
   c.number_of_cores = 8;
   c.number_of_logical_processors = 16;
+  c.load_pct = 12;
 
   PB::Metrics::MetricsBundle section;
   c.build_metrics(&section);
 
   // current_mhz, max_mhz, frequency_pct, cores, logical_processors, load_pct, l2_cache, l3_cache
   EXPECT_EQ(section.value_size(), 8);
+}
+
+TEST(CpuFrequency, BuildMetricsSkipsMissingLoadSample) {
+  cpu_frequency_check::cpu_frequency c;
+  c.name = "CPU0";
+  c.current_mhz = 3000;
+  c.max_mhz = 4500;
+
+  PB::Metrics::MetricsBundle section;
+  c.build_metrics(&section);
+
+  // load_pct is absent this cycle: no fabricated 0 metric (#1391).
+  EXPECT_EQ(section.value_size(), 7);
+  for (const auto &value : section.value()) {
+    EXPECT_EQ(value.key().find("load_pct"), std::string::npos) << value.key();
+  }
 }
 
 TEST(CpuFrequency, ArchitectureMapping) {
@@ -144,14 +167,105 @@ TEST(CpuFrequency, SocketAndLoadAccessors) {
   c.load_pct = 42;
   EXPECT_EQ(c.get_socket_id(), "CPU0");
   EXPECT_EQ(c.get_socket(), "CPU 1");
-  EXPECT_EQ(c.get_load_pct(), 42);
+  ASSERT_TRUE(c.get_load_pct());
+  EXPECT_EQ(*c.get_load_pct(), 42);
 }
 
 TEST(CpuFrequency, SocketDefaultsEmpty) {
   cpu_frequency_check::cpu_frequency c;
   EXPECT_EQ(c.socket_id, "");
   EXPECT_EQ(c.socket, "");
-  EXPECT_EQ(c.load_pct, 0);
+  EXPECT_FALSE(c.load_pct);
+}
+
+// ============================================================================
+// check_cpu_frequency() filter tests: rows without a load sample (#1391)
+// ============================================================================
+
+namespace {
+cpu_frequency_check::cpus_type one_cpu(const boost::optional<long long> load) {
+  cpu_frequency_check::cpu_frequency c;
+  c.name = "CPU A";
+  c.socket_id = "CPU0";
+  c.socket = "CPU 1";
+  c.current_mhz = 3000;
+  c.max_mhz = 4000;
+  c.number_of_cores = 8;
+  c.number_of_logical_processors = 16;
+  c.load_pct = load;
+  return {c};
+}
+
+PB::Common::ResultCode run_frequency_check(const cpu_frequency_check::cpus_type &data, const std::vector<std::string> &args,
+                                           PB::Commands::QueryResponseMessage::Response &response) {
+  PB::Commands::QueryRequestMessage::Request request;
+  request.set_command("check_cpu_frequency");
+  for (const std::string &a : args) request.add_arguments(a);
+  cpu_frequency_check::check::check_cpu_frequency(request, &response, data);
+  return response.result();
+}
+
+std::string all_messages(const PB::Commands::QueryResponseMessage::Response &r) {
+  std::string out;
+  for (int i = 0; i < r.lines_size(); ++i) {
+    if (!out.empty()) out += "\n";
+    out += r.lines(i).message();
+  }
+  return out;
+}
+
+std::vector<std::string> perf_aliases(const PB::Commands::QueryResponseMessage::Response &r) {
+  std::vector<std::string> out;
+  for (int i = 0; i < r.lines_size(); ++i) {
+    for (int j = 0; j < r.lines(i).perf_size(); ++j) out.push_back(r.lines(i).perf(j).alias());
+  }
+  return out;
+}
+}  // namespace
+
+TEST(CheckCpuFrequency, MissingLoadSampleIsNotEvaluatedAgainstLoadThresholds) {
+  // A row with no load sample must neither trip a load threshold nor read as
+  // an idle 0; every numeric comparison against a missing value is sure-false.
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_frequency_check(one_cpu(boost::none), {"warning=load_pct > 90", "critical=load_pct > 99"}, response), PB::Common::ResultCode::OK)
+      << all_messages(response);
+  EXPECT_EQ(run_frequency_check(one_cpu(boost::none), {"warning=load_pct < 5"}, response), PB::Common::ResultCode::OK) << all_messages(response);
+}
+
+TEST(CheckCpuFrequency, PresentLoadSampleStillTripsLoadThresholds) {
+  PB::Commands::QueryResponseMessage::Response response;
+  EXPECT_EQ(run_frequency_check(one_cpu(95), {"warning=load_pct > 90"}, response), PB::Common::ResultCode::WARNING) << all_messages(response);
+
+  const std::vector<std::string> aliases = perf_aliases(response);
+  EXPECT_NE(std::find(aliases.begin(), aliases.end(), "CPU A_load_pct"), aliases.end()) << all_messages(response);
+}
+
+TEST(CheckCpuFrequency, MissingLoadSampleRendersNoLoadSample) {
+  PB::Commands::QueryResponseMessage::Response response;
+  run_frequency_check(one_cpu(boost::none), {"filter=none", "detail-syntax=%(name): %(load_pct)"}, response);
+
+  const std::string message = all_messages(response);
+  EXPECT_NE(message.find("no load sample"), std::string::npos) << message;
+}
+
+TEST(CheckCpuFrequency, MissingLoadSampleEmitsNoLoadPerfData) {
+  PB::Commands::QueryResponseMessage::Response response;
+  // load_pct is the only metric asked for, so any perfdata at all would be a
+  // fabricated reading for a socket WMI had no sample for.
+  run_frequency_check(one_cpu(boost::none), {"filter=none", "warning=none", "critical=none", "perf-config=extra(load_pct)"}, response);
+
+  EXPECT_TRUE(perf_aliases(response).empty()) << all_messages(response);
+}
+
+TEST(CheckCpuFrequency, LoadKeywordComparableAgainstTheNoValueString) {
+  PB::Commands::QueryResponseMessage::Response response;
+  // The presence test documented for optional keywords.
+  EXPECT_EQ(run_frequency_check(one_cpu(boost::none), {"filter=none", "warning=load_pct = 'no load sample'"}, response), PB::Common::ResultCode::WARNING)
+      << all_messages(response);
+
+  PB::Commands::QueryResponseMessage::Response with_sample;
+  EXPECT_EQ(run_frequency_check(one_cpu(0), {"filter=none", "warning=load_pct = 'no load sample'"}, with_sample), PB::Common::ResultCode::OK)
+      << all_messages(with_sample);
 }
 
 // ============================================================================

--- a/tests/checksystem-commands.test.ts
+++ b/tests/checksystem-commands.test.ts
@@ -519,6 +519,32 @@ describe("CheckSystem commands", () => {
     expect(msg).toMatch(/l2=\S+ l3=\S+/);
   });
 
+  it("check_cpu_frequency load_pct is a sample or explicitly absent (Windows, #1391)", async () => {
+    if (!onWindows) return; // load_pct comes from Win32_Processor.LoadPercentage.
+    const q = await pollQuery(
+      key,
+      "check_cpu_frequency",
+      {
+        // LoadPercentage is 0-100 and a missing sample compares sure-false,
+        // so these never trip: deterministic OK whenever there is data at all.
+        warning: "load_pct > 100",
+        critical: "load_pct > 100",
+        "detail-syntax": "load=${load_pct}",
+      },
+      (r) => r.result !== UNKNOWN,
+      20_000,
+    );
+    if (q.result === UNKNOWN) {
+      expect(messageOf(q)).toMatch(/no cpu frequency/i);
+      return; // Same no-WMI-clock-data contract as the base test above.
+    }
+    expect(q.result).toBe(OK);
+    // A cycle where WMI has no LoadPercentage sample renders the explicit
+    // no-value marker; it must never become a fabricated 0 or discard the
+    // whole collection (#1391).
+    expect(messageOf(q)).toMatch(/load=(\d{1,3}\b|no load sample)/);
+  });
+
   // --- check_network ----------------------------------------------------------
 
   it("check_network lists at least one interface with throughput perf", async () => {


### PR DESCRIPTION
Fixes #1391

## Problem

`Win32_Processor.LoadPercentage` is occasionally NULL (WMI does not always have a sample ready), and `row::get_int` had no case for that: `ChangeType` from `VT_NULL` fails for both integer targets, so the `DISP_E_TYPEMISMATCH` exception escaped half-way through the row, propagated through `query_wmi()`/`fetch()`, and the auxiliary collector logged

```
Failed to get CPU frequency metrics: ... Failed to convert LoadPercentage to number:80020005: ...
```

while throwing away the entire cycle's clock speeds and core counts. One NULL field cost the caller the whole collection.

## Fix

**`wmi_query`: explicit optional accessor, `get_int` stays throwing.**
- New `row::get_int_opt()` returns `boost::none` for `VT_NULL`/`VT_EMPTY`, so optional fields opt in per call site.
- `get_int()` is rebased on it and keeps throwing for mandatory fields — now with a clear `"<col> is NULL"` message instead of the localized COM type-mismatch text.
- A property that does not exist still throws from **both** accessors, so typos in column names keep surfacing loudly.

**`check_cpu_frequency`: `LoadPercentage` becomes a real optional** (the same `add_optional_int_var` pattern as check_disk_health, #1392): a missing sample renders as `no load sample`, compares false against every numeric threshold, and emits no perfdata/metric — never a fabricated 0, which is a valid idle reading. `load_pct = 'no load sample'` is the presence test. The row's clocks, cores and inventory survive the cycle.

The pre-existing `get_int_or_zero` and `catch (...)` workarounds for the inventory columns (`L2CacheSize`, `L3CacheSize`, `Architecture`) collapse into `get_int_opt`, which no longer hides genuine conversion errors.

`CurrentClockSpeed`/`MaxClockSpeed`/core counts deliberately stay mandatory: if those are NULL the row is useless anyway, and the next cycle recovers.

## Scope

The mechanism plus the reported call site. The other `get_int` callers (`check_storagepool`, `check_shadowcopy`, `check_share`, `check_disk_io`, ...) keep today's behaviour and can adopt `get_int_opt` for their legitimately-nullable fields as follow-ups, since each needs a per-field decision about what absence means.

The mangled localized error text noted in the issue (`Incompatibilità??`) is a separate encoding bug in `error::format::from_system` and is not addressed here — though this path no longer produces localized text at all.

## Tests

- `wmi_query_test`: deterministic NULL coverage — `SpawnInstance` yields an instance whose properties are all `VT_NULL`, no dependence on host state: `get_int_opt` → `none`, `get_int` → throws, `get_string` keeps its `<NULL>` contract, nonexistent column still throws.
- `check_cpu_frequency_test`: request-driven filter tests for the no-sample row — thresholds are sure-false, renders `no load sample`, emits no perfdata, presence test works, and a present sample still trips thresholds and emits perf.
- `tests/checksystem-commands.test.ts`: REST case pinning the sample-or-absent contract (`load=<0-100>` or `load=no load sample`, always OK).

Local runs: `wmi_query_test` 40/40, `check_system_test` 444/444, `check_disk_test` 194/194; all five modules that compile `wmi_query.cpp` build clean; jest suite typechecks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
