### PR TITLE
Configurable number rendering for check messages

### DIFF
--- a/docs/docs/concepts/checks.md
+++ b/docs/docs/concepts/checks.md
@@ -428,6 +428,47 @@ long output, shown as a block — which is the point of the exercise.
     a long multi-line result is cut off sooner than the single-line form would be.
 <!-- @formatter:on -->
 
+### Number formatting
+
+By default every byte value scales on its own and carries up to three decimals, which is how a
+single line ends up reading `141.085GB/0.983TB` — two units, six decimals, one disk. Four options
+change that, and they are available on every filter check:
+
+| Option                 | Effect                                                        | Default          |
+|------------------------|---------------------------------------------------------------|------------------|
+| `decimals`             | Decimals to render, exactly (`2` → `25.20`)                   | `-1` (up to 3)   |
+| `byte-unit`            | Pin every byte value to one unit: `B`…`EB`                    | auto per value   |
+| `decimal-separator`    | Radix character — `,` for the European rendering              | `.`              |
+| `thousands-separator`  | Digit grouping for the integer part                           | none             |
+
+```shell
+check_drivesize drive=/ show-all=true
+OK /: 141.085GB/0.983TB used
+
+check_drivesize drive=/ show-all=true decimals=2 byte-unit=GB
+OK /: 141.09GB/1006.85GB used
+
+check_drivesize drive=/ show-all=true decimals=2 byte-unit=GB decimal-separator=, thousands-separator=.
+OK /: 141,09GB/1.006,85GB used
+```
+
+They apply to the byte and percentage keywords and to the
+[functions](#6-functions-transforming-values) below.
+
+<!-- @formatter:off -->
+!!! note "Only the message changes"
+    Performance data is generated from the raw values, so it keeps its full precision and its `.`
+    radix character whatever you set here — graphs and time series are unaffected. The numbers you
+    write in a `filter`, `warning` or `critical` are parsed by the filter language and always use
+    `.` as well: `warning=used > 1.5g` means the same thing with `decimal-separator=,` in force.
+
+!!! tip "Setting it once"
+    These are ordinary check options, so an alias fixes them for a whole command:
+    `[/settings/external scripts/alias] alias_disk = check_drivesize decimals=2 byte-unit=GB`.
+    Real-time filters take the same values as the `decimals`, `byte unit`, `decimal separator` and
+    `thousands separator` settings keys, which inherit from the default template.
+<!-- @formatter:on -->
+
 ---
 
 ## 6. Functions — Transforming Values
@@ -461,15 +502,23 @@ filter        = "scale(rate, 1000000) > 100"
 
 ### Built-in functions
 
-These are available wherever the check exposes them — `check_pdh` ships them today; other checks
-add their own. Run `<check> help` to see the list for a given check.
+These are available wherever the check exposes them — every check with byte-valued keywords does,
+including `check_drivesize`, `check_memory`, `check_network`, `check_pdh` and the disk checks. Run
+`<check> help` to see the list for a given check.
 
-| Function                     | Returns | Purpose                                                                  |
-|------------------------------|---------|--------------------------------------------------------------------------|
-| `format_bytes(value)`        | string  | Auto-scaled human-readable bytes — `4194304 → "4MB"` (1024-based)        |
-| `format_bytes(value, 'MB')`  | string  | Fixed unit. Units: `B`, `K`/`KB`, `M`/`MB`, `G`/`GB`, `T`/`TB`           |
-| `convert_bytes(value, 'MB')` | float   | Numeric value in the named unit — use in thresholds                      |
-| `scale(value, divisor)`      | float   | Divide by an arbitrary divisor — for decimal units (Mbps, etc.)          |
+| Function                        | Returns | Purpose                                                                  |
+|---------------------------------|---------|--------------------------------------------------------------------------|
+| `format_bytes(value)`           | string  | Auto-scaled human-readable bytes — `4194304 → "4MB"` (1024-based)        |
+| `format_bytes(value, 'MB')`     | string  | Fixed unit, without the suffix. Units: `B`, `KB`, `MB`, `GB`, `TB`, …    |
+| `format_bytes(value, 'MB', 1)`  | string  | The same with exactly one decimal                                        |
+| `format_number(value, 2)`       | string  | Any number with a fixed number of decimals — percentages, rates, …       |
+| `convert_bytes(value, 'MB')`    | float   | Numeric value in the named unit — use in thresholds                      |
+| `scale(value, divisor)`         | float   | Divide by an arbitrary divisor — for decimal units (Mbps, etc.)          |
+
+Unit names are case insensitive (`GB`, `gb` and `g` all mean the same thing) and a unit that names
+nothing is reported rather than rendered: `format_bytes(used, 'ZB')` makes the check return UNKNOWN
+with `Unknown byte unit: ZB`. Without an explicit `decimals` argument these follow the check's
+[number formatting](#number-formatting) options.
 
 ### Recipes
 

--- a/docs/docs/reference/check/CheckDisk.md
+++ b/docs/docs/reference/check/CheckDisk.md
@@ -137,25 +137,29 @@ Device-state keywords (populated on `has_device = 1` rows): `friendly_name`,
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                             | Default Value                                                                                                                       |
-|----------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| <a id="check_disk_health_filter"></a>[filter](../common-options.md#filter)                         | name != '_Total'                                                                                                                    |
-| <a id="check_disk_health_warning"></a>[warning](../common-options.md#warning)                      | (has_space = 1 and free_pct < 20) or percent_disk_time > 80 or (has_device = 1 and health_status = 'Warning')                       |
-| <a id="check_disk_health_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                                                     |
-| <a id="check_disk_health_critical"></a>[critical](../common-options.md#critical)                   | (has_space = 1 and free_pct < 10) or percent_disk_time > 95 or (has_device = 1 and (health_status = 'Unhealthy' or is_offline = 1)) |
-| <a id="check_disk_health_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                                                     |
-| <a id="check_disk_health_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                                                     |
-| <a id="check_disk_health_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                                               |
-| <a id="check_disk_health_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                                               |
-| <a id="check_disk_health_empty-state"></a>[empty-state](../common-options.md#empty-state)          | critical                                                                                                                            |
-| <a id="check_disk_health_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                                                     |
-| <a id="check_disk_health_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                                               |
-| <a id="check_disk_health_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                                                   |
-| <a id="check_disk_health_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                                                  |
-| <a id="check_disk_health_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All disks are healthy.                                                                                                   |
-| <a id="check_disk_health_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                                                                                     |
-| <a id="check_disk_health_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${free_pct} free, ${percent_disk_time}% busy, q=${queue_length} iops=${iops}                                               |
-| <a id="check_disk_health_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                                                                                             |
+| Option                                                                                                            | Default Value                                                                                                                       |
+|-------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
+| <a id="check_disk_health_filter"></a>[filter](../common-options.md#filter)                                        | name != '_Total'                                                                                                                    |
+| <a id="check_disk_health_warning"></a>[warning](../common-options.md#warning)                                     | (has_space = 1 and free_pct < 20) or percent_disk_time > 80 or (has_device = 1 and health_status = 'Warning')                       |
+| <a id="check_disk_health_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                                                     |
+| <a id="check_disk_health_critical"></a>[critical](../common-options.md#critical)                                  | (has_space = 1 and free_pct < 10) or percent_disk_time > 95 or (has_device = 1 and (health_status = 'Unhealthy' or is_offline = 1)) |
+| <a id="check_disk_health_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                                                     |
+| <a id="check_disk_health_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                                                     |
+| <a id="check_disk_health_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                                               |
+| <a id="check_disk_health_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                                               |
+| <a id="check_disk_health_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | critical                                                                                                                            |
+| <a id="check_disk_health_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                                                     |
+| <a id="check_disk_health_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                                               |
+| <a id="check_disk_health_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                                                   |
+| <a id="check_disk_health_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                                                  |
+| <a id="check_disk_health_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All disks are healthy.                                                                                                   |
+| <a id="check_disk_health_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                                                                                     |
+| <a id="check_disk_health_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${free_pct} free, ${percent_disk_time}% busy, q=${queue_length} iops=${iops}                                               |
+| <a id="check_disk_health_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                                                                                             |
+| <a id="check_disk_health_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                                                     |
+| <a id="check_disk_health_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                                                     |
+| <a id="check_disk_health_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                                                  |
+| <a id="check_disk_health_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                                                     |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -340,25 +344,29 @@ OK: All disk I/O seems ok.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                         | Default Value                                                                                                        |
-|------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
-| <a id="check_disk_io_filter"></a>[filter](../common-options.md#filter)                         | name != '_Total'                                                                                                     |
-| <a id="check_disk_io_warning"></a>[warning](../common-options.md#warning)                      | percent_disk_time > 80                                                                                               |
-| <a id="check_disk_io_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                                      |
-| <a id="check_disk_io_critical"></a>[critical](../common-options.md#critical)                   | percent_disk_time > 95                                                                                               |
-| <a id="check_disk_io_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                                      |
-| <a id="check_disk_io_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                                      |
-| <a id="check_disk_io_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                                |
-| <a id="check_disk_io_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                                |
-| <a id="check_disk_io_empty-state"></a>[empty-state](../common-options.md#empty-state)          | critical                                                                                                             |
-| <a id="check_disk_io_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                                      |
-| <a id="check_disk_io_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                                |
-| <a id="check_disk_io_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                                    |
-| <a id="check_disk_io_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                                   |
-| <a id="check_disk_io_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All disk I/O seems ok.                                                                                    |
-| <a id="check_disk_io_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                                                                      |
-| <a id="check_disk_io_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${percent_disk_time}% busy, read=${read_bytes_per_sec}B/s write=${write_bytes_per_sec}B/s q=${queue_length} |
-| <a id="check_disk_io_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                                                                              |
+| Option                                                                                                        | Default Value                                                                                                        |
+|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| <a id="check_disk_io_filter"></a>[filter](../common-options.md#filter)                                        | name != '_Total'                                                                                                     |
+| <a id="check_disk_io_warning"></a>[warning](../common-options.md#warning)                                     | percent_disk_time > 80                                                                                               |
+| <a id="check_disk_io_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                                      |
+| <a id="check_disk_io_critical"></a>[critical](../common-options.md#critical)                                  | percent_disk_time > 95                                                                                               |
+| <a id="check_disk_io_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                                      |
+| <a id="check_disk_io_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                                      |
+| <a id="check_disk_io_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                                |
+| <a id="check_disk_io_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                                |
+| <a id="check_disk_io_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | critical                                                                                                             |
+| <a id="check_disk_io_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                                      |
+| <a id="check_disk_io_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                                |
+| <a id="check_disk_io_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                                    |
+| <a id="check_disk_io_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                                   |
+| <a id="check_disk_io_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All disk I/O seems ok.                                                                                    |
+| <a id="check_disk_io_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                                                                      |
+| <a id="check_disk_io_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${percent_disk_time}% busy, read=${read_bytes_per_sec}B/s write=${write_bytes_per_sec}B/s q=${queue_length} |
+| <a id="check_disk_io_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                                                                              |
+| <a id="check_disk_io_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                                      |
+| <a id="check_disk_io_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                                      |
+| <a id="check_disk_io_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                                   |
+| <a id="check_disk_io_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                                      |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -509,25 +517,29 @@ The amount of data to write, in bytes or with a byte unit (e.g. 512, 4k, 1M). Ma
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                            | Default Value           |
-|---------------------------------------------------------------------------------------------------|-------------------------|
-| <a id="check_disk_write_filter"></a>[filter](../common-options.md#filter)                         |                         |
-| <a id="check_disk_write_warning"></a>[warning](../common-options.md#warning)                      |                         |
-| <a id="check_disk_write_warn"></a>[warn](../common-options.md#warn)                               |                         |
-| <a id="check_disk_write_critical"></a>[critical](../common-options.md#critical)                   | has_issues = 1          |
-| <a id="check_disk_write_crit"></a>[crit](../common-options.md#crit)                               |                         |
-| <a id="check_disk_write_ok"></a>[ok](../common-options.md#ok)                                     |                         |
-| <a id="check_disk_write_debug"></a>[debug](../common-options.md#debug)                            | false                   |
-| <a id="check_disk_write_show-all"></a>[show-all](../common-options.md#show-all)                   | false                   |
-| <a id="check_disk_write_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                 |
-| <a id="check_disk_write_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                         |
-| <a id="check_disk_write_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                   |
-| <a id="check_disk_write_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                       |
-| <a id="check_disk_write_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}      |
-| <a id="check_disk_write_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(list)      |
-| <a id="check_disk_write_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No write test performed |
-| <a id="check_disk_write_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | %(path): %(message)     |
-| <a id="check_disk_write_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | %(path)                 |
+| Option                                                                                                           | Default Value           |
+|------------------------------------------------------------------------------------------------------------------|-------------------------|
+| <a id="check_disk_write_filter"></a>[filter](../common-options.md#filter)                                        |                         |
+| <a id="check_disk_write_warning"></a>[warning](../common-options.md#warning)                                     |                         |
+| <a id="check_disk_write_warn"></a>[warn](../common-options.md#warn)                                              |                         |
+| <a id="check_disk_write_critical"></a>[critical](../common-options.md#critical)                                  | has_issues = 1          |
+| <a id="check_disk_write_crit"></a>[crit](../common-options.md#crit)                                              |                         |
+| <a id="check_disk_write_ok"></a>[ok](../common-options.md#ok)                                                    |                         |
+| <a id="check_disk_write_debug"></a>[debug](../common-options.md#debug)                                           | false                   |
+| <a id="check_disk_write_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                   |
+| <a id="check_disk_write_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                 |
+| <a id="check_disk_write_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                         |
+| <a id="check_disk_write_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                   |
+| <a id="check_disk_write_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                       |
+| <a id="check_disk_write_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}      |
+| <a id="check_disk_write_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(list)      |
+| <a id="check_disk_write_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No write test performed |
+| <a id="check_disk_write_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | %(path): %(message)     |
+| <a id="check_disk_write_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | %(path)                 |
+| <a id="check_disk_write_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                         |
+| <a id="check_disk_write_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                         |
+| <a id="check_disk_write_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                      |
+| <a id="check_disk_write_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                         |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -914,25 +926,29 @@ check_drivesize "filter=full_in = 'never'"
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                           | Default Value                          |
-    |--------------------------------------------------------------------------------------------------|----------------------------------------|
-    | <a id="check_drivesize_filter"></a>[filter](../common-options.md#filter)                         | mounted = 1                            |
-    | <a id="check_drivesize_warning"></a>[warning](../common-options.md#warning)                      | used > 80%                             |
-    | <a id="check_drivesize_warn"></a>[warn](../common-options.md#warn)                               |                                        |
-    | <a id="check_drivesize_critical"></a>[critical](../common-options.md#critical)                   | used > 90%                             |
-    | <a id="check_drivesize_crit"></a>[crit](../common-options.md#crit)                               |                                        |
-    | <a id="check_drivesize_ok"></a>[ok](../common-options.md#ok)                                     |                                        |
-    | <a id="check_drivesize_debug"></a>[debug](../common-options.md#debug)                            | false                                  |
-    | <a id="check_drivesize_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                  |
-    | <a id="check_drivesize_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                |
-    | <a id="check_drivesize_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                        |
-    | <a id="check_drivesize_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                  |
-    | <a id="check_drivesize_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                      |
-    | <a id="check_drivesize_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status} ${problem_list}              |
-    | <a id="check_drivesize_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status) All %(count) drive(s) are ok |
-    | <a id="check_drivesize_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No drives found             |
-    | <a id="check_drivesize_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${drive_or_name}: ${used}/${size} used |
-    | <a id="check_drivesize_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${drive_or_id}                         |
+    | Option                                                                                                          | Default Value                          |
+    |-----------------------------------------------------------------------------------------------------------------|----------------------------------------|
+    | <a id="check_drivesize_filter"></a>[filter](../common-options.md#filter)                                        | mounted = 1                            |
+    | <a id="check_drivesize_warning"></a>[warning](../common-options.md#warning)                                     | used > 80%                             |
+    | <a id="check_drivesize_warn"></a>[warn](../common-options.md#warn)                                              |                                        |
+    | <a id="check_drivesize_critical"></a>[critical](../common-options.md#critical)                                  | used > 90%                             |
+    | <a id="check_drivesize_crit"></a>[crit](../common-options.md#crit)                                              |                                        |
+    | <a id="check_drivesize_ok"></a>[ok](../common-options.md#ok)                                                    |                                        |
+    | <a id="check_drivesize_debug"></a>[debug](../common-options.md#debug)                                           | false                                  |
+    | <a id="check_drivesize_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                  |
+    | <a id="check_drivesize_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                |
+    | <a id="check_drivesize_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                        |
+    | <a id="check_drivesize_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                  |
+    | <a id="check_drivesize_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                      |
+    | <a id="check_drivesize_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status} ${problem_list}              |
+    | <a id="check_drivesize_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status) All %(count) drive(s) are ok |
+    | <a id="check_drivesize_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No drives found             |
+    | <a id="check_drivesize_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${drive_or_name}: ${used}/${size} used |
+    | <a id="check_drivesize_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${drive_or_id}                         |
+    | <a id="check_drivesize_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                        |
+    | <a id="check_drivesize_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                        |
+    | <a id="check_drivesize_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                     |
+    | <a id="check_drivesize_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                        |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -981,25 +997,29 @@ check_drivesize "filter=full_in = 'never'"
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                           | Default Value                          |
-    |--------------------------------------------------------------------------------------------------|----------------------------------------|
-    | <a id="check_drivesize_filter"></a>[filter](../common-options.md#filter)                         | mounted = 1                            |
-    | <a id="check_drivesize_warning"></a>[warning](../common-options.md#warning)                      | used > 80%                             |
-    | <a id="check_drivesize_warn"></a>[warn](../common-options.md#warn)                               |                                        |
-    | <a id="check_drivesize_critical"></a>[critical](../common-options.md#critical)                   | used > 90%                             |
-    | <a id="check_drivesize_crit"></a>[crit](../common-options.md#crit)                               |                                        |
-    | <a id="check_drivesize_ok"></a>[ok](../common-options.md#ok)                                     |                                        |
-    | <a id="check_drivesize_debug"></a>[debug](../common-options.md#debug)                            | false                                  |
-    | <a id="check_drivesize_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                  |
-    | <a id="check_drivesize_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                |
-    | <a id="check_drivesize_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                        |
-    | <a id="check_drivesize_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                  |
-    | <a id="check_drivesize_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                      |
-    | <a id="check_drivesize_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status} ${problem_list}              |
-    | <a id="check_drivesize_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status) All %(count) drive(s) are ok |
-    | <a id="check_drivesize_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No drives found             |
-    | <a id="check_drivesize_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${drive_or_name}: ${used}/${size} used |
-    | <a id="check_drivesize_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${drive_or_id}                         |
+    | Option                                                                                                          | Default Value                          |
+    |-----------------------------------------------------------------------------------------------------------------|----------------------------------------|
+    | <a id="check_drivesize_filter"></a>[filter](../common-options.md#filter)                                        | mounted = 1                            |
+    | <a id="check_drivesize_warning"></a>[warning](../common-options.md#warning)                                     | used > 80%                             |
+    | <a id="check_drivesize_warn"></a>[warn](../common-options.md#warn)                                              |                                        |
+    | <a id="check_drivesize_critical"></a>[critical](../common-options.md#critical)                                  | used > 90%                             |
+    | <a id="check_drivesize_crit"></a>[crit](../common-options.md#crit)                                              |                                        |
+    | <a id="check_drivesize_ok"></a>[ok](../common-options.md#ok)                                                    |                                        |
+    | <a id="check_drivesize_debug"></a>[debug](../common-options.md#debug)                                           | false                                  |
+    | <a id="check_drivesize_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                  |
+    | <a id="check_drivesize_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                |
+    | <a id="check_drivesize_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                        |
+    | <a id="check_drivesize_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                  |
+    | <a id="check_drivesize_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                      |
+    | <a id="check_drivesize_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status} ${problem_list}              |
+    | <a id="check_drivesize_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status) All %(count) drive(s) are ok |
+    | <a id="check_drivesize_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No drives found             |
+    | <a id="check_drivesize_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${drive_or_name}: ${used}/${size} used |
+    | <a id="check_drivesize_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${drive_or_id}                         |
+    | <a id="check_drivesize_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                        |
+    | <a id="check_drivesize_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                        |
+    | <a id="check_drivesize_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                     |
+    | <a id="check_drivesize_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                        |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1275,25 +1295,29 @@ Silently skip top-level paths that do not exist, instead of failing the whole ch
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                       | Default Value                                                |
-|----------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| <a id="check_files_filter"></a>[filter](../common-options.md#filter)                         |                                                              |
-| <a id="check_files_warning"></a>[warning](../common-options.md#warning)                      |                                                              |
-| <a id="check_files_warn"></a>[warn](../common-options.md#warn)                               |                                                              |
-| <a id="check_files_critical"></a>[critical](../common-options.md#critical)                   |                                                              |
-| <a id="check_files_crit"></a>[crit](../common-options.md#crit)                               |                                                              |
-| <a id="check_files_ok"></a>[ok](../common-options.md#ok)                                     |                                                              |
-| <a id="check_files_debug"></a>[debug](../common-options.md#debug)                            | false                                                        |
-| <a id="check_files_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                        |
-| <a id="check_files_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                      |
-| <a id="check_files_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                              |
-| <a id="check_files_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                        |
-| <a id="check_files_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                            |
-| <a id="check_files_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_count}/${count} files (${problem_list}) |
-| <a id="check_files_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) files are ok                         |
-| <a id="check_files_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No files found                                               |
-| <a id="check_files_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}                                                      |
-| <a id="check_files_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                      |
+| Option                                                                                                      | Default Value                                                |
+|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| <a id="check_files_filter"></a>[filter](../common-options.md#filter)                                        |                                                              |
+| <a id="check_files_warning"></a>[warning](../common-options.md#warning)                                     |                                                              |
+| <a id="check_files_warn"></a>[warn](../common-options.md#warn)                                              |                                                              |
+| <a id="check_files_critical"></a>[critical](../common-options.md#critical)                                  |                                                              |
+| <a id="check_files_crit"></a>[crit](../common-options.md#crit)                                              |                                                              |
+| <a id="check_files_ok"></a>[ok](../common-options.md#ok)                                                    |                                                              |
+| <a id="check_files_debug"></a>[debug](../common-options.md#debug)                                           | false                                                        |
+| <a id="check_files_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                        |
+| <a id="check_files_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                      |
+| <a id="check_files_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                              |
+| <a id="check_files_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                        |
+| <a id="check_files_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                            |
+| <a id="check_files_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_count}/${count} files (${problem_list}) |
+| <a id="check_files_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) files are ok                         |
+| <a id="check_files_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No files found                                               |
+| <a id="check_files_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}                                                      |
+| <a id="check_files_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                      |
+| <a id="check_files_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                              |
+| <a id="check_files_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                              |
+| <a id="check_files_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                           |
+| <a id="check_files_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                              |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1439,25 +1463,29 @@ OK: mounts are as expected
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                       | Default Value                                  |
-|----------------------------------------------------------------------------------------------|------------------------------------------------|
-| <a id="check_mount_filter"></a>[filter](../common-options.md#filter)                         |                                                |
-| <a id="check_mount_warning"></a>[warning](../common-options.md#warning)                      | has_issues = 1                                 |
-| <a id="check_mount_warn"></a>[warn](../common-options.md#warn)                               |                                                |
-| <a id="check_mount_critical"></a>[critical](../common-options.md#critical)                   | issues like 'not mounted'                      |
-| <a id="check_mount_crit"></a>[crit](../common-options.md#crit)                               |                                                |
-| <a id="check_mount_ok"></a>[ok](../common-options.md#ok)                                     |                                                |
-| <a id="check_mount_debug"></a>[debug](../common-options.md#debug)                            | false                                          |
-| <a id="check_mount_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                          |
-| <a id="check_mount_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                        |
-| <a id="check_mount_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                |
-| <a id="check_mount_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                          |
-| <a id="check_mount_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                              |
-| <a id="check_mount_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                     |
-| <a id="check_mount_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): mounts are as expected              |
-| <a id="check_mount_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | check_mount found nothing matching this filter |
-| <a id="check_mount_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | mount ${mount} ${issues}                       |
-| <a id="check_mount_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${mount}                                       |
+| Option                                                                                                      | Default Value                                  |
+|-------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+| <a id="check_mount_filter"></a>[filter](../common-options.md#filter)                                        |                                                |
+| <a id="check_mount_warning"></a>[warning](../common-options.md#warning)                                     | has_issues = 1                                 |
+| <a id="check_mount_warn"></a>[warn](../common-options.md#warn)                                              |                                                |
+| <a id="check_mount_critical"></a>[critical](../common-options.md#critical)                                  | issues like 'not mounted'                      |
+| <a id="check_mount_crit"></a>[crit](../common-options.md#crit)                                              |                                                |
+| <a id="check_mount_ok"></a>[ok](../common-options.md#ok)                                                    |                                                |
+| <a id="check_mount_debug"></a>[debug](../common-options.md#debug)                                           | false                                          |
+| <a id="check_mount_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                          |
+| <a id="check_mount_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                        |
+| <a id="check_mount_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                |
+| <a id="check_mount_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                          |
+| <a id="check_mount_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                              |
+| <a id="check_mount_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                     |
+| <a id="check_mount_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): mounts are as expected              |
+| <a id="check_mount_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | check_mount found nothing matching this filter |
+| <a id="check_mount_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | mount ${mount} ${issues}                       |
+| <a id="check_mount_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${mount}                                       |
+| <a id="check_mount_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                |
+| <a id="check_mount_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                |
+| <a id="check_mount_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                             |
+| <a id="check_mount_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1584,25 +1612,29 @@ OK: \\?\Volume{4c2b...}\: 12 copies, newest 2026-07-11 07:00:03 UTC
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                            | Default Value                                                |
-|---------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-| <a id="check_shadowcopy_filter"></a>[filter](../common-options.md#filter)                         |                                                              |
-| <a id="check_shadowcopy_warning"></a>[warning](../common-options.md#warning)                      | newest > 26h                                                 |
-| <a id="check_shadowcopy_warn"></a>[warn](../common-options.md#warn)                               |                                                              |
-| <a id="check_shadowcopy_critical"></a>[critical](../common-options.md#critical)                   | newest > 50h                                                 |
-| <a id="check_shadowcopy_crit"></a>[crit](../common-options.md#crit)                               |                                                              |
-| <a id="check_shadowcopy_ok"></a>[ok](../common-options.md#ok)                                     |                                                              |
-| <a id="check_shadowcopy_debug"></a>[debug](../common-options.md#debug)                            | false                                                        |
-| <a id="check_shadowcopy_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                        |
-| <a id="check_shadowcopy_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                           |
-| <a id="check_shadowcopy_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                              |
-| <a id="check_shadowcopy_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                        |
-| <a id="check_shadowcopy_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                            |
-| <a id="check_shadowcopy_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                           |
-| <a id="check_shadowcopy_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) volume(s) have recent shadow copies. |
-| <a id="check_shadowcopy_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No shadow copies found                            |
-| <a id="check_shadowcopy_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${volume}: ${copies} copies, newest ${newest_date}           |
-| <a id="check_shadowcopy_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${volume}                                                    |
+| Option                                                                                                           | Default Value                                                |
+|------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+| <a id="check_shadowcopy_filter"></a>[filter](../common-options.md#filter)                                        |                                                              |
+| <a id="check_shadowcopy_warning"></a>[warning](../common-options.md#warning)                                     | newest > 26h                                                 |
+| <a id="check_shadowcopy_warn"></a>[warn](../common-options.md#warn)                                              |                                                              |
+| <a id="check_shadowcopy_critical"></a>[critical](../common-options.md#critical)                                  | newest > 50h                                                 |
+| <a id="check_shadowcopy_crit"></a>[crit](../common-options.md#crit)                                              |                                                              |
+| <a id="check_shadowcopy_ok"></a>[ok](../common-options.md#ok)                                                    |                                                              |
+| <a id="check_shadowcopy_debug"></a>[debug](../common-options.md#debug)                                           | false                                                        |
+| <a id="check_shadowcopy_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                        |
+| <a id="check_shadowcopy_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                           |
+| <a id="check_shadowcopy_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                              |
+| <a id="check_shadowcopy_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                        |
+| <a id="check_shadowcopy_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                            |
+| <a id="check_shadowcopy_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                           |
+| <a id="check_shadowcopy_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) volume(s) have recent shadow copies. |
+| <a id="check_shadowcopy_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No shadow copies found                            |
+| <a id="check_shadowcopy_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${volume}: ${copies} copies, newest ${newest_date}           |
+| <a id="check_shadowcopy_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${volume}                                                    |
+| <a id="check_shadowcopy_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                              |
+| <a id="check_shadowcopy_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                              |
+| <a id="check_shadowcopy_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                           |
+| <a id="check_shadowcopy_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                              |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1732,25 +1764,29 @@ OK: All 2 share(s) ok.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                       | Default Value                                          |
-|----------------------------------------------------------------------------------------------|--------------------------------------------------------|
-| <a id="check_share_filter"></a>[filter](../common-options.md#filter)                         |                                                        |
-| <a id="check_share_warning"></a>[warning](../common-options.md#warning)                      |                                                        |
-| <a id="check_share_warn"></a>[warn](../common-options.md#warn)                               |                                                        |
-| <a id="check_share_critical"></a>[critical](../common-options.md#critical)                   | not exists                                             |
-| <a id="check_share_crit"></a>[crit](../common-options.md#crit)                               |                                                        |
-| <a id="check_share_ok"></a>[ok](../common-options.md#ok)                                     |                                                        |
-| <a id="check_share_debug"></a>[debug](../common-options.md#debug)                            | false                                                  |
-| <a id="check_share_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                  |
-| <a id="check_share_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                     |
-| <a id="check_share_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                        |
-| <a id="check_share_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                  |
-| <a id="check_share_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                      |
-| <a id="check_share_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                     |
-| <a id="check_share_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) share(s) ok.                   |
-| <a id="check_share_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No shares found                             |
-| <a id="check_share_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name} (type=${type}, path=${path}, exists=${exists}) |
-| <a id="check_share_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                |
+| Option                                                                                                      | Default Value                                          |
+|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| <a id="check_share_filter"></a>[filter](../common-options.md#filter)                                        |                                                        |
+| <a id="check_share_warning"></a>[warning](../common-options.md#warning)                                     |                                                        |
+| <a id="check_share_warn"></a>[warn](../common-options.md#warn)                                              |                                                        |
+| <a id="check_share_critical"></a>[critical](../common-options.md#critical)                                  | not exists                                             |
+| <a id="check_share_crit"></a>[crit](../common-options.md#crit)                                              |                                                        |
+| <a id="check_share_ok"></a>[ok](../common-options.md#ok)                                                    |                                                        |
+| <a id="check_share_debug"></a>[debug](../common-options.md#debug)                                           | false                                                  |
+| <a id="check_share_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                  |
+| <a id="check_share_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                     |
+| <a id="check_share_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                        |
+| <a id="check_share_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                  |
+| <a id="check_share_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                      |
+| <a id="check_share_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                     |
+| <a id="check_share_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) share(s) ok.                   |
+| <a id="check_share_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No shares found                             |
+| <a id="check_share_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name} (type=${type}, path=${path}, exists=${exists}) |
+| <a id="check_share_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                |
+| <a id="check_share_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                        |
+| <a id="check_share_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                        |
+| <a id="check_share_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                     |
+| <a id="check_share_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1912,25 +1948,29 @@ Return OK instead of failing when the file does not exist. Intended for files th
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                             | Default Value                          |
-|----------------------------------------------------------------------------------------------------|----------------------------------------|
-| <a id="check_single_file_filter"></a>[filter](../common-options.md#filter)                         |                                        |
-| <a id="check_single_file_warning"></a>[warning](../common-options.md#warning)                      |                                        |
-| <a id="check_single_file_warn"></a>[warn](../common-options.md#warn)                               |                                        |
-| <a id="check_single_file_critical"></a>[critical](../common-options.md#critical)                   |                                        |
-| <a id="check_single_file_crit"></a>[crit](../common-options.md#crit)                               |                                        |
-| <a id="check_single_file_ok"></a>[ok](../common-options.md#ok)                                     |                                        |
-| <a id="check_single_file_debug"></a>[debug](../common-options.md#debug)                            | false                                  |
-| <a id="check_single_file_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                  |
-| <a id="check_single_file_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                     |
-| <a id="check_single_file_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                        |
-| <a id="check_single_file_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                  |
-| <a id="check_single_file_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                      |
-| <a id="check_single_file_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | %(status): %(list)                     |
-| <a id="check_single_file_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(filename) is ok           |
-| <a id="check_single_file_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No file inspected                      |
-| <a id="check_single_file_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | %(filename) (size=%(size), age=%(age)) |
-| <a id="check_single_file_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | %(filename)                            |
+| Option                                                                                                            | Default Value                          |
+|-------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| <a id="check_single_file_filter"></a>[filter](../common-options.md#filter)                                        |                                        |
+| <a id="check_single_file_warning"></a>[warning](../common-options.md#warning)                                     |                                        |
+| <a id="check_single_file_warn"></a>[warn](../common-options.md#warn)                                              |                                        |
+| <a id="check_single_file_critical"></a>[critical](../common-options.md#critical)                                  |                                        |
+| <a id="check_single_file_crit"></a>[crit](../common-options.md#crit)                                              |                                        |
+| <a id="check_single_file_ok"></a>[ok](../common-options.md#ok)                                                    |                                        |
+| <a id="check_single_file_debug"></a>[debug](../common-options.md#debug)                                           | false                                  |
+| <a id="check_single_file_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                  |
+| <a id="check_single_file_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                     |
+| <a id="check_single_file_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                        |
+| <a id="check_single_file_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                  |
+| <a id="check_single_file_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                      |
+| <a id="check_single_file_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | %(status): %(list)                     |
+| <a id="check_single_file_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(filename) is ok           |
+| <a id="check_single_file_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No file inspected                      |
+| <a id="check_single_file_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | %(filename) (size=%(size), age=%(age)) |
+| <a id="check_single_file_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | %(filename)                            |
+| <a id="check_single_file_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                        |
+| <a id="check_single_file_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                        |
+| <a id="check_single_file_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                     |
+| <a id="check_single_file_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2036,25 +2076,29 @@ Keywords: `name`, `health_status` (Healthy/Warning/Unhealthy/Unknown),
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                             | Default Value                                       |
-|----------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| <a id="check_storagepool_filter"></a>[filter](../common-options.md#filter)                         |                                                     |
-| <a id="check_storagepool_warning"></a>[warning](../common-options.md#warning)                      | health_status = 'Warning' or free_pct < 20          |
-| <a id="check_storagepool_warn"></a>[warn](../common-options.md#warn)                               |                                                     |
-| <a id="check_storagepool_critical"></a>[critical](../common-options.md#critical)                   | health_status = 'Unhealthy' or free_pct < 10        |
-| <a id="check_storagepool_crit"></a>[crit](../common-options.md#crit)                               |                                                     |
-| <a id="check_storagepool_ok"></a>[ok](../common-options.md#ok)                                     |                                                     |
-| <a id="check_storagepool_debug"></a>[debug](../common-options.md#debug)                            | false                                               |
-| <a id="check_storagepool_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                               |
-| <a id="check_storagepool_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                  |
-| <a id="check_storagepool_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                     |
-| <a id="check_storagepool_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                               |
-| <a id="check_storagepool_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                   |
-| <a id="check_storagepool_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                  |
-| <a id="check_storagepool_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All storage pools are healthy.           |
-| <a id="check_storagepool_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No storage pools found                   |
-| <a id="check_storagepool_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${health_status}, ${used}/${capacity} used |
-| <a id="check_storagepool_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                             |
+| Option                                                                                                            | Default Value                                       |
+|-------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| <a id="check_storagepool_filter"></a>[filter](../common-options.md#filter)                                        |                                                     |
+| <a id="check_storagepool_warning"></a>[warning](../common-options.md#warning)                                     | health_status = 'Warning' or free_pct < 20          |
+| <a id="check_storagepool_warn"></a>[warn](../common-options.md#warn)                                              |                                                     |
+| <a id="check_storagepool_critical"></a>[critical](../common-options.md#critical)                                  | health_status = 'Unhealthy' or free_pct < 10        |
+| <a id="check_storagepool_crit"></a>[crit](../common-options.md#crit)                                              |                                                     |
+| <a id="check_storagepool_ok"></a>[ok](../common-options.md#ok)                                                    |                                                     |
+| <a id="check_storagepool_debug"></a>[debug](../common-options.md#debug)                                           | false                                               |
+| <a id="check_storagepool_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                               |
+| <a id="check_storagepool_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                  |
+| <a id="check_storagepool_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                     |
+| <a id="check_storagepool_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                               |
+| <a id="check_storagepool_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                   |
+| <a id="check_storagepool_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                  |
+| <a id="check_storagepool_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All storage pools are healthy.           |
+| <a id="check_storagepool_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No storage pools found                   |
+| <a id="check_storagepool_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${health_status}, ${used}/${capacity} used |
+| <a id="check_storagepool_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                             |
+| <a id="check_storagepool_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                     |
+| <a id="check_storagepool_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                     |
+| <a id="check_storagepool_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                  |
+| <a id="check_storagepool_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                     |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2160,25 +2204,29 @@ check_uncpath path=\\a\share path=\\b\share "crit=free_pct < 10" "top-syntax=${s
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                         | Default Value                                |
-|------------------------------------------------------------------------------------------------|----------------------------------------------|
-| <a id="check_uncpath_filter"></a>[filter](../common-options.md#filter)                         |                                              |
-| <a id="check_uncpath_warning"></a>[warning](../common-options.md#warning)                      | used_pct > 80                                |
-| <a id="check_uncpath_warn"></a>[warn](../common-options.md#warn)                               |                                              |
-| <a id="check_uncpath_critical"></a>[critical](../common-options.md#critical)                   | used_pct > 90                                |
-| <a id="check_uncpath_crit"></a>[crit](../common-options.md#crit)                               |                                              |
-| <a id="check_uncpath_ok"></a>[ok](../common-options.md#ok)                                     |                                              |
-| <a id="check_uncpath_debug"></a>[debug](../common-options.md#debug)                            | false                                        |
-| <a id="check_uncpath_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                        |
-| <a id="check_uncpath_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                      |
-| <a id="check_uncpath_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                              |
-| <a id="check_uncpath_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                        |
-| <a id="check_uncpath_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                            |
-| <a id="check_uncpath_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                           |
-| <a id="check_uncpath_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All UNC paths are ok.             |
-| <a id="check_uncpath_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No paths checked                  |
-| <a id="check_uncpath_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${path}: ${used}/${size} used (${free} free) |
-| <a id="check_uncpath_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${path}                                      |
+| Option                                                                                                        | Default Value                                |
+|---------------------------------------------------------------------------------------------------------------|----------------------------------------------|
+| <a id="check_uncpath_filter"></a>[filter](../common-options.md#filter)                                        |                                              |
+| <a id="check_uncpath_warning"></a>[warning](../common-options.md#warning)                                     | used_pct > 80                                |
+| <a id="check_uncpath_warn"></a>[warn](../common-options.md#warn)                                              |                                              |
+| <a id="check_uncpath_critical"></a>[critical](../common-options.md#critical)                                  | used_pct > 90                                |
+| <a id="check_uncpath_crit"></a>[crit](../common-options.md#crit)                                              |                                              |
+| <a id="check_uncpath_ok"></a>[ok](../common-options.md#ok)                                                    |                                              |
+| <a id="check_uncpath_debug"></a>[debug](../common-options.md#debug)                                           | false                                        |
+| <a id="check_uncpath_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                        |
+| <a id="check_uncpath_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                      |
+| <a id="check_uncpath_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                              |
+| <a id="check_uncpath_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                        |
+| <a id="check_uncpath_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                            |
+| <a id="check_uncpath_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                           |
+| <a id="check_uncpath_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All UNC paths are ok.             |
+| <a id="check_uncpath_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No paths checked                  |
+| <a id="check_uncpath_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${path}: ${used}/${size} used (${free} free) |
+| <a id="check_uncpath_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${path}                                      |
+| <a id="check_uncpath_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                              |
+| <a id="check_uncpath_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                              |
+| <a id="check_uncpath_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                           |
+| <a id="check_uncpath_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                              |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/check/CheckHelpers.md
+++ b/docs/docs/reference/check/CheckHelpers.md
@@ -440,26 +440,30 @@ List of arguments (for wrapped command)
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                       | Default Value                                          |
-|----------------------------------------------------------------------------------------------|--------------------------------------------------------|
-| <a id="render_perf_filter"></a>[filter](../common-options.md#filter)                         |                                                        |
-| <a id="render_perf_warning"></a>[warning](../common-options.md#warning)                      |                                                        |
-| <a id="render_perf_warn"></a>[warn](../common-options.md#warn)                               |                                                        |
-| <a id="render_perf_critical"></a>[critical](../common-options.md#critical)                   |                                                        |
-| <a id="render_perf_crit"></a>[crit](../common-options.md#crit)                               |                                                        |
-| <a id="render_perf_ok"></a>[ok](../common-options.md#ok)                                     |                                                        |
-| <a id="render_perf_debug"></a>[debug](../common-options.md#debug)                            | false                                                  |
-| <a id="render_perf_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                  |
-| <a id="render_perf_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                |
-| <a id="render_perf_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                        |
-| <a id="render_perf_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                  |
-| <a id="render_perf_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                      |
-| <a id="render_perf_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | %(status): %(message) %(list)                          |
-| <a id="render_perf_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                        |
-| <a id="render_perf_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                        |
-| <a id="render_perf_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | %(key)	%(value)	%(unit)	%(warn)	%(crit)	%(min)	%(max)
+| Option                                                                                                      | Default Value                                          |
+|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| <a id="render_perf_filter"></a>[filter](../common-options.md#filter)                                        |                                                        |
+| <a id="render_perf_warning"></a>[warning](../common-options.md#warning)                                     |                                                        |
+| <a id="render_perf_warn"></a>[warn](../common-options.md#warn)                                              |                                                        |
+| <a id="render_perf_critical"></a>[critical](../common-options.md#critical)                                  |                                                        |
+| <a id="render_perf_crit"></a>[crit](../common-options.md#crit)                                              |                                                        |
+| <a id="render_perf_ok"></a>[ok](../common-options.md#ok)                                                    |                                                        |
+| <a id="render_perf_debug"></a>[debug](../common-options.md#debug)                                           | false                                                  |
+| <a id="render_perf_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                  |
+| <a id="render_perf_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                |
+| <a id="render_perf_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                        |
+| <a id="render_perf_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                  |
+| <a id="render_perf_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                      |
+| <a id="render_perf_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | %(status): %(message) %(list)                          |
+| <a id="render_perf_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                        |
+| <a id="render_perf_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                        |
+| <a id="render_perf_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | %(key)	%(value)	%(unit)	%(warn)	%(crit)	%(min)	%(max)
  |
-| <a id="render_perf_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | %(key)                                                 |
+| <a id="render_perf_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | %(key)                                                 |
+| <a id="render_perf_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                        |
+| <a id="render_perf_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                        |
+| <a id="render_perf_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                     |
+| <a id="render_perf_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/check/CheckLogFile.md
+++ b/docs/docs/reference/check/CheckLogFile.md
@@ -391,25 +391,29 @@ This only decides which end `max-lines` counts from; lines are always reported i
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                         | Default Value                       |
-|------------------------------------------------------------------------------------------------|-------------------------------------|
-| <a id="check_logfile_filter"></a>[filter](../common-options.md#filter)                         |                                     |
-| <a id="check_logfile_warning"></a>[warning](../common-options.md#warning)                      |                                     |
-| <a id="check_logfile_warn"></a>[warn](../common-options.md#warn)                               |                                     |
-| <a id="check_logfile_critical"></a>[critical](../common-options.md#critical)                   |                                     |
-| <a id="check_logfile_crit"></a>[crit](../common-options.md#crit)                               |                                     |
-| <a id="check_logfile_ok"></a>[ok](../common-options.md#ok)                                     |                                     |
-| <a id="check_logfile_debug"></a>[debug](../common-options.md#debug)                            | false                               |
-| <a id="check_logfile_show-all"></a>[show-all](../common-options.md#show-all)                   | false                               |
-| <a id="check_logfile_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                             |
-| <a id="check_logfile_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                     |
-| <a id="check_logfile_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                               |
-| <a id="check_logfile_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                   |
-| <a id="check_logfile_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${count}/${total} (${problem_list}) |
-| <a id="check_logfile_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                     |
-| <a id="check_logfile_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): Nothing found            |
-| <a id="check_logfile_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${column1}                          |
-| <a id="check_logfile_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${column1}                          |
+| Option                                                                                                        | Default Value                       |
+|---------------------------------------------------------------------------------------------------------------|-------------------------------------|
+| <a id="check_logfile_filter"></a>[filter](../common-options.md#filter)                                        |                                     |
+| <a id="check_logfile_warning"></a>[warning](../common-options.md#warning)                                     |                                     |
+| <a id="check_logfile_warn"></a>[warn](../common-options.md#warn)                                              |                                     |
+| <a id="check_logfile_critical"></a>[critical](../common-options.md#critical)                                  |                                     |
+| <a id="check_logfile_crit"></a>[crit](../common-options.md#crit)                                              |                                     |
+| <a id="check_logfile_ok"></a>[ok](../common-options.md#ok)                                                    |                                     |
+| <a id="check_logfile_debug"></a>[debug](../common-options.md#debug)                                           | false                               |
+| <a id="check_logfile_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                               |
+| <a id="check_logfile_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                             |
+| <a id="check_logfile_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                     |
+| <a id="check_logfile_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                               |
+| <a id="check_logfile_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                   |
+| <a id="check_logfile_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${count}/${total} (${problem_list}) |
+| <a id="check_logfile_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                     |
+| <a id="check_logfile_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): Nothing found            |
+| <a id="check_logfile_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${column1}                          |
+| <a id="check_logfile_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${column1}                          |
+| <a id="check_logfile_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                     |
+| <a id="check_logfile_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                     |
+| <a id="check_logfile_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                  |
+| <a id="check_logfile_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                     |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/check/CheckNSCP.md
+++ b/docs/docs/reference/check/CheckNSCP.md
@@ -60,25 +60,29 @@ Check if there is a newer version of NSClient++ available on GitHub. The result 
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                             | Default Value                          |
-|----------------------------------------------------------------------------------------------------|----------------------------------------|
-| <a id="check_nscp_update_filter"></a>[filter](../common-options.md#filter)                         |                                        |
-| <a id="check_nscp_update_warning"></a>[warning](../common-options.md#warning)                      | update_available = 1                   |
-| <a id="check_nscp_update_warn"></a>[warn](../common-options.md#warn)                               |                                        |
-| <a id="check_nscp_update_critical"></a>[critical](../common-options.md#critical)                   | update_available = 1                   |
-| <a id="check_nscp_update_crit"></a>[crit](../common-options.md#crit)                               |                                        |
-| <a id="check_nscp_update_ok"></a>[ok](../common-options.md#ok)                                     |                                        |
-| <a id="check_nscp_update_debug"></a>[debug](../common-options.md#debug)                            | false                                  |
-| <a id="check_nscp_update_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                  |
-| <a id="check_nscp_update_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                |
-| <a id="check_nscp_update_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                        |
-| <a id="check_nscp_update_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                  |
-| <a id="check_nscp_update_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                      |
-| <a id="check_nscp_update_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                     |
-| <a id="check_nscp_update_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                        |
-| <a id="check_nscp_update_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                        |
-| <a id="check_nscp_update_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${version} (latest: ${latest_version}) |
-| <a id="check_nscp_update_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | version                                |
+| Option                                                                                                            | Default Value                          |
+|-------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+| <a id="check_nscp_update_filter"></a>[filter](../common-options.md#filter)                                        |                                        |
+| <a id="check_nscp_update_warning"></a>[warning](../common-options.md#warning)                                     | update_available = 1                   |
+| <a id="check_nscp_update_warn"></a>[warn](../common-options.md#warn)                                              |                                        |
+| <a id="check_nscp_update_critical"></a>[critical](../common-options.md#critical)                                  | update_available = 1                   |
+| <a id="check_nscp_update_crit"></a>[crit](../common-options.md#crit)                                              |                                        |
+| <a id="check_nscp_update_ok"></a>[ok](../common-options.md#ok)                                                    |                                        |
+| <a id="check_nscp_update_debug"></a>[debug](../common-options.md#debug)                                           | false                                  |
+| <a id="check_nscp_update_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                  |
+| <a id="check_nscp_update_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                |
+| <a id="check_nscp_update_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                        |
+| <a id="check_nscp_update_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                  |
+| <a id="check_nscp_update_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                      |
+| <a id="check_nscp_update_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                     |
+| <a id="check_nscp_update_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                        |
+| <a id="check_nscp_update_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                        |
+| <a id="check_nscp_update_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${version} (latest: ${latest_version}) |
+| <a id="check_nscp_update_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | version                                |
+| <a id="check_nscp_update_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                        |
+| <a id="check_nscp_update_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                        |
+| <a id="check_nscp_update_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                     |
+| <a id="check_nscp_update_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -128,25 +132,29 @@ Check the version of NSClient++ which is used.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                              | Default Value        |
-|-----------------------------------------------------------------------------------------------------|----------------------|
-| <a id="check_nscp_version_filter"></a>[filter](../common-options.md#filter)                         |                      |
-| <a id="check_nscp_version_warning"></a>[warning](../common-options.md#warning)                      |                      |
-| <a id="check_nscp_version_warn"></a>[warn](../common-options.md#warn)                               |                      |
-| <a id="check_nscp_version_critical"></a>[critical](../common-options.md#critical)                   |                      |
-| <a id="check_nscp_version_crit"></a>[crit](../common-options.md#crit)                               |                      |
-| <a id="check_nscp_version_ok"></a>[ok](../common-options.md#ok)                                     |                      |
-| <a id="check_nscp_version_debug"></a>[debug](../common-options.md#debug)                            | false                |
-| <a id="check_nscp_version_show-all"></a>[show-all](../common-options.md#show-all)                   | false                |
-| <a id="check_nscp_version_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored              |
-| <a id="check_nscp_version_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                      |
-| <a id="check_nscp_version_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                |
-| <a id="check_nscp_version_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                    |
-| <a id="check_nscp_version_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}   |
-| <a id="check_nscp_version_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                      |
-| <a id="check_nscp_version_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                      |
-| <a id="check_nscp_version_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${version} (${date}) |
-| <a id="check_nscp_version_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | version              |
+| Option                                                                                                             | Default Value        |
+|--------------------------------------------------------------------------------------------------------------------|----------------------|
+| <a id="check_nscp_version_filter"></a>[filter](../common-options.md#filter)                                        |                      |
+| <a id="check_nscp_version_warning"></a>[warning](../common-options.md#warning)                                     |                      |
+| <a id="check_nscp_version_warn"></a>[warn](../common-options.md#warn)                                              |                      |
+| <a id="check_nscp_version_critical"></a>[critical](../common-options.md#critical)                                  |                      |
+| <a id="check_nscp_version_crit"></a>[crit](../common-options.md#crit)                                              |                      |
+| <a id="check_nscp_version_ok"></a>[ok](../common-options.md#ok)                                                    |                      |
+| <a id="check_nscp_version_debug"></a>[debug](../common-options.md#debug)                                           | false                |
+| <a id="check_nscp_version_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                |
+| <a id="check_nscp_version_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored              |
+| <a id="check_nscp_version_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                      |
+| <a id="check_nscp_version_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                |
+| <a id="check_nscp_version_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                    |
+| <a id="check_nscp_version_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}   |
+| <a id="check_nscp_version_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                      |
+| <a id="check_nscp_version_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                      |
+| <a id="check_nscp_version_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${version} (${date}) |
+| <a id="check_nscp_version_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | version              |
+| <a id="check_nscp_version_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                      |
+| <a id="check_nscp_version_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                      |
+| <a id="check_nscp_version_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                   |
+| <a id="check_nscp_version_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                      |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/check/CheckNet.md
+++ b/docs/docs/reference/check/CheckNet.md
@@ -195,25 +195,29 @@ OK: total/all: 231|'total_all_close_wait'=0;0;0 'total_all_closing'=0;0;0 'total
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                             | Default Value                        |
-|----------------------------------------------------------------------------------------------------|--------------------------------------|
-| <a id="check_connections_filter"></a>[filter](../common-options.md#filter)                         | protocol = 'total'                   |
-| <a id="check_connections_warning"></a>[warning](../common-options.md#warning)                      | total_connections > 1000             |
-| <a id="check_connections_warn"></a>[warn](../common-options.md#warn)                               |                                      |
-| <a id="check_connections_critical"></a>[critical](../common-options.md#critical)                   | total_connections > 2000             |
-| <a id="check_connections_crit"></a>[crit](../common-options.md#crit)                               |                                      |
-| <a id="check_connections_ok"></a>[ok](../common-options.md#ok)                                     |                                      |
-| <a id="check_connections_debug"></a>[debug](../common-options.md#debug)                            | false                                |
-| <a id="check_connections_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                |
-| <a id="check_connections_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                              |
-| <a id="check_connections_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                      |
-| <a id="check_connections_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                |
-| <a id="check_connections_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                    |
-| <a id="check_connections_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                   |
-| <a id="check_connections_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(list)                   |
-| <a id="check_connections_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No connection data                   |
-| <a id="check_connections_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${protocol}/${state}: ${connections} |
-| <a id="check_connections_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${protocol}_${state}                 |
+| Option                                                                                                            | Default Value                        |
+|-------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| <a id="check_connections_filter"></a>[filter](../common-options.md#filter)                                        | protocol = 'total'                   |
+| <a id="check_connections_warning"></a>[warning](../common-options.md#warning)                                     | total_connections > 1000             |
+| <a id="check_connections_warn"></a>[warn](../common-options.md#warn)                                              |                                      |
+| <a id="check_connections_critical"></a>[critical](../common-options.md#critical)                                  | total_connections > 2000             |
+| <a id="check_connections_crit"></a>[crit](../common-options.md#crit)                                              |                                      |
+| <a id="check_connections_ok"></a>[ok](../common-options.md#ok)                                                    |                                      |
+| <a id="check_connections_debug"></a>[debug](../common-options.md#debug)                                           | false                                |
+| <a id="check_connections_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                |
+| <a id="check_connections_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                              |
+| <a id="check_connections_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                      |
+| <a id="check_connections_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                |
+| <a id="check_connections_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                    |
+| <a id="check_connections_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                   |
+| <a id="check_connections_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(list)                   |
+| <a id="check_connections_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No connection data                   |
+| <a id="check_connections_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${protocol}/${state}: ${connections} |
+| <a id="check_connections_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${protocol}_${state}                 |
+| <a id="check_connections_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                      |
+| <a id="check_connections_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                      |
+| <a id="check_connections_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                   |
+| <a id="check_connections_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                      |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -392,25 +396,29 @@ Timeout in milliseconds.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                     | Default Value                                                 |
-|--------------------------------------------------------------------------------------------|---------------------------------------------------------------|
-| <a id="check_dns_filter"></a>[filter](../common-options.md#filter)                         |                                                               |
-| <a id="check_dns_warning"></a>[warning](../common-options.md#warning)                      | time > 1000                                                   |
-| <a id="check_dns_warn"></a>[warn](../common-options.md#warn)                               |                                                               |
-| <a id="check_dns_critical"></a>[critical](../common-options.md#critical)                   | result != 'ok'                                                |
-| <a id="check_dns_crit"></a>[crit](../common-options.md#crit)                               |                                                               |
-| <a id="check_dns_ok"></a>[ok](../common-options.md#ok)                                     |                                                               |
-| <a id="check_dns_debug"></a>[debug](../common-options.md#debug)                            | false                                                         |
-| <a id="check_dns_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                         |
-| <a id="check_dns_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                       |
-| <a id="check_dns_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                               |
-| <a id="check_dns_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                         |
-| <a id="check_dns_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                             |
-| <a id="check_dns_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                                    |
-| <a id="check_dns_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(list)                                            |
-| <a id="check_dns_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No DNS lookup performed                                       |
-| <a id="check_dns_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${host} -> ${addresses} (${records}) in ${time}ms [${result}] |
-| <a id="check_dns_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${host}                                                       |
+| Option                                                                                                    | Default Value                                                 |
+|-----------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| <a id="check_dns_filter"></a>[filter](../common-options.md#filter)                                        |                                                               |
+| <a id="check_dns_warning"></a>[warning](../common-options.md#warning)                                     | time > 1000                                                   |
+| <a id="check_dns_warn"></a>[warn](../common-options.md#warn)                                              |                                                               |
+| <a id="check_dns_critical"></a>[critical](../common-options.md#critical)                                  | result != 'ok'                                                |
+| <a id="check_dns_crit"></a>[crit](../common-options.md#crit)                                              |                                                               |
+| <a id="check_dns_ok"></a>[ok](../common-options.md#ok)                                                    |                                                               |
+| <a id="check_dns_debug"></a>[debug](../common-options.md#debug)                                           | false                                                         |
+| <a id="check_dns_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                         |
+| <a id="check_dns_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                       |
+| <a id="check_dns_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                               |
+| <a id="check_dns_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                         |
+| <a id="check_dns_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                             |
+| <a id="check_dns_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                                    |
+| <a id="check_dns_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(list)                                            |
+| <a id="check_dns_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No DNS lookup performed                                       |
+| <a id="check_dns_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${host} -> ${addresses} (${records}) in ${time}ms [${result}] |
+| <a id="check_dns_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${host}                                                       |
+| <a id="check_dns_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                               |
+| <a id="check_dns_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                               |
+| <a id="check_dns_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                            |
+| <a id="check_dns_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                               |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -689,25 +697,29 @@ Path to a CA bundle to use when verifying the server certificate.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                      | Default Value                                       |
-|---------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| <a id="check_http_filter"></a>[filter](../common-options.md#filter)                         |                                                     |
-| <a id="check_http_warning"></a>[warning](../common-options.md#warning)                      | time > 5000                                         |
-| <a id="check_http_warn"></a>[warn](../common-options.md#warn)                               |                                                     |
-| <a id="check_http_critical"></a>[critical](../common-options.md#critical)                   | code < 200 or code >= 400 or result != 'ok'         |
-| <a id="check_http_crit"></a>[crit](../common-options.md#crit)                               |                                                     |
-| <a id="check_http_ok"></a>[ok](../common-options.md#ok)                                     |                                                     |
-| <a id="check_http_debug"></a>[debug](../common-options.md#debug)                            | false                                               |
-| <a id="check_http_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                               |
-| <a id="check_http_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                             |
-| <a id="check_http_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                     |
-| <a id="check_http_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                               |
-| <a id="check_http_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                   |
-| <a id="check_http_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                          |
-| <a id="check_http_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(list)                                  |
-| <a id="check_http_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No URL checked                                      |
-| <a id="check_http_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${url} -> ${code} ${result} (${size}B in ${time}ms) |
-| <a id="check_http_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${url}                                              |
+| Option                                                                                                     | Default Value                                       |
+|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| <a id="check_http_filter"></a>[filter](../common-options.md#filter)                                        |                                                     |
+| <a id="check_http_warning"></a>[warning](../common-options.md#warning)                                     | time > 5000                                         |
+| <a id="check_http_warn"></a>[warn](../common-options.md#warn)                                              |                                                     |
+| <a id="check_http_critical"></a>[critical](../common-options.md#critical)                                  | code < 200 or code >= 400 or result != 'ok'         |
+| <a id="check_http_crit"></a>[crit](../common-options.md#crit)                                              |                                                     |
+| <a id="check_http_ok"></a>[ok](../common-options.md#ok)                                                    |                                                     |
+| <a id="check_http_debug"></a>[debug](../common-options.md#debug)                                           | false                                               |
+| <a id="check_http_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                               |
+| <a id="check_http_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                             |
+| <a id="check_http_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                     |
+| <a id="check_http_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                               |
+| <a id="check_http_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                   |
+| <a id="check_http_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                          |
+| <a id="check_http_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(list)                                  |
+| <a id="check_http_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No URL checked                                      |
+| <a id="check_http_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${url} -> ${code} ${result} (${size}B in ${time}ms) |
+| <a id="check_http_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${url}                                              |
+| <a id="check_http_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                     |
+| <a id="check_http_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                     |
+| <a id="check_http_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                  |
+| <a id="check_http_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                     |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1027,25 +1039,29 @@ Number of queries to send to each server (default: 1). At least 2 are needed for
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                            | Default Value                                          |
-|---------------------------------------------------------------------------------------------------|--------------------------------------------------------|
-| <a id="check_ntp_offset_filter"></a>[filter](../common-options.md#filter)                         |                                                        |
-| <a id="check_ntp_offset_warning"></a>[warning](../common-options.md#warning)                      | offset > 50 or stratum >= 16                           |
-| <a id="check_ntp_offset_warn"></a>[warn](../common-options.md#warn)                               |                                                        |
-| <a id="check_ntp_offset_critical"></a>[critical](../common-options.md#critical)                   | offset > 100 or stratum >= 16 or result != 'ok'        |
-| <a id="check_ntp_offset_crit"></a>[crit](../common-options.md#crit)                               |                                                        |
-| <a id="check_ntp_offset_ok"></a>[ok](../common-options.md#ok)                                     |                                                        |
-| <a id="check_ntp_offset_debug"></a>[debug](../common-options.md#debug)                            | false                                                  |
-| <a id="check_ntp_offset_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                  |
-| <a id="check_ntp_offset_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                |
-| <a id="check_ntp_offset_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                        |
-| <a id="check_ntp_offset_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                  |
-| <a id="check_ntp_offset_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                      |
-| <a id="check_ntp_offset_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                             |
-| <a id="check_ntp_offset_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(list)                                     |
-| <a id="check_ntp_offset_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No NTP server checked                                  |
-| <a id="check_ntp_offset_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${server} offset=${offset_signed}ms stratum=${stratum} |
-| <a id="check_ntp_offset_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${server}                                              |
+| Option                                                                                                           | Default Value                                          |
+|------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------|
+| <a id="check_ntp_offset_filter"></a>[filter](../common-options.md#filter)                                        |                                                        |
+| <a id="check_ntp_offset_warning"></a>[warning](../common-options.md#warning)                                     | offset > 50 or stratum >= 16                           |
+| <a id="check_ntp_offset_warn"></a>[warn](../common-options.md#warn)                                              |                                                        |
+| <a id="check_ntp_offset_critical"></a>[critical](../common-options.md#critical)                                  | offset > 100 or stratum >= 16 or result != 'ok'        |
+| <a id="check_ntp_offset_crit"></a>[crit](../common-options.md#crit)                                              |                                                        |
+| <a id="check_ntp_offset_ok"></a>[ok](../common-options.md#ok)                                                    |                                                        |
+| <a id="check_ntp_offset_debug"></a>[debug](../common-options.md#debug)                                           | false                                                  |
+| <a id="check_ntp_offset_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                  |
+| <a id="check_ntp_offset_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                |
+| <a id="check_ntp_offset_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                        |
+| <a id="check_ntp_offset_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                  |
+| <a id="check_ntp_offset_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                      |
+| <a id="check_ntp_offset_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                             |
+| <a id="check_ntp_offset_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(list)                                     |
+| <a id="check_ntp_offset_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No NTP server checked                                  |
+| <a id="check_ntp_offset_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${server} offset=${offset_signed}ms stratum=${stratum} |
+| <a id="check_ntp_offset_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${server}                                              |
+| <a id="check_ntp_offset_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                        |
+| <a id="check_ntp_offset_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                        |
+| <a id="check_ntp_offset_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                     |
+| <a id="check_ntp_offset_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1332,25 +1348,29 @@ TTL / hop limit to set on outgoing packets (0 keeps the system default). Note th
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                      | Default Value                                     |
-|---------------------------------------------------------------------------------------------|---------------------------------------------------|
-| <a id="check_ping_filter"></a>[filter](../common-options.md#filter)                         |                                                   |
-| <a id="check_ping_warning"></a>[warning](../common-options.md#warning)                      | time > 60 or loss > 5%                            |
-| <a id="check_ping_warn"></a>[warn](../common-options.md#warn)                               |                                                   |
-| <a id="check_ping_critical"></a>[critical](../common-options.md#critical)                   | time > 100 or loss > 10%                          |
-| <a id="check_ping_crit"></a>[crit](../common-options.md#crit)                               |                                                   |
-| <a id="check_ping_ok"></a>[ok](../common-options.md#ok)                                     |                                                   |
-| <a id="check_ping_debug"></a>[debug](../common-options.md#debug)                            | false                                             |
-| <a id="check_ping_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                             |
-| <a id="check_ping_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                           |
-| <a id="check_ping_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                   |
-| <a id="check_ping_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                             |
-| <a id="check_ping_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                 |
-| <a id="check_ping_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${ok_count}/${count} (${problem_list}) |
-| <a id="check_ping_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) hosts are ok              |
-| <a id="check_ping_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No hosts found                                    |
-| <a id="check_ping_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${ip} Packet loss = ${loss}%, RTA = ${time}ms     |
-| <a id="check_ping_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${host}                                           |
+| Option                                                                                                     | Default Value                                     |
+|------------------------------------------------------------------------------------------------------------|---------------------------------------------------|
+| <a id="check_ping_filter"></a>[filter](../common-options.md#filter)                                        |                                                   |
+| <a id="check_ping_warning"></a>[warning](../common-options.md#warning)                                     | time > 60 or loss > 5%                            |
+| <a id="check_ping_warn"></a>[warn](../common-options.md#warn)                                              |                                                   |
+| <a id="check_ping_critical"></a>[critical](../common-options.md#critical)                                  | time > 100 or loss > 10%                          |
+| <a id="check_ping_crit"></a>[crit](../common-options.md#crit)                                              |                                                   |
+| <a id="check_ping_ok"></a>[ok](../common-options.md#ok)                                                    |                                                   |
+| <a id="check_ping_debug"></a>[debug](../common-options.md#debug)                                           | false                                             |
+| <a id="check_ping_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                             |
+| <a id="check_ping_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                           |
+| <a id="check_ping_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                   |
+| <a id="check_ping_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                             |
+| <a id="check_ping_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                 |
+| <a id="check_ping_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${ok_count}/${count} (${problem_list}) |
+| <a id="check_ping_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) hosts are ok              |
+| <a id="check_ping_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No hosts found                                    |
+| <a id="check_ping_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${ip} Packet loss = ${loss}%, RTA = ${time}ms     |
+| <a id="check_ping_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${host}                                           |
+| <a id="check_ping_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                   |
+| <a id="check_ping_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                   |
+| <a id="check_ping_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                |
+| <a id="check_ping_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                   |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1569,25 +1589,29 @@ Certificate verify mode when --ssl is used: none (default), peer, ... (peer requ
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                     | Default Value                          |
-|--------------------------------------------------------------------------------------------|----------------------------------------|
-| <a id="check_ssh_filter"></a>[filter](../common-options.md#filter)                         |                                        |
-| <a id="check_ssh_warning"></a>[warning](../common-options.md#warning)                      | time > 1000                            |
-| <a id="check_ssh_warn"></a>[warn](../common-options.md#warn)                               |                                        |
-| <a id="check_ssh_critical"></a>[critical](../common-options.md#critical)                   | time > 5000 or result != 'ok'          |
-| <a id="check_ssh_crit"></a>[crit](../common-options.md#crit)                               |                                        |
-| <a id="check_ssh_ok"></a>[ok](../common-options.md#ok)                                     |                                        |
-| <a id="check_ssh_debug"></a>[debug](../common-options.md#debug)                            | false                                  |
-| <a id="check_ssh_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                  |
-| <a id="check_ssh_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                |
-| <a id="check_ssh_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                        |
-| <a id="check_ssh_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                  |
-| <a id="check_ssh_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                      |
-| <a id="check_ssh_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}             |
-| <a id="check_ssh_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(list)                     |
-| <a id="check_ssh_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No hosts checked                       |
-| <a id="check_ssh_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${host}:${port} ${result} in ${time}ms |
-| <a id="check_ssh_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${host}_${port}                        |
+| Option                                                                                                    | Default Value                          |
+|-----------------------------------------------------------------------------------------------------------|----------------------------------------|
+| <a id="check_ssh_filter"></a>[filter](../common-options.md#filter)                                        |                                        |
+| <a id="check_ssh_warning"></a>[warning](../common-options.md#warning)                                     | time > 1000                            |
+| <a id="check_ssh_warn"></a>[warn](../common-options.md#warn)                                              |                                        |
+| <a id="check_ssh_critical"></a>[critical](../common-options.md#critical)                                  | time > 5000 or result != 'ok'          |
+| <a id="check_ssh_crit"></a>[crit](../common-options.md#crit)                                              |                                        |
+| <a id="check_ssh_ok"></a>[ok](../common-options.md#ok)                                                    |                                        |
+| <a id="check_ssh_debug"></a>[debug](../common-options.md#debug)                                           | false                                  |
+| <a id="check_ssh_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                  |
+| <a id="check_ssh_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                |
+| <a id="check_ssh_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                        |
+| <a id="check_ssh_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                  |
+| <a id="check_ssh_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                      |
+| <a id="check_ssh_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}             |
+| <a id="check_ssh_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(list)                     |
+| <a id="check_ssh_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No hosts checked                       |
+| <a id="check_ssh_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${host}:${port} ${result} in ${time}ms |
+| <a id="check_ssh_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${host}_${port}                        |
+| <a id="check_ssh_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                        |
+| <a id="check_ssh_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                        |
+| <a id="check_ssh_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                     |
+| <a id="check_ssh_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1862,25 +1886,29 @@ Certificate verify mode when --ssl is used: none (default), peer, ... (peer requ
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                     | Default Value                          |
-|--------------------------------------------------------------------------------------------|----------------------------------------|
-| <a id="check_tcp_filter"></a>[filter](../common-options.md#filter)                         |                                        |
-| <a id="check_tcp_warning"></a>[warning](../common-options.md#warning)                      | time > 1000                            |
-| <a id="check_tcp_warn"></a>[warn](../common-options.md#warn)                               |                                        |
-| <a id="check_tcp_critical"></a>[critical](../common-options.md#critical)                   | time > 5000 or result != 'ok'          |
-| <a id="check_tcp_crit"></a>[crit](../common-options.md#crit)                               |                                        |
-| <a id="check_tcp_ok"></a>[ok](../common-options.md#ok)                                     |                                        |
-| <a id="check_tcp_debug"></a>[debug](../common-options.md#debug)                            | false                                  |
-| <a id="check_tcp_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                  |
-| <a id="check_tcp_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                |
-| <a id="check_tcp_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                        |
-| <a id="check_tcp_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                  |
-| <a id="check_tcp_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                      |
-| <a id="check_tcp_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}             |
-| <a id="check_tcp_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(list)                     |
-| <a id="check_tcp_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No hosts checked                       |
-| <a id="check_tcp_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${host}:${port} ${result} in ${time}ms |
-| <a id="check_tcp_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${host}_${port}                        |
+| Option                                                                                                    | Default Value                          |
+|-----------------------------------------------------------------------------------------------------------|----------------------------------------|
+| <a id="check_tcp_filter"></a>[filter](../common-options.md#filter)                                        |                                        |
+| <a id="check_tcp_warning"></a>[warning](../common-options.md#warning)                                     | time > 1000                            |
+| <a id="check_tcp_warn"></a>[warn](../common-options.md#warn)                                              |                                        |
+| <a id="check_tcp_critical"></a>[critical](../common-options.md#critical)                                  | time > 5000 or result != 'ok'          |
+| <a id="check_tcp_crit"></a>[crit](../common-options.md#crit)                                              |                                        |
+| <a id="check_tcp_ok"></a>[ok](../common-options.md#ok)                                                    |                                        |
+| <a id="check_tcp_debug"></a>[debug](../common-options.md#debug)                                           | false                                  |
+| <a id="check_tcp_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                  |
+| <a id="check_tcp_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                |
+| <a id="check_tcp_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                        |
+| <a id="check_tcp_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                  |
+| <a id="check_tcp_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                      |
+| <a id="check_tcp_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}             |
+| <a id="check_tcp_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(list)                     |
+| <a id="check_tcp_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No hosts checked                       |
+| <a id="check_tcp_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${host}:${port} ${result} in ${time}ms |
+| <a id="check_tcp_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${host}_${port}                        |
+| <a id="check_tcp_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                        |
+| <a id="check_tcp_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                        |
+| <a id="check_tcp_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                     |
+| <a id="check_tcp_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/check/CheckSecurity.md
+++ b/docs/docs/reference/check/CheckSecurity.md
@@ -186,25 +186,29 @@ Do not evaluate the genuine state (skips the SLIsGenuineLocal call); genuine_sta
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                            | Default Value                                                                       |
-|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
-| <a id="check_activation_filter"></a>[filter](../common-options.md#filter)                         |                                                                                     |
-| <a id="check_activation_warning"></a>[warning](../common-options.md#warning)                      | grace_days > 0 and grace_days < 30                                                  |
-| <a id="check_activation_warn"></a>[warn](../common-options.md#warn)                               |                                                                                     |
-| <a id="check_activation_critical"></a>[critical](../common-options.md#critical)                   | licensed = 0                                                                        |
-| <a id="check_activation_crit"></a>[crit](../common-options.md#crit)                               |                                                                                     |
-| <a id="check_activation_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                     |
-| <a id="check_activation_debug"></a>[debug](../common-options.md#debug)                            | false                                                                               |
-| <a id="check_activation_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                               |
-| <a id="check_activation_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                             |
-| <a id="check_activation_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                     |
-| <a id="check_activation_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                               |
-| <a id="check_activation_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                   |
-| <a id="check_activation_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                  |
-| <a id="check_activation_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): ${list}                                                                  |
-| <a id="check_activation_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No licensing information found (Software Licensing service unavailable?) |
-| <a id="check_activation_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${activation_status} (${genuine_state}, grace ${grace_days}d)              |
-| <a id="check_activation_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | license                                                                             |
+| Option                                                                                                           | Default Value                                                                       |
+|------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| <a id="check_activation_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                     |
+| <a id="check_activation_warning"></a>[warning](../common-options.md#warning)                                     | grace_days > 0 and grace_days < 30                                                  |
+| <a id="check_activation_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                     |
+| <a id="check_activation_critical"></a>[critical](../common-options.md#critical)                                  | licensed = 0                                                                        |
+| <a id="check_activation_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                     |
+| <a id="check_activation_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                     |
+| <a id="check_activation_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                               |
+| <a id="check_activation_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                               |
+| <a id="check_activation_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                             |
+| <a id="check_activation_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                     |
+| <a id="check_activation_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                               |
+| <a id="check_activation_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                   |
+| <a id="check_activation_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                  |
+| <a id="check_activation_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): ${list}                                                                  |
+| <a id="check_activation_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No licensing information found (Software Licensing service unavailable?) |
+| <a id="check_activation_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${activation_status} (${genuine_state}, grace ${grace_days}d)              |
+| <a id="check_activation_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | license                                                                             |
+| <a id="check_activation_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                     |
+| <a id="check_activation_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                     |
+| <a id="check_activation_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                  |
+| <a id="check_activation_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                     |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -308,25 +312,29 @@ L        cli UNKNOWN: check_antivirus is not supported on this platform (Windows
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                           | Default Value                                         |
-|--------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| <a id="check_antivirus_filter"></a>[filter](../common-options.md#filter)                         |                                                       |
-| <a id="check_antivirus_warning"></a>[warning](../common-options.md#warning)                      |                                                       |
-| <a id="check_antivirus_warn"></a>[warn](../common-options.md#warn)                               |                                                       |
-| <a id="check_antivirus_critical"></a>[critical](../common-options.md#critical)                   | enabled = 0 or up_to_date = 0                         |
-| <a id="check_antivirus_crit"></a>[crit](../common-options.md#crit)                               |                                                       |
-| <a id="check_antivirus_ok"></a>[ok](../common-options.md#ok)                                     |                                                       |
-| <a id="check_antivirus_debug"></a>[debug](../common-options.md#debug)                            | false                                                 |
-| <a id="check_antivirus_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                 |
-| <a id="check_antivirus_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                               |
-| <a id="check_antivirus_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                       |
-| <a id="check_antivirus_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                 |
-| <a id="check_antivirus_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                     |
-| <a id="check_antivirus_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                    |
-| <a id="check_antivirus_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | ${status}: ${count} antivirus product(s) healthy      |
-| <a id="check_antivirus_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No antivirus product registered                       |
-| <a id="check_antivirus_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name} (enabled=${enabled} up_to_date=${up_to_date}) |
-| <a id="check_antivirus_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                               |
+| Option                                                                                                          | Default Value                                         |
+|-----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| <a id="check_antivirus_filter"></a>[filter](../common-options.md#filter)                                        |                                                       |
+| <a id="check_antivirus_warning"></a>[warning](../common-options.md#warning)                                     |                                                       |
+| <a id="check_antivirus_warn"></a>[warn](../common-options.md#warn)                                              |                                                       |
+| <a id="check_antivirus_critical"></a>[critical](../common-options.md#critical)                                  | enabled = 0 or up_to_date = 0                         |
+| <a id="check_antivirus_crit"></a>[crit](../common-options.md#crit)                                              |                                                       |
+| <a id="check_antivirus_ok"></a>[ok](../common-options.md#ok)                                                    |                                                       |
+| <a id="check_antivirus_debug"></a>[debug](../common-options.md#debug)                                           | false                                                 |
+| <a id="check_antivirus_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                 |
+| <a id="check_antivirus_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                               |
+| <a id="check_antivirus_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                       |
+| <a id="check_antivirus_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                 |
+| <a id="check_antivirus_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                     |
+| <a id="check_antivirus_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                    |
+| <a id="check_antivirus_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | ${status}: ${count} antivirus product(s) healthy      |
+| <a id="check_antivirus_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No antivirus product registered                       |
+| <a id="check_antivirus_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name} (enabled=${enabled} up_to_date=${up_to_date}) |
+| <a id="check_antivirus_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                               |
+| <a id="check_antivirus_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                       |
+| <a id="check_antivirus_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                       |
+| <a id="check_antivirus_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                    |
+| <a id="check_antivirus_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                       |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -417,25 +425,29 @@ L        cli UNKNOWN: check_bitlocker is not supported on this platform (Windows
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                           | Default Value                               |
-|--------------------------------------------------------------------------------------------------|---------------------------------------------|
-| <a id="check_bitlocker_filter"></a>[filter](../common-options.md#filter)                         |                                             |
-| <a id="check_bitlocker_warning"></a>[warning](../common-options.md#warning)                      |                                             |
-| <a id="check_bitlocker_warn"></a>[warn](../common-options.md#warn)                               |                                             |
-| <a id="check_bitlocker_critical"></a>[critical](../common-options.md#critical)                   | protected = 0                               |
-| <a id="check_bitlocker_crit"></a>[crit](../common-options.md#crit)                               |                                             |
-| <a id="check_bitlocker_ok"></a>[ok](../common-options.md#ok)                                     |                                             |
-| <a id="check_bitlocker_debug"></a>[debug](../common-options.md#debug)                            | false                                       |
-| <a id="check_bitlocker_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                       |
-| <a id="check_bitlocker_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                     |
-| <a id="check_bitlocker_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                             |
-| <a id="check_bitlocker_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                       |
-| <a id="check_bitlocker_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                           |
-| <a id="check_bitlocker_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                          |
-| <a id="check_bitlocker_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | ${status}: all ${count} volume(s) protected |
-| <a id="check_bitlocker_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No encryptable volumes found                |
-| <a id="check_bitlocker_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${drive} protected=${protected}             |
-| <a id="check_bitlocker_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${drive}                                    |
+| Option                                                                                                          | Default Value                               |
+|-----------------------------------------------------------------------------------------------------------------|---------------------------------------------|
+| <a id="check_bitlocker_filter"></a>[filter](../common-options.md#filter)                                        |                                             |
+| <a id="check_bitlocker_warning"></a>[warning](../common-options.md#warning)                                     |                                             |
+| <a id="check_bitlocker_warn"></a>[warn](../common-options.md#warn)                                              |                                             |
+| <a id="check_bitlocker_critical"></a>[critical](../common-options.md#critical)                                  | protected = 0                               |
+| <a id="check_bitlocker_crit"></a>[crit](../common-options.md#crit)                                              |                                             |
+| <a id="check_bitlocker_ok"></a>[ok](../common-options.md#ok)                                                    |                                             |
+| <a id="check_bitlocker_debug"></a>[debug](../common-options.md#debug)                                           | false                                       |
+| <a id="check_bitlocker_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                       |
+| <a id="check_bitlocker_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                     |
+| <a id="check_bitlocker_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                             |
+| <a id="check_bitlocker_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                       |
+| <a id="check_bitlocker_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                           |
+| <a id="check_bitlocker_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                          |
+| <a id="check_bitlocker_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | ${status}: all ${count} volume(s) protected |
+| <a id="check_bitlocker_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No encryptable volumes found                |
+| <a id="check_bitlocker_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${drive} protected=${protected}             |
+| <a id="check_bitlocker_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${drive}                                    |
+| <a id="check_bitlocker_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                             |
+| <a id="check_bitlocker_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                             |
+| <a id="check_bitlocker_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                          |
+| <a id="check_bitlocker_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                             |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -637,25 +649,29 @@ Windows store location: LocalMachine or CurrentUser. Windows only.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                             | Default Value                                      |
-|----------------------------------------------------------------------------------------------------|----------------------------------------------------|
-| <a id="check_certificate_filter"></a>[filter](../common-options.md#filter)                         |                                                    |
-| <a id="check_certificate_warning"></a>[warning](../common-options.md#warning)                      | expires_in < 30                                    |
-| <a id="check_certificate_warn"></a>[warn](../common-options.md#warn)                               |                                                    |
-| <a id="check_certificate_critical"></a>[critical](../common-options.md#critical)                   | expires_in < 10                                    |
-| <a id="check_certificate_crit"></a>[crit](../common-options.md#crit)                               |                                                    |
-| <a id="check_certificate_ok"></a>[ok](../common-options.md#ok)                                     |                                                    |
-| <a id="check_certificate_debug"></a>[debug](../common-options.md#debug)                            | false                                              |
-| <a id="check_certificate_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                              |
-| <a id="check_certificate_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                            |
-| <a id="check_certificate_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                    |
-| <a id="check_certificate_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                              |
-| <a id="check_certificate_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                  |
-| <a id="check_certificate_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                         |
-| <a id="check_certificate_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): all %(count) certificate(s) are ok      |
-| <a id="check_certificate_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No certificates found                              |
-| <a id="check_certificate_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${subject} expires in ${expires_in}d (${valid_to}) |
-| <a id="check_certificate_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${subject}                                         |
+| Option                                                                                                            | Default Value                                      |
+|-------------------------------------------------------------------------------------------------------------------|----------------------------------------------------|
+| <a id="check_certificate_filter"></a>[filter](../common-options.md#filter)                                        |                                                    |
+| <a id="check_certificate_warning"></a>[warning](../common-options.md#warning)                                     | expires_in < 30                                    |
+| <a id="check_certificate_warn"></a>[warn](../common-options.md#warn)                                              |                                                    |
+| <a id="check_certificate_critical"></a>[critical](../common-options.md#critical)                                  | expires_in < 10                                    |
+| <a id="check_certificate_crit"></a>[crit](../common-options.md#crit)                                              |                                                    |
+| <a id="check_certificate_ok"></a>[ok](../common-options.md#ok)                                                    |                                                    |
+| <a id="check_certificate_debug"></a>[debug](../common-options.md#debug)                                           | false                                              |
+| <a id="check_certificate_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                              |
+| <a id="check_certificate_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                            |
+| <a id="check_certificate_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                    |
+| <a id="check_certificate_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                              |
+| <a id="check_certificate_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                  |
+| <a id="check_certificate_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                         |
+| <a id="check_certificate_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): all %(count) certificate(s) are ok      |
+| <a id="check_certificate_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No certificates found                              |
+| <a id="check_certificate_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${subject} expires in ${expires_in}d (${valid_to}) |
+| <a id="check_certificate_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${subject}                                         |
+| <a id="check_certificate_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                    |
+| <a id="check_certificate_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                    |
+| <a id="check_certificate_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                 |
+| <a id="check_certificate_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                    |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -796,25 +812,29 @@ OK: Defender enabled=1 realtime=1 tamper=1 sig_age=0d sig=1.455.84.0 engine=1.1.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                          | Default Value                                                                                                                                                    |
-|-------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <a id="check_defender_filter"></a>[filter](../common-options.md#filter)                         |                                                                                                                                                                  |
-| <a id="check_defender_warning"></a>[warning](../common-options.md#warning)                      | signature_age > 3                                                                                                                                                |
-| <a id="check_defender_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                                                                                  |
-| <a id="check_defender_critical"></a>[critical](../common-options.md#critical)                   | enabled = 0 or realtime_enabled = 0 or signature_age > 7                                                                                                         |
-| <a id="check_defender_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                                                                                  |
-| <a id="check_defender_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                                                                                  |
-| <a id="check_defender_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                                                                            |
-| <a id="check_defender_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                                                                            |
-| <a id="check_defender_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                                                                                                          |
-| <a id="check_defender_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                                                                                  |
-| <a id="check_defender_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                                                                            |
-| <a id="check_defender_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                                                                                |
-| <a id="check_defender_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                                                                               |
-| <a id="check_defender_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): Microsoft Defender healthy (signature age ${signature_age}d)                                                                                          |
-| <a id="check_defender_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): Microsoft Defender status unavailable (not installed or another antivirus is active)                                                                  |
-| <a id="check_defender_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | Defender enabled=${enabled} realtime=${realtime_enabled} tamper=${tamper_protection} sig_age=${signature_age}d sig=${signature_version} engine=${engine_version} |
-| <a id="check_defender_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | defender                                                                                                                                                         |
+| Option                                                                                                         | Default Value                                                                                                                                                    |
+|----------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <a id="check_defender_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                                                                                                  |
+| <a id="check_defender_warning"></a>[warning](../common-options.md#warning)                                     | signature_age > 3                                                                                                                                                |
+| <a id="check_defender_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                                                                                  |
+| <a id="check_defender_critical"></a>[critical](../common-options.md#critical)                                  | enabled = 0 or realtime_enabled = 0 or signature_age > 7                                                                                                         |
+| <a id="check_defender_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                                                                                  |
+| <a id="check_defender_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                                                                                  |
+| <a id="check_defender_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                                                                            |
+| <a id="check_defender_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                                                                            |
+| <a id="check_defender_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                                                                                                          |
+| <a id="check_defender_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                                                                                  |
+| <a id="check_defender_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                                                                            |
+| <a id="check_defender_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                                                                                |
+| <a id="check_defender_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                                                                               |
+| <a id="check_defender_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): Microsoft Defender healthy (signature age ${signature_age}d)                                                                                          |
+| <a id="check_defender_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): Microsoft Defender status unavailable (not installed or another antivirus is active)                                                                  |
+| <a id="check_defender_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | Defender enabled=${enabled} realtime=${realtime_enabled} tamper=${tamper_protection} sig_age=${signature_age}d sig=${signature_version} engine=${engine_version} |
+| <a id="check_defender_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | defender                                                                                                                                                         |
+| <a id="check_defender_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                                                                                  |
+| <a id="check_defender_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                                                                                  |
+| <a id="check_defender_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                                                                               |
+| <a id="check_defender_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                                                                                  |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1023,25 +1043,29 @@ L        cli UNKNOWN: check_file_security is not supported on this platform (Win
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                               | Default Value                                                                          |
-|------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| <a id="check_file_security_filter"></a>[filter](../common-options.md#filter)                         |                                                                                        |
-| <a id="check_file_security_warning"></a>[warning](../common-options.md#warning)                      | unexpected_write = 1                                                                   |
-| <a id="check_file_security_warn"></a>[warn](../common-options.md#warn)                               |                                                                                        |
-| <a id="check_file_security_critical"></a>[critical](../common-options.md#critical)                   | exists = 0 or readable = 0 or owner_expected = 0 or world_writable = 1                 |
-| <a id="check_file_security_crit"></a>[crit](../common-options.md#crit)                               |                                                                                        |
-| <a id="check_file_security_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                        |
-| <a id="check_file_security_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                  |
-| <a id="check_file_security_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                  |
-| <a id="check_file_security_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                                |
-| <a id="check_file_security_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                        |
-| <a id="check_file_security_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                  |
-| <a id="check_file_security_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                      |
-| <a id="check_file_security_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                     |
-| <a id="check_file_security_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): all %(count) path(s) have the expected owner and no unexpected write access |
-| <a id="check_file_security_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No paths checked                                                            |
-| <a id="check_file_security_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${path}: ${state}                                                                      |
-| <a id="check_file_security_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${path}                                                                                |
+| Option                                                                                                              | Default Value                                                                          |
+|---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| <a id="check_file_security_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                        |
+| <a id="check_file_security_warning"></a>[warning](../common-options.md#warning)                                     | unexpected_write = 1                                                                   |
+| <a id="check_file_security_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                        |
+| <a id="check_file_security_critical"></a>[critical](../common-options.md#critical)                                  | exists = 0 or readable = 0 or owner_expected = 0 or world_writable = 1                 |
+| <a id="check_file_security_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                        |
+| <a id="check_file_security_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                        |
+| <a id="check_file_security_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                  |
+| <a id="check_file_security_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                  |
+| <a id="check_file_security_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                                |
+| <a id="check_file_security_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                        |
+| <a id="check_file_security_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                  |
+| <a id="check_file_security_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                      |
+| <a id="check_file_security_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                     |
+| <a id="check_file_security_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): all %(count) path(s) have the expected owner and no unexpected write access |
+| <a id="check_file_security_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No paths checked                                                            |
+| <a id="check_file_security_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${path}: ${state}                                                                      |
+| <a id="check_file_security_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${path}                                                                                |
+| <a id="check_file_security_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                        |
+| <a id="check_file_security_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                        |
+| <a id="check_file_security_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                     |
+| <a id="check_file_security_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1203,25 +1227,29 @@ L        cli UNKNOWN: check_firewall is not supported on this platform (Windows-
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                          | Default Value                                       |
-|-------------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| <a id="check_firewall_filter"></a>[filter](../common-options.md#filter)                         |                                                     |
-| <a id="check_firewall_warning"></a>[warning](../common-options.md#warning)                      |                                                     |
-| <a id="check_firewall_warn"></a>[warn](../common-options.md#warn)                               |                                                     |
-| <a id="check_firewall_critical"></a>[critical](../common-options.md#critical)                   | enabled = 0                                         |
-| <a id="check_firewall_crit"></a>[crit](../common-options.md#crit)                               |                                                     |
-| <a id="check_firewall_ok"></a>[ok](../common-options.md#ok)                                     |                                                     |
-| <a id="check_firewall_debug"></a>[debug](../common-options.md#debug)                            | false                                               |
-| <a id="check_firewall_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                               |
-| <a id="check_firewall_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                             |
-| <a id="check_firewall_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                     |
-| <a id="check_firewall_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                               |
-| <a id="check_firewall_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                   |
-| <a id="check_firewall_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                          |
-| <a id="check_firewall_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): all %(count) firewall profile(s) enabled |
-| <a id="check_firewall_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No firewall profiles found                          |
-| <a id="check_firewall_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${profile}=${enabled}                               |
-| <a id="check_firewall_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${profile}                                          |
+| Option                                                                                                         | Default Value                                       |
+|----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| <a id="check_firewall_filter"></a>[filter](../common-options.md#filter)                                        |                                                     |
+| <a id="check_firewall_warning"></a>[warning](../common-options.md#warning)                                     |                                                     |
+| <a id="check_firewall_warn"></a>[warn](../common-options.md#warn)                                              |                                                     |
+| <a id="check_firewall_critical"></a>[critical](../common-options.md#critical)                                  | enabled = 0                                         |
+| <a id="check_firewall_crit"></a>[crit](../common-options.md#crit)                                              |                                                     |
+| <a id="check_firewall_ok"></a>[ok](../common-options.md#ok)                                                    |                                                     |
+| <a id="check_firewall_debug"></a>[debug](../common-options.md#debug)                                           | false                                               |
+| <a id="check_firewall_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                               |
+| <a id="check_firewall_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                             |
+| <a id="check_firewall_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                     |
+| <a id="check_firewall_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                               |
+| <a id="check_firewall_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                   |
+| <a id="check_firewall_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                          |
+| <a id="check_firewall_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): all %(count) firewall profile(s) enabled |
+| <a id="check_firewall_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No firewall profiles found                          |
+| <a id="check_firewall_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${profile}=${enabled}                               |
+| <a id="check_firewall_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${profile}                                          |
+| <a id="check_firewall_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                     |
+| <a id="check_firewall_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                     |
+| <a id="check_firewall_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                  |
+| <a id="check_firewall_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                     |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1398,25 +1426,29 @@ L        cli UNKNOWN: check_firewall_rules is not supported on this platform (Wi
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                                | Default Value                                        |
-|-------------------------------------------------------------------------------------------------------|------------------------------------------------------|
-| <a id="check_firewall_rules_filter"></a>[filter](../common-options.md#filter)                         |                                                      |
-| <a id="check_firewall_rules_warning"></a>[warning](../common-options.md#warning)                      |                                                      |
-| <a id="check_firewall_rules_warn"></a>[warn](../common-options.md#warn)                               |                                                      |
-| <a id="check_firewall_rules_critical"></a>[critical](../common-options.md#critical)                   | present = 0                                          |
-| <a id="check_firewall_rules_crit"></a>[crit](../common-options.md#crit)                               |                                                      |
-| <a id="check_firewall_rules_ok"></a>[ok](../common-options.md#ok)                                     |                                                      |
-| <a id="check_firewall_rules_debug"></a>[debug](../common-options.md#debug)                            | false                                                |
-| <a id="check_firewall_rules_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                |
-| <a id="check_firewall_rules_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                   |
-| <a id="check_firewall_rules_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                      |
-| <a id="check_firewall_rules_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                |
-| <a id="check_firewall_rules_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                    |
-| <a id="check_firewall_rules_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                           |
-| <a id="check_firewall_rules_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(count) rule(s) checked, all as expected |
-| <a id="check_firewall_rules_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No firewall rules matched                 |
-| <a id="check_firewall_rules_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${state}                                    |
-| <a id="check_firewall_rules_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                              |
+| Option                                                                                                               | Default Value                                        |
+|----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------|
+| <a id="check_firewall_rules_filter"></a>[filter](../common-options.md#filter)                                        |                                                      |
+| <a id="check_firewall_rules_warning"></a>[warning](../common-options.md#warning)                                     |                                                      |
+| <a id="check_firewall_rules_warn"></a>[warn](../common-options.md#warn)                                              |                                                      |
+| <a id="check_firewall_rules_critical"></a>[critical](../common-options.md#critical)                                  | present = 0                                          |
+| <a id="check_firewall_rules_crit"></a>[crit](../common-options.md#crit)                                              |                                                      |
+| <a id="check_firewall_rules_ok"></a>[ok](../common-options.md#ok)                                                    |                                                      |
+| <a id="check_firewall_rules_debug"></a>[debug](../common-options.md#debug)                                           | false                                                |
+| <a id="check_firewall_rules_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                |
+| <a id="check_firewall_rules_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                   |
+| <a id="check_firewall_rules_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                      |
+| <a id="check_firewall_rules_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                |
+| <a id="check_firewall_rules_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                    |
+| <a id="check_firewall_rules_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                           |
+| <a id="check_firewall_rules_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(count) rule(s) checked, all as expected |
+| <a id="check_firewall_rules_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No firewall rules matched                 |
+| <a id="check_firewall_rules_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${state}                                    |
+| <a id="check_firewall_rules_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                              |
+| <a id="check_firewall_rules_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                      |
+| <a id="check_firewall_rules_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                      |
+| <a id="check_firewall_rules_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                   |
+| <a id="check_firewall_rules_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                      |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1570,25 +1602,29 @@ OK: All 2 member(s) are on the expected list.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                               | Default Value                                               |
-|------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
-| <a id="check_group_members_filter"></a>[filter](../common-options.md#filter)                         |                                                             |
-| <a id="check_group_members_warning"></a>[warning](../common-options.md#warning)                      |                                                             |
-| <a id="check_group_members_warn"></a>[warn](../common-options.md#warn)                               |                                                             |
-| <a id="check_group_members_critical"></a>[critical](../common-options.md#critical)                   | expected = 0                                                |
-| <a id="check_group_members_crit"></a>[crit](../common-options.md#crit)                               |                                                             |
-| <a id="check_group_members_ok"></a>[ok](../common-options.md#ok)                                     |                                                             |
-| <a id="check_group_members_debug"></a>[debug](../common-options.md#debug)                            | false                                                       |
-| <a id="check_group_members_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                       |
-| <a id="check_group_members_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                          |
-| <a id="check_group_members_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                             |
-| <a id="check_group_members_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                       |
-| <a id="check_group_members_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                           |
-| <a id="check_group_members_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                          |
-| <a id="check_group_members_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) member(s) are on the expected list. |
-| <a id="check_group_members_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): Group is empty                                   |
-| <a id="check_group_members_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${member} (${type})                                         |
-| <a id="check_group_members_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${member}                                                   |
+| Option                                                                                                              | Default Value                                               |
+|---------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| <a id="check_group_members_filter"></a>[filter](../common-options.md#filter)                                        |                                                             |
+| <a id="check_group_members_warning"></a>[warning](../common-options.md#warning)                                     |                                                             |
+| <a id="check_group_members_warn"></a>[warn](../common-options.md#warn)                                              |                                                             |
+| <a id="check_group_members_critical"></a>[critical](../common-options.md#critical)                                  | expected = 0                                                |
+| <a id="check_group_members_crit"></a>[crit](../common-options.md#crit)                                              |                                                             |
+| <a id="check_group_members_ok"></a>[ok](../common-options.md#ok)                                                    |                                                             |
+| <a id="check_group_members_debug"></a>[debug](../common-options.md#debug)                                           | false                                                       |
+| <a id="check_group_members_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                       |
+| <a id="check_group_members_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                          |
+| <a id="check_group_members_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                             |
+| <a id="check_group_members_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                       |
+| <a id="check_group_members_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                           |
+| <a id="check_group_members_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                          |
+| <a id="check_group_members_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) member(s) are on the expected list. |
+| <a id="check_group_members_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): Group is empty                                   |
+| <a id="check_group_members_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${member} (${type})                                         |
+| <a id="check_group_members_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${member}                                                   |
+| <a id="check_group_members_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                             |
+| <a id="check_group_members_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                             |
+| <a id="check_group_members_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                          |
+| <a id="check_group_members_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                             |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1702,25 +1738,29 @@ OK: All 5 local account(s) ok.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                                | Default Value                                                                                           |
-|-------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
-| <a id="check_local_accounts_filter"></a>[filter](../common-options.md#filter)                         |                                                                                                         |
-| <a id="check_local_accounts_warning"></a>[warning](../common-options.md#warning)                      | enabled = 1 and is_builtin_guest = 1                                                                    |
-| <a id="check_local_accounts_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                         |
-| <a id="check_local_accounts_critical"></a>[critical](../common-options.md#critical)                   | enabled = 1 and password_required = 0                                                                   |
-| <a id="check_local_accounts_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                         |
-| <a id="check_local_accounts_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                         |
-| <a id="check_local_accounts_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                   |
-| <a id="check_local_accounts_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                   |
-| <a id="check_local_accounts_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                                                                      |
-| <a id="check_local_accounts_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                         |
-| <a id="check_local_accounts_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                   |
-| <a id="check_local_accounts_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                       |
-| <a id="check_local_accounts_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                      |
-| <a id="check_local_accounts_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) local account(s) ok.                                                            |
-| <a id="check_local_accounts_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No local accounts found                                                                      |
-| <a id="check_local_accounts_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name} (enabled=${enabled}, pw_req=${password_required}, pw_exp=${password_expires}, locked=${locked}) |
-| <a id="check_local_accounts_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                                                                 |
+| Option                                                                                                               | Default Value                                                                                           |
+|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------|
+| <a id="check_local_accounts_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                                         |
+| <a id="check_local_accounts_warning"></a>[warning](../common-options.md#warning)                                     | enabled = 1 and is_builtin_guest = 1                                                                    |
+| <a id="check_local_accounts_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                         |
+| <a id="check_local_accounts_critical"></a>[critical](../common-options.md#critical)                                  | enabled = 1 and password_required = 0                                                                   |
+| <a id="check_local_accounts_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                         |
+| <a id="check_local_accounts_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                         |
+| <a id="check_local_accounts_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                   |
+| <a id="check_local_accounts_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                   |
+| <a id="check_local_accounts_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                                                                      |
+| <a id="check_local_accounts_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                         |
+| <a id="check_local_accounts_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                   |
+| <a id="check_local_accounts_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                       |
+| <a id="check_local_accounts_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                      |
+| <a id="check_local_accounts_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) local account(s) ok.                                                            |
+| <a id="check_local_accounts_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No local accounts found                                                                      |
+| <a id="check_local_accounts_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name} (enabled=${enabled}, pw_req=${password_required}, pw_exp=${password_expires}, locked=${locked}) |
+| <a id="check_local_accounts_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                                                                 |
+| <a id="check_local_accounts_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                         |
+| <a id="check_local_accounts_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                         |
+| <a id="check_local_accounts_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                      |
+| <a id="check_local_accounts_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                         |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1813,25 +1853,29 @@ L        cli UNKNOWN: check_nla is not supported on this platform (Windows Netwo
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                     | Default Value              |
-|--------------------------------------------------------------------------------------------|----------------------------|
-| <a id="check_nla_filter"></a>[filter](../common-options.md#filter)                         |                            |
-| <a id="check_nla_warning"></a>[warning](../common-options.md#warning)                      |                            |
-| <a id="check_nla_warn"></a>[warn](../common-options.md#warn)                               |                            |
-| <a id="check_nla_critical"></a>[critical](../common-options.md#critical)                   |                            |
-| <a id="check_nla_crit"></a>[crit](../common-options.md#crit)                               |                            |
-| <a id="check_nla_ok"></a>[ok](../common-options.md#ok)                                     |                            |
-| <a id="check_nla_debug"></a>[debug](../common-options.md#debug)                            | false                      |
-| <a id="check_nla_show-all"></a>[show-all](../common-options.md#show-all)                   | false                      |
-| <a id="check_nla_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                         |
-| <a id="check_nla_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                            |
-| <a id="check_nla_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                      |
-| <a id="check_nla_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                          |
-| <a id="check_nla_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}         |
-| <a id="check_nla_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | ${status}: all networks ok |
-| <a id="check_nla_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No networks found          |
-| <a id="check_nla_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${network}=${category}     |
-| <a id="check_nla_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${network}                 |
+| Option                                                                                                    | Default Value              |
+|-----------------------------------------------------------------------------------------------------------|----------------------------|
+| <a id="check_nla_filter"></a>[filter](../common-options.md#filter)                                        |                            |
+| <a id="check_nla_warning"></a>[warning](../common-options.md#warning)                                     |                            |
+| <a id="check_nla_warn"></a>[warn](../common-options.md#warn)                                              |                            |
+| <a id="check_nla_critical"></a>[critical](../common-options.md#critical)                                  |                            |
+| <a id="check_nla_crit"></a>[crit](../common-options.md#crit)                                              |                            |
+| <a id="check_nla_ok"></a>[ok](../common-options.md#ok)                                                    |                            |
+| <a id="check_nla_debug"></a>[debug](../common-options.md#debug)                                           | false                      |
+| <a id="check_nla_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                      |
+| <a id="check_nla_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                         |
+| <a id="check_nla_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                            |
+| <a id="check_nla_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                      |
+| <a id="check_nla_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                          |
+| <a id="check_nla_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}         |
+| <a id="check_nla_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | ${status}: all networks ok |
+| <a id="check_nla_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No networks found          |
+| <a id="check_nla_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${network}=${category}     |
+| <a id="check_nla_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${network}                 |
+| <a id="check_nla_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                            |
+| <a id="check_nla_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                            |
+| <a id="check_nla_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                         |
+| <a id="check_nla_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                            |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1917,25 +1961,29 @@ L        cli UNKNOWN: check_secureboot is not supported on this platform (Window
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                            | Default Value                                         |
-|---------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| <a id="check_secureboot_filter"></a>[filter](../common-options.md#filter)                         |                                                       |
-| <a id="check_secureboot_warning"></a>[warning](../common-options.md#warning)                      |                                                       |
-| <a id="check_secureboot_warn"></a>[warn](../common-options.md#warn)                               |                                                       |
-| <a id="check_secureboot_critical"></a>[critical](../common-options.md#critical)                   | enabled = 0                                           |
-| <a id="check_secureboot_crit"></a>[crit](../common-options.md#crit)                               |                                                       |
-| <a id="check_secureboot_ok"></a>[ok](../common-options.md#ok)                                     |                                                       |
-| <a id="check_secureboot_debug"></a>[debug](../common-options.md#debug)                            | false                                                 |
-| <a id="check_secureboot_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                 |
-| <a id="check_secureboot_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                               |
-| <a id="check_secureboot_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                       |
-| <a id="check_secureboot_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                 |
-| <a id="check_secureboot_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                     |
-| <a id="check_secureboot_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                    |
-| <a id="check_secureboot_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | ${status}: secure boot is enabled                     |
-| <a id="check_secureboot_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No Secure Boot state                                  |
-| <a id="check_secureboot_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | secure boot enabled=${enabled} supported=${supported} |
-| <a id="check_secureboot_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | secureboot                                            |
+| Option                                                                                                           | Default Value                                         |
+|------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| <a id="check_secureboot_filter"></a>[filter](../common-options.md#filter)                                        |                                                       |
+| <a id="check_secureboot_warning"></a>[warning](../common-options.md#warning)                                     |                                                       |
+| <a id="check_secureboot_warn"></a>[warn](../common-options.md#warn)                                              |                                                       |
+| <a id="check_secureboot_critical"></a>[critical](../common-options.md#critical)                                  | enabled = 0                                           |
+| <a id="check_secureboot_crit"></a>[crit](../common-options.md#crit)                                              |                                                       |
+| <a id="check_secureboot_ok"></a>[ok](../common-options.md#ok)                                                    |                                                       |
+| <a id="check_secureboot_debug"></a>[debug](../common-options.md#debug)                                           | false                                                 |
+| <a id="check_secureboot_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                 |
+| <a id="check_secureboot_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                               |
+| <a id="check_secureboot_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                       |
+| <a id="check_secureboot_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                 |
+| <a id="check_secureboot_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                     |
+| <a id="check_secureboot_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                    |
+| <a id="check_secureboot_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | ${status}: secure boot is enabled                     |
+| <a id="check_secureboot_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No Secure Boot state                                  |
+| <a id="check_secureboot_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | secure boot enabled=${enabled} supported=${supported} |
+| <a id="check_secureboot_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | secureboot                                            |
+| <a id="check_secureboot_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                       |
+| <a id="check_secureboot_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                       |
+| <a id="check_secureboot_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                    |
+| <a id="check_secureboot_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                       |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2033,25 +2081,29 @@ check_users "crit=session_state = 'disconnected'" "detail-syntax=${user} (${sess
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                       | Default Value                                  |
-|----------------------------------------------------------------------------------------------|------------------------------------------------|
-| <a id="check_users_filter"></a>[filter](../common-options.md#filter)                         |                                                |
-| <a id="check_users_warning"></a>[warning](../common-options.md#warning)                      |                                                |
-| <a id="check_users_warn"></a>[warn](../common-options.md#warn)                               |                                                |
-| <a id="check_users_critical"></a>[critical](../common-options.md#critical)                   |                                                |
-| <a id="check_users_crit"></a>[crit](../common-options.md#crit)                               |                                                |
-| <a id="check_users_ok"></a>[ok](../common-options.md#ok)                                     |                                                |
-| <a id="check_users_debug"></a>[debug](../common-options.md#debug)                            | false                                          |
-| <a id="check_users_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                          |
-| <a id="check_users_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                             |
-| <a id="check_users_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                |
-| <a id="check_users_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                          |
-| <a id="check_users_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                              |
-| <a id="check_users_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${count} user(s) logged on: ${list} |
-| <a id="check_users_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | ${status}: ${count} user(s) logged on          |
-| <a id="check_users_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No users logged on                             |
-| <a id="check_users_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${user}                                        |
-| <a id="check_users_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${user}                                        |
+| Option                                                                                                      | Default Value                                  |
+|-------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+| <a id="check_users_filter"></a>[filter](../common-options.md#filter)                                        |                                                |
+| <a id="check_users_warning"></a>[warning](../common-options.md#warning)                                     |                                                |
+| <a id="check_users_warn"></a>[warn](../common-options.md#warn)                                              |                                                |
+| <a id="check_users_critical"></a>[critical](../common-options.md#critical)                                  |                                                |
+| <a id="check_users_crit"></a>[crit](../common-options.md#crit)                                              |                                                |
+| <a id="check_users_ok"></a>[ok](../common-options.md#ok)                                                    |                                                |
+| <a id="check_users_debug"></a>[debug](../common-options.md#debug)                                           | false                                          |
+| <a id="check_users_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                          |
+| <a id="check_users_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                             |
+| <a id="check_users_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                |
+| <a id="check_users_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                          |
+| <a id="check_users_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                              |
+| <a id="check_users_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${count} user(s) logged on: ${list} |
+| <a id="check_users_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | ${status}: ${count} user(s) logged on          |
+| <a id="check_users_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No users logged on                             |
+| <a id="check_users_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${user}                                        |
+| <a id="check_users_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${user}                                        |
+| <a id="check_users_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                |
+| <a id="check_users_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                |
+| <a id="check_users_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                             |
+| <a id="check_users_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/check/CheckSystem.md
+++ b/docs/docs/reference/check/CheckSystem.md
@@ -92,25 +92,29 @@ A list of all short hand aliases for queries (check commands)
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                         | Default Value                                            |
-|------------------------------------------------------------------------------------------------|----------------------------------------------------------|
-| <a id="check_battery_filter"></a>[filter](../common-options.md#filter)                         | battery_present = 'true'                                 |
-| <a id="check_battery_warning"></a>[warning](../common-options.md#warning)                      | charge < 20                                              |
-| <a id="check_battery_warn"></a>[warn](../common-options.md#warn)                               |                                                          |
-| <a id="check_battery_critical"></a>[critical](../common-options.md#critical)                   | charge < 10                                              |
-| <a id="check_battery_crit"></a>[crit](../common-options.md#crit)                               |                                                          |
-| <a id="check_battery_ok"></a>[ok](../common-options.md#ok)                                     |                                                          |
-| <a id="check_battery_debug"></a>[debug](../common-options.md#debug)                            | false                                                    |
-| <a id="check_battery_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                    |
-| <a id="check_battery_empty-state"></a>[empty-state](../common-options.md#empty-state)          | warning                                                  |
-| <a id="check_battery_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                          |
-| <a id="check_battery_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                    |
-| <a id="check_battery_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                        |
-| <a id="check_battery_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                       |
-| <a id="check_battery_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): No battery found or all batteries ok.         |
-| <a id="check_battery_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No battery found                                         |
-| <a id="check_battery_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${charge}% (${power_source}, ${battery_status}) |
-| <a id="check_battery_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                  |
+| Option                                                                                                        | Default Value                                            |
+|---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------|
+| <a id="check_battery_filter"></a>[filter](../common-options.md#filter)                                        | battery_present = 'true'                                 |
+| <a id="check_battery_warning"></a>[warning](../common-options.md#warning)                                     | charge < 20                                              |
+| <a id="check_battery_warn"></a>[warn](../common-options.md#warn)                                              |                                                          |
+| <a id="check_battery_critical"></a>[critical](../common-options.md#critical)                                  | charge < 10                                              |
+| <a id="check_battery_crit"></a>[crit](../common-options.md#crit)                                              |                                                          |
+| <a id="check_battery_ok"></a>[ok](../common-options.md#ok)                                                    |                                                          |
+| <a id="check_battery_debug"></a>[debug](../common-options.md#debug)                                           | false                                                    |
+| <a id="check_battery_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                    |
+| <a id="check_battery_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | warning                                                  |
+| <a id="check_battery_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                          |
+| <a id="check_battery_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                    |
+| <a id="check_battery_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                        |
+| <a id="check_battery_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                       |
+| <a id="check_battery_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): No battery found or all batteries ok.         |
+| <a id="check_battery_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No battery found                                         |
+| <a id="check_battery_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${charge}% (${power_source}, ${battery_status}) |
+| <a id="check_battery_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                  |
+| <a id="check_battery_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                          |
+| <a id="check_battery_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                          |
+| <a id="check_battery_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                       |
+| <a id="check_battery_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                          |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -384,25 +388,29 @@ CPU Load ok
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                     | Default Value              |
-    |--------------------------------------------------------------------------------------------|----------------------------|
-    | <a id="check_cpu_filter"></a>[filter](../common-options.md#filter)                         | core = 'total'             |
-    | <a id="check_cpu_warning"></a>[warning](../common-options.md#warning)                      | load > 80                  |
-    | <a id="check_cpu_warn"></a>[warn](../common-options.md#warn)                               |                            |
-    | <a id="check_cpu_critical"></a>[critical](../common-options.md#critical)                   | load > 90                  |
-    | <a id="check_cpu_crit"></a>[crit](../common-options.md#crit)                               |                            |
-    | <a id="check_cpu_ok"></a>[ok](../common-options.md#ok)                                     |                            |
-    | <a id="check_cpu_debug"></a>[debug](../common-options.md#debug)                            | false                      |
-    | <a id="check_cpu_show-all"></a>[show-all](../common-options.md#show-all)                   | false                      |
-    | <a id="check_cpu_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                    |
-    | <a id="check_cpu_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                            |
-    | <a id="check_cpu_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                      |
-    | <a id="check_cpu_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                          |
-    | <a id="check_cpu_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list} |
-    | <a id="check_cpu_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): CPU load is ok. |
-    | <a id="check_cpu_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                            |
-    | <a id="check_cpu_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${time}: ${load}%          |
-    | <a id="check_cpu_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${core} ${time}            |
+    | Option                                                                                                    | Default Value              |
+    |-----------------------------------------------------------------------------------------------------------|----------------------------|
+    | <a id="check_cpu_filter"></a>[filter](../common-options.md#filter)                                        | core = 'total'             |
+    | <a id="check_cpu_warning"></a>[warning](../common-options.md#warning)                                     | load > 80                  |
+    | <a id="check_cpu_warn"></a>[warn](../common-options.md#warn)                                              |                            |
+    | <a id="check_cpu_critical"></a>[critical](../common-options.md#critical)                                  | load > 90                  |
+    | <a id="check_cpu_crit"></a>[crit](../common-options.md#crit)                                              |                            |
+    | <a id="check_cpu_ok"></a>[ok](../common-options.md#ok)                                                    |                            |
+    | <a id="check_cpu_debug"></a>[debug](../common-options.md#debug)                                           | false                      |
+    | <a id="check_cpu_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                      |
+    | <a id="check_cpu_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                    |
+    | <a id="check_cpu_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                            |
+    | <a id="check_cpu_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                      |
+    | <a id="check_cpu_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                          |
+    | <a id="check_cpu_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list} |
+    | <a id="check_cpu_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): CPU load is ok. |
+    | <a id="check_cpu_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                            |
+    | <a id="check_cpu_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${time}: ${load}%          |
+    | <a id="check_cpu_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${core} ${time}            |
+    | <a id="check_cpu_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                            |
+    | <a id="check_cpu_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                            |
+    | <a id="check_cpu_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                         |
+    | <a id="check_cpu_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                            |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -425,25 +433,29 @@ CPU Load ok
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                     | Default Value              |
-    |--------------------------------------------------------------------------------------------|----------------------------|
-    | <a id="check_cpu_filter"></a>[filter](../common-options.md#filter)                         | core = 'total'             |
-    | <a id="check_cpu_warning"></a>[warning](../common-options.md#warning)                      | load > 80                  |
-    | <a id="check_cpu_warn"></a>[warn](../common-options.md#warn)                               |                            |
-    | <a id="check_cpu_critical"></a>[critical](../common-options.md#critical)                   | load > 90                  |
-    | <a id="check_cpu_crit"></a>[crit](../common-options.md#crit)                               |                            |
-    | <a id="check_cpu_ok"></a>[ok](../common-options.md#ok)                                     |                            |
-    | <a id="check_cpu_debug"></a>[debug](../common-options.md#debug)                            | false                      |
-    | <a id="check_cpu_show-all"></a>[show-all](../common-options.md#show-all)                   | false                      |
-    | <a id="check_cpu_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                    |
-    | <a id="check_cpu_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                            |
-    | <a id="check_cpu_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                      |
-    | <a id="check_cpu_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                          |
-    | <a id="check_cpu_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list} |
-    | <a id="check_cpu_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): CPU load is ok. |
-    | <a id="check_cpu_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                            |
-    | <a id="check_cpu_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${time}: ${load}%          |
-    | <a id="check_cpu_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${core} ${time}            |
+    | Option                                                                                                    | Default Value              |
+    |-----------------------------------------------------------------------------------------------------------|----------------------------|
+    | <a id="check_cpu_filter"></a>[filter](../common-options.md#filter)                                        | core = 'total'             |
+    | <a id="check_cpu_warning"></a>[warning](../common-options.md#warning)                                     | load > 80                  |
+    | <a id="check_cpu_warn"></a>[warn](../common-options.md#warn)                                              |                            |
+    | <a id="check_cpu_critical"></a>[critical](../common-options.md#critical)                                  | load > 90                  |
+    | <a id="check_cpu_crit"></a>[crit](../common-options.md#crit)                                              |                            |
+    | <a id="check_cpu_ok"></a>[ok](../common-options.md#ok)                                                    |                            |
+    | <a id="check_cpu_debug"></a>[debug](../common-options.md#debug)                                           | false                      |
+    | <a id="check_cpu_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                      |
+    | <a id="check_cpu_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                    |
+    | <a id="check_cpu_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                            |
+    | <a id="check_cpu_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                      |
+    | <a id="check_cpu_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                          |
+    | <a id="check_cpu_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list} |
+    | <a id="check_cpu_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): CPU load is ok. |
+    | <a id="check_cpu_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                            |
+    | <a id="check_cpu_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${time}: ${load}%          |
+    | <a id="check_cpu_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${core} ${time}            |
+    | <a id="check_cpu_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                            |
+    | <a id="check_cpu_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                            |
+    | <a id="check_cpu_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                         |
+    | <a id="check_cpu_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                            |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -568,25 +580,29 @@ OK: Intel(R) Core(TM) Ultra 7 265H: 2200/2200 MHz (100%)
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                               | Default Value                                              |
-|------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
-| <a id="check_cpu_frequency_filter"></a>[filter](../common-options.md#filter)                         |                                                            |
-| <a id="check_cpu_frequency_warning"></a>[warning](../common-options.md#warning)                      |                                                            |
-| <a id="check_cpu_frequency_warn"></a>[warn](../common-options.md#warn)                               |                                                            |
-| <a id="check_cpu_frequency_critical"></a>[critical](../common-options.md#critical)                   |                                                            |
-| <a id="check_cpu_frequency_crit"></a>[crit](../common-options.md#crit)                               |                                                            |
-| <a id="check_cpu_frequency_ok"></a>[ok](../common-options.md#ok)                                     |                                                            |
-| <a id="check_cpu_frequency_debug"></a>[debug](../common-options.md#debug)                            | false                                                      |
-| <a id="check_cpu_frequency_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                      |
-| <a id="check_cpu_frequency_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                    |
-| <a id="check_cpu_frequency_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                            |
-| <a id="check_cpu_frequency_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                      |
-| <a id="check_cpu_frequency_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                          |
-| <a id="check_cpu_frequency_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                         |
-| <a id="check_cpu_frequency_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All CPU frequencies seem ok.                    |
-| <a id="check_cpu_frequency_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                            |
-| <a id="check_cpu_frequency_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${current_mhz}/${max_mhz} MHz (${frequency_pct}%) |
-| <a id="check_cpu_frequency_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                    |
+| Option                                                                                                              | Default Value                                              |
+|---------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------|
+| <a id="check_cpu_frequency_filter"></a>[filter](../common-options.md#filter)                                        |                                                            |
+| <a id="check_cpu_frequency_warning"></a>[warning](../common-options.md#warning)                                     |                                                            |
+| <a id="check_cpu_frequency_warn"></a>[warn](../common-options.md#warn)                                              |                                                            |
+| <a id="check_cpu_frequency_critical"></a>[critical](../common-options.md#critical)                                  |                                                            |
+| <a id="check_cpu_frequency_crit"></a>[crit](../common-options.md#crit)                                              |                                                            |
+| <a id="check_cpu_frequency_ok"></a>[ok](../common-options.md#ok)                                                    |                                                            |
+| <a id="check_cpu_frequency_debug"></a>[debug](../common-options.md#debug)                                           | false                                                      |
+| <a id="check_cpu_frequency_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                      |
+| <a id="check_cpu_frequency_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                    |
+| <a id="check_cpu_frequency_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                            |
+| <a id="check_cpu_frequency_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                      |
+| <a id="check_cpu_frequency_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                          |
+| <a id="check_cpu_frequency_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                         |
+| <a id="check_cpu_frequency_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All CPU frequencies seem ok.                    |
+| <a id="check_cpu_frequency_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                            |
+| <a id="check_cpu_frequency_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${current_mhz}/${max_mhz} MHz (${frequency_pct}%) |
+| <a id="check_cpu_frequency_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                    |
+| <a id="check_cpu_frequency_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                            |
+| <a id="check_cpu_frequency_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                            |
+| <a id="check_cpu_frequency_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                         |
+| <a id="check_cpu_frequency_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                            |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -633,25 +649,29 @@ Check CPU utilization broken down by user/system/iowait/steal/guest.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                                 | Default Value                                                                        |
-|--------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| <a id="check_cpu_utilization_filter"></a>[filter](../common-options.md#filter)                         |                                                                                      |
-| <a id="check_cpu_utilization_warning"></a>[warning](../common-options.md#warning)                      | usage > 90                                                                           |
-| <a id="check_cpu_utilization_warn"></a>[warn](../common-options.md#warn)                               |                                                                                      |
-| <a id="check_cpu_utilization_critical"></a>[critical](../common-options.md#critical)                   | usage > 95                                                                           |
-| <a id="check_cpu_utilization_crit"></a>[crit](../common-options.md#crit)                               |                                                                                      |
-| <a id="check_cpu_utilization_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                      |
-| <a id="check_cpu_utilization_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                |
-| <a id="check_cpu_utilization_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                |
-| <a id="check_cpu_utilization_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                                              |
-| <a id="check_cpu_utilization_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                      |
-| <a id="check_cpu_utilization_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                |
-| <a id="check_cpu_utilization_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                    |
-| <a id="check_cpu_utilization_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                   |
-| <a id="check_cpu_utilization_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                                      |
-| <a id="check_cpu_utilization_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                                      |
-| <a id="check_cpu_utilization_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | user: ${user}% system: ${system}% iowait: ${iowait}% steal: ${steal}% idle: ${idle}% |
-| <a id="check_cpu_utilization_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | cpu                                                                                  |
+| Option                                                                                                                | Default Value                                                                        |
+|-----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| <a id="check_cpu_utilization_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                      |
+| <a id="check_cpu_utilization_warning"></a>[warning](../common-options.md#warning)                                     | usage > 90                                                                           |
+| <a id="check_cpu_utilization_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                      |
+| <a id="check_cpu_utilization_critical"></a>[critical](../common-options.md#critical)                                  | usage > 95                                                                           |
+| <a id="check_cpu_utilization_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                      |
+| <a id="check_cpu_utilization_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                      |
+| <a id="check_cpu_utilization_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                |
+| <a id="check_cpu_utilization_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                |
+| <a id="check_cpu_utilization_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                                              |
+| <a id="check_cpu_utilization_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                      |
+| <a id="check_cpu_utilization_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                |
+| <a id="check_cpu_utilization_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                    |
+| <a id="check_cpu_utilization_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                   |
+| <a id="check_cpu_utilization_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                                      |
+| <a id="check_cpu_utilization_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                                      |
+| <a id="check_cpu_utilization_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | user: ${user}% system: ${system}% iowait: ${iowait}% steal: ${steal}% idle: ${idle}% |
+| <a id="check_cpu_utilization_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | cpu                                                                                  |
+| <a id="check_cpu_utilization_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                      |
+| <a id="check_cpu_utilization_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                      |
+| <a id="check_cpu_utilization_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                   |
+| <a id="check_cpu_utilization_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                      |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -779,25 +799,29 @@ OK: Dell Inc. Dell Pro Max 16 MC16250 (Notebook), serial=ABC1234, 2 memory modul
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                          | Default Value                                                                             |
-|-------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
-| <a id="check_hardware_filter"></a>[filter](../common-options.md#filter)                         |                                                                                           |
-| <a id="check_hardware_warning"></a>[warning](../common-options.md#warning)                      |                                                                                           |
-| <a id="check_hardware_warn"></a>[warn](../common-options.md#warn)                               |                                                                                           |
-| <a id="check_hardware_critical"></a>[critical](../common-options.md#critical)                   |                                                                                           |
-| <a id="check_hardware_crit"></a>[crit](../common-options.md#crit)                               |                                                                                           |
-| <a id="check_hardware_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                           |
-| <a id="check_hardware_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                     |
-| <a id="check_hardware_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                     |
-| <a id="check_hardware_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                                                   |
-| <a id="check_hardware_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                           |
-| <a id="check_hardware_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                     |
-| <a id="check_hardware_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                         |
-| <a id="check_hardware_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                        |
-| <a id="check_hardware_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                                           |
-| <a id="check_hardware_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                                           |
-| <a id="check_hardware_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${vendor} ${model} (${chassis}), serial=${serial}, ${modules} memory module(s), ${memory} |
-| <a id="check_hardware_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | hardware                                                                                  |
+| Option                                                                                                         | Default Value                                                                             |
+|----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
+| <a id="check_hardware_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                           |
+| <a id="check_hardware_warning"></a>[warning](../common-options.md#warning)                                     |                                                                                           |
+| <a id="check_hardware_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                           |
+| <a id="check_hardware_critical"></a>[critical](../common-options.md#critical)                                  |                                                                                           |
+| <a id="check_hardware_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                           |
+| <a id="check_hardware_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                           |
+| <a id="check_hardware_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                     |
+| <a id="check_hardware_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                     |
+| <a id="check_hardware_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                                                   |
+| <a id="check_hardware_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                           |
+| <a id="check_hardware_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                     |
+| <a id="check_hardware_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                         |
+| <a id="check_hardware_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                        |
+| <a id="check_hardware_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                                           |
+| <a id="check_hardware_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                                           |
+| <a id="check_hardware_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${vendor} ${model} (${chassis}), serial=${serial}, ${modules} memory module(s), ${memory} |
+| <a id="check_hardware_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | hardware                                                                                  |
+| <a id="check_hardware_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                           |
+| <a id="check_hardware_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                           |
+| <a id="check_hardware_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                        |
+| <a id="check_hardware_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                           |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -968,25 +992,29 @@ OK: WEB01 (web01.corp.example.com), domain=corp.example.com
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                          | Default Value                               |
-    |-------------------------------------------------------------------------------------------------|---------------------------------------------|
-    | <a id="check_hostname_filter"></a>[filter](../common-options.md#filter)                         |                                             |
-    | <a id="check_hostname_warning"></a>[warning](../common-options.md#warning)                      |                                             |
-    | <a id="check_hostname_warn"></a>[warn](../common-options.md#warn)                               |                                             |
-    | <a id="check_hostname_critical"></a>[critical](../common-options.md#critical)                   |                                             |
-    | <a id="check_hostname_crit"></a>[crit](../common-options.md#crit)                               |                                             |
-    | <a id="check_hostname_ok"></a>[ok](../common-options.md#ok)                                     |                                             |
-    | <a id="check_hostname_debug"></a>[debug](../common-options.md#debug)                            | false                                       |
-    | <a id="check_hostname_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                       |
-    | <a id="check_hostname_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                     |
-    | <a id="check_hostname_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                             |
-    | <a id="check_hostname_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                       |
-    | <a id="check_hostname_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                           |
-    | <a id="check_hostname_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                          |
-    | <a id="check_hostname_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                             |
-    | <a id="check_hostname_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                             |
-    | <a id="check_hostname_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${hostname} (${fqdn}), ${join}=${join_name} |
-    | <a id="check_hostname_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | hostname                                    |
+    | Option                                                                                                         | Default Value                               |
+    |----------------------------------------------------------------------------------------------------------------|---------------------------------------------|
+    | <a id="check_hostname_filter"></a>[filter](../common-options.md#filter)                                        |                                             |
+    | <a id="check_hostname_warning"></a>[warning](../common-options.md#warning)                                     |                                             |
+    | <a id="check_hostname_warn"></a>[warn](../common-options.md#warn)                                              |                                             |
+    | <a id="check_hostname_critical"></a>[critical](../common-options.md#critical)                                  |                                             |
+    | <a id="check_hostname_crit"></a>[crit](../common-options.md#crit)                                              |                                             |
+    | <a id="check_hostname_ok"></a>[ok](../common-options.md#ok)                                                    |                                             |
+    | <a id="check_hostname_debug"></a>[debug](../common-options.md#debug)                                           | false                                       |
+    | <a id="check_hostname_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                       |
+    | <a id="check_hostname_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                     |
+    | <a id="check_hostname_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                             |
+    | <a id="check_hostname_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                       |
+    | <a id="check_hostname_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                           |
+    | <a id="check_hostname_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                          |
+    | <a id="check_hostname_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                             |
+    | <a id="check_hostname_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                             |
+    | <a id="check_hostname_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${hostname} (${fqdn}), ${join}=${join_name} |
+    | <a id="check_hostname_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | hostname                                    |
+    | <a id="check_hostname_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                             |
+    | <a id="check_hostname_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                             |
+    | <a id="check_hostname_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                          |
+    | <a id="check_hostname_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                             |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -998,25 +1026,29 @@ OK: WEB01 (web01.corp.example.com), domain=corp.example.com
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                          | Default Value                           |
-    |-------------------------------------------------------------------------------------------------|-----------------------------------------|
-    | <a id="check_hostname_filter"></a>[filter](../common-options.md#filter)                         |                                         |
-    | <a id="check_hostname_warning"></a>[warning](../common-options.md#warning)                      |                                         |
-    | <a id="check_hostname_warn"></a>[warn](../common-options.md#warn)                               |                                         |
-    | <a id="check_hostname_critical"></a>[critical](../common-options.md#critical)                   |                                         |
-    | <a id="check_hostname_crit"></a>[crit](../common-options.md#crit)                               |                                         |
-    | <a id="check_hostname_ok"></a>[ok](../common-options.md#ok)                                     |                                         |
-    | <a id="check_hostname_debug"></a>[debug](../common-options.md#debug)                            | false                                   |
-    | <a id="check_hostname_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                   |
-    | <a id="check_hostname_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                 |
-    | <a id="check_hostname_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                         |
-    | <a id="check_hostname_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                   |
-    | <a id="check_hostname_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                       |
-    | <a id="check_hostname_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                      |
-    | <a id="check_hostname_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                         |
-    | <a id="check_hostname_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                         |
-    | <a id="check_hostname_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${hostname} (${fqdn}), domain=${domain} |
-    | <a id="check_hostname_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | hostname                                |
+    | Option                                                                                                         | Default Value                           |
+    |----------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+    | <a id="check_hostname_filter"></a>[filter](../common-options.md#filter)                                        |                                         |
+    | <a id="check_hostname_warning"></a>[warning](../common-options.md#warning)                                     |                                         |
+    | <a id="check_hostname_warn"></a>[warn](../common-options.md#warn)                                              |                                         |
+    | <a id="check_hostname_critical"></a>[critical](../common-options.md#critical)                                  |                                         |
+    | <a id="check_hostname_crit"></a>[crit](../common-options.md#crit)                                              |                                         |
+    | <a id="check_hostname_ok"></a>[ok](../common-options.md#ok)                                                    |                                         |
+    | <a id="check_hostname_debug"></a>[debug](../common-options.md#debug)                                           | false                                   |
+    | <a id="check_hostname_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                   |
+    | <a id="check_hostname_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                 |
+    | <a id="check_hostname_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                         |
+    | <a id="check_hostname_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                   |
+    | <a id="check_hostname_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                       |
+    | <a id="check_hostname_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                      |
+    | <a id="check_hostname_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                         |
+    | <a id="check_hostname_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                         |
+    | <a id="check_hostname_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${hostname} (${fqdn}), domain=${domain} |
+    | <a id="check_hostname_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | hostname                                |
+    | <a id="check_hostname_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                         |
+    | <a id="check_hostname_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                         |
+    | <a id="check_hostname_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                      |
+    | <a id="check_hostname_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                         |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1210,25 +1242,29 @@ OK: 101 software packages installed.
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                                    | Default Value                                    |
-    |-----------------------------------------------------------------------------------------------------------|--------------------------------------------------|
-    | <a id="check_installed_software_filter"></a>[filter](../common-options.md#filter)                         | system_component = 0                             |
-    | <a id="check_installed_software_warning"></a>[warning](../common-options.md#warning)                      |                                                  |
-    | <a id="check_installed_software_warn"></a>[warn](../common-options.md#warn)                               |                                                  |
-    | <a id="check_installed_software_critical"></a>[critical](../common-options.md#critical)                   |                                                  |
-    | <a id="check_installed_software_crit"></a>[crit](../common-options.md#crit)                               |                                                  |
-    | <a id="check_installed_software_ok"></a>[ok](../common-options.md#ok)                                     |                                                  |
-    | <a id="check_installed_software_debug"></a>[debug](../common-options.md#debug)                            | false                                            |
-    | <a id="check_installed_software_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                            |
-    | <a id="check_installed_software_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                               |
-    | <a id="check_installed_software_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                  |
-    | <a id="check_installed_software_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                            |
-    | <a id="check_installed_software_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                |
-    | <a id="check_installed_software_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                       |
-    | <a id="check_installed_software_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(count) software packages installed. |
-    | <a id="check_installed_software_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No installed software found           |
-    | <a id="check_installed_software_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name} ${version} (${publisher})                |
-    | <a id="check_installed_software_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                          |
+    | Option                                                                                                                   | Default Value                                    |
+    |--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+    | <a id="check_installed_software_filter"></a>[filter](../common-options.md#filter)                                        | system_component = 0                             |
+    | <a id="check_installed_software_warning"></a>[warning](../common-options.md#warning)                                     |                                                  |
+    | <a id="check_installed_software_warn"></a>[warn](../common-options.md#warn)                                              |                                                  |
+    | <a id="check_installed_software_critical"></a>[critical](../common-options.md#critical)                                  |                                                  |
+    | <a id="check_installed_software_crit"></a>[crit](../common-options.md#crit)                                              |                                                  |
+    | <a id="check_installed_software_ok"></a>[ok](../common-options.md#ok)                                                    |                                                  |
+    | <a id="check_installed_software_debug"></a>[debug](../common-options.md#debug)                                           | false                                            |
+    | <a id="check_installed_software_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                            |
+    | <a id="check_installed_software_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                               |
+    | <a id="check_installed_software_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                  |
+    | <a id="check_installed_software_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                            |
+    | <a id="check_installed_software_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                |
+    | <a id="check_installed_software_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                       |
+    | <a id="check_installed_software_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(count) software packages installed. |
+    | <a id="check_installed_software_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No installed software found           |
+    | <a id="check_installed_software_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name} ${version} (${publisher})                |
+    | <a id="check_installed_software_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                          |
+    | <a id="check_installed_software_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                  |
+    | <a id="check_installed_software_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                  |
+    | <a id="check_installed_software_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                               |
+    | <a id="check_installed_software_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                  |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1240,25 +1276,29 @@ OK: 101 software packages installed.
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                                    | Default Value                                    |
-    |-----------------------------------------------------------------------------------------------------------|--------------------------------------------------|
-    | <a id="check_installed_software_filter"></a>[filter](../common-options.md#filter)                         |                                                  |
-    | <a id="check_installed_software_warning"></a>[warning](../common-options.md#warning)                      |                                                  |
-    | <a id="check_installed_software_warn"></a>[warn](../common-options.md#warn)                               |                                                  |
-    | <a id="check_installed_software_critical"></a>[critical](../common-options.md#critical)                   |                                                  |
-    | <a id="check_installed_software_crit"></a>[crit](../common-options.md#crit)                               |                                                  |
-    | <a id="check_installed_software_ok"></a>[ok](../common-options.md#ok)                                     |                                                  |
-    | <a id="check_installed_software_debug"></a>[debug](../common-options.md#debug)                            | false                                            |
-    | <a id="check_installed_software_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                            |
-    | <a id="check_installed_software_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                               |
-    | <a id="check_installed_software_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                  |
-    | <a id="check_installed_software_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                            |
-    | <a id="check_installed_software_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                |
-    | <a id="check_installed_software_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                       |
-    | <a id="check_installed_software_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): %(count) software packages installed. |
-    | <a id="check_installed_software_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No installed software found           |
-    | <a id="check_installed_software_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name} ${version} (${publisher})                |
-    | <a id="check_installed_software_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                          |
+    | Option                                                                                                                   | Default Value                                    |
+    |--------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+    | <a id="check_installed_software_filter"></a>[filter](../common-options.md#filter)                                        |                                                  |
+    | <a id="check_installed_software_warning"></a>[warning](../common-options.md#warning)                                     |                                                  |
+    | <a id="check_installed_software_warn"></a>[warn](../common-options.md#warn)                                              |                                                  |
+    | <a id="check_installed_software_critical"></a>[critical](../common-options.md#critical)                                  |                                                  |
+    | <a id="check_installed_software_crit"></a>[crit](../common-options.md#crit)                                              |                                                  |
+    | <a id="check_installed_software_ok"></a>[ok](../common-options.md#ok)                                                    |                                                  |
+    | <a id="check_installed_software_debug"></a>[debug](../common-options.md#debug)                                           | false                                            |
+    | <a id="check_installed_software_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                            |
+    | <a id="check_installed_software_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                               |
+    | <a id="check_installed_software_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                  |
+    | <a id="check_installed_software_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                            |
+    | <a id="check_installed_software_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                |
+    | <a id="check_installed_software_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                       |
+    | <a id="check_installed_software_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): %(count) software packages installed. |
+    | <a id="check_installed_software_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No installed software found           |
+    | <a id="check_installed_software_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name} ${version} (${publisher})                |
+    | <a id="check_installed_software_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                          |
+    | <a id="check_installed_software_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                  |
+    | <a id="check_installed_software_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                  |
+    | <a id="check_installed_software_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                               |
+    | <a id="check_installed_software_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                  |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1425,25 +1465,29 @@ OK: paged pool 1.685GB, nonpaged pool 2.571GB, cache 284.676MB, 57.2 hard faults
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                               | Default Value                                                                                                  |
-    |------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
-    | <a id="check_kernel_memory_filter"></a>[filter](../common-options.md#filter)                         |                                                                                                                |
-    | <a id="check_kernel_memory_warning"></a>[warning](../common-options.md#warning)                      |                                                                                                                |
-    | <a id="check_kernel_memory_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                                |
-    | <a id="check_kernel_memory_critical"></a>[critical](../common-options.md#critical)                   |                                                                                                                |
-    | <a id="check_kernel_memory_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                                |
-    | <a id="check_kernel_memory_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                                |
-    | <a id="check_kernel_memory_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                          |
-    | <a id="check_kernel_memory_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                          |
-    | <a id="check_kernel_memory_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                                                                        |
-    | <a id="check_kernel_memory_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                                |
-    | <a id="check_kernel_memory_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                          |
-    | <a id="check_kernel_memory_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                              |
-    | <a id="check_kernel_memory_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                             |
-    | <a id="check_kernel_memory_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                                                                |
-    | <a id="check_kernel_memory_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                                                                |
-    | <a id="check_kernel_memory_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | paged pool ${pool_paged}, nonpaged pool ${pool_nonpaged}, cache ${cache}, ${hard_faults_per_sec} hard faults/s |
-    | <a id="check_kernel_memory_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | kernel                                                                                                         |
+    | Option                                                                                                              | Default Value                                                                                                  |
+    |---------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+    | <a id="check_kernel_memory_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                                                |
+    | <a id="check_kernel_memory_warning"></a>[warning](../common-options.md#warning)                                     |                                                                                                                |
+    | <a id="check_kernel_memory_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                                |
+    | <a id="check_kernel_memory_critical"></a>[critical](../common-options.md#critical)                                  |                                                                                                                |
+    | <a id="check_kernel_memory_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                                |
+    | <a id="check_kernel_memory_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                                |
+    | <a id="check_kernel_memory_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                          |
+    | <a id="check_kernel_memory_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                          |
+    | <a id="check_kernel_memory_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                                                                        |
+    | <a id="check_kernel_memory_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                                |
+    | <a id="check_kernel_memory_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                          |
+    | <a id="check_kernel_memory_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                              |
+    | <a id="check_kernel_memory_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                             |
+    | <a id="check_kernel_memory_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                                                                |
+    | <a id="check_kernel_memory_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                                                                |
+    | <a id="check_kernel_memory_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | paged pool ${pool_paged}, nonpaged pool ${pool_nonpaged}, cache ${cache}, ${hard_faults_per_sec} hard faults/s |
+    | <a id="check_kernel_memory_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | kernel                                                                                                         |
+    | <a id="check_kernel_memory_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                                |
+    | <a id="check_kernel_memory_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                                |
+    | <a id="check_kernel_memory_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                             |
+    | <a id="check_kernel_memory_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                                |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1455,25 +1499,29 @@ OK: paged pool 1.685GB, nonpaged pool 2.571GB, cache 284.676MB, 57.2 hard faults
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                               | Default Value                                                                                              |
-    |------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
-    | <a id="check_kernel_memory_filter"></a>[filter](../common-options.md#filter)                         |                                                                                                            |
-    | <a id="check_kernel_memory_warning"></a>[warning](../common-options.md#warning)                      |                                                                                                            |
-    | <a id="check_kernel_memory_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                            |
-    | <a id="check_kernel_memory_critical"></a>[critical](../common-options.md#critical)                   |                                                                                                            |
-    | <a id="check_kernel_memory_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                            |
-    | <a id="check_kernel_memory_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                            |
-    | <a id="check_kernel_memory_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                      |
-    | <a id="check_kernel_memory_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                      |
-    | <a id="check_kernel_memory_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                                                                    |
-    | <a id="check_kernel_memory_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                            |
-    | <a id="check_kernel_memory_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                      |
-    | <a id="check_kernel_memory_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                          |
-    | <a id="check_kernel_memory_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                         |
-    | <a id="check_kernel_memory_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                                                            |
-    | <a id="check_kernel_memory_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                                                            |
-    | <a id="check_kernel_memory_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | slab ${slab} (${slab_unreclaimable} unreclaimable), cache ${cache}, ${major_faults_per_sec} major faults/s |
-    | <a id="check_kernel_memory_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | kernel                                                                                                     |
+    | Option                                                                                                              | Default Value                                                                                              |
+    |---------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------|
+    | <a id="check_kernel_memory_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                                            |
+    | <a id="check_kernel_memory_warning"></a>[warning](../common-options.md#warning)                                     |                                                                                                            |
+    | <a id="check_kernel_memory_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                            |
+    | <a id="check_kernel_memory_critical"></a>[critical](../common-options.md#critical)                                  |                                                                                                            |
+    | <a id="check_kernel_memory_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                            |
+    | <a id="check_kernel_memory_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                            |
+    | <a id="check_kernel_memory_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                      |
+    | <a id="check_kernel_memory_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                      |
+    | <a id="check_kernel_memory_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                                                                    |
+    | <a id="check_kernel_memory_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                            |
+    | <a id="check_kernel_memory_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                      |
+    | <a id="check_kernel_memory_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                          |
+    | <a id="check_kernel_memory_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                         |
+    | <a id="check_kernel_memory_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                                                            |
+    | <a id="check_kernel_memory_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                                                            |
+    | <a id="check_kernel_memory_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | slab ${slab} (${slab_unreclaimable} unreclaimable), cache ${cache}, ${major_faults_per_sec} major faults/s |
+    | <a id="check_kernel_memory_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | kernel                                                                                                     |
+    | <a id="check_kernel_memory_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                            |
+    | <a id="check_kernel_memory_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                            |
+    | <a id="check_kernel_memory_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                         |
+    | <a id="check_kernel_memory_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                            |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1648,25 +1696,29 @@ OK - Context Switches 119058.5/s, System Calls 268702.6/s, Processes 628, Thread
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                              | Default Value                        |
-    |-----------------------------------------------------------------------------------------------------|--------------------------------------|
-    | <a id="check_kernel_stats_filter"></a>[filter](../common-options.md#filter)                         |                                      |
-    | <a id="check_kernel_stats_warning"></a>[warning](../common-options.md#warning)                      | name = 'threads' and current > 8000  |
-    | <a id="check_kernel_stats_warn"></a>[warn](../common-options.md#warn)                               |                                      |
-    | <a id="check_kernel_stats_critical"></a>[critical](../common-options.md#critical)                   | name = 'threads' and current > 10000 |
-    | <a id="check_kernel_stats_crit"></a>[crit](../common-options.md#crit)                               |                                      |
-    | <a id="check_kernel_stats_ok"></a>[ok](../common-options.md#ok)                                     |                                      |
-    | <a id="check_kernel_stats_debug"></a>[debug](../common-options.md#debug)                            | false                                |
-    | <a id="check_kernel_stats_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                |
-    | <a id="check_kernel_stats_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                              |
-    | <a id="check_kernel_stats_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                      |
-    | <a id="check_kernel_stats_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                |
-    | <a id="check_kernel_stats_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                    |
-    | <a id="check_kernel_stats_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status} - ${list}                  |
-    | <a id="check_kernel_stats_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                      |
-    | <a id="check_kernel_stats_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                      |
-    | <a id="check_kernel_stats_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${label} ${human}                    |
-    | <a id="check_kernel_stats_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                              |
+    | Option                                                                                                             | Default Value                        |
+    |--------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+    | <a id="check_kernel_stats_filter"></a>[filter](../common-options.md#filter)                                        |                                      |
+    | <a id="check_kernel_stats_warning"></a>[warning](../common-options.md#warning)                                     | name = 'threads' and current > 8000  |
+    | <a id="check_kernel_stats_warn"></a>[warn](../common-options.md#warn)                                              |                                      |
+    | <a id="check_kernel_stats_critical"></a>[critical](../common-options.md#critical)                                  | name = 'threads' and current > 10000 |
+    | <a id="check_kernel_stats_crit"></a>[crit](../common-options.md#crit)                                              |                                      |
+    | <a id="check_kernel_stats_ok"></a>[ok](../common-options.md#ok)                                                    |                                      |
+    | <a id="check_kernel_stats_debug"></a>[debug](../common-options.md#debug)                                           | false                                |
+    | <a id="check_kernel_stats_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                |
+    | <a id="check_kernel_stats_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                              |
+    | <a id="check_kernel_stats_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                      |
+    | <a id="check_kernel_stats_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                |
+    | <a id="check_kernel_stats_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                    |
+    | <a id="check_kernel_stats_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status} - ${list}                  |
+    | <a id="check_kernel_stats_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                      |
+    | <a id="check_kernel_stats_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                      |
+    | <a id="check_kernel_stats_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${label} ${human}                    |
+    | <a id="check_kernel_stats_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                              |
+    | <a id="check_kernel_stats_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                      |
+    | <a id="check_kernel_stats_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                      |
+    | <a id="check_kernel_stats_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                   |
+    | <a id="check_kernel_stats_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                      |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1687,25 +1739,29 @@ OK - Context Switches 119058.5/s, System Calls 268702.6/s, Processes 628, Thread
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                              | Default Value                        |
-    |-----------------------------------------------------------------------------------------------------|--------------------------------------|
-    | <a id="check_kernel_stats_filter"></a>[filter](../common-options.md#filter)                         |                                      |
-    | <a id="check_kernel_stats_warning"></a>[warning](../common-options.md#warning)                      | name = 'threads' and current > 8000  |
-    | <a id="check_kernel_stats_warn"></a>[warn](../common-options.md#warn)                               |                                      |
-    | <a id="check_kernel_stats_critical"></a>[critical](../common-options.md#critical)                   | name = 'threads' and current > 10000 |
-    | <a id="check_kernel_stats_crit"></a>[crit](../common-options.md#crit)                               |                                      |
-    | <a id="check_kernel_stats_ok"></a>[ok](../common-options.md#ok)                                     |                                      |
-    | <a id="check_kernel_stats_debug"></a>[debug](../common-options.md#debug)                            | false                                |
-    | <a id="check_kernel_stats_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                |
-    | <a id="check_kernel_stats_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                              |
-    | <a id="check_kernel_stats_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                      |
-    | <a id="check_kernel_stats_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                |
-    | <a id="check_kernel_stats_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                    |
-    | <a id="check_kernel_stats_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status} - ${list}                  |
-    | <a id="check_kernel_stats_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                      |
-    | <a id="check_kernel_stats_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                      |
-    | <a id="check_kernel_stats_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${label} ${human}                    |
-    | <a id="check_kernel_stats_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                              |
+    | Option                                                                                                             | Default Value                        |
+    |--------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+    | <a id="check_kernel_stats_filter"></a>[filter](../common-options.md#filter)                                        |                                      |
+    | <a id="check_kernel_stats_warning"></a>[warning](../common-options.md#warning)                                     | name = 'threads' and current > 8000  |
+    | <a id="check_kernel_stats_warn"></a>[warn](../common-options.md#warn)                                              |                                      |
+    | <a id="check_kernel_stats_critical"></a>[critical](../common-options.md#critical)                                  | name = 'threads' and current > 10000 |
+    | <a id="check_kernel_stats_crit"></a>[crit](../common-options.md#crit)                                              |                                      |
+    | <a id="check_kernel_stats_ok"></a>[ok](../common-options.md#ok)                                                    |                                      |
+    | <a id="check_kernel_stats_debug"></a>[debug](../common-options.md#debug)                                           | false                                |
+    | <a id="check_kernel_stats_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                |
+    | <a id="check_kernel_stats_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                              |
+    | <a id="check_kernel_stats_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                      |
+    | <a id="check_kernel_stats_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                |
+    | <a id="check_kernel_stats_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                    |
+    | <a id="check_kernel_stats_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status} - ${list}                  |
+    | <a id="check_kernel_stats_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                      |
+    | <a id="check_kernel_stats_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                      |
+    | <a id="check_kernel_stats_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${label} ${human}                    |
+    | <a id="check_kernel_stats_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                              |
+    | <a id="check_kernel_stats_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                      |
+    | <a id="check_kernel_stats_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                      |
+    | <a id="check_kernel_stats_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                   |
+    | <a id="check_kernel_stats_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                      |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -1916,25 +1972,29 @@ Divide the load averages by the number of CPUs (reports the 'scaled' per-core lo
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                      | Default Value                                       |
-|---------------------------------------------------------------------------------------------|-----------------------------------------------------|
-| <a id="check_load_filter"></a>[filter](../common-options.md#filter)                         |                                                     |
-| <a id="check_load_warning"></a>[warning](../common-options.md#warning)                      |                                                     |
-| <a id="check_load_warn"></a>[warn](../common-options.md#warn)                               |                                                     |
-| <a id="check_load_critical"></a>[critical](../common-options.md#critical)                   |                                                     |
-| <a id="check_load_crit"></a>[crit](../common-options.md#crit)                               |                                                     |
-| <a id="check_load_ok"></a>[ok](../common-options.md#ok)                                     |                                                     |
-| <a id="check_load_debug"></a>[debug](../common-options.md#debug)                            | false                                               |
-| <a id="check_load_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                               |
-| <a id="check_load_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                             |
-| <a id="check_load_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                     |
-| <a id="check_load_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                               |
-| <a id="check_load_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                   |
-| <a id="check_load_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                  |
-| <a id="check_load_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                     |
-| <a id="check_load_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                     |
-| <a id="check_load_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${type} load average: ${load1}, ${load5}, ${load15} |
-| <a id="check_load_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${type}                                             |
+| Option                                                                                                     | Default Value                                       |
+|------------------------------------------------------------------------------------------------------------|-----------------------------------------------------|
+| <a id="check_load_filter"></a>[filter](../common-options.md#filter)                                        |                                                     |
+| <a id="check_load_warning"></a>[warning](../common-options.md#warning)                                     |                                                     |
+| <a id="check_load_warn"></a>[warn](../common-options.md#warn)                                              |                                                     |
+| <a id="check_load_critical"></a>[critical](../common-options.md#critical)                                  |                                                     |
+| <a id="check_load_crit"></a>[crit](../common-options.md#crit)                                              |                                                     |
+| <a id="check_load_ok"></a>[ok](../common-options.md#ok)                                                    |                                                     |
+| <a id="check_load_debug"></a>[debug](../common-options.md#debug)                                           | false                                               |
+| <a id="check_load_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                               |
+| <a id="check_load_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                             |
+| <a id="check_load_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                     |
+| <a id="check_load_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                               |
+| <a id="check_load_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                   |
+| <a id="check_load_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                  |
+| <a id="check_load_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                     |
+| <a id="check_load_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                     |
+| <a id="check_load_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${type} load average: ${load1}, ${load5}, ${load15} |
+| <a id="check_load_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${type}                                             |
+| <a id="check_load_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                     |
+| <a id="check_load_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                     |
+| <a id="check_load_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                  |
+| <a id="check_load_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                     |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2054,25 +2114,29 @@ page = 8.05G, physical = 7.85G
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                        | Default Value            |
-    |-----------------------------------------------------------------------------------------------|--------------------------|
-    | <a id="check_memory_filter"></a>[filter](../common-options.md#filter)                         |                          |
-    | <a id="check_memory_warning"></a>[warning](../common-options.md#warning)                      | used > 80%               |
-    | <a id="check_memory_warn"></a>[warn](../common-options.md#warn)                               |                          |
-    | <a id="check_memory_critical"></a>[critical](../common-options.md#critical)                   | used > 90%               |
-    | <a id="check_memory_crit"></a>[crit](../common-options.md#crit)                               |                          |
-    | <a id="check_memory_ok"></a>[ok](../common-options.md#ok)                                     |                          |
-    | <a id="check_memory_debug"></a>[debug](../common-options.md#debug)                            | false                    |
-    | <a id="check_memory_show-all"></a>[show-all](../common-options.md#show-all)                   | false                    |
-    | <a id="check_memory_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                  |
-    | <a id="check_memory_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                          |
-    | <a id="check_memory_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                    |
-    | <a id="check_memory_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                        |
-    | <a id="check_memory_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}       |
-    | <a id="check_memory_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                          |
-    | <a id="check_memory_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                          |
-    | <a id="check_memory_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${type}: ${used}/${size} |
-    | <a id="check_memory_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${type}                  |
+    | Option                                                                                                       | Default Value            |
+    |--------------------------------------------------------------------------------------------------------------|--------------------------|
+    | <a id="check_memory_filter"></a>[filter](../common-options.md#filter)                                        |                          |
+    | <a id="check_memory_warning"></a>[warning](../common-options.md#warning)                                     | used > 80%               |
+    | <a id="check_memory_warn"></a>[warn](../common-options.md#warn)                                              |                          |
+    | <a id="check_memory_critical"></a>[critical](../common-options.md#critical)                                  | used > 90%               |
+    | <a id="check_memory_crit"></a>[crit](../common-options.md#crit)                                              |                          |
+    | <a id="check_memory_ok"></a>[ok](../common-options.md#ok)                                                    |                          |
+    | <a id="check_memory_debug"></a>[debug](../common-options.md#debug)                                           | false                    |
+    | <a id="check_memory_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                    |
+    | <a id="check_memory_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                  |
+    | <a id="check_memory_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                          |
+    | <a id="check_memory_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                    |
+    | <a id="check_memory_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                        |
+    | <a id="check_memory_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}       |
+    | <a id="check_memory_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                          |
+    | <a id="check_memory_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                          |
+    | <a id="check_memory_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${type}: ${used}/${size} |
+    | <a id="check_memory_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${type}                  |
+    | <a id="check_memory_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                          |
+    | <a id="check_memory_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                          |
+    | <a id="check_memory_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                       |
+    | <a id="check_memory_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                          |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2093,25 +2157,29 @@ page = 8.05G, physical = 7.85G
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                        | Default Value      |
-    |-----------------------------------------------------------------------------------------------|--------------------|
-    | <a id="check_memory_filter"></a>[filter](../common-options.md#filter)                         |                    |
-    | <a id="check_memory_warning"></a>[warning](../common-options.md#warning)                      | used > 80%         |
-    | <a id="check_memory_warn"></a>[warn](../common-options.md#warn)                               |                    |
-    | <a id="check_memory_critical"></a>[critical](../common-options.md#critical)                   | used > 90%         |
-    | <a id="check_memory_crit"></a>[crit](../common-options.md#crit)                               |                    |
-    | <a id="check_memory_ok"></a>[ok](../common-options.md#ok)                                     |                    |
-    | <a id="check_memory_debug"></a>[debug](../common-options.md#debug)                            | false              |
-    | <a id="check_memory_show-all"></a>[show-all](../common-options.md#show-all)                   | false              |
-    | <a id="check_memory_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored            |
-    | <a id="check_memory_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                    |
-    | <a id="check_memory_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false              |
-    | <a id="check_memory_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                  |
-    | <a id="check_memory_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list} |
-    | <a id="check_memory_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                    |
-    | <a id="check_memory_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                    |
-    | <a id="check_memory_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${type} = ${used}  |
-    | <a id="check_memory_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${type}            |
+    | Option                                                                                                       | Default Value      |
+    |--------------------------------------------------------------------------------------------------------------|--------------------|
+    | <a id="check_memory_filter"></a>[filter](../common-options.md#filter)                                        |                    |
+    | <a id="check_memory_warning"></a>[warning](../common-options.md#warning)                                     | used > 80%         |
+    | <a id="check_memory_warn"></a>[warn](../common-options.md#warn)                                              |                    |
+    | <a id="check_memory_critical"></a>[critical](../common-options.md#critical)                                  | used > 90%         |
+    | <a id="check_memory_crit"></a>[crit](../common-options.md#crit)                                              |                    |
+    | <a id="check_memory_ok"></a>[ok](../common-options.md#ok)                                                    |                    |
+    | <a id="check_memory_debug"></a>[debug](../common-options.md#debug)                                           | false              |
+    | <a id="check_memory_show-all"></a>[show-all](../common-options.md#show-all)                                  | false              |
+    | <a id="check_memory_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored            |
+    | <a id="check_memory_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                    |
+    | <a id="check_memory_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false              |
+    | <a id="check_memory_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                  |
+    | <a id="check_memory_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list} |
+    | <a id="check_memory_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                    |
+    | <a id="check_memory_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                    |
+    | <a id="check_memory_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${type} = ${used}  |
+    | <a id="check_memory_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${type}            |
+    | <a id="check_memory_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                    |
+    | <a id="check_memory_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                    |
+    | <a id="check_memory_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                 |
+    | <a id="check_memory_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                    |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2478,25 +2546,29 @@ page = 8.05G, physical = 7.85G
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                         | Default Value                                 |
-    |------------------------------------------------------------------------------------------------|-----------------------------------------------|
-    | <a id="check_network_filter"></a>[filter](../common-options.md#filter)                         |                                               |
-    | <a id="check_network_warning"></a>[warning](../common-options.md#warning)                      | throughput > 10000                            |
-    | <a id="check_network_warn"></a>[warn](../common-options.md#warn)                               |                                               |
-    | <a id="check_network_critical"></a>[critical](../common-options.md#critical)                   | throughput > 100000                           |
-    | <a id="check_network_crit"></a>[crit](../common-options.md#crit)                               |                                               |
-    | <a id="check_network_ok"></a>[ok](../common-options.md#ok)                                     |                                               |
-    | <a id="check_network_debug"></a>[debug](../common-options.md#debug)                            | false                                         |
-    | <a id="check_network_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                         |
-    | <a id="check_network_empty-state"></a>[empty-state](../common-options.md#empty-state)          | critical                                      |
-    | <a id="check_network_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                               |
-    | <a id="check_network_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                         |
-    | <a id="check_network_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                             |
-    | <a id="check_network_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                            |
-    | <a id="check_network_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): Network interfaces seem ok.        |
-    | <a id="check_network_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                               |
-    | <a id="check_network_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name} >${sent_human}/s <${received_human}/s |
-    | <a id="check_network_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                       |
+    | Option                                                                                                        | Default Value                                 |
+    |---------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+    | <a id="check_network_filter"></a>[filter](../common-options.md#filter)                                        |                                               |
+    | <a id="check_network_warning"></a>[warning](../common-options.md#warning)                                     | throughput > 10000                            |
+    | <a id="check_network_warn"></a>[warn](../common-options.md#warn)                                              |                                               |
+    | <a id="check_network_critical"></a>[critical](../common-options.md#critical)                                  | throughput > 100000                           |
+    | <a id="check_network_crit"></a>[crit](../common-options.md#crit)                                              |                                               |
+    | <a id="check_network_ok"></a>[ok](../common-options.md#ok)                                                    |                                               |
+    | <a id="check_network_debug"></a>[debug](../common-options.md#debug)                                           | false                                         |
+    | <a id="check_network_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                         |
+    | <a id="check_network_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | critical                                      |
+    | <a id="check_network_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                               |
+    | <a id="check_network_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                         |
+    | <a id="check_network_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                             |
+    | <a id="check_network_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                            |
+    | <a id="check_network_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): Network interfaces seem ok.        |
+    | <a id="check_network_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                               |
+    | <a id="check_network_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name} >${sent_human}/s <${received_human}/s |
+    | <a id="check_network_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                       |
+    | <a id="check_network_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                               |
+    | <a id="check_network_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                               |
+    | <a id="check_network_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                            |
+    | <a id="check_network_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                               |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2508,25 +2580,29 @@ page = 8.05G, physical = 7.85G
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                         | Default Value                                 |
-    |------------------------------------------------------------------------------------------------|-----------------------------------------------|
-    | <a id="check_network_filter"></a>[filter](../common-options.md#filter)                         |                                               |
-    | <a id="check_network_warning"></a>[warning](../common-options.md#warning)                      | throughput > 10000                            |
-    | <a id="check_network_warn"></a>[warn](../common-options.md#warn)                               |                                               |
-    | <a id="check_network_critical"></a>[critical](../common-options.md#critical)                   | throughput > 100000                           |
-    | <a id="check_network_crit"></a>[crit](../common-options.md#crit)                               |                                               |
-    | <a id="check_network_ok"></a>[ok](../common-options.md#ok)                                     |                                               |
-    | <a id="check_network_debug"></a>[debug](../common-options.md#debug)                            | false                                         |
-    | <a id="check_network_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                         |
-    | <a id="check_network_empty-state"></a>[empty-state](../common-options.md#empty-state)          | critical                                      |
-    | <a id="check_network_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                               |
-    | <a id="check_network_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                         |
-    | <a id="check_network_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                             |
-    | <a id="check_network_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                            |
-    | <a id="check_network_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): Network interfaces seem ok.        |
-    | <a id="check_network_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                               |
-    | <a id="check_network_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name} >${sent_human}/s <${received_human}/s |
-    | <a id="check_network_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                       |
+    | Option                                                                                                        | Default Value                                 |
+    |---------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+    | <a id="check_network_filter"></a>[filter](../common-options.md#filter)                                        |                                               |
+    | <a id="check_network_warning"></a>[warning](../common-options.md#warning)                                     | throughput > 10000                            |
+    | <a id="check_network_warn"></a>[warn](../common-options.md#warn)                                              |                                               |
+    | <a id="check_network_critical"></a>[critical](../common-options.md#critical)                                  | throughput > 100000                           |
+    | <a id="check_network_crit"></a>[crit](../common-options.md#crit)                                              |                                               |
+    | <a id="check_network_ok"></a>[ok](../common-options.md#ok)                                                    |                                               |
+    | <a id="check_network_debug"></a>[debug](../common-options.md#debug)                                           | false                                         |
+    | <a id="check_network_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                         |
+    | <a id="check_network_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | critical                                      |
+    | <a id="check_network_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                               |
+    | <a id="check_network_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                         |
+    | <a id="check_network_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                             |
+    | <a id="check_network_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                            |
+    | <a id="check_network_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): Network interfaces seem ok.        |
+    | <a id="check_network_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                               |
+    | <a id="check_network_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name} >${sent_human}/s <${received_human}/s |
+    | <a id="check_network_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                       |
+    | <a id="check_network_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                               |
+    | <a id="check_network_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                               |
+    | <a id="check_network_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                            |
+    | <a id="check_network_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                               |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2790,25 +2866,29 @@ page = 8.05G, physical = 7.85G
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                            | Default Value                                                             |
-    |---------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-    | <a id="check_os_updates_filter"></a>[filter](../common-options.md#filter)                         |                                                                           |
-    | <a id="check_os_updates_warning"></a>[warning](../common-options.md#warning)                      | updates > 0                                                               |
-    | <a id="check_os_updates_warn"></a>[warn](../common-options.md#warn)                               |                                                                           |
-    | <a id="check_os_updates_critical"></a>[critical](../common-options.md#critical)                   | security > 0 or critical > 0                                              |
-    | <a id="check_os_updates_crit"></a>[crit](../common-options.md#crit)                               |                                                                           |
-    | <a id="check_os_updates_ok"></a>[ok](../common-options.md#ok)                                     |                                                                           |
-    | <a id="check_os_updates_debug"></a>[debug](../common-options.md#debug)                            | false                                                                     |
-    | <a id="check_os_updates_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                     |
-    | <a id="check_os_updates_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                                        |
-    | <a id="check_os_updates_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                           |
-    | <a id="check_os_updates_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                     |
-    | <a id="check_os_updates_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                         |
-    | <a id="check_os_updates_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                        |
-    | <a id="check_os_updates_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): No updates available.                                          |
-    | <a id="check_os_updates_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                           |
-    | <a id="check_os_updates_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${updates} updates available (${security} security, ${critical} critical) |
-    | <a id="check_os_updates_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | updates                                                                   |
+    | Option                                                                                                           | Default Value                                                             |
+    |------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+    | <a id="check_os_updates_filter"></a>[filter](../common-options.md#filter)                                        |                                                                           |
+    | <a id="check_os_updates_warning"></a>[warning](../common-options.md#warning)                                     | updates > 0                                                               |
+    | <a id="check_os_updates_warn"></a>[warn](../common-options.md#warn)                                              |                                                                           |
+    | <a id="check_os_updates_critical"></a>[critical](../common-options.md#critical)                                  | security > 0 or critical > 0                                              |
+    | <a id="check_os_updates_crit"></a>[crit](../common-options.md#crit)                                              |                                                                           |
+    | <a id="check_os_updates_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                           |
+    | <a id="check_os_updates_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                     |
+    | <a id="check_os_updates_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                     |
+    | <a id="check_os_updates_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                                        |
+    | <a id="check_os_updates_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                           |
+    | <a id="check_os_updates_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                     |
+    | <a id="check_os_updates_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                         |
+    | <a id="check_os_updates_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                        |
+    | <a id="check_os_updates_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): No updates available.                                          |
+    | <a id="check_os_updates_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                           |
+    | <a id="check_os_updates_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${updates} updates available (${security} security, ${critical} critical) |
+    | <a id="check_os_updates_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | updates                                                                   |
+    | <a id="check_os_updates_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                           |
+    | <a id="check_os_updates_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                           |
+    | <a id="check_os_updates_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                        |
+    | <a id="check_os_updates_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                           |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2820,25 +2900,29 @@ page = 8.05G, physical = 7.85G
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                            | Default Value                                                      |
-    |---------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
-    | <a id="check_os_updates_filter"></a>[filter](../common-options.md#filter)                         |                                                                    |
-    | <a id="check_os_updates_warning"></a>[warning](../common-options.md#warning)                      | updates > 0                                                        |
-    | <a id="check_os_updates_warn"></a>[warn](../common-options.md#warn)                               |                                                                    |
-    | <a id="check_os_updates_critical"></a>[critical](../common-options.md#critical)                   | security > 0                                                       |
-    | <a id="check_os_updates_crit"></a>[crit](../common-options.md#crit)                               |                                                                    |
-    | <a id="check_os_updates_ok"></a>[ok](../common-options.md#ok)                                     |                                                                    |
-    | <a id="check_os_updates_debug"></a>[debug](../common-options.md#debug)                            | false                                                              |
-    | <a id="check_os_updates_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                              |
-    | <a id="check_os_updates_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                                 |
-    | <a id="check_os_updates_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                    |
-    | <a id="check_os_updates_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                              |
-    | <a id="check_os_updates_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                  |
-    | <a id="check_os_updates_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                 |
-    | <a id="check_os_updates_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): No updates available.                                   |
-    | <a id="check_os_updates_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                    |
-    | <a id="check_os_updates_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${updates} updates available (${security} security) via ${manager} |
-    | <a id="check_os_updates_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | updates                                                            |
+    | Option                                                                                                           | Default Value                                                      |
+    |------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------|
+    | <a id="check_os_updates_filter"></a>[filter](../common-options.md#filter)                                        |                                                                    |
+    | <a id="check_os_updates_warning"></a>[warning](../common-options.md#warning)                                     | updates > 0                                                        |
+    | <a id="check_os_updates_warn"></a>[warn](../common-options.md#warn)                                              |                                                                    |
+    | <a id="check_os_updates_critical"></a>[critical](../common-options.md#critical)                                  | security > 0                                                       |
+    | <a id="check_os_updates_crit"></a>[crit](../common-options.md#crit)                                              |                                                                    |
+    | <a id="check_os_updates_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                    |
+    | <a id="check_os_updates_debug"></a>[debug](../common-options.md#debug)                                           | false                                                              |
+    | <a id="check_os_updates_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                              |
+    | <a id="check_os_updates_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                                 |
+    | <a id="check_os_updates_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                    |
+    | <a id="check_os_updates_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                              |
+    | <a id="check_os_updates_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                  |
+    | <a id="check_os_updates_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                 |
+    | <a id="check_os_updates_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): No updates available.                                   |
+    | <a id="check_os_updates_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                    |
+    | <a id="check_os_updates_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${updates} updates available (${security} security) via ${manager} |
+    | <a id="check_os_updates_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | updates                                                            |
+    | <a id="check_os_updates_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                    |
+    | <a id="check_os_updates_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                    |
+    | <a id="check_os_updates_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                 |
+    | <a id="check_os_updates_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                    |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2964,25 +3048,29 @@ OK: 5CG1234ABC / American Megatrends Inc. BIOS 1.7.0 / 10.0.22631.3810 x64|'vers
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                            | Default Value                          |
-    |---------------------------------------------------------------------------------------------------|----------------------------------------|
-    | <a id="check_os_version_filter"></a>[filter](../common-options.md#filter)                         |                                        |
-    | <a id="check_os_version_warning"></a>[warning](../common-options.md#warning)                      | version <= 50                          |
-    | <a id="check_os_version_warn"></a>[warn](../common-options.md#warn)                               |                                        |
-    | <a id="check_os_version_critical"></a>[critical](../common-options.md#critical)                   | version <= 50                          |
-    | <a id="check_os_version_crit"></a>[crit](../common-options.md#crit)                               |                                        |
-    | <a id="check_os_version_ok"></a>[ok](../common-options.md#ok)                                     |                                        |
-    | <a id="check_os_version_debug"></a>[debug](../common-options.md#debug)                            | false                                  |
-    | <a id="check_os_version_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                  |
-    | <a id="check_os_version_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                |
-    | <a id="check_os_version_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                        |
-    | <a id="check_os_version_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                  |
-    | <a id="check_os_version_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                      |
-    | <a id="check_os_version_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                     |
-    | <a id="check_os_version_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                        |
-    | <a id="check_os_version_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                        |
-    | <a id="check_os_version_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${version} (${kernel_version}) ${arch} |
-    | <a id="check_os_version_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | version                                |
+    | Option                                                                                                           | Default Value                          |
+    |------------------------------------------------------------------------------------------------------------------|----------------------------------------|
+    | <a id="check_os_version_filter"></a>[filter](../common-options.md#filter)                                        |                                        |
+    | <a id="check_os_version_warning"></a>[warning](../common-options.md#warning)                                     | version <= 50                          |
+    | <a id="check_os_version_warn"></a>[warn](../common-options.md#warn)                                              |                                        |
+    | <a id="check_os_version_critical"></a>[critical](../common-options.md#critical)                                  | version <= 50                          |
+    | <a id="check_os_version_crit"></a>[crit](../common-options.md#crit)                                              |                                        |
+    | <a id="check_os_version_ok"></a>[ok](../common-options.md#ok)                                                    |                                        |
+    | <a id="check_os_version_debug"></a>[debug](../common-options.md#debug)                                           | false                                  |
+    | <a id="check_os_version_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                  |
+    | <a id="check_os_version_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                |
+    | <a id="check_os_version_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                        |
+    | <a id="check_os_version_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                  |
+    | <a id="check_os_version_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                      |
+    | <a id="check_os_version_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                     |
+    | <a id="check_os_version_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                        |
+    | <a id="check_os_version_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                        |
+    | <a id="check_os_version_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${version} (${kernel_version}) ${arch} |
+    | <a id="check_os_version_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | version                                |
+    | <a id="check_os_version_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                        |
+    | <a id="check_os_version_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                        |
+    | <a id="check_os_version_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                     |
+    | <a id="check_os_version_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                        |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -2994,25 +3082,29 @@ OK: 5CG1234ABC / American Megatrends Inc. BIOS 1.7.0 / 10.0.22631.3810 x64|'vers
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                            | Default Value                    |
-    |---------------------------------------------------------------------------------------------------|----------------------------------|
-    | <a id="check_os_version_filter"></a>[filter](../common-options.md#filter)                         |                                  |
-    | <a id="check_os_version_warning"></a>[warning](../common-options.md#warning)                      |                                  |
-    | <a id="check_os_version_warn"></a>[warn](../common-options.md#warn)                               |                                  |
-    | <a id="check_os_version_critical"></a>[critical](../common-options.md#critical)                   |                                  |
-    | <a id="check_os_version_crit"></a>[crit](../common-options.md#crit)                               |                                  |
-    | <a id="check_os_version_ok"></a>[ok](../common-options.md#ok)                                     |                                  |
-    | <a id="check_os_version_debug"></a>[debug](../common-options.md#debug)                            | false                            |
-    | <a id="check_os_version_show-all"></a>[show-all](../common-options.md#show-all)                   | false                            |
-    | <a id="check_os_version_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                          |
-    | <a id="check_os_version_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                  |
-    | <a id="check_os_version_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                            |
-    | <a id="check_os_version_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                |
-    | <a id="check_os_version_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}               |
-    | <a id="check_os_version_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                  |
-    | <a id="check_os_version_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                  |
-    | <a id="check_os_version_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${os} (kernel ${kernel_release}) |
-    | <a id="check_os_version_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | kernel_release                   |
+    | Option                                                                                                           | Default Value                    |
+    |------------------------------------------------------------------------------------------------------------------|----------------------------------|
+    | <a id="check_os_version_filter"></a>[filter](../common-options.md#filter)                                        |                                  |
+    | <a id="check_os_version_warning"></a>[warning](../common-options.md#warning)                                     |                                  |
+    | <a id="check_os_version_warn"></a>[warn](../common-options.md#warn)                                              |                                  |
+    | <a id="check_os_version_critical"></a>[critical](../common-options.md#critical)                                  |                                  |
+    | <a id="check_os_version_crit"></a>[crit](../common-options.md#crit)                                              |                                  |
+    | <a id="check_os_version_ok"></a>[ok](../common-options.md#ok)                                                    |                                  |
+    | <a id="check_os_version_debug"></a>[debug](../common-options.md#debug)                                           | false                            |
+    | <a id="check_os_version_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                            |
+    | <a id="check_os_version_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                          |
+    | <a id="check_os_version_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                  |
+    | <a id="check_os_version_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                            |
+    | <a id="check_os_version_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                |
+    | <a id="check_os_version_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}               |
+    | <a id="check_os_version_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                  |
+    | <a id="check_os_version_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                  |
+    | <a id="check_os_version_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${os} (kernel ${kernel_release}) |
+    | <a id="check_os_version_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | kernel_release                   |
+    | <a id="check_os_version_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                  |
+    | <a id="check_os_version_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                  |
+    | <a id="check_os_version_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                               |
+    | <a id="check_os_version_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                  |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -3134,25 +3226,29 @@ check_pagefile help
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                          | Default Value             |
-|-------------------------------------------------------------------------------------------------|---------------------------|
-| <a id="check_pagefile_filter"></a>[filter](../common-options.md#filter)                         |                           |
-| <a id="check_pagefile_warning"></a>[warning](../common-options.md#warning)                      | used > 60%                |
-| <a id="check_pagefile_warn"></a>[warn](../common-options.md#warn)                               |                           |
-| <a id="check_pagefile_critical"></a>[critical](../common-options.md#critical)                   | used > 80%                |
-| <a id="check_pagefile_crit"></a>[crit](../common-options.md#crit)                               |                           |
-| <a id="check_pagefile_ok"></a>[ok](../common-options.md#ok)                                     |                           |
-| <a id="check_pagefile_debug"></a>[debug](../common-options.md#debug)                            | false                     |
-| <a id="check_pagefile_show-all"></a>[show-all](../common-options.md#show-all)                   | false                     |
-| <a id="check_pagefile_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                   |
-| <a id="check_pagefile_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                           |
-| <a id="check_pagefile_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                     |
-| <a id="check_pagefile_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                         |
-| <a id="check_pagefile_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}        |
-| <a id="check_pagefile_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                           |
-| <a id="check_pagefile_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                           |
-| <a id="check_pagefile_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name} ${used} (${size}) |
-| <a id="check_pagefile_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                   |
+| Option                                                                                                         | Default Value             |
+|----------------------------------------------------------------------------------------------------------------|---------------------------|
+| <a id="check_pagefile_filter"></a>[filter](../common-options.md#filter)                                        |                           |
+| <a id="check_pagefile_warning"></a>[warning](../common-options.md#warning)                                     | used > 60%                |
+| <a id="check_pagefile_warn"></a>[warn](../common-options.md#warn)                                              |                           |
+| <a id="check_pagefile_critical"></a>[critical](../common-options.md#critical)                                  | used > 80%                |
+| <a id="check_pagefile_crit"></a>[crit](../common-options.md#crit)                                              |                           |
+| <a id="check_pagefile_ok"></a>[ok](../common-options.md#ok)                                                    |                           |
+| <a id="check_pagefile_debug"></a>[debug](../common-options.md#debug)                                           | false                     |
+| <a id="check_pagefile_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                     |
+| <a id="check_pagefile_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                   |
+| <a id="check_pagefile_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                           |
+| <a id="check_pagefile_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                     |
+| <a id="check_pagefile_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                         |
+| <a id="check_pagefile_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}        |
+| <a id="check_pagefile_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                           |
+| <a id="check_pagefile_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                           |
+| <a id="check_pagefile_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name} ${used} (${size}) |
+| <a id="check_pagefile_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                   |
+| <a id="check_pagefile_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                           |
+| <a id="check_pagefile_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                           |
+| <a id="check_pagefile_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                        |
+| <a id="check_pagefile_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                           |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -3296,25 +3392,29 @@ OK: 42 hotfixes installed, newest KB5034441 on 3/12/2024 (18d ago)
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                           | Default Value      |
-|--------------------------------------------------------------------------------------------------|--------------------|
-| <a id="check_patch_age_filter"></a>[filter](../common-options.md#filter)                         |                    |
-| <a id="check_patch_age_warning"></a>[warning](../common-options.md#warning)                      |                    |
-| <a id="check_patch_age_warn"></a>[warn](../common-options.md#warn)                               |                    |
-| <a id="check_patch_age_critical"></a>[critical](../common-options.md#critical)                   | missing > 0        |
-| <a id="check_patch_age_crit"></a>[crit](../common-options.md#crit)                               |                    |
-| <a id="check_patch_age_ok"></a>[ok](../common-options.md#ok)                                     |                    |
-| <a id="check_patch_age_debug"></a>[debug](../common-options.md#debug)                            | false              |
-| <a id="check_patch_age_show-all"></a>[show-all](../common-options.md#show-all)                   | false              |
-| <a id="check_patch_age_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored            |
-| <a id="check_patch_age_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                    |
-| <a id="check_patch_age_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false              |
-| <a id="check_patch_age_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                  |
-| <a id="check_patch_age_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list} |
-| <a id="check_patch_age_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                    |
-| <a id="check_patch_age_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                    |
-| <a id="check_patch_age_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${message}         |
-| <a id="check_patch_age_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | patch              |
+| Option                                                                                                          | Default Value      |
+|-----------------------------------------------------------------------------------------------------------------|--------------------|
+| <a id="check_patch_age_filter"></a>[filter](../common-options.md#filter)                                        |                    |
+| <a id="check_patch_age_warning"></a>[warning](../common-options.md#warning)                                     |                    |
+| <a id="check_patch_age_warn"></a>[warn](../common-options.md#warn)                                              |                    |
+| <a id="check_patch_age_critical"></a>[critical](../common-options.md#critical)                                  | missing > 0        |
+| <a id="check_patch_age_crit"></a>[crit](../common-options.md#crit)                                              |                    |
+| <a id="check_patch_age_ok"></a>[ok](../common-options.md#ok)                                                    |                    |
+| <a id="check_patch_age_debug"></a>[debug](../common-options.md#debug)                                           | false              |
+| <a id="check_patch_age_show-all"></a>[show-all](../common-options.md#show-all)                                  | false              |
+| <a id="check_patch_age_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored            |
+| <a id="check_patch_age_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                    |
+| <a id="check_patch_age_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false              |
+| <a id="check_patch_age_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                  |
+| <a id="check_patch_age_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list} |
+| <a id="check_patch_age_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                    |
+| <a id="check_patch_age_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                    |
+| <a id="check_patch_age_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${message}         |
+| <a id="check_patch_age_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | patch              |
+| <a id="check_patch_age_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                    |
+| <a id="check_patch_age_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                    |
+| <a id="check_patch_age_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                 |
+| <a id="check_patch_age_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                    |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -3494,25 +3594,29 @@ If we should ignore errors when checking counters, for instance missing counters
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                     | Default Value       |
-|--------------------------------------------------------------------------------------------|---------------------|
-| <a id="check_pdh_filter"></a>[filter](../common-options.md#filter)                         |                     |
-| <a id="check_pdh_warning"></a>[warning](../common-options.md#warning)                      |                     |
-| <a id="check_pdh_warn"></a>[warn](../common-options.md#warn)                               |                     |
-| <a id="check_pdh_critical"></a>[critical](../common-options.md#critical)                   |                     |
-| <a id="check_pdh_crit"></a>[crit](../common-options.md#crit)                               |                     |
-| <a id="check_pdh_ok"></a>[ok](../common-options.md#ok)                                     |                     |
-| <a id="check_pdh_debug"></a>[debug](../common-options.md#debug)                            | false               |
-| <a id="check_pdh_show-all"></a>[show-all](../common-options.md#show-all)                   | false               |
-| <a id="check_pdh_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown             |
-| <a id="check_pdh_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                     |
-| <a id="check_pdh_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false               |
-| <a id="check_pdh_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                   |
-| <a id="check_pdh_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}  |
-| <a id="check_pdh_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                     |
-| <a id="check_pdh_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                     |
-| <a id="check_pdh_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${alias} = ${value} |
-| <a id="check_pdh_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${alias}            |
+| Option                                                                                                    | Default Value       |
+|-----------------------------------------------------------------------------------------------------------|---------------------|
+| <a id="check_pdh_filter"></a>[filter](../common-options.md#filter)                                        |                     |
+| <a id="check_pdh_warning"></a>[warning](../common-options.md#warning)                                     |                     |
+| <a id="check_pdh_warn"></a>[warn](../common-options.md#warn)                                              |                     |
+| <a id="check_pdh_critical"></a>[critical](../common-options.md#critical)                                  |                     |
+| <a id="check_pdh_crit"></a>[crit](../common-options.md#crit)                                              |                     |
+| <a id="check_pdh_ok"></a>[ok](../common-options.md#ok)                                                    |                     |
+| <a id="check_pdh_debug"></a>[debug](../common-options.md#debug)                                           | false               |
+| <a id="check_pdh_show-all"></a>[show-all](../common-options.md#show-all)                                  | false               |
+| <a id="check_pdh_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown             |
+| <a id="check_pdh_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                     |
+| <a id="check_pdh_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false               |
+| <a id="check_pdh_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                   |
+| <a id="check_pdh_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}  |
+| <a id="check_pdh_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                     |
+| <a id="check_pdh_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                     |
+| <a id="check_pdh_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${alias} = ${value} |
+| <a id="check_pdh_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${alias}            |
+| <a id="check_pdh_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                     |
+| <a id="check_pdh_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                     |
+| <a id="check_pdh_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                  |
+| <a id="check_pdh_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                     |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -3623,25 +3727,29 @@ OK: No reboot pending
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                                | Default Value                |
-|-------------------------------------------------------------------------------------------------------|------------------------------|
-| <a id="check_pending_reboot_filter"></a>[filter](../common-options.md#filter)                         |                              |
-| <a id="check_pending_reboot_warning"></a>[warning](../common-options.md#warning)                      | pending = 1                  |
-| <a id="check_pending_reboot_warn"></a>[warn](../common-options.md#warn)                               |                              |
-| <a id="check_pending_reboot_critical"></a>[critical](../common-options.md#critical)                   |                              |
-| <a id="check_pending_reboot_crit"></a>[crit](../common-options.md#crit)                               |                              |
-| <a id="check_pending_reboot_ok"></a>[ok](../common-options.md#ok)                                     |                              |
-| <a id="check_pending_reboot_debug"></a>[debug](../common-options.md#debug)                            | false                        |
-| <a id="check_pending_reboot_show-all"></a>[show-all](../common-options.md#show-all)                   | false                        |
-| <a id="check_pending_reboot_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                      |
-| <a id="check_pending_reboot_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                              |
-| <a id="check_pending_reboot_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                        |
-| <a id="check_pending_reboot_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                            |
-| <a id="check_pending_reboot_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}           |
-| <a id="check_pending_reboot_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): No reboot pending |
-| <a id="check_pending_reboot_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                              |
-| <a id="check_pending_reboot_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${message}                   |
-| <a id="check_pending_reboot_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | reboot                       |
+| Option                                                                                                               | Default Value                |
+|----------------------------------------------------------------------------------------------------------------------|------------------------------|
+| <a id="check_pending_reboot_filter"></a>[filter](../common-options.md#filter)                                        |                              |
+| <a id="check_pending_reboot_warning"></a>[warning](../common-options.md#warning)                                     | pending = 1                  |
+| <a id="check_pending_reboot_warn"></a>[warn](../common-options.md#warn)                                              |                              |
+| <a id="check_pending_reboot_critical"></a>[critical](../common-options.md#critical)                                  |                              |
+| <a id="check_pending_reboot_crit"></a>[crit](../common-options.md#crit)                                              |                              |
+| <a id="check_pending_reboot_ok"></a>[ok](../common-options.md#ok)                                                    |                              |
+| <a id="check_pending_reboot_debug"></a>[debug](../common-options.md#debug)                                           | false                        |
+| <a id="check_pending_reboot_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                        |
+| <a id="check_pending_reboot_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                      |
+| <a id="check_pending_reboot_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                              |
+| <a id="check_pending_reboot_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                        |
+| <a id="check_pending_reboot_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                            |
+| <a id="check_pending_reboot_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}           |
+| <a id="check_pending_reboot_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): No reboot pending |
+| <a id="check_pending_reboot_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                              |
+| <a id="check_pending_reboot_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${message}                   |
+| <a id="check_pending_reboot_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | reboot                       |
+| <a id="check_pending_reboot_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                              |
+| <a id="check_pending_reboot_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                              |
+| <a id="check_pending_reboot_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                           |
+| <a id="check_pending_reboot_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                              |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -3784,25 +3892,29 @@ OK: All 2 job(s) ok.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                           | Default Value                                                  |
-|--------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
-| <a id="check_printjobs_filter"></a>[filter](../common-options.md#filter)                         |                                                                |
-| <a id="check_printjobs_warning"></a>[warning](../common-options.md#warning)                      | age > 600                                                      |
-| <a id="check_printjobs_warn"></a>[warn](../common-options.md#warn)                               |                                                                |
-| <a id="check_printjobs_critical"></a>[critical](../common-options.md#critical)                   | error = 1 or blocked = 1 or user_intervention = 1              |
-| <a id="check_printjobs_crit"></a>[crit](../common-options.md#crit)                               |                                                                |
-| <a id="check_printjobs_ok"></a>[ok](../common-options.md#ok)                                     |                                                                |
-| <a id="check_printjobs_debug"></a>[debug](../common-options.md#debug)                            | false                                                          |
-| <a id="check_printjobs_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                          |
-| <a id="check_printjobs_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                             |
-| <a id="check_printjobs_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                |
-| <a id="check_printjobs_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                          |
-| <a id="check_printjobs_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                              |
-| <a id="check_printjobs_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                             |
-| <a id="check_printjobs_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) job(s) ok.                             |
-| <a id="check_printjobs_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No print jobs queued                                |
-| <a id="check_printjobs_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${printer}: '${document}' by ${owner} (${job_status}, ${age}s) |
-| <a id="check_printjobs_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${printer}_${id}                                               |
+| Option                                                                                                          | Default Value                                                  |
+|-----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------|
+| <a id="check_printjobs_filter"></a>[filter](../common-options.md#filter)                                        |                                                                |
+| <a id="check_printjobs_warning"></a>[warning](../common-options.md#warning)                                     | age > 600                                                      |
+| <a id="check_printjobs_warn"></a>[warn](../common-options.md#warn)                                              |                                                                |
+| <a id="check_printjobs_critical"></a>[critical](../common-options.md#critical)                                  | error = 1 or blocked = 1 or user_intervention = 1              |
+| <a id="check_printjobs_crit"></a>[crit](../common-options.md#crit)                                              |                                                                |
+| <a id="check_printjobs_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                |
+| <a id="check_printjobs_debug"></a>[debug](../common-options.md#debug)                                           | false                                                          |
+| <a id="check_printjobs_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                          |
+| <a id="check_printjobs_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                             |
+| <a id="check_printjobs_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                |
+| <a id="check_printjobs_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                          |
+| <a id="check_printjobs_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                              |
+| <a id="check_printjobs_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                             |
+| <a id="check_printjobs_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) job(s) ok.                             |
+| <a id="check_printjobs_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No print jobs queued                                |
+| <a id="check_printjobs_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${printer}: '${document}' by ${owner} (${job_status}, ${age}s) |
+| <a id="check_printjobs_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${printer}_${id}                                               |
+| <a id="check_printjobs_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                |
+| <a id="check_printjobs_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                |
+| <a id="check_printjobs_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                             |
+| <a id="check_printjobs_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -3960,25 +4072,29 @@ OK: All 4 printer(s) ok.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                            | Default Value                                 |
-|---------------------------------------------------------------------------------------------------|-----------------------------------------------|
-| <a id="check_printqueue_filter"></a>[filter](../common-options.md#filter)                         |                                               |
-| <a id="check_printqueue_warning"></a>[warning](../common-options.md#warning)                      | jobs > 10                                     |
-| <a id="check_printqueue_warn"></a>[warn](../common-options.md#warn)                               |                                               |
-| <a id="check_printqueue_critical"></a>[critical](../common-options.md#critical)                   | error = 1                                     |
-| <a id="check_printqueue_crit"></a>[crit](../common-options.md#crit)                               |                                               |
-| <a id="check_printqueue_ok"></a>[ok](../common-options.md#ok)                                     |                                               |
-| <a id="check_printqueue_debug"></a>[debug](../common-options.md#debug)                            | false                                         |
-| <a id="check_printqueue_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                         |
-| <a id="check_printqueue_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                            |
-| <a id="check_printqueue_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                               |
-| <a id="check_printqueue_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                         |
-| <a id="check_printqueue_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                             |
-| <a id="check_printqueue_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                            |
-| <a id="check_printqueue_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) printer(s) ok.        |
-| <a id="check_printqueue_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No printers found                  |
-| <a id="check_printqueue_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${printer}: ${printer_status}, ${jobs} job(s) |
-| <a id="check_printqueue_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${printer}                                    |
+| Option                                                                                                           | Default Value                                 |
+|------------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+| <a id="check_printqueue_filter"></a>[filter](../common-options.md#filter)                                        |                                               |
+| <a id="check_printqueue_warning"></a>[warning](../common-options.md#warning)                                     | jobs > 10                                     |
+| <a id="check_printqueue_warn"></a>[warn](../common-options.md#warn)                                              |                                               |
+| <a id="check_printqueue_critical"></a>[critical](../common-options.md#critical)                                  | error = 1                                     |
+| <a id="check_printqueue_crit"></a>[crit](../common-options.md#crit)                                              |                                               |
+| <a id="check_printqueue_ok"></a>[ok](../common-options.md#ok)                                                    |                                               |
+| <a id="check_printqueue_debug"></a>[debug](../common-options.md#debug)                                           | false                                         |
+| <a id="check_printqueue_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                         |
+| <a id="check_printqueue_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                            |
+| <a id="check_printqueue_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                               |
+| <a id="check_printqueue_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                         |
+| <a id="check_printqueue_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                             |
+| <a id="check_printqueue_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                            |
+| <a id="check_printqueue_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) printer(s) ok.        |
+| <a id="check_printqueue_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No printers found                  |
+| <a id="check_printqueue_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${printer}: ${printer_status}, ${jobs} job(s) |
+| <a id="check_printqueue_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${printer}                                    |
+| <a id="check_printqueue_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                               |
+| <a id="check_printqueue_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                               |
+| <a id="check_printqueue_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                            |
+| <a id="check_printqueue_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                               |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -4206,25 +4322,29 @@ commit limit (RAM + pagefile). Both work with `total=true` aggregation.
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                         | Default Value                    |
-    |------------------------------------------------------------------------------------------------|----------------------------------|
-    | <a id="check_process_filter"></a>[filter](../common-options.md#filter)                         | state != 'unreadable'            |
-    | <a id="check_process_warning"></a>[warning](../common-options.md#warning)                      | state not in ('started')         |
-    | <a id="check_process_warn"></a>[warn](../common-options.md#warn)                               |                                  |
-    | <a id="check_process_critical"></a>[critical](../common-options.md#critical)                   | state = 'stopped', count = 0     |
-    | <a id="check_process_crit"></a>[crit](../common-options.md#crit)                               |                                  |
-    | <a id="check_process_ok"></a>[ok](../common-options.md#ok)                                     |                                  |
-    | <a id="check_process_debug"></a>[debug](../common-options.md#debug)                            | false                            |
-    | <a id="check_process_show-all"></a>[show-all](../common-options.md#show-all)                   | false                            |
-    | <a id="check_process_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                          |
-    | <a id="check_process_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                  |
-    | <a id="check_process_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                            |
-    | <a id="check_process_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                |
-    | <a id="check_process_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}       |
-    | <a id="check_process_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): all processes are ok. |
-    | <a id="check_process_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | UNKNOWN: No processes found      |
-    | <a id="check_process_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${exe}=${state}                  |
-    | <a id="check_process_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${exe}                           |
+    | Option                                                                                                        | Default Value                    |
+    |---------------------------------------------------------------------------------------------------------------|----------------------------------|
+    | <a id="check_process_filter"></a>[filter](../common-options.md#filter)                                        | state != 'unreadable'            |
+    | <a id="check_process_warning"></a>[warning](../common-options.md#warning)                                     | state not in ('started')         |
+    | <a id="check_process_warn"></a>[warn](../common-options.md#warn)                                              |                                  |
+    | <a id="check_process_critical"></a>[critical](../common-options.md#critical)                                  | state = 'stopped', count = 0     |
+    | <a id="check_process_crit"></a>[crit](../common-options.md#crit)                                              |                                  |
+    | <a id="check_process_ok"></a>[ok](../common-options.md#ok)                                                    |                                  |
+    | <a id="check_process_debug"></a>[debug](../common-options.md#debug)                                           | false                            |
+    | <a id="check_process_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                            |
+    | <a id="check_process_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                          |
+    | <a id="check_process_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                  |
+    | <a id="check_process_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                            |
+    | <a id="check_process_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                |
+    | <a id="check_process_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}       |
+    | <a id="check_process_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): all processes are ok. |
+    | <a id="check_process_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | UNKNOWN: No processes found      |
+    | <a id="check_process_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${exe}=${state}                  |
+    | <a id="check_process_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${exe}                           |
+    | <a id="check_process_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                  |
+    | <a id="check_process_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                  |
+    | <a id="check_process_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                               |
+    | <a id="check_process_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                  |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -4266,25 +4386,29 @@ commit limit (RAM + pagefile). Both work with `total=true` aggregation.
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                         | Default Value                    |
-    |------------------------------------------------------------------------------------------------|----------------------------------|
-    | <a id="check_process_filter"></a>[filter](../common-options.md#filter)                         | state != 'unreadable'            |
-    | <a id="check_process_warning"></a>[warning](../common-options.md#warning)                      | state not in ('started')         |
-    | <a id="check_process_warn"></a>[warn](../common-options.md#warn)                               |                                  |
-    | <a id="check_process_critical"></a>[critical](../common-options.md#critical)                   | state = 'stopped', count = 0     |
-    | <a id="check_process_crit"></a>[crit](../common-options.md#crit)                               |                                  |
-    | <a id="check_process_ok"></a>[ok](../common-options.md#ok)                                     |                                  |
-    | <a id="check_process_debug"></a>[debug](../common-options.md#debug)                            | false                            |
-    | <a id="check_process_show-all"></a>[show-all](../common-options.md#show-all)                   | false                            |
-    | <a id="check_process_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                          |
-    | <a id="check_process_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                  |
-    | <a id="check_process_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                            |
-    | <a id="check_process_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                |
-    | <a id="check_process_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}       |
-    | <a id="check_process_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): all processes are ok. |
-    | <a id="check_process_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | UNKNOWN: No processes found      |
-    | <a id="check_process_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${exe}=${state}                  |
-    | <a id="check_process_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${exe}                           |
+    | Option                                                                                                        | Default Value                    |
+    |---------------------------------------------------------------------------------------------------------------|----------------------------------|
+    | <a id="check_process_filter"></a>[filter](../common-options.md#filter)                                        | state != 'unreadable'            |
+    | <a id="check_process_warning"></a>[warning](../common-options.md#warning)                                     | state not in ('started')         |
+    | <a id="check_process_warn"></a>[warn](../common-options.md#warn)                                              |                                  |
+    | <a id="check_process_critical"></a>[critical](../common-options.md#critical)                                  | state = 'stopped', count = 0     |
+    | <a id="check_process_crit"></a>[crit](../common-options.md#crit)                                              |                                  |
+    | <a id="check_process_ok"></a>[ok](../common-options.md#ok)                                                    |                                  |
+    | <a id="check_process_debug"></a>[debug](../common-options.md#debug)                                           | false                            |
+    | <a id="check_process_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                            |
+    | <a id="check_process_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                          |
+    | <a id="check_process_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                  |
+    | <a id="check_process_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                            |
+    | <a id="check_process_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                |
+    | <a id="check_process_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}       |
+    | <a id="check_process_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): all processes are ok. |
+    | <a id="check_process_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | UNKNOWN: No processes found      |
+    | <a id="check_process_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${exe}=${state}                  |
+    | <a id="check_process_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${exe}                           |
+    | <a id="check_process_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                  |
+    | <a id="check_process_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                  |
+    | <a id="check_process_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                               |
+    | <a id="check_process_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                  |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -4396,25 +4520,29 @@ commit limit (RAM + pagefile). Both work with `total=true` aggregation.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                                 | Default Value                             |
-|--------------------------------------------------------------------------------------------------------|-------------------------------------------|
-| <a id="check_process_history_filter"></a>[filter](../common-options.md#filter)                         |                                           |
-| <a id="check_process_history_warning"></a>[warning](../common-options.md#warning)                      |                                           |
-| <a id="check_process_history_warn"></a>[warn](../common-options.md#warn)                               |                                           |
-| <a id="check_process_history_critical"></a>[critical](../common-options.md#critical)                   |                                           |
-| <a id="check_process_history_crit"></a>[crit](../common-options.md#crit)                               |                                           |
-| <a id="check_process_history_ok"></a>[ok](../common-options.md#ok)                                     |                                           |
-| <a id="check_process_history_debug"></a>[debug](../common-options.md#debug)                            | false                                     |
-| <a id="check_process_history_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                     |
-| <a id="check_process_history_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                        |
-| <a id="check_process_history_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                           |
-| <a id="check_process_history_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                     |
-| <a id="check_process_history_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                         |
-| <a id="check_process_history_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                |
-| <a id="check_process_history_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): ${count} processes in history. |
-| <a id="check_process_history_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                           |
-| <a id="check_process_history_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${exe} (${running})                       |
-| <a id="check_process_history_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${exe}                                    |
+| Option                                                                                                                | Default Value                             |
+|-----------------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| <a id="check_process_history_filter"></a>[filter](../common-options.md#filter)                                        |                                           |
+| <a id="check_process_history_warning"></a>[warning](../common-options.md#warning)                                     |                                           |
+| <a id="check_process_history_warn"></a>[warn](../common-options.md#warn)                                              |                                           |
+| <a id="check_process_history_critical"></a>[critical](../common-options.md#critical)                                  |                                           |
+| <a id="check_process_history_crit"></a>[crit](../common-options.md#crit)                                              |                                           |
+| <a id="check_process_history_ok"></a>[ok](../common-options.md#ok)                                                    |                                           |
+| <a id="check_process_history_debug"></a>[debug](../common-options.md#debug)                                           | false                                     |
+| <a id="check_process_history_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                     |
+| <a id="check_process_history_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                        |
+| <a id="check_process_history_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                           |
+| <a id="check_process_history_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                     |
+| <a id="check_process_history_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                         |
+| <a id="check_process_history_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                |
+| <a id="check_process_history_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): ${count} processes in history. |
+| <a id="check_process_history_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                           |
+| <a id="check_process_history_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${exe} (${running})                       |
+| <a id="check_process_history_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${exe}                                    |
+| <a id="check_process_history_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                           |
+| <a id="check_process_history_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                           |
+| <a id="check_process_history_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                        |
+| <a id="check_process_history_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                           |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -4472,25 +4600,29 @@ Time window to check for new processes (e.g., 5m, 1h, 30s). Processes first seen
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                                     | Default Value                      |
-|------------------------------------------------------------------------------------------------------------|------------------------------------|
-| <a id="check_process_history_new_filter"></a>[filter](../common-options.md#filter)                         |                                    |
-| <a id="check_process_history_new_warning"></a>[warning](../common-options.md#warning)                      |                                    |
-| <a id="check_process_history_new_warn"></a>[warn](../common-options.md#warn)                               |                                    |
-| <a id="check_process_history_new_critical"></a>[critical](../common-options.md#critical)                   |                                    |
-| <a id="check_process_history_new_crit"></a>[crit](../common-options.md#crit)                               |                                    |
-| <a id="check_process_history_new_ok"></a>[ok](../common-options.md#ok)                                     |                                    |
-| <a id="check_process_history_new_debug"></a>[debug](../common-options.md#debug)                            | false                              |
-| <a id="check_process_history_new_show-all"></a>[show-all](../common-options.md#show-all)                   | false                              |
-| <a id="check_process_history_new_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                 |
-| <a id="check_process_history_new_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                    |
-| <a id="check_process_history_new_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                              |
-| <a id="check_process_history_new_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                  |
-| <a id="check_process_history_new_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                 |
-| <a id="check_process_history_new_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): No new processes found. |
-| <a id="check_process_history_new_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                    |
-| <a id="check_process_history_new_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${exe} (first seen: ${first_seen}) |
-| <a id="check_process_history_new_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${exe}                             |
+| Option                                                                                                                    | Default Value                      |
+|---------------------------------------------------------------------------------------------------------------------------|------------------------------------|
+| <a id="check_process_history_new_filter"></a>[filter](../common-options.md#filter)                                        |                                    |
+| <a id="check_process_history_new_warning"></a>[warning](../common-options.md#warning)                                     |                                    |
+| <a id="check_process_history_new_warn"></a>[warn](../common-options.md#warn)                                              |                                    |
+| <a id="check_process_history_new_critical"></a>[critical](../common-options.md#critical)                                  |                                    |
+| <a id="check_process_history_new_crit"></a>[crit](../common-options.md#crit)                                              |                                    |
+| <a id="check_process_history_new_ok"></a>[ok](../common-options.md#ok)                                                    |                                    |
+| <a id="check_process_history_new_debug"></a>[debug](../common-options.md#debug)                                           | false                              |
+| <a id="check_process_history_new_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                              |
+| <a id="check_process_history_new_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                 |
+| <a id="check_process_history_new_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                    |
+| <a id="check_process_history_new_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                              |
+| <a id="check_process_history_new_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                  |
+| <a id="check_process_history_new_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                 |
+| <a id="check_process_history_new_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): No new processes found. |
+| <a id="check_process_history_new_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                    |
+| <a id="check_process_history_new_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${exe} (first seen: ${first_seen}) |
+| <a id="check_process_history_new_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${exe}                             |
+| <a id="check_process_history_new_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                    |
+| <a id="check_process_history_new_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                    |
+| <a id="check_process_history_new_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                 |
+| <a id="check_process_history_new_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                    |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -4638,25 +4770,29 @@ Recursively enumerate all sub-keys below each starting key
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                              | Default Value                                                             |
-|-----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
-| <a id="check_registry_key_filter"></a>[filter](../common-options.md#filter)                         |                                                                           |
-| <a id="check_registry_key_warning"></a>[warning](../common-options.md#warning)                      |                                                                           |
-| <a id="check_registry_key_warn"></a>[warn](../common-options.md#warn)                               |                                                                           |
-| <a id="check_registry_key_critical"></a>[critical](../common-options.md#critical)                   | not exists                                                                |
-| <a id="check_registry_key_crit"></a>[crit](../common-options.md#crit)                               |                                                                           |
-| <a id="check_registry_key_ok"></a>[ok](../common-options.md#ok)                                     |                                                                           |
-| <a id="check_registry_key_debug"></a>[debug](../common-options.md#debug)                            | false                                                                     |
-| <a id="check_registry_key_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                     |
-| <a id="check_registry_key_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                   |
-| <a id="check_registry_key_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                           |
-| <a id="check_registry_key_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                     |
-| <a id="check_registry_key_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                         |
-| <a id="check_registry_key_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}                                                |
-| <a id="check_registry_key_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | ${status}: All %(count) registry key(s) are ok.                           |
-| <a id="check_registry_key_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | ${status}: No registry keys found                                         |
-| <a id="check_registry_key_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${path}: exists=${exists}, subkeys=${subkey_count}, values=${value_count} |
-| <a id="check_registry_key_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${path}                                                                   |
+| Option                                                                                                             | Default Value                                                             |
+|--------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| <a id="check_registry_key_filter"></a>[filter](../common-options.md#filter)                                        |                                                                           |
+| <a id="check_registry_key_warning"></a>[warning](../common-options.md#warning)                                     |                                                                           |
+| <a id="check_registry_key_warn"></a>[warn](../common-options.md#warn)                                              |                                                                           |
+| <a id="check_registry_key_critical"></a>[critical](../common-options.md#critical)                                  | not exists                                                                |
+| <a id="check_registry_key_crit"></a>[crit](../common-options.md#crit)                                              |                                                                           |
+| <a id="check_registry_key_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                           |
+| <a id="check_registry_key_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                     |
+| <a id="check_registry_key_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                     |
+| <a id="check_registry_key_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                   |
+| <a id="check_registry_key_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                           |
+| <a id="check_registry_key_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                     |
+| <a id="check_registry_key_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                         |
+| <a id="check_registry_key_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}                                                |
+| <a id="check_registry_key_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | ${status}: All %(count) registry key(s) are ok.                           |
+| <a id="check_registry_key_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | ${status}: No registry keys found                                         |
+| <a id="check_registry_key_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${path}: exists=${exists}, subkeys=${subkey_count}, values=${value_count} |
+| <a id="check_registry_key_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${path}                                                                   |
+| <a id="check_registry_key_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                           |
+| <a id="check_registry_key_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                           |
+| <a id="check_registry_key_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                        |
+| <a id="check_registry_key_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                           |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -4830,25 +4966,29 @@ Recursively enumerate values in all sub-keys
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                                | Default Value                           |
-|-------------------------------------------------------------------------------------------------------|-----------------------------------------|
-| <a id="check_registry_value_filter"></a>[filter](../common-options.md#filter)                         |                                         |
-| <a id="check_registry_value_warning"></a>[warning](../common-options.md#warning)                      |                                         |
-| <a id="check_registry_value_warn"></a>[warn](../common-options.md#warn)                               |                                         |
-| <a id="check_registry_value_critical"></a>[critical](../common-options.md#critical)                   | not exists                              |
-| <a id="check_registry_value_crit"></a>[crit](../common-options.md#crit)                               |                                         |
-| <a id="check_registry_value_ok"></a>[ok](../common-options.md#ok)                                     |                                         |
-| <a id="check_registry_value_debug"></a>[debug](../common-options.md#debug)                            | false                                   |
-| <a id="check_registry_value_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                   |
-| <a id="check_registry_value_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                 |
-| <a id="check_registry_value_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                         |
-| <a id="check_registry_value_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                   |
-| <a id="check_registry_value_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                       |
-| <a id="check_registry_value_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}              |
-| <a id="check_registry_value_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | ${status}: %(list).                     |
-| <a id="check_registry_value_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | ${status}: No registry values found     |
-| <a id="check_registry_value_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${path}: ${string_value} (type=${type}) |
-| <a id="check_registry_value_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${path}                                 |
+| Option                                                                                                               | Default Value                           |
+|----------------------------------------------------------------------------------------------------------------------|-----------------------------------------|
+| <a id="check_registry_value_filter"></a>[filter](../common-options.md#filter)                                        |                                         |
+| <a id="check_registry_value_warning"></a>[warning](../common-options.md#warning)                                     |                                         |
+| <a id="check_registry_value_warn"></a>[warn](../common-options.md#warn)                                              |                                         |
+| <a id="check_registry_value_critical"></a>[critical](../common-options.md#critical)                                  | not exists                              |
+| <a id="check_registry_value_crit"></a>[crit](../common-options.md#crit)                                              |                                         |
+| <a id="check_registry_value_ok"></a>[ok](../common-options.md#ok)                                                    |                                         |
+| <a id="check_registry_value_debug"></a>[debug](../common-options.md#debug)                                           | false                                   |
+| <a id="check_registry_value_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                   |
+| <a id="check_registry_value_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                 |
+| <a id="check_registry_value_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                         |
+| <a id="check_registry_value_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                   |
+| <a id="check_registry_value_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                       |
+| <a id="check_registry_value_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}              |
+| <a id="check_registry_value_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | ${status}: %(list).                     |
+| <a id="check_registry_value_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | ${status}: No registry values found     |
+| <a id="check_registry_value_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${path}: ${string_value} (type=${type}) |
+| <a id="check_registry_value_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${path}                                 |
+| <a id="check_registry_value_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                         |
+| <a id="check_registry_value_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                         |
+| <a id="check_registry_value_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                      |
+| <a id="check_registry_value_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                         |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -5083,25 +5223,29 @@ filter, so the rollup is stable even when the check itself is OK.
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                         | Default Value                                           |
-    |------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-    | <a id="check_service_filter"></a>[filter](../common-options.md#filter)                         |                                                         |
-    | <a id="check_service_warning"></a>[warning](../common-options.md#warning)                      | not state_is_perfect()                                  |
-    | <a id="check_service_warn"></a>[warn](../common-options.md#warn)                               |                                                         |
-    | <a id="check_service_critical"></a>[critical](../common-options.md#critical)                   | not state_is_ok()                                       |
-    | <a id="check_service_crit"></a>[crit](../common-options.md#crit)                               |                                                         |
-    | <a id="check_service_ok"></a>[ok](../common-options.md#ok)                                     |                                                         |
-    | <a id="check_service_debug"></a>[debug](../common-options.md#debug)                            | false                                                   |
-    | <a id="check_service_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                   |
-    | <a id="check_service_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                 |
-    | <a id="check_service_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                         |
-    | <a id="check_service_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                   |
-    | <a id="check_service_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                       |
-    | <a id="check_service_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${crit_list}, delayed (${warn_list})         |
-    | <a id="check_service_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) service(s) are ok.              |
-    | <a id="check_service_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No services found                            |
-    | <a id="check_service_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}=${state}, exit=%(exit_code), type=%(start_type) |
-    | <a id="check_service_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                 |
+    | Option                                                                                                        | Default Value                                           |
+    |---------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+    | <a id="check_service_filter"></a>[filter](../common-options.md#filter)                                        |                                                         |
+    | <a id="check_service_warning"></a>[warning](../common-options.md#warning)                                     | not state_is_perfect()                                  |
+    | <a id="check_service_warn"></a>[warn](../common-options.md#warn)                                              |                                                         |
+    | <a id="check_service_critical"></a>[critical](../common-options.md#critical)                                  | not state_is_ok()                                       |
+    | <a id="check_service_crit"></a>[crit](../common-options.md#crit)                                              |                                                         |
+    | <a id="check_service_ok"></a>[ok](../common-options.md#ok)                                                    |                                                         |
+    | <a id="check_service_debug"></a>[debug](../common-options.md#debug)                                           | false                                                   |
+    | <a id="check_service_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                   |
+    | <a id="check_service_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                 |
+    | <a id="check_service_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                         |
+    | <a id="check_service_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                   |
+    | <a id="check_service_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                       |
+    | <a id="check_service_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${crit_list}, delayed (${warn_list})         |
+    | <a id="check_service_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) service(s) are ok.              |
+    | <a id="check_service_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No services found                            |
+    | <a id="check_service_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}=${state}, exit=%(exit_code), type=%(start_type) |
+    | <a id="check_service_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                 |
+    | <a id="check_service_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                         |
+    | <a id="check_service_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                         |
+    | <a id="check_service_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                      |
+    | <a id="check_service_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                         |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -5131,25 +5275,29 @@ filter, so the rollup is stable even when the check itself is OK.
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                         | Default Value                                                                                   |
-    |------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
-    | <a id="check_service_filter"></a>[filter](../common-options.md#filter)                         | active != 'inactive'                                                                            |
-    | <a id="check_service_warning"></a>[warning](../common-options.md#warning)                      |                                                                                                 |
-    | <a id="check_service_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                 |
-    | <a id="check_service_critical"></a>[critical](../common-options.md#critical)                   | ( state not in ('running', 'oneshot', 'static') or active = 'failed' ) and preset != 'disabled' |
-    | <a id="check_service_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                 |
-    | <a id="check_service_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                 |
-    | <a id="check_service_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                           |
-    | <a id="check_service_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                           |
-    | <a id="check_service_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                                         |
-    | <a id="check_service_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                 |
-    | <a id="check_service_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                           |
-    | <a id="check_service_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                               |
-    | <a id="check_service_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${crit_list}                                                                         |
-    | <a id="check_service_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) service(s) are ok.                                                      |
-    | <a id="check_service_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No services found                                                                    |
-    | <a id="check_service_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}=${state}                                                                                |
-    | <a id="check_service_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                                                         |
+    | Option                                                                                                        | Default Value                                                                                   |
+    |---------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|
+    | <a id="check_service_filter"></a>[filter](../common-options.md#filter)                                        | active != 'inactive'                                                                            |
+    | <a id="check_service_warning"></a>[warning](../common-options.md#warning)                                     |                                                                                                 |
+    | <a id="check_service_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                 |
+    | <a id="check_service_critical"></a>[critical](../common-options.md#critical)                                  | ( state not in ('running', 'oneshot', 'static') or active = 'failed' ) and preset != 'disabled' |
+    | <a id="check_service_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                 |
+    | <a id="check_service_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                 |
+    | <a id="check_service_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                           |
+    | <a id="check_service_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                           |
+    | <a id="check_service_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                                         |
+    | <a id="check_service_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                 |
+    | <a id="check_service_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                           |
+    | <a id="check_service_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                               |
+    | <a id="check_service_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${crit_list}                                                                         |
+    | <a id="check_service_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) service(s) are ok.                                                      |
+    | <a id="check_service_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No services found                                                                    |
+    | <a id="check_service_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}=${state}                                                                                |
+    | <a id="check_service_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                                                         |
+    | <a id="check_service_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                 |
+    | <a id="check_service_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                 |
+    | <a id="check_service_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                              |
+    | <a id="check_service_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                 |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -5294,25 +5442,29 @@ OK: in 172032B/s, out 28672B/s
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                         | Default Value                                                              |
-    |------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
-    | <a id="check_swap_io_filter"></a>[filter](../common-options.md#filter)                         |                                                                            |
-    | <a id="check_swap_io_warning"></a>[warning](../common-options.md#warning)                      |                                                                            |
-    | <a id="check_swap_io_warn"></a>[warn](../common-options.md#warn)                               |                                                                            |
-    | <a id="check_swap_io_critical"></a>[critical](../common-options.md#critical)                   |                                                                            |
-    | <a id="check_swap_io_crit"></a>[crit](../common-options.md#crit)                               |                                                                            |
-    | <a id="check_swap_io_ok"></a>[ok](../common-options.md#ok)                                     |                                                                            |
-    | <a id="check_swap_io_debug"></a>[debug](../common-options.md#debug)                            | false                                                                      |
-    | <a id="check_swap_io_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                      |
-    | <a id="check_swap_io_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                                    |
-    | <a id="check_swap_io_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                            |
-    | <a id="check_swap_io_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                      |
-    | <a id="check_swap_io_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                          |
-    | <a id="check_swap_io_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                         |
-    | <a id="check_swap_io_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                            |
-    | <a id="check_swap_io_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                            |
-    | <a id="check_swap_io_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${swap_count} page file(s), in ${swap_in} pages/s, out ${swap_out} pages/s |
-    | <a id="check_swap_io_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | io                                                                         |
+    | Option                                                                                                        | Default Value                                                              |
+    |---------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------|
+    | <a id="check_swap_io_filter"></a>[filter](../common-options.md#filter)                                        |                                                                            |
+    | <a id="check_swap_io_warning"></a>[warning](../common-options.md#warning)                                     |                                                                            |
+    | <a id="check_swap_io_warn"></a>[warn](../common-options.md#warn)                                              |                                                                            |
+    | <a id="check_swap_io_critical"></a>[critical](../common-options.md#critical)                                  |                                                                            |
+    | <a id="check_swap_io_crit"></a>[crit](../common-options.md#crit)                                              |                                                                            |
+    | <a id="check_swap_io_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                            |
+    | <a id="check_swap_io_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                      |
+    | <a id="check_swap_io_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                      |
+    | <a id="check_swap_io_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                                    |
+    | <a id="check_swap_io_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                            |
+    | <a id="check_swap_io_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                      |
+    | <a id="check_swap_io_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                          |
+    | <a id="check_swap_io_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                         |
+    | <a id="check_swap_io_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                            |
+    | <a id="check_swap_io_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                            |
+    | <a id="check_swap_io_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${swap_count} page file(s), in ${swap_in} pages/s, out ${swap_out} pages/s |
+    | <a id="check_swap_io_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | io                                                                         |
+    | <a id="check_swap_io_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                            |
+    | <a id="check_swap_io_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                            |
+    | <a id="check_swap_io_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                         |
+    | <a id="check_swap_io_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                            |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -5324,25 +5476,29 @@ OK: in 172032B/s, out 28672B/s
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                         | Default Value                                                               |
-    |------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
-    | <a id="check_swap_io_filter"></a>[filter](../common-options.md#filter)                         |                                                                             |
-    | <a id="check_swap_io_warning"></a>[warning](../common-options.md#warning)                      |                                                                             |
-    | <a id="check_swap_io_warn"></a>[warn](../common-options.md#warn)                               |                                                                             |
-    | <a id="check_swap_io_critical"></a>[critical](../common-options.md#critical)                   |                                                                             |
-    | <a id="check_swap_io_crit"></a>[crit](../common-options.md#crit)                               |                                                                             |
-    | <a id="check_swap_io_ok"></a>[ok](../common-options.md#ok)                                     |                                                                             |
-    | <a id="check_swap_io_debug"></a>[debug](../common-options.md#debug)                            | false                                                                       |
-    | <a id="check_swap_io_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                       |
-    | <a id="check_swap_io_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                                                     |
-    | <a id="check_swap_io_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                             |
-    | <a id="check_swap_io_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                       |
-    | <a id="check_swap_io_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                           |
-    | <a id="check_swap_io_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                          |
-    | <a id="check_swap_io_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                             |
-    | <a id="check_swap_io_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                                                             |
-    | <a id="check_swap_io_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${swap_count} swap device(s) in ${swap_in} pages/s, out ${swap_out} pages/s |
-    | <a id="check_swap_io_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | io                                                                          |
+    | Option                                                                                                        | Default Value                                                               |
+    |---------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------|
+    | <a id="check_swap_io_filter"></a>[filter](../common-options.md#filter)                                        |                                                                             |
+    | <a id="check_swap_io_warning"></a>[warning](../common-options.md#warning)                                     |                                                                             |
+    | <a id="check_swap_io_warn"></a>[warn](../common-options.md#warn)                                              |                                                                             |
+    | <a id="check_swap_io_critical"></a>[critical](../common-options.md#critical)                                  |                                                                             |
+    | <a id="check_swap_io_crit"></a>[crit](../common-options.md#crit)                                              |                                                                             |
+    | <a id="check_swap_io_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                             |
+    | <a id="check_swap_io_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                       |
+    | <a id="check_swap_io_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                       |
+    | <a id="check_swap_io_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                                                     |
+    | <a id="check_swap_io_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                             |
+    | <a id="check_swap_io_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                       |
+    | <a id="check_swap_io_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                           |
+    | <a id="check_swap_io_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                          |
+    | <a id="check_swap_io_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                             |
+    | <a id="check_swap_io_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                                                             |
+    | <a id="check_swap_io_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${swap_count} swap device(s) in ${swap_in} pages/s, out ${swap_out} pages/s |
+    | <a id="check_swap_io_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | io                                                                          |
+    | <a id="check_swap_io_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                             |
+    | <a id="check_swap_io_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                             |
+    | <a id="check_swap_io_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                          |
+    | <a id="check_swap_io_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                             |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -5404,25 +5560,29 @@ OK: in 172032B/s, out 28672B/s
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                             | Default Value                         |
-    |----------------------------------------------------------------------------------------------------|---------------------------------------|
-    | <a id="check_temperature_filter"></a>[filter](../common-options.md#filter)                         |                                       |
-    | <a id="check_temperature_warning"></a>[warning](../common-options.md#warning)                      | temperature > 70                      |
-    | <a id="check_temperature_warn"></a>[warn](../common-options.md#warn)                               |                                       |
-    | <a id="check_temperature_critical"></a>[critical](../common-options.md#critical)                   | temperature > 90                      |
-    | <a id="check_temperature_crit"></a>[crit](../common-options.md#crit)                               |                                       |
-    | <a id="check_temperature_ok"></a>[ok](../common-options.md#ok)                                     |                                       |
-    | <a id="check_temperature_debug"></a>[debug](../common-options.md#debug)                            | false                                 |
-    | <a id="check_temperature_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                 |
-    | <a id="check_temperature_empty-state"></a>[empty-state](../common-options.md#empty-state)          | critical                              |
-    | <a id="check_temperature_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                       |
-    | <a id="check_temperature_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                 |
-    | <a id="check_temperature_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                     |
-    | <a id="check_temperature_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                    |
-    | <a id="check_temperature_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All thermal zones seem ok. |
-    | <a id="check_temperature_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                       |
-    | <a id="check_temperature_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${temperature} C             |
-    | <a id="check_temperature_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                               |
+    | Option                                                                                                            | Default Value                         |
+    |-------------------------------------------------------------------------------------------------------------------|---------------------------------------|
+    | <a id="check_temperature_filter"></a>[filter](../common-options.md#filter)                                        |                                       |
+    | <a id="check_temperature_warning"></a>[warning](../common-options.md#warning)                                     | temperature > 70                      |
+    | <a id="check_temperature_warn"></a>[warn](../common-options.md#warn)                                              |                                       |
+    | <a id="check_temperature_critical"></a>[critical](../common-options.md#critical)                                  | temperature > 90                      |
+    | <a id="check_temperature_crit"></a>[crit](../common-options.md#crit)                                              |                                       |
+    | <a id="check_temperature_ok"></a>[ok](../common-options.md#ok)                                                    |                                       |
+    | <a id="check_temperature_debug"></a>[debug](../common-options.md#debug)                                           | false                                 |
+    | <a id="check_temperature_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                 |
+    | <a id="check_temperature_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | critical                              |
+    | <a id="check_temperature_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                       |
+    | <a id="check_temperature_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                 |
+    | <a id="check_temperature_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                     |
+    | <a id="check_temperature_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                    |
+    | <a id="check_temperature_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All thermal zones seem ok. |
+    | <a id="check_temperature_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                       |
+    | <a id="check_temperature_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${temperature} C             |
+    | <a id="check_temperature_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                               |
+    | <a id="check_temperature_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                       |
+    | <a id="check_temperature_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                       |
+    | <a id="check_temperature_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                    |
+    | <a id="check_temperature_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                       |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -5434,25 +5594,29 @@ OK: in 172032B/s, out 28672B/s
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                             | Default Value                 |
-    |----------------------------------------------------------------------------------------------------|-------------------------------|
-    | <a id="check_temperature_filter"></a>[filter](../common-options.md#filter)                         |                               |
-    | <a id="check_temperature_warning"></a>[warning](../common-options.md#warning)                      | temperature > 70              |
-    | <a id="check_temperature_warn"></a>[warn](../common-options.md#warn)                               |                               |
-    | <a id="check_temperature_critical"></a>[critical](../common-options.md#critical)                   | temperature > 90              |
-    | <a id="check_temperature_crit"></a>[crit](../common-options.md#crit)                               |                               |
-    | <a id="check_temperature_ok"></a>[ok](../common-options.md#ok)                                     |                               |
-    | <a id="check_temperature_debug"></a>[debug](../common-options.md#debug)                            | false                         |
-    | <a id="check_temperature_show-all"></a>[show-all](../common-options.md#show-all)                   | false                         |
-    | <a id="check_temperature_empty-state"></a>[empty-state](../common-options.md#empty-state)          | critical                      |
-    | <a id="check_temperature_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                               |
-    | <a id="check_temperature_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                         |
-    | <a id="check_temperature_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                             |
-    | <a id="check_temperature_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}            |
-    | <a id="check_temperature_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): Temperature is ok. |
-    | <a id="check_temperature_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                               |
-    | <a id="check_temperature_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${temperature}C      |
-    | <a id="check_temperature_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                       |
+    | Option                                                                                                            | Default Value                 |
+    |-------------------------------------------------------------------------------------------------------------------|-------------------------------|
+    | <a id="check_temperature_filter"></a>[filter](../common-options.md#filter)                                        |                               |
+    | <a id="check_temperature_warning"></a>[warning](../common-options.md#warning)                                     | temperature > 70              |
+    | <a id="check_temperature_warn"></a>[warn](../common-options.md#warn)                                              |                               |
+    | <a id="check_temperature_critical"></a>[critical](../common-options.md#critical)                                  | temperature > 90              |
+    | <a id="check_temperature_crit"></a>[crit](../common-options.md#crit)                                              |                               |
+    | <a id="check_temperature_ok"></a>[ok](../common-options.md#ok)                                                    |                               |
+    | <a id="check_temperature_debug"></a>[debug](../common-options.md#debug)                                           | false                         |
+    | <a id="check_temperature_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                         |
+    | <a id="check_temperature_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | critical                      |
+    | <a id="check_temperature_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                               |
+    | <a id="check_temperature_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                         |
+    | <a id="check_temperature_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                             |
+    | <a id="check_temperature_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}            |
+    | <a id="check_temperature_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): Temperature is ok. |
+    | <a id="check_temperature_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                               |
+    | <a id="check_temperature_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${temperature}C      |
+    | <a id="check_temperature_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                       |
+    | <a id="check_temperature_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                               |
+    | <a id="check_temperature_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                               |
+    | <a id="check_temperature_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                            |
+    | <a id="check_temperature_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                               |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -5560,25 +5724,29 @@ Largest time unit used to render ${uptime}: s|m|h|d|w (default: w). For a 6-week
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                        | Default Value                             |
-|-----------------------------------------------------------------------------------------------|-------------------------------------------|
-| <a id="check_uptime_filter"></a>[filter](../common-options.md#filter)                         |                                           |
-| <a id="check_uptime_warning"></a>[warning](../common-options.md#warning)                      | uptime < 2d                               |
-| <a id="check_uptime_warn"></a>[warn](../common-options.md#warn)                               |                                           |
-| <a id="check_uptime_critical"></a>[critical](../common-options.md#critical)                   | uptime < 1d                               |
-| <a id="check_uptime_crit"></a>[crit](../common-options.md#crit)                               |                                           |
-| <a id="check_uptime_ok"></a>[ok](../common-options.md#ok)                                     |                                           |
-| <a id="check_uptime_debug"></a>[debug](../common-options.md#debug)                            | false                                     |
-| <a id="check_uptime_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                     |
-| <a id="check_uptime_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                                   |
-| <a id="check_uptime_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                           |
-| <a id="check_uptime_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                     |
-| <a id="check_uptime_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                         |
-| <a id="check_uptime_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                        |
-| <a id="check_uptime_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                           |
-| <a id="check_uptime_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                           |
-| <a id="check_uptime_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | uptime: ${uptime}h, boot: ${boot} (${tz}) |
-| <a id="check_uptime_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | uptime                                    |
+| Option                                                                                                       | Default Value                             |
+|--------------------------------------------------------------------------------------------------------------|-------------------------------------------|
+| <a id="check_uptime_filter"></a>[filter](../common-options.md#filter)                                        |                                           |
+| <a id="check_uptime_warning"></a>[warning](../common-options.md#warning)                                     | uptime < 2d                               |
+| <a id="check_uptime_warn"></a>[warn](../common-options.md#warn)                                              |                                           |
+| <a id="check_uptime_critical"></a>[critical](../common-options.md#critical)                                  | uptime < 1d                               |
+| <a id="check_uptime_crit"></a>[crit](../common-options.md#crit)                                              |                                           |
+| <a id="check_uptime_ok"></a>[ok](../common-options.md#ok)                                                    |                                           |
+| <a id="check_uptime_debug"></a>[debug](../common-options.md#debug)                                           | false                                     |
+| <a id="check_uptime_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                     |
+| <a id="check_uptime_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                                   |
+| <a id="check_uptime_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                           |
+| <a id="check_uptime_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                     |
+| <a id="check_uptime_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                         |
+| <a id="check_uptime_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                        |
+| <a id="check_uptime_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                           |
+| <a id="check_uptime_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                           |
+| <a id="check_uptime_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | uptime: ${uptime}h, boot: ${boot} (${tz}) |
+| <a id="check_uptime_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | uptime                                    |
+| <a id="check_uptime_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                           |
+| <a id="check_uptime_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                           |
+| <a id="check_uptime_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                        |
+| <a id="check_uptime_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                           |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -5766,25 +5934,29 @@ L        cli OK: the Windows Time service is stopped (start type demand)|'w32tim
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                         | Default Value                      |
-|------------------------------------------------------------------------------------------------|------------------------------------|
-| <a id="check_w32time_filter"></a>[filter](../common-options.md#filter)                         |                                    |
-| <a id="check_w32time_warning"></a>[warning](../common-options.md#warning)                      | offset > 1000                      |
-| <a id="check_w32time_warn"></a>[warn](../common-options.md#warn)                               |                                    |
-| <a id="check_w32time_critical"></a>[critical](../common-options.md#critical)                   | synchronized = 0 or offset > 30000 |
-| <a id="check_w32time_crit"></a>[crit](../common-options.md#crit)                               |                                    |
-| <a id="check_w32time_ok"></a>[ok](../common-options.md#ok)                                     |                                    |
-| <a id="check_w32time_debug"></a>[debug](../common-options.md#debug)                            | false                              |
-| <a id="check_w32time_show-all"></a>[show-all](../common-options.md#show-all)                   | false                              |
-| <a id="check_w32time_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored                            |
-| <a id="check_w32time_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                    |
-| <a id="check_w32time_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                              |
-| <a id="check_w32time_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                  |
-| <a id="check_w32time_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                 |
-| <a id="check_w32time_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                    |
-| <a id="check_w32time_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |                                    |
-| <a id="check_w32time_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${state}                           |
-| <a id="check_w32time_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | w32time                            |
+| Option                                                                                                        | Default Value                      |
+|---------------------------------------------------------------------------------------------------------------|------------------------------------|
+| <a id="check_w32time_filter"></a>[filter](../common-options.md#filter)                                        |                                    |
+| <a id="check_w32time_warning"></a>[warning](../common-options.md#warning)                                     | offset > 1000                      |
+| <a id="check_w32time_warn"></a>[warn](../common-options.md#warn)                                              |                                    |
+| <a id="check_w32time_critical"></a>[critical](../common-options.md#critical)                                  | synchronized = 0 or offset > 30000 |
+| <a id="check_w32time_crit"></a>[crit](../common-options.md#crit)                                              |                                    |
+| <a id="check_w32time_ok"></a>[ok](../common-options.md#ok)                                                    |                                    |
+| <a id="check_w32time_debug"></a>[debug](../common-options.md#debug)                                           | false                              |
+| <a id="check_w32time_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                              |
+| <a id="check_w32time_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored                            |
+| <a id="check_w32time_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                    |
+| <a id="check_w32time_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                              |
+| <a id="check_w32time_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                  |
+| <a id="check_w32time_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                 |
+| <a id="check_w32time_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                    |
+| <a id="check_w32time_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |                                    |
+| <a id="check_w32time_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${state}                           |
+| <a id="check_w32time_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | w32time                            |
+| <a id="check_w32time_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                    |
+| <a id="check_w32time_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                    |
+| <a id="check_w32time_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                 |
+| <a id="check_w32time_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                    |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/common-options.md
+++ b/docs/docs/reference/common-options.md
@@ -11,26 +11,30 @@ These options are available on all filter based commands. Default values are com
 listed on each command's reference page.
 
 
-| Option                            | Description                                                                                                               |
-|-----------------------------------|---------------------------------------------------------------------------------------------------------------------------|
-| [filter](#filter)                 | Filter which marks interesting items.                                                                                     |
-| [warning](#warning)               | Filter which marks items which generates a warning state.                                                                 |
-| [warn](#warn)                     | Short alias for warning                                                                                                   |
-| [critical](#critical)             | Filter which marks items which generates a critical state.                                                                |
-| [crit](#crit)                     | Short alias for critical.                                                                                                 |
-| [ok](#ok)                         | Filter which marks items which generates an ok state.                                                                     |
-| [debug](#debug)                   | Show debugging information in the log                                                                                     |
-| [show-all](#show-all)             | Show details for all matches regardless of status (normally details are only showed for warnings and criticals).          |
-| [empty-state](#empty-state)       | Return status to use when nothing matched filter.                                                                         |
-| [perf-config](#perf-config)       | Performance data generation configuration                                                                                 |
-| [escape-html](#escape-html)       | Escape any < and > characters to prevent HTML encoding                                                                    |
-| [list-separator](#list-separator) | String used to separate the items of %(list), %(ok_list), %(warn_list), %(crit_list), %(problem_list) and %(detail_list). |
-| [top-syntax](#top-syntax)         | Top level syntax.                                                                                                         |
-| [ok-syntax](#ok-syntax)           | ok syntax.                                                                                                                |
-| [empty-syntax](#empty-syntax)     | Empty syntax.                                                                                                             |
-| [detail-syntax](#detail-syntax)   | Detail level syntax.                                                                                                      |
-| [perf-syntax](#perf-syntax)       | Performance alias syntax.                                                                                                 |
-| [unique-index](#unique-index)     | Unique syntax.                                                                                                            |
+| Option                                      | Description                                                                                                                                                                           |
+|---------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [filter](#filter)                           | Filter which marks interesting items.                                                                                                                                                 |
+| [warning](#warning)                         | Filter which marks items which generates a warning state.                                                                                                                             |
+| [warn](#warn)                               | Short alias for warning                                                                                                                                                               |
+| [critical](#critical)                       | Filter which marks items which generates a critical state.                                                                                                                            |
+| [crit](#crit)                               | Short alias for critical.                                                                                                                                                             |
+| [ok](#ok)                                   | Filter which marks items which generates an ok state.                                                                                                                                 |
+| [debug](#debug)                             | Show debugging information in the log                                                                                                                                                 |
+| [show-all](#show-all)                       | Show details for all matches regardless of status (normally details are only showed for warnings and criticals).                                                                      |
+| [empty-state](#empty-state)                 | Return status to use when nothing matched filter.                                                                                                                                     |
+| [perf-config](#perf-config)                 | Performance data generation configuration                                                                                                                                             |
+| [escape-html](#escape-html)                 | Escape any < and > characters to prevent HTML encoding                                                                                                                                |
+| [list-separator](#list-separator)           | String used to separate the items of %(list), %(ok_list), %(warn_list), %(crit_list), %(problem_list) and %(detail_list).                                                             |
+| [top-syntax](#top-syntax)                   | Top level syntax.                                                                                                                                                                     |
+| [ok-syntax](#ok-syntax)                     | ok syntax.                                                                                                                                                                            |
+| [empty-syntax](#empty-syntax)               | Empty syntax.                                                                                                                                                                         |
+| [detail-syntax](#detail-syntax)             | Detail level syntax.                                                                                                                                                                  |
+| [perf-syntax](#perf-syntax)                 | Performance alias syntax.                                                                                                                                                             |
+| [unique-index](#unique-index)               | Unique syntax.                                                                                                                                                                        |
+| [byte-unit](#byte-unit)                     | Unit to render every byte value of the message in: B, KB, MB, GB, TB, PB or EB.                                                                                                       |
+| [decimal-separator](#decimal-separator)     | Character to use as the decimal separator of the message, for instance "," for the European rendering (default ".").                                                                  |
+| [decimals](#decimals)                       | Number of decimals to render the numbers of the message with, for instance 1 to turn "25.191GB" into "25.2GB".                                                                        |
+| [thousands-separator](#thousands-separator) | Character to group the thousands of the message with, for instance "." to render 1006.85 GB as "1.006,85" (together with decimal-separator=,). Empty (the default) means no grouping. |
 
 
 
@@ -127,6 +131,28 @@ This is the syntax for the base names of the performance data.
 
 Unique syntax.
 Used to filter unique items (counted will still increase but messages will not repeated)
+
+<h4 id="byte-unit">byte-unit</h4>
+
+Unit to render every byte value of the message in: B, KB, MB, GB, TB, PB or EB.
+By default each value scales on its own, which is why a single line can read "140.293GB/0.983TB"; pinning the unit makes the values comparable ("140.29GB/1006.85GB").
+Performance data is unaffected - its unit is chosen separately and can be set with perf-config.
+
+<h4 id="decimal-separator">decimal-separator</h4>
+
+Character to use as the decimal separator of the message, for instance "," for the European rendering (default ".").
+Only the message is affected: performance data and the numbers you write in a filter or threshold always use ".", as their consumers require.
+
+<h4 id="decimals">decimals</h4>
+
+Number of decimals to render the numbers of the message with, for instance 1 to turn "25.191GB" into "25.2GB".
+Applies to the byte and percentage keywords and to format_bytes()/format_number(); -1 (the default) keeps the historical rendering of up to three decimals with the trailing zeros stripped.
+Performance data is unaffected - it is generated from the raw values so that graphs keep their full precision.
+
+<h4 id="thousands-separator">thousands-separator</h4>
+
+Character to group the thousands of the message with, for instance "." to render 1006.85 GB as "1.006,85" (together with decimal-separator=,). Empty (the default) means no grouping.
+Only the message is affected: performance data and the numbers you write in a filter or threshold are never grouped.
 
 
 ## Standard options

--- a/docs/docs/reference/misc/CheckDocker.md
+++ b/docs/docs/reference/misc/CheckDocker.md
@@ -155,25 +155,29 @@ Failed to connect to docker daemon at '/var/run/missing.sock': Failed to connect
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                        | Default Value                |
-    |-----------------------------------------------------------------------------------------------|------------------------------|
-    | <a id="check_docker_filter"></a>[filter](../common-options.md#filter)                         |                              |
-    | <a id="check_docker_warning"></a>[warning](../common-options.md#warning)                      |                              |
-    | <a id="check_docker_warn"></a>[warn](../common-options.md#warn)                               |                              |
-    | <a id="check_docker_critical"></a>[critical](../common-options.md#critical)                   | container_state != 'running' |
-    | <a id="check_docker_crit"></a>[crit](../common-options.md#crit)                               |                              |
-    | <a id="check_docker_ok"></a>[ok](../common-options.md#ok)                                     |                              |
-    | <a id="check_docker_debug"></a>[debug](../common-options.md#debug)                            | false                        |
-    | <a id="check_docker_show-all"></a>[show-all](../common-options.md#show-all)                   | false                        |
-    | <a id="check_docker_empty-state"></a>[empty-state](../common-options.md#empty-state)          | warning                      |
-    | <a id="check_docker_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                              |
-    | <a id="check_docker_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                        |
-    | <a id="check_docker_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                            |
-    | <a id="check_docker_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}           |
-    | <a id="check_docker_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                              |
-    | <a id="check_docker_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No containers found          |
-    | <a id="check_docker_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${names}=${container_state}  |
-    | <a id="check_docker_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${names}                     |
+    | Option                                                                                                       | Default Value                |
+    |--------------------------------------------------------------------------------------------------------------|------------------------------|
+    | <a id="check_docker_filter"></a>[filter](../common-options.md#filter)                                        |                              |
+    | <a id="check_docker_warning"></a>[warning](../common-options.md#warning)                                     |                              |
+    | <a id="check_docker_warn"></a>[warn](../common-options.md#warn)                                              |                              |
+    | <a id="check_docker_critical"></a>[critical](../common-options.md#critical)                                  | container_state != 'running' |
+    | <a id="check_docker_crit"></a>[crit](../common-options.md#crit)                                              |                              |
+    | <a id="check_docker_ok"></a>[ok](../common-options.md#ok)                                                    |                              |
+    | <a id="check_docker_debug"></a>[debug](../common-options.md#debug)                                           | false                        |
+    | <a id="check_docker_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                        |
+    | <a id="check_docker_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | warning                      |
+    | <a id="check_docker_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                              |
+    | <a id="check_docker_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                        |
+    | <a id="check_docker_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                            |
+    | <a id="check_docker_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}           |
+    | <a id="check_docker_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                              |
+    | <a id="check_docker_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No containers found          |
+    | <a id="check_docker_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${names}=${container_state}  |
+    | <a id="check_docker_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${names}                     |
+    | <a id="check_docker_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                              |
+    | <a id="check_docker_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                              |
+    | <a id="check_docker_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                           |
+    | <a id="check_docker_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                              |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -215,25 +219,29 @@ Failed to connect to docker daemon at '/var/run/missing.sock': Failed to connect
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                        | Default Value                |
-    |-----------------------------------------------------------------------------------------------|------------------------------|
-    | <a id="check_docker_filter"></a>[filter](../common-options.md#filter)                         |                              |
-    | <a id="check_docker_warning"></a>[warning](../common-options.md#warning)                      |                              |
-    | <a id="check_docker_warn"></a>[warn](../common-options.md#warn)                               |                              |
-    | <a id="check_docker_critical"></a>[critical](../common-options.md#critical)                   | container_state != 'running' |
-    | <a id="check_docker_crit"></a>[crit](../common-options.md#crit)                               |                              |
-    | <a id="check_docker_ok"></a>[ok](../common-options.md#ok)                                     |                              |
-    | <a id="check_docker_debug"></a>[debug](../common-options.md#debug)                            | false                        |
-    | <a id="check_docker_show-all"></a>[show-all](../common-options.md#show-all)                   | false                        |
-    | <a id="check_docker_empty-state"></a>[empty-state](../common-options.md#empty-state)          | warning                      |
-    | <a id="check_docker_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                              |
-    | <a id="check_docker_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                        |
-    | <a id="check_docker_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                            |
-    | <a id="check_docker_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}           |
-    | <a id="check_docker_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                              |
-    | <a id="check_docker_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No containers found          |
-    | <a id="check_docker_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${names}=${container_state}  |
-    | <a id="check_docker_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${names}                     |
+    | Option                                                                                                       | Default Value                |
+    |--------------------------------------------------------------------------------------------------------------|------------------------------|
+    | <a id="check_docker_filter"></a>[filter](../common-options.md#filter)                                        |                              |
+    | <a id="check_docker_warning"></a>[warning](../common-options.md#warning)                                     |                              |
+    | <a id="check_docker_warn"></a>[warn](../common-options.md#warn)                                              |                              |
+    | <a id="check_docker_critical"></a>[critical](../common-options.md#critical)                                  | container_state != 'running' |
+    | <a id="check_docker_crit"></a>[crit](../common-options.md#crit)                                              |                              |
+    | <a id="check_docker_ok"></a>[ok](../common-options.md#ok)                                                    |                              |
+    | <a id="check_docker_debug"></a>[debug](../common-options.md#debug)                                           | false                        |
+    | <a id="check_docker_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                        |
+    | <a id="check_docker_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | warning                      |
+    | <a id="check_docker_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                              |
+    | <a id="check_docker_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                        |
+    | <a id="check_docker_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                            |
+    | <a id="check_docker_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}           |
+    | <a id="check_docker_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                              |
+    | <a id="check_docker_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No containers found          |
+    | <a id="check_docker_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${names}=${container_state}  |
+    | <a id="check_docker_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${names}                     |
+    | <a id="check_docker_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                              |
+    | <a id="check_docker_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                              |
+    | <a id="check_docker_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                           |
+    | <a id="check_docker_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                              |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -350,25 +358,29 @@ OK: build cache 13752766549 (reclaimable 13752766549)|'docker build cache'=13752
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                           | Default Value                                 |
-    |--------------------------------------------------------------------------------------------------|-----------------------------------------------|
-    | <a id="check_docker_df_filter"></a>[filter](../common-options.md#filter)                         |                                               |
-    | <a id="check_docker_df_warning"></a>[warning](../common-options.md#warning)                      |                                               |
-    | <a id="check_docker_df_warn"></a>[warn](../common-options.md#warn)                               |                                               |
-    | <a id="check_docker_df_critical"></a>[critical](../common-options.md#critical)                   |                                               |
-    | <a id="check_docker_df_crit"></a>[crit](../common-options.md#crit)                               |                                               |
-    | <a id="check_docker_df_ok"></a>[ok](../common-options.md#ok)                                     |                                               |
-    | <a id="check_docker_df_debug"></a>[debug](../common-options.md#debug)                            | false                                         |
-    | <a id="check_docker_df_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                         |
-    | <a id="check_docker_df_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                       |
-    | <a id="check_docker_df_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                               |
-    | <a id="check_docker_df_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                         |
-    | <a id="check_docker_df_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                             |
-    | <a id="check_docker_df_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                            |
-    | <a id="check_docker_df_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                               |
-    | <a id="check_docker_df_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No disk usage information returned |
-    | <a id="check_docker_df_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${message}                                    |
-    | <a id="check_docker_df_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | docker                                        |
+    | Option                                                                                                          | Default Value                                 |
+    |-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+    | <a id="check_docker_df_filter"></a>[filter](../common-options.md#filter)                                        |                                               |
+    | <a id="check_docker_df_warning"></a>[warning](../common-options.md#warning)                                     |                                               |
+    | <a id="check_docker_df_warn"></a>[warn](../common-options.md#warn)                                              |                                               |
+    | <a id="check_docker_df_critical"></a>[critical](../common-options.md#critical)                                  |                                               |
+    | <a id="check_docker_df_crit"></a>[crit](../common-options.md#crit)                                              |                                               |
+    | <a id="check_docker_df_ok"></a>[ok](../common-options.md#ok)                                                    |                                               |
+    | <a id="check_docker_df_debug"></a>[debug](../common-options.md#debug)                                           | false                                         |
+    | <a id="check_docker_df_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                         |
+    | <a id="check_docker_df_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                       |
+    | <a id="check_docker_df_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                               |
+    | <a id="check_docker_df_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                         |
+    | <a id="check_docker_df_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                             |
+    | <a id="check_docker_df_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                            |
+    | <a id="check_docker_df_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                               |
+    | <a id="check_docker_df_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No disk usage information returned |
+    | <a id="check_docker_df_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${message}                                    |
+    | <a id="check_docker_df_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | docker                                        |
+    | <a id="check_docker_df_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                               |
+    | <a id="check_docker_df_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                               |
+    | <a id="check_docker_df_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                            |
+    | <a id="check_docker_df_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                               |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -400,25 +412,29 @@ OK: build cache 13752766549 (reclaimable 13752766549)|'docker build cache'=13752
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                           | Default Value                                 |
-    |--------------------------------------------------------------------------------------------------|-----------------------------------------------|
-    | <a id="check_docker_df_filter"></a>[filter](../common-options.md#filter)                         |                                               |
-    | <a id="check_docker_df_warning"></a>[warning](../common-options.md#warning)                      |                                               |
-    | <a id="check_docker_df_warn"></a>[warn](../common-options.md#warn)                               |                                               |
-    | <a id="check_docker_df_critical"></a>[critical](../common-options.md#critical)                   |                                               |
-    | <a id="check_docker_df_crit"></a>[crit](../common-options.md#crit)                               |                                               |
-    | <a id="check_docker_df_ok"></a>[ok](../common-options.md#ok)                                     |                                               |
-    | <a id="check_docker_df_debug"></a>[debug](../common-options.md#debug)                            | false                                         |
-    | <a id="check_docker_df_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                         |
-    | <a id="check_docker_df_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                       |
-    | <a id="check_docker_df_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                               |
-    | <a id="check_docker_df_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                         |
-    | <a id="check_docker_df_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                             |
-    | <a id="check_docker_df_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                            |
-    | <a id="check_docker_df_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                               |
-    | <a id="check_docker_df_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No disk usage information returned |
-    | <a id="check_docker_df_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${message}                                    |
-    | <a id="check_docker_df_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | docker                                        |
+    | Option                                                                                                          | Default Value                                 |
+    |-----------------------------------------------------------------------------------------------------------------|-----------------------------------------------|
+    | <a id="check_docker_df_filter"></a>[filter](../common-options.md#filter)                                        |                                               |
+    | <a id="check_docker_df_warning"></a>[warning](../common-options.md#warning)                                     |                                               |
+    | <a id="check_docker_df_warn"></a>[warn](../common-options.md#warn)                                              |                                               |
+    | <a id="check_docker_df_critical"></a>[critical](../common-options.md#critical)                                  |                                               |
+    | <a id="check_docker_df_crit"></a>[crit](../common-options.md#crit)                                              |                                               |
+    | <a id="check_docker_df_ok"></a>[ok](../common-options.md#ok)                                                    |                                               |
+    | <a id="check_docker_df_debug"></a>[debug](../common-options.md#debug)                                           | false                                         |
+    | <a id="check_docker_df_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                         |
+    | <a id="check_docker_df_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                       |
+    | <a id="check_docker_df_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                               |
+    | <a id="check_docker_df_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                         |
+    | <a id="check_docker_df_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                             |
+    | <a id="check_docker_df_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                            |
+    | <a id="check_docker_df_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                               |
+    | <a id="check_docker_df_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No disk usage information returned |
+    | <a id="check_docker_df_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${message}                                    |
+    | <a id="check_docker_df_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | docker                                        |
+    | <a id="check_docker_df_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                               |
+    | <a id="check_docker_df_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                               |
+    | <a id="check_docker_df_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                            |
+    | <a id="check_docker_df_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                               |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -526,25 +542,29 @@ Failed to connect to docker daemon at '/var/run/missing.sock': Failed to connect
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                             | Default Value                                                                                                       |
-    |----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-    | <a id="check_docker_info_filter"></a>[filter](../common-options.md#filter)                         |                                                                                                                     |
-    | <a id="check_docker_info_warning"></a>[warning](../common-options.md#warning)                      |                                                                                                                     |
-    | <a id="check_docker_info_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                                     |
-    | <a id="check_docker_info_critical"></a>[critical](../common-options.md#critical)                   |                                                                                                                     |
-    | <a id="check_docker_info_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                                     |
-    | <a id="check_docker_info_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                                     |
-    | <a id="check_docker_info_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                               |
-    | <a id="check_docker_info_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                               |
-    | <a id="check_docker_info_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                                                             |
-    | <a id="check_docker_info_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                                     |
-    | <a id="check_docker_info_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                               |
-    | <a id="check_docker_info_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                                   |
-    | <a id="check_docker_info_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                                  |
-    | <a id="check_docker_info_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                                                                     |
-    | <a id="check_docker_info_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No daemon information returned                                                                           |
-    | <a id="check_docker_info_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | docker ${version} on ${name}: ${running} running, ${paused} paused, ${stopped} stopped containers, ${images} images |
-    | <a id="check_docker_info_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                                                                             |
+    | Option                                                                                                            | Default Value                                                                                                       |
+    |-------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+    | <a id="check_docker_info_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                                                     |
+    | <a id="check_docker_info_warning"></a>[warning](../common-options.md#warning)                                     |                                                                                                                     |
+    | <a id="check_docker_info_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                                     |
+    | <a id="check_docker_info_critical"></a>[critical](../common-options.md#critical)                                  |                                                                                                                     |
+    | <a id="check_docker_info_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                                     |
+    | <a id="check_docker_info_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                                     |
+    | <a id="check_docker_info_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                               |
+    | <a id="check_docker_info_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                               |
+    | <a id="check_docker_info_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                                                             |
+    | <a id="check_docker_info_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                                     |
+    | <a id="check_docker_info_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                               |
+    | <a id="check_docker_info_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                                   |
+    | <a id="check_docker_info_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                                  |
+    | <a id="check_docker_info_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                                                                     |
+    | <a id="check_docker_info_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No daemon information returned                                                                           |
+    | <a id="check_docker_info_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | docker ${version} on ${name}: ${running} running, ${paused} paused, ${stopped} stopped containers, ${images} images |
+    | <a id="check_docker_info_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                                                                             |
+    | <a id="check_docker_info_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                                     |
+    | <a id="check_docker_info_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                                     |
+    | <a id="check_docker_info_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                                  |
+    | <a id="check_docker_info_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                                     |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -576,25 +596,29 @@ Failed to connect to docker daemon at '/var/run/missing.sock': Failed to connect
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                             | Default Value                                                                                                       |
-    |----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-    | <a id="check_docker_info_filter"></a>[filter](../common-options.md#filter)                         |                                                                                                                     |
-    | <a id="check_docker_info_warning"></a>[warning](../common-options.md#warning)                      |                                                                                                                     |
-    | <a id="check_docker_info_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                                     |
-    | <a id="check_docker_info_critical"></a>[critical](../common-options.md#critical)                   |                                                                                                                     |
-    | <a id="check_docker_info_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                                     |
-    | <a id="check_docker_info_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                                     |
-    | <a id="check_docker_info_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                               |
-    | <a id="check_docker_info_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                               |
-    | <a id="check_docker_info_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                                                             |
-    | <a id="check_docker_info_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                                     |
-    | <a id="check_docker_info_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                               |
-    | <a id="check_docker_info_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                                   |
-    | <a id="check_docker_info_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                                  |
-    | <a id="check_docker_info_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                                                                     |
-    | <a id="check_docker_info_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No daemon information returned                                                                           |
-    | <a id="check_docker_info_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | docker ${version} on ${name}: ${running} running, ${paused} paused, ${stopped} stopped containers, ${images} images |
-    | <a id="check_docker_info_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                                                                             |
+    | Option                                                                                                            | Default Value                                                                                                       |
+    |-------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+    | <a id="check_docker_info_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                                                     |
+    | <a id="check_docker_info_warning"></a>[warning](../common-options.md#warning)                                     |                                                                                                                     |
+    | <a id="check_docker_info_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                                     |
+    | <a id="check_docker_info_critical"></a>[critical](../common-options.md#critical)                                  |                                                                                                                     |
+    | <a id="check_docker_info_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                                     |
+    | <a id="check_docker_info_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                                     |
+    | <a id="check_docker_info_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                               |
+    | <a id="check_docker_info_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                               |
+    | <a id="check_docker_info_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                                                             |
+    | <a id="check_docker_info_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                                     |
+    | <a id="check_docker_info_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                               |
+    | <a id="check_docker_info_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                                   |
+    | <a id="check_docker_info_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                                  |
+    | <a id="check_docker_info_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                                                                     |
+    | <a id="check_docker_info_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No daemon information returned                                                                           |
+    | <a id="check_docker_info_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | docker ${version} on ${name}: ${running} running, ${paused} paused, ${stopped} stopped containers, ${images} images |
+    | <a id="check_docker_info_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                                                                             |
+    | <a id="check_docker_info_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                                     |
+    | <a id="check_docker_info_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                                     |
+    | <a id="check_docker_info_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                                  |
+    | <a id="check_docker_info_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                                     |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -711,25 +735,29 @@ OK: app-backend: 0 restarts, up 236s, exit=0 oom=0|'app-backend restarts'=0;0;0
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                                 | Default Value                                           |
-    |--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-    | <a id="check_docker_restarts_filter"></a>[filter](../common-options.md#filter)                         |                                                         |
-    | <a id="check_docker_restarts_warning"></a>[warning](../common-options.md#warning)                      | restart_count > 3 and started < 15m and started >= 0    |
-    | <a id="check_docker_restarts_warn"></a>[warn](../common-options.md#warn)                               |                                                         |
-    | <a id="check_docker_restarts_critical"></a>[critical](../common-options.md#critical)                   | oom_killed = 1                                          |
-    | <a id="check_docker_restarts_crit"></a>[crit](../common-options.md#crit)                               |                                                         |
-    | <a id="check_docker_restarts_ok"></a>[ok](../common-options.md#ok)                                     |                                                         |
-    | <a id="check_docker_restarts_debug"></a>[debug](../common-options.md#debug)                            | false                                                   |
-    | <a id="check_docker_restarts_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                   |
-    | <a id="check_docker_restarts_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                      |
-    | <a id="check_docker_restarts_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                         |
-    | <a id="check_docker_restarts_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                   |
-    | <a id="check_docker_restarts_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                       |
-    | <a id="check_docker_restarts_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                      |
-    | <a id="check_docker_restarts_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                         |
-    | <a id="check_docker_restarts_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No containers found                                     |
-    | <a id="check_docker_restarts_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${names}: ${restart_count} restarts, ${container_state} |
-    | <a id="check_docker_restarts_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${names}                                                |
+    | Option                                                                                                                | Default Value                                           |
+    |-----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+    | <a id="check_docker_restarts_filter"></a>[filter](../common-options.md#filter)                                        |                                                         |
+    | <a id="check_docker_restarts_warning"></a>[warning](../common-options.md#warning)                                     | restart_count > 3 and started < 15m and started >= 0    |
+    | <a id="check_docker_restarts_warn"></a>[warn](../common-options.md#warn)                                              |                                                         |
+    | <a id="check_docker_restarts_critical"></a>[critical](../common-options.md#critical)                                  | oom_killed = 1                                          |
+    | <a id="check_docker_restarts_crit"></a>[crit](../common-options.md#crit)                                              |                                                         |
+    | <a id="check_docker_restarts_ok"></a>[ok](../common-options.md#ok)                                                    |                                                         |
+    | <a id="check_docker_restarts_debug"></a>[debug](../common-options.md#debug)                                           | false                                                   |
+    | <a id="check_docker_restarts_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                   |
+    | <a id="check_docker_restarts_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                      |
+    | <a id="check_docker_restarts_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                         |
+    | <a id="check_docker_restarts_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                   |
+    | <a id="check_docker_restarts_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                       |
+    | <a id="check_docker_restarts_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                      |
+    | <a id="check_docker_restarts_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                         |
+    | <a id="check_docker_restarts_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No containers found                                     |
+    | <a id="check_docker_restarts_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${names}: ${restart_count} restarts, ${container_state} |
+    | <a id="check_docker_restarts_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${names}                                                |
+    | <a id="check_docker_restarts_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                         |
+    | <a id="check_docker_restarts_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                         |
+    | <a id="check_docker_restarts_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                      |
+    | <a id="check_docker_restarts_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                         |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -764,25 +792,29 @@ OK: app-backend: 0 restarts, up 236s, exit=0 oom=0|'app-backend restarts'=0;0;0
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                                 | Default Value                                           |
-    |--------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
-    | <a id="check_docker_restarts_filter"></a>[filter](../common-options.md#filter)                         |                                                         |
-    | <a id="check_docker_restarts_warning"></a>[warning](../common-options.md#warning)                      | restart_count > 3 and started < 15m and started >= 0    |
-    | <a id="check_docker_restarts_warn"></a>[warn](../common-options.md#warn)                               |                                                         |
-    | <a id="check_docker_restarts_critical"></a>[critical](../common-options.md#critical)                   | oom_killed = 1                                          |
-    | <a id="check_docker_restarts_crit"></a>[crit](../common-options.md#crit)                               |                                                         |
-    | <a id="check_docker_restarts_ok"></a>[ok](../common-options.md#ok)                                     |                                                         |
-    | <a id="check_docker_restarts_debug"></a>[debug](../common-options.md#debug)                            | false                                                   |
-    | <a id="check_docker_restarts_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                   |
-    | <a id="check_docker_restarts_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                      |
-    | <a id="check_docker_restarts_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                         |
-    | <a id="check_docker_restarts_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                   |
-    | <a id="check_docker_restarts_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                       |
-    | <a id="check_docker_restarts_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                      |
-    | <a id="check_docker_restarts_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                         |
-    | <a id="check_docker_restarts_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No containers found                                     |
-    | <a id="check_docker_restarts_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${names}: ${restart_count} restarts, ${container_state} |
-    | <a id="check_docker_restarts_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${names}                                                |
+    | Option                                                                                                                | Default Value                                           |
+    |-----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------|
+    | <a id="check_docker_restarts_filter"></a>[filter](../common-options.md#filter)                                        |                                                         |
+    | <a id="check_docker_restarts_warning"></a>[warning](../common-options.md#warning)                                     | restart_count > 3 and started < 15m and started >= 0    |
+    | <a id="check_docker_restarts_warn"></a>[warn](../common-options.md#warn)                                              |                                                         |
+    | <a id="check_docker_restarts_critical"></a>[critical](../common-options.md#critical)                                  | oom_killed = 1                                          |
+    | <a id="check_docker_restarts_crit"></a>[crit](../common-options.md#crit)                                              |                                                         |
+    | <a id="check_docker_restarts_ok"></a>[ok](../common-options.md#ok)                                                    |                                                         |
+    | <a id="check_docker_restarts_debug"></a>[debug](../common-options.md#debug)                                           | false                                                   |
+    | <a id="check_docker_restarts_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                   |
+    | <a id="check_docker_restarts_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                      |
+    | <a id="check_docker_restarts_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                         |
+    | <a id="check_docker_restarts_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                   |
+    | <a id="check_docker_restarts_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                       |
+    | <a id="check_docker_restarts_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                      |
+    | <a id="check_docker_restarts_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                         |
+    | <a id="check_docker_restarts_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No containers found                                     |
+    | <a id="check_docker_restarts_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${names}: ${restart_count} restarts, ${container_state} |
+    | <a id="check_docker_restarts_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${names}                                                |
+    | <a id="check_docker_restarts_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                         |
+    | <a id="check_docker_restarts_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                         |
+    | <a id="check_docker_restarts_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                      |
+    | <a id="check_docker_restarts_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                         |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -896,25 +928,29 @@ OK: web-frontend: cpu 1%, memory 12.4MB of 15.35GB (0%), app-backend: cpu 2%, me
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                              | Default Value                                                |
-    |-----------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-    | <a id="check_docker_stats_filter"></a>[filter](../common-options.md#filter)                         |                                                              |
-    | <a id="check_docker_stats_warning"></a>[warning](../common-options.md#warning)                      |                                                              |
-    | <a id="check_docker_stats_warn"></a>[warn](../common-options.md#warn)                               |                                                              |
-    | <a id="check_docker_stats_critical"></a>[critical](../common-options.md#critical)                   |                                                              |
-    | <a id="check_docker_stats_crit"></a>[crit](../common-options.md#crit)                               |                                                              |
-    | <a id="check_docker_stats_ok"></a>[ok](../common-options.md#ok)                                     |                                                              |
-    | <a id="check_docker_stats_debug"></a>[debug](../common-options.md#debug)                            | false                                                        |
-    | <a id="check_docker_stats_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                        |
-    | <a id="check_docker_stats_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                           |
-    | <a id="check_docker_stats_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                              |
-    | <a id="check_docker_stats_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                        |
-    | <a id="check_docker_stats_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                            |
-    | <a id="check_docker_stats_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                           |
-    | <a id="check_docker_stats_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                              |
-    | <a id="check_docker_stats_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No running containers                                        |
-    | <a id="check_docker_stats_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${names}: cpu ${cpu_pct}%, memory ${memory} (${memory_pct}%) |
-    | <a id="check_docker_stats_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${names}                                                     |
+    | Option                                                                                                             | Default Value                                                |
+    |--------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+    | <a id="check_docker_stats_filter"></a>[filter](../common-options.md#filter)                                        |                                                              |
+    | <a id="check_docker_stats_warning"></a>[warning](../common-options.md#warning)                                     |                                                              |
+    | <a id="check_docker_stats_warn"></a>[warn](../common-options.md#warn)                                              |                                                              |
+    | <a id="check_docker_stats_critical"></a>[critical](../common-options.md#critical)                                  |                                                              |
+    | <a id="check_docker_stats_crit"></a>[crit](../common-options.md#crit)                                              |                                                              |
+    | <a id="check_docker_stats_ok"></a>[ok](../common-options.md#ok)                                                    |                                                              |
+    | <a id="check_docker_stats_debug"></a>[debug](../common-options.md#debug)                                           | false                                                        |
+    | <a id="check_docker_stats_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                        |
+    | <a id="check_docker_stats_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                           |
+    | <a id="check_docker_stats_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                              |
+    | <a id="check_docker_stats_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                        |
+    | <a id="check_docker_stats_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                            |
+    | <a id="check_docker_stats_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                           |
+    | <a id="check_docker_stats_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                              |
+    | <a id="check_docker_stats_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No running containers                                        |
+    | <a id="check_docker_stats_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${names}: cpu ${cpu_pct}%, memory ${memory} (${memory_pct}%) |
+    | <a id="check_docker_stats_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${names}                                                     |
+    | <a id="check_docker_stats_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                              |
+    | <a id="check_docker_stats_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                              |
+    | <a id="check_docker_stats_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                           |
+    | <a id="check_docker_stats_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                              |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -949,25 +985,29 @@ OK: web-frontend: cpu 1%, memory 12.4MB of 15.35GB (0%), app-backend: cpu 2%, me
     These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-    | Option                                                                                              | Default Value                                                |
-    |-----------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
-    | <a id="check_docker_stats_filter"></a>[filter](../common-options.md#filter)                         |                                                              |
-    | <a id="check_docker_stats_warning"></a>[warning](../common-options.md#warning)                      |                                                              |
-    | <a id="check_docker_stats_warn"></a>[warn](../common-options.md#warn)                               |                                                              |
-    | <a id="check_docker_stats_critical"></a>[critical](../common-options.md#critical)                   |                                                              |
-    | <a id="check_docker_stats_crit"></a>[crit](../common-options.md#crit)                               |                                                              |
-    | <a id="check_docker_stats_ok"></a>[ok](../common-options.md#ok)                                     |                                                              |
-    | <a id="check_docker_stats_debug"></a>[debug](../common-options.md#debug)                            | false                                                        |
-    | <a id="check_docker_stats_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                        |
-    | <a id="check_docker_stats_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                           |
-    | <a id="check_docker_stats_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                              |
-    | <a id="check_docker_stats_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                        |
-    | <a id="check_docker_stats_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                            |
-    | <a id="check_docker_stats_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                           |
-    | <a id="check_docker_stats_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                              |
-    | <a id="check_docker_stats_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | No running containers                                        |
-    | <a id="check_docker_stats_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${names}: cpu ${cpu_pct}%, memory ${memory} (${memory_pct}%) |
-    | <a id="check_docker_stats_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${names}                                                     |
+    | Option                                                                                                             | Default Value                                                |
+    |--------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------|
+    | <a id="check_docker_stats_filter"></a>[filter](../common-options.md#filter)                                        |                                                              |
+    | <a id="check_docker_stats_warning"></a>[warning](../common-options.md#warning)                                     |                                                              |
+    | <a id="check_docker_stats_warn"></a>[warn](../common-options.md#warn)                                              |                                                              |
+    | <a id="check_docker_stats_critical"></a>[critical](../common-options.md#critical)                                  |                                                              |
+    | <a id="check_docker_stats_crit"></a>[crit](../common-options.md#crit)                                              |                                                              |
+    | <a id="check_docker_stats_ok"></a>[ok](../common-options.md#ok)                                                    |                                                              |
+    | <a id="check_docker_stats_debug"></a>[debug](../common-options.md#debug)                                           | false                                                        |
+    | <a id="check_docker_stats_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                        |
+    | <a id="check_docker_stats_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                           |
+    | <a id="check_docker_stats_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                              |
+    | <a id="check_docker_stats_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                        |
+    | <a id="check_docker_stats_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                            |
+    | <a id="check_docker_stats_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                           |
+    | <a id="check_docker_stats_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                              |
+    | <a id="check_docker_stats_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | No running containers                                        |
+    | <a id="check_docker_stats_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${names}: cpu ${cpu_pct}%, memory ${memory} (${memory_pct}%) |
+    | <a id="check_docker_stats_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${names}                                                     |
+    | <a id="check_docker_stats_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                              |
+    | <a id="check_docker_stats_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                              |
+    | <a id="check_docker_stats_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                           |
+    | <a id="check_docker_stats_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                              |
 
 
     This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/misc/CheckMySQL.md
+++ b/docs/docs/reference/misc/CheckMySQL.md
@@ -201,25 +201,29 @@ Query (read/write) timeout in seconds.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                       | Default Value                                                                                                      |
-|----------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
-| <a id="check_mysql_filter"></a>[filter](../common-options.md#filter)                         |                                                                                                                    |
-| <a id="check_mysql_warning"></a>[warning](../common-options.md#warning)                      |                                                                                                                    |
-| <a id="check_mysql_warn"></a>[warn](../common-options.md#warn)                               |                                                                                                                    |
-| <a id="check_mysql_critical"></a>[critical](../common-options.md#critical)                   |                                                                                                                    |
-| <a id="check_mysql_crit"></a>[crit](../common-options.md#crit)                               |                                                                                                                    |
-| <a id="check_mysql_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                                                    |
-| <a id="check_mysql_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                                              |
-| <a id="check_mysql_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                                              |
-| <a id="check_mysql_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                                                            |
-| <a id="check_mysql_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                                                    |
-| <a id="check_mysql_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                                              |
-| <a id="check_mysql_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                                                  |
-| <a id="check_mysql_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                                                 |
-| <a id="check_mysql_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                                                                    |
-| <a id="check_mysql_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No server information returned                                                                          |
-| <a id="check_mysql_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${flavor} ${version}, uptime ${uptime}s, connections ${threads_connected}/${max_connections} (${connections_pct}%) |
-| <a id="check_mysql_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${flavor}                                                                                                          |
+| Option                                                                                                      | Default Value                                                                                                      |
+|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| <a id="check_mysql_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                                                    |
+| <a id="check_mysql_warning"></a>[warning](../common-options.md#warning)                                     |                                                                                                                    |
+| <a id="check_mysql_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                                                    |
+| <a id="check_mysql_critical"></a>[critical](../common-options.md#critical)                                  |                                                                                                                    |
+| <a id="check_mysql_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                                                    |
+| <a id="check_mysql_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                                                    |
+| <a id="check_mysql_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                                              |
+| <a id="check_mysql_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                                              |
+| <a id="check_mysql_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                                                            |
+| <a id="check_mysql_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                                                    |
+| <a id="check_mysql_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                                              |
+| <a id="check_mysql_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                                                  |
+| <a id="check_mysql_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                                                 |
+| <a id="check_mysql_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                                                                    |
+| <a id="check_mysql_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No server information returned                                                                          |
+| <a id="check_mysql_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${flavor} ${version}, uptime ${uptime}s, connections ${threads_connected}/${max_connections} (${connections_pct}%) |
+| <a id="check_mysql_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${flavor}                                                                                                          |
+| <a id="check_mysql_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                                                    |
+| <a id="check_mysql_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                                                    |
+| <a id="check_mysql_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                                                 |
+| <a id="check_mysql_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                                                    |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -380,25 +384,29 @@ Query (read/write) timeout in seconds.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                             | Default Value |
-|----------------------------------------------------------------------------------------------------|---------------|
-| <a id="check_mysql_query_filter"></a>[filter](../common-options.md#filter)                         |               |
-| <a id="check_mysql_query_warning"></a>[warning](../common-options.md#warning)                      |               |
-| <a id="check_mysql_query_warn"></a>[warn](../common-options.md#warn)                               |               |
-| <a id="check_mysql_query_critical"></a>[critical](../common-options.md#critical)                   |               |
-| <a id="check_mysql_query_crit"></a>[crit](../common-options.md#crit)                               |               |
-| <a id="check_mysql_query_ok"></a>[ok](../common-options.md#ok)                                     |               |
-| <a id="check_mysql_query_debug"></a>[debug](../common-options.md#debug)                            | false         |
-| <a id="check_mysql_query_show-all"></a>[show-all](../common-options.md#show-all)                   | false         |
-| <a id="check_mysql_query_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored       |
-| <a id="check_mysql_query_perf-config"></a>[perf-config](../common-options.md#perf-config)          |               |
-| <a id="check_mysql_query_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false         |
-| <a id="check_mysql_query_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,             |
-| <a id="check_mysql_query_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${list}       |
-| <a id="check_mysql_query_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |               |
-| <a id="check_mysql_query_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |               |
-| <a id="check_mysql_query_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | %(line)       |
-| <a id="check_mysql_query_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          |               |
+| Option                                                                                                            | Default Value |
+|-------------------------------------------------------------------------------------------------------------------|---------------|
+| <a id="check_mysql_query_filter"></a>[filter](../common-options.md#filter)                                        |               |
+| <a id="check_mysql_query_warning"></a>[warning](../common-options.md#warning)                                     |               |
+| <a id="check_mysql_query_warn"></a>[warn](../common-options.md#warn)                                              |               |
+| <a id="check_mysql_query_critical"></a>[critical](../common-options.md#critical)                                  |               |
+| <a id="check_mysql_query_crit"></a>[crit](../common-options.md#crit)                                              |               |
+| <a id="check_mysql_query_ok"></a>[ok](../common-options.md#ok)                                                    |               |
+| <a id="check_mysql_query_debug"></a>[debug](../common-options.md#debug)                                           | false         |
+| <a id="check_mysql_query_show-all"></a>[show-all](../common-options.md#show-all)                                  | false         |
+| <a id="check_mysql_query_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored       |
+| <a id="check_mysql_query_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |               |
+| <a id="check_mysql_query_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false         |
+| <a id="check_mysql_query_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,             |
+| <a id="check_mysql_query_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${list}       |
+| <a id="check_mysql_query_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |               |
+| <a id="check_mysql_query_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |               |
+| <a id="check_mysql_query_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | %(line)       |
+| <a id="check_mysql_query_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         |               |
+| <a id="check_mysql_query_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |               |
+| <a id="check_mysql_query_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |               |
+| <a id="check_mysql_query_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1            |
+| <a id="check_mysql_query_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |               |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/windows/CheckEventLog.md
+++ b/docs/docs/reference/windows/CheckEventLog.md
@@ -294,26 +294,30 @@ Use bookmarks to only look for messages since last check (with the same bookmark
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                          | Default Value                                  |
-|-------------------------------------------------------------------------------------------------|------------------------------------------------|
-| <a id="check_eventlog_filter"></a>[filter](../common-options.md#filter)                         | level in ('warning', 'error', 'critical')      |
-| <a id="check_eventlog_warning"></a>[warning](../common-options.md#warning)                      | level = 'warning', problem_count > 0           |
-| <a id="check_eventlog_warn"></a>[warn](../common-options.md#warn)                               |                                                |
-| <a id="check_eventlog_critical"></a>[critical](../common-options.md#critical)                   | level in ('error', 'critical')                 |
-| <a id="check_eventlog_crit"></a>[crit](../common-options.md#crit)                               |                                                |
-| <a id="check_eventlog_ok"></a>[ok](../common-options.md#ok)                                     |                                                |
-| <a id="check_eventlog_debug"></a>[debug](../common-options.md#debug)                            | false                                          |
-| <a id="check_eventlog_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                          |
-| <a id="check_eventlog_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                             |
-| <a id="check_eventlog_perf-config"></a>[perf-config](../common-options.md#perf-config)          | level(ignored:true)                            |
-| <a id="check_eventlog_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                          |
-| <a id="check_eventlog_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                              |
-| <a id="check_eventlog_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${count} message(s) ${problem_list} |
-| <a id="check_eventlog_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): Event log seems fine                |
-| <a id="check_eventlog_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No entries found                    |
-| <a id="check_eventlog_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${file} ${source} (${message})                 |
-| <a id="check_eventlog_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${file}_${source}                              |
-| <a id="check_eventlog_unique-index"></a>[unique-index](../common-options.md#unique-index)       |                                                |
+| Option                                                                                                         | Default Value                                  |
+|----------------------------------------------------------------------------------------------------------------|------------------------------------------------|
+| <a id="check_eventlog_filter"></a>[filter](../common-options.md#filter)                                        | level in ('warning', 'error', 'critical')      |
+| <a id="check_eventlog_warning"></a>[warning](../common-options.md#warning)                                     | level = 'warning', problem_count > 0           |
+| <a id="check_eventlog_warn"></a>[warn](../common-options.md#warn)                                              |                                                |
+| <a id="check_eventlog_critical"></a>[critical](../common-options.md#critical)                                  | level in ('error', 'critical')                 |
+| <a id="check_eventlog_crit"></a>[crit](../common-options.md#crit)                                              |                                                |
+| <a id="check_eventlog_ok"></a>[ok](../common-options.md#ok)                                                    |                                                |
+| <a id="check_eventlog_debug"></a>[debug](../common-options.md#debug)                                           | false                                          |
+| <a id="check_eventlog_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                          |
+| <a id="check_eventlog_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                             |
+| <a id="check_eventlog_perf-config"></a>[perf-config](../common-options.md#perf-config)                         | level(ignored:true)                            |
+| <a id="check_eventlog_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                          |
+| <a id="check_eventlog_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                              |
+| <a id="check_eventlog_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${count} message(s) ${problem_list} |
+| <a id="check_eventlog_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): Event log seems fine                |
+| <a id="check_eventlog_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No entries found                    |
+| <a id="check_eventlog_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${file} ${source} (${message})                 |
+| <a id="check_eventlog_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${file}_${source}                              |
+| <a id="check_eventlog_unique-index"></a>[unique-index](../common-options.md#unique-index)                      |                                                |
+| <a id="check_eventlog_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                |
+| <a id="check_eventlog_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                |
+| <a id="check_eventlog_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                             |
+| <a id="check_eventlog_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/windows/CheckMSSQL.md
+++ b/docs/docs/reference/windows/CheckMSSQL.md
@@ -171,25 +171,29 @@ Trust the server certificate (TrustServerCertificate=yes, modern ODBC drivers on
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                       | Default Value                                                                        |
-|----------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
-| <a id="check_mssql_filter"></a>[filter](../common-options.md#filter)                         |                                                                                      |
-| <a id="check_mssql_warning"></a>[warning](../common-options.md#warning)                      |                                                                                      |
-| <a id="check_mssql_warn"></a>[warn](../common-options.md#warn)                               |                                                                                      |
-| <a id="check_mssql_critical"></a>[critical](../common-options.md#critical)                   |                                                                                      |
-| <a id="check_mssql_crit"></a>[crit](../common-options.md#crit)                               |                                                                                      |
-| <a id="check_mssql_ok"></a>[ok](../common-options.md#ok)                                     |                                                                                      |
-| <a id="check_mssql_debug"></a>[debug](../common-options.md#debug)                            | false                                                                                |
-| <a id="check_mssql_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                                |
-| <a id="check_mssql_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                              |
-| <a id="check_mssql_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                                      |
-| <a id="check_mssql_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                                |
-| <a id="check_mssql_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                                    |
-| <a id="check_mssql_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${list}                                                                   |
-| <a id="check_mssql_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |                                                                                      |
-| <a id="check_mssql_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No server information returned                                            |
-| <a id="check_mssql_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${server_name}: SQL Server ${version} ${product_level} ${edition}, uptime ${uptime}s |
-| <a id="check_mssql_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${server_name}                                                                       |
+| Option                                                                                                      | Default Value                                                                        |
+|-------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|
+| <a id="check_mssql_filter"></a>[filter](../common-options.md#filter)                                        |                                                                                      |
+| <a id="check_mssql_warning"></a>[warning](../common-options.md#warning)                                     |                                                                                      |
+| <a id="check_mssql_warn"></a>[warn](../common-options.md#warn)                                              |                                                                                      |
+| <a id="check_mssql_critical"></a>[critical](../common-options.md#critical)                                  |                                                                                      |
+| <a id="check_mssql_crit"></a>[crit](../common-options.md#crit)                                              |                                                                                      |
+| <a id="check_mssql_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                                      |
+| <a id="check_mssql_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                                |
+| <a id="check_mssql_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                                |
+| <a id="check_mssql_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                              |
+| <a id="check_mssql_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                                      |
+| <a id="check_mssql_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                                |
+| <a id="check_mssql_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                                    |
+| <a id="check_mssql_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${list}                                                                   |
+| <a id="check_mssql_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |                                                                                      |
+| <a id="check_mssql_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No server information returned                                            |
+| <a id="check_mssql_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${server_name}: SQL Server ${version} ${product_level} ${edition}, uptime ${uptime}s |
+| <a id="check_mssql_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${server_name}                                                                       |
+| <a id="check_mssql_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                                      |
+| <a id="check_mssql_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                                      |
+| <a id="check_mssql_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                                   |
+| <a id="check_mssql_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                                      |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -380,25 +384,29 @@ Trust the server certificate (TrustServerCertificate=yes, modern ODBC drivers on
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                              | Default Value                                                    |
-|-----------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
-| <a id="check_mssql_backup_filter"></a>[filter](../common-options.md#filter)                         |                                                                  |
-| <a id="check_mssql_backup_warning"></a>[warning](../common-options.md#warning)                      | full_age > 3d                                                    |
-| <a id="check_mssql_backup_warn"></a>[warn](../common-options.md#warn)                               |                                                                  |
-| <a id="check_mssql_backup_critical"></a>[critical](../common-options.md#critical)                   | full_age < 0 or full_age > 7d                                    |
-| <a id="check_mssql_backup_crit"></a>[crit](../common-options.md#crit)                               |                                                                  |
-| <a id="check_mssql_backup_ok"></a>[ok](../common-options.md#ok)                                     |                                                                  |
-| <a id="check_mssql_backup_debug"></a>[debug](../common-options.md#debug)                            | false                                                            |
-| <a id="check_mssql_backup_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                            |
-| <a id="check_mssql_backup_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                          |
-| <a id="check_mssql_backup_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                  |
-| <a id="check_mssql_backup_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                            |
-| <a id="check_mssql_backup_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                |
-| <a id="check_mssql_backup_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_count}/${count} databases (${problem_list}) |
-| <a id="check_mssql_backup_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) databases have recent backups            |
-| <a id="check_mssql_backup_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No databases found                                    |
-| <a id="check_mssql_backup_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: last full backup ${full_age}s ago                       |
-| <a id="check_mssql_backup_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                          |
+| Option                                                                                                             | Default Value                                                    |
+|--------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------|
+| <a id="check_mssql_backup_filter"></a>[filter](../common-options.md#filter)                                        |                                                                  |
+| <a id="check_mssql_backup_warning"></a>[warning](../common-options.md#warning)                                     | full_age > 3d                                                    |
+| <a id="check_mssql_backup_warn"></a>[warn](../common-options.md#warn)                                              |                                                                  |
+| <a id="check_mssql_backup_critical"></a>[critical](../common-options.md#critical)                                  | full_age < 0 or full_age > 7d                                    |
+| <a id="check_mssql_backup_crit"></a>[crit](../common-options.md#crit)                                              |                                                                  |
+| <a id="check_mssql_backup_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                  |
+| <a id="check_mssql_backup_debug"></a>[debug](../common-options.md#debug)                                           | false                                                            |
+| <a id="check_mssql_backup_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                            |
+| <a id="check_mssql_backup_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                          |
+| <a id="check_mssql_backup_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                  |
+| <a id="check_mssql_backup_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                            |
+| <a id="check_mssql_backup_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                |
+| <a id="check_mssql_backup_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_count}/${count} databases (${problem_list}) |
+| <a id="check_mssql_backup_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) databases have recent backups            |
+| <a id="check_mssql_backup_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No databases found                                    |
+| <a id="check_mssql_backup_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: last full backup ${full_age}s ago                       |
+| <a id="check_mssql_backup_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                          |
+| <a id="check_mssql_backup_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                  |
+| <a id="check_mssql_backup_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                  |
+| <a id="check_mssql_backup_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                               |
+| <a id="check_mssql_backup_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                  |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -543,25 +551,29 @@ Trust the server certificate (TrustServerCertificate=yes, modern ODBC drivers on
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                                 | Default Value                                                          |
-|--------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| <a id="check_mssql_databases_filter"></a>[filter](../common-options.md#filter)                         |                                                                        |
-| <a id="check_mssql_databases_warning"></a>[warning](../common-options.md#warning)                      | state = 'RESTORING' or state = 'RECOVERING' or state = 'OFFLINE'       |
-| <a id="check_mssql_databases_warn"></a>[warn](../common-options.md#warn)                               |                                                                        |
-| <a id="check_mssql_databases_critical"></a>[critical](../common-options.md#critical)                   | state = 'SUSPECT' or state = 'EMERGENCY' or state = 'RECOVERY_PENDING' |
-| <a id="check_mssql_databases_crit"></a>[crit](../common-options.md#crit)                               |                                                                        |
-| <a id="check_mssql_databases_ok"></a>[ok](../common-options.md#ok)                                     |                                                                        |
-| <a id="check_mssql_databases_debug"></a>[debug](../common-options.md#debug)                            | false                                                                  |
-| <a id="check_mssql_databases_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                                  |
-| <a id="check_mssql_databases_empty-state"></a>[empty-state](../common-options.md#empty-state)          | unknown                                                                |
-| <a id="check_mssql_databases_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                                        |
-| <a id="check_mssql_databases_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                                  |
-| <a id="check_mssql_databases_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                                      |
-| <a id="check_mssql_databases_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_count}/${count} databases (${problem_list})       |
-| <a id="check_mssql_databases_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) databases are ONLINE                           |
-| <a id="check_mssql_databases_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No databases found                                          |
-| <a id="check_mssql_databases_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${state}                                                      |
-| <a id="check_mssql_databases_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                                |
+| Option                                                                                                                | Default Value                                                          |
+|-----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
+| <a id="check_mssql_databases_filter"></a>[filter](../common-options.md#filter)                                        |                                                                        |
+| <a id="check_mssql_databases_warning"></a>[warning](../common-options.md#warning)                                     | state = 'RESTORING' or state = 'RECOVERING' or state = 'OFFLINE'       |
+| <a id="check_mssql_databases_warn"></a>[warn](../common-options.md#warn)                                              |                                                                        |
+| <a id="check_mssql_databases_critical"></a>[critical](../common-options.md#critical)                                  | state = 'SUSPECT' or state = 'EMERGENCY' or state = 'RECOVERY_PENDING' |
+| <a id="check_mssql_databases_crit"></a>[crit](../common-options.md#crit)                                              |                                                                        |
+| <a id="check_mssql_databases_ok"></a>[ok](../common-options.md#ok)                                                    |                                                                        |
+| <a id="check_mssql_databases_debug"></a>[debug](../common-options.md#debug)                                           | false                                                                  |
+| <a id="check_mssql_databases_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                                  |
+| <a id="check_mssql_databases_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | unknown                                                                |
+| <a id="check_mssql_databases_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                                        |
+| <a id="check_mssql_databases_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                                  |
+| <a id="check_mssql_databases_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                                      |
+| <a id="check_mssql_databases_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_count}/${count} databases (${problem_list})       |
+| <a id="check_mssql_databases_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) databases are ONLINE                           |
+| <a id="check_mssql_databases_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No databases found                                          |
+| <a id="check_mssql_databases_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${state}                                                      |
+| <a id="check_mssql_databases_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                                |
+| <a id="check_mssql_databases_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                                        |
+| <a id="check_mssql_databases_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                                        |
+| <a id="check_mssql_databases_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                                     |
+| <a id="check_mssql_databases_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                                        |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -732,25 +744,29 @@ Trust the server certificate (TrustServerCertificate=yes, modern ODBC drivers on
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                            | Default Value                                               |
-|---------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
-| <a id="check_mssql_jobs_filter"></a>[filter](../common-options.md#filter)                         | enabled = 1                                                 |
-| <a id="check_mssql_jobs_warning"></a>[warning](../common-options.md#warning)                      | last_run_status = 'canceled' or last_run_status = 'retry'   |
-| <a id="check_mssql_jobs_warn"></a>[warn](../common-options.md#warn)                               |                                                             |
-| <a id="check_mssql_jobs_critical"></a>[critical](../common-options.md#critical)                   | last_run_status = 'failed'                                  |
-| <a id="check_mssql_jobs_crit"></a>[crit](../common-options.md#crit)                               |                                                             |
-| <a id="check_mssql_jobs_ok"></a>[ok](../common-options.md#ok)                                     |                                                             |
-| <a id="check_mssql_jobs_debug"></a>[debug](../common-options.md#debug)                            | false                                                       |
-| <a id="check_mssql_jobs_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                                       |
-| <a id="check_mssql_jobs_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ok                                                          |
-| <a id="check_mssql_jobs_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                                             |
-| <a id="check_mssql_jobs_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                                       |
-| <a id="check_mssql_jobs_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                                           |
-| <a id="check_mssql_jobs_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_count}/${count} jobs (${problem_list}) |
-| <a id="check_mssql_jobs_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All %(count) jobs succeeded                      |
-| <a id="check_mssql_jobs_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No enabled SQL Agent jobs found                  |
-| <a id="check_mssql_jobs_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${name}: ${last_run_status}                                 |
-| <a id="check_mssql_jobs_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${name}                                                     |
+| Option                                                                                                           | Default Value                                               |
+|------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------|
+| <a id="check_mssql_jobs_filter"></a>[filter](../common-options.md#filter)                                        | enabled = 1                                                 |
+| <a id="check_mssql_jobs_warning"></a>[warning](../common-options.md#warning)                                     | last_run_status = 'canceled' or last_run_status = 'retry'   |
+| <a id="check_mssql_jobs_warn"></a>[warn](../common-options.md#warn)                                              |                                                             |
+| <a id="check_mssql_jobs_critical"></a>[critical](../common-options.md#critical)                                  | last_run_status = 'failed'                                  |
+| <a id="check_mssql_jobs_crit"></a>[crit](../common-options.md#crit)                                              |                                                             |
+| <a id="check_mssql_jobs_ok"></a>[ok](../common-options.md#ok)                                                    |                                                             |
+| <a id="check_mssql_jobs_debug"></a>[debug](../common-options.md#debug)                                           | false                                                       |
+| <a id="check_mssql_jobs_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                                       |
+| <a id="check_mssql_jobs_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ok                                                          |
+| <a id="check_mssql_jobs_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                                             |
+| <a id="check_mssql_jobs_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                                       |
+| <a id="check_mssql_jobs_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                                           |
+| <a id="check_mssql_jobs_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_count}/${count} jobs (${problem_list}) |
+| <a id="check_mssql_jobs_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All %(count) jobs succeeded                      |
+| <a id="check_mssql_jobs_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No enabled SQL Agent jobs found                  |
+| <a id="check_mssql_jobs_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${name}: ${last_run_status}                                 |
+| <a id="check_mssql_jobs_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${name}                                                     |
+| <a id="check_mssql_jobs_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                                             |
+| <a id="check_mssql_jobs_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                                             |
+| <a id="check_mssql_jobs_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                                          |
+| <a id="check_mssql_jobs_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                                             |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.
@@ -919,25 +935,29 @@ Trust the server certificate (TrustServerCertificate=yes, modern ODBC drivers on
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                             | Default Value |
-|----------------------------------------------------------------------------------------------------|---------------|
-| <a id="check_mssql_query_filter"></a>[filter](../common-options.md#filter)                         |               |
-| <a id="check_mssql_query_warning"></a>[warning](../common-options.md#warning)                      |               |
-| <a id="check_mssql_query_warn"></a>[warn](../common-options.md#warn)                               |               |
-| <a id="check_mssql_query_critical"></a>[critical](../common-options.md#critical)                   |               |
-| <a id="check_mssql_query_crit"></a>[crit](../common-options.md#crit)                               |               |
-| <a id="check_mssql_query_ok"></a>[ok](../common-options.md#ok)                                     |               |
-| <a id="check_mssql_query_debug"></a>[debug](../common-options.md#debug)                            | false         |
-| <a id="check_mssql_query_show-all"></a>[show-all](../common-options.md#show-all)                   | false         |
-| <a id="check_mssql_query_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored       |
-| <a id="check_mssql_query_perf-config"></a>[perf-config](../common-options.md#perf-config)          |               |
-| <a id="check_mssql_query_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false         |
-| <a id="check_mssql_query_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,             |
-| <a id="check_mssql_query_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${list}       |
-| <a id="check_mssql_query_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |               |
-| <a id="check_mssql_query_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |               |
-| <a id="check_mssql_query_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | %(line)       |
-| <a id="check_mssql_query_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          |               |
+| Option                                                                                                            | Default Value |
+|-------------------------------------------------------------------------------------------------------------------|---------------|
+| <a id="check_mssql_query_filter"></a>[filter](../common-options.md#filter)                                        |               |
+| <a id="check_mssql_query_warning"></a>[warning](../common-options.md#warning)                                     |               |
+| <a id="check_mssql_query_warn"></a>[warn](../common-options.md#warn)                                              |               |
+| <a id="check_mssql_query_critical"></a>[critical](../common-options.md#critical)                                  |               |
+| <a id="check_mssql_query_crit"></a>[crit](../common-options.md#crit)                                              |               |
+| <a id="check_mssql_query_ok"></a>[ok](../common-options.md#ok)                                                    |               |
+| <a id="check_mssql_query_debug"></a>[debug](../common-options.md#debug)                                           | false         |
+| <a id="check_mssql_query_show-all"></a>[show-all](../common-options.md#show-all)                                  | false         |
+| <a id="check_mssql_query_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored       |
+| <a id="check_mssql_query_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |               |
+| <a id="check_mssql_query_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false         |
+| <a id="check_mssql_query_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,             |
+| <a id="check_mssql_query_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${list}       |
+| <a id="check_mssql_query_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |               |
+| <a id="check_mssql_query_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |               |
+| <a id="check_mssql_query_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | %(line)       |
+| <a id="check_mssql_query_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         |               |
+| <a id="check_mssql_query_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |               |
+| <a id="check_mssql_query_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |               |
+| <a id="check_mssql_query_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1            |
+| <a id="check_mssql_query_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |               |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/windows/CheckTaskSched.md
+++ b/docs/docs/reference/windows/CheckTaskSched.md
@@ -145,25 +145,29 @@ The name of the computer that you want to connect to.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                           | Default Value                         |
-|--------------------------------------------------------------------------------------------------|---------------------------------------|
-| <a id="check_tasksched_filter"></a>[filter](../common-options.md#filter)                         | enabled = 1                           |
-| <a id="check_tasksched_warning"></a>[warning](../common-options.md#warning)                      | exit_code != 0                        |
-| <a id="check_tasksched_warn"></a>[warn](../common-options.md#warn)                               |                                       |
-| <a id="check_tasksched_critical"></a>[critical](../common-options.md#critical)                   | exit_code < 0                         |
-| <a id="check_tasksched_crit"></a>[crit](../common-options.md#crit)                               |                                       |
-| <a id="check_tasksched_ok"></a>[ok](../common-options.md#ok)                                     |                                       |
-| <a id="check_tasksched_debug"></a>[debug](../common-options.md#debug)                            | false                                 |
-| <a id="check_tasksched_show-all"></a>[show-all](../common-options.md#show-all)                   | false                                 |
-| <a id="check_tasksched_empty-state"></a>[empty-state](../common-options.md#empty-state)          | warning                               |
-| <a id="check_tasksched_perf-config"></a>[perf-config](../common-options.md#perf-config)          |                                       |
-| <a id="check_tasksched_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false                                 |
-| <a id="check_tasksched_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,                                     |
-| <a id="check_tasksched_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${status}: ${problem_list}            |
-| <a id="check_tasksched_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                | %(status): All tasks are ok           |
-| <a id="check_tasksched_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       | %(status): No tasks found             |
-| <a id="check_tasksched_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | ${folder}/${title}: ${exit_code} != 0 |
-| <a id="check_tasksched_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          | ${title}                              |
+| Option                                                                                                          | Default Value                         |
+|-----------------------------------------------------------------------------------------------------------------|---------------------------------------|
+| <a id="check_tasksched_filter"></a>[filter](../common-options.md#filter)                                        | enabled = 1                           |
+| <a id="check_tasksched_warning"></a>[warning](../common-options.md#warning)                                     | exit_code != 0                        |
+| <a id="check_tasksched_warn"></a>[warn](../common-options.md#warn)                                              |                                       |
+| <a id="check_tasksched_critical"></a>[critical](../common-options.md#critical)                                  | exit_code < 0                         |
+| <a id="check_tasksched_crit"></a>[crit](../common-options.md#crit)                                              |                                       |
+| <a id="check_tasksched_ok"></a>[ok](../common-options.md#ok)                                                    |                                       |
+| <a id="check_tasksched_debug"></a>[debug](../common-options.md#debug)                                           | false                                 |
+| <a id="check_tasksched_show-all"></a>[show-all](../common-options.md#show-all)                                  | false                                 |
+| <a id="check_tasksched_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | warning                               |
+| <a id="check_tasksched_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |                                       |
+| <a id="check_tasksched_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false                                 |
+| <a id="check_tasksched_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,                                     |
+| <a id="check_tasksched_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${status}: ${problem_list}            |
+| <a id="check_tasksched_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               | %(status): All tasks are ok           |
+| <a id="check_tasksched_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      | %(status): No tasks found             |
+| <a id="check_tasksched_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | ${folder}/${title}: ${exit_code} != 0 |
+| <a id="check_tasksched_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         | ${title}                              |
+| <a id="check_tasksched_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |                                       |
+| <a id="check_tasksched_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |                                       |
+| <a id="check_tasksched_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1                                    |
+| <a id="check_tasksched_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |                                       |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/reference/windows/CheckWMI.md
+++ b/docs/docs/reference/windows/CheckWMI.md
@@ -125,25 +125,29 @@ The WMI root namespace to bind to.
 These options are shared by all filter based commands and are described on the [common options](../common-options.md#common-options) page; the default values below are specific to this command.
 
 
-| Option                                                                                     | Default Value |
-|--------------------------------------------------------------------------------------------|---------------|
-| <a id="check_wmi_filter"></a>[filter](../common-options.md#filter)                         |               |
-| <a id="check_wmi_warning"></a>[warning](../common-options.md#warning)                      |               |
-| <a id="check_wmi_warn"></a>[warn](../common-options.md#warn)                               |               |
-| <a id="check_wmi_critical"></a>[critical](../common-options.md#critical)                   |               |
-| <a id="check_wmi_crit"></a>[crit](../common-options.md#crit)                               |               |
-| <a id="check_wmi_ok"></a>[ok](../common-options.md#ok)                                     |               |
-| <a id="check_wmi_debug"></a>[debug](../common-options.md#debug)                            | false         |
-| <a id="check_wmi_show-all"></a>[show-all](../common-options.md#show-all)                   | false         |
-| <a id="check_wmi_empty-state"></a>[empty-state](../common-options.md#empty-state)          | ignored       |
-| <a id="check_wmi_perf-config"></a>[perf-config](../common-options.md#perf-config)          |               |
-| <a id="check_wmi_escape-html"></a>[escape-html](../common-options.md#escape-html)          | false         |
-| <a id="check_wmi_list-separator"></a>[list-separator](../common-options.md#list-separator) | ,             |
-| <a id="check_wmi_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)             | ${list}       |
-| <a id="check_wmi_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                |               |
-| <a id="check_wmi_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)       |               |
-| <a id="check_wmi_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)    | %(line)       |
-| <a id="check_wmi_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)          |               |
+| Option                                                                                                    | Default Value |
+|-----------------------------------------------------------------------------------------------------------|---------------|
+| <a id="check_wmi_filter"></a>[filter](../common-options.md#filter)                                        |               |
+| <a id="check_wmi_warning"></a>[warning](../common-options.md#warning)                                     |               |
+| <a id="check_wmi_warn"></a>[warn](../common-options.md#warn)                                              |               |
+| <a id="check_wmi_critical"></a>[critical](../common-options.md#critical)                                  |               |
+| <a id="check_wmi_crit"></a>[crit](../common-options.md#crit)                                              |               |
+| <a id="check_wmi_ok"></a>[ok](../common-options.md#ok)                                                    |               |
+| <a id="check_wmi_debug"></a>[debug](../common-options.md#debug)                                           | false         |
+| <a id="check_wmi_show-all"></a>[show-all](../common-options.md#show-all)                                  | false         |
+| <a id="check_wmi_empty-state"></a>[empty-state](../common-options.md#empty-state)                         | ignored       |
+| <a id="check_wmi_perf-config"></a>[perf-config](../common-options.md#perf-config)                         |               |
+| <a id="check_wmi_escape-html"></a>[escape-html](../common-options.md#escape-html)                         | false         |
+| <a id="check_wmi_list-separator"></a>[list-separator](../common-options.md#list-separator)                | ,             |
+| <a id="check_wmi_top-syntax"></a>[top-syntax](../common-options.md#top-syntax)                            | ${list}       |
+| <a id="check_wmi_ok-syntax"></a>[ok-syntax](../common-options.md#ok-syntax)                               |               |
+| <a id="check_wmi_empty-syntax"></a>[empty-syntax](../common-options.md#empty-syntax)                      |               |
+| <a id="check_wmi_detail-syntax"></a>[detail-syntax](../common-options.md#detail-syntax)                   | %(line)       |
+| <a id="check_wmi_perf-syntax"></a>[perf-syntax](../common-options.md#perf-syntax)                         |               |
+| <a id="check_wmi_byte-unit"></a>[byte-unit](../common-options.md#byte-unit)                               |               |
+| <a id="check_wmi_decimal-separator"></a>[decimal-separator](../common-options.md#decimal-separator)       |               |
+| <a id="check_wmi_decimals"></a>[decimals](../common-options.md#decimals)                                  | -1            |
+| <a id="check_wmi_thousands-separator"></a>[thousands-separator](../common-options.md#thousands-separator) |               |
 
 
 This command also accepts the standard [help options](../common-options.md#standard-options): help, help-pb, show-default, help-short.

--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -92,6 +92,28 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### A runaway `decimals` in a check message can no longer crash the check
+
+**Fixed in:** next · **Severity:** Low
+
+The number-rendering options added for check messages (issue
+[#1428](https://github.com/mickem/nscp/issues/1428)) include a `decimals` count
+that is passed straight to `std::setprecision`. A large value — from a REST
+query argument such as `decimals=1000000000`, from the `format_bytes()` /
+`format_number()` third argument, or from a `decimals` settings key — makes the
+renderer build a fraction with that many digits, allocating a huge string and
+crashing the check (and with it the querying worker). Because a check argument
+can reach this from a remote monitoring request where argument passing is
+enabled, an unbounded value is a denial-of-service foot-gun. `decimals` is now
+bounded to 15 (the most a `double` can represent): the query option and the
+function argument reject anything larger with `Invalid decimals` / `decimals
+must not exceed 15`, the settings key clamps it, and `render_fixed` clamps as a
+last-resort backstop so no internal caller can trigger the allocation either.
+
+**What to do:** nothing required. Defaults are unchanged; only an out-of-range
+`decimals` behaves differently, and only by being rejected or clamped instead of
+crashing.
+
 ### Host name placeholders are sanitized before they land in a local path
 
 **Fixed in:** next · **Severity:** Low

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -41,7 +41,12 @@ page tracks those in one place. Full per-release detail lives in each
   the message: performance data keeps its full precision and its `.` radix, and
   so do the numbers you write in a filter or a threshold. Real-time filters take
   the same settings as `decimals`, `byte unit`, `decimal separator` and
-  `thousands separator` keys, inheritable from the default template.
+  `thousands separator` keys, inheritable from the default template. `decimals`
+  is capped at 15 (a `double` carries no more than that): the query option and
+  the `format_bytes()`/`format_number()` argument reject a larger value, and the
+  settings key clamps it, so a typo like `decimals=1000000` can no longer make a
+  check try to render a multi-megabyte number. 🔒 See
+  [security notices](../security/notices.md#a-runaway-decimals-in-a-check-message-can-no-longer-crash-the-check).
 - **An unknown unit in `format_bytes()` is now reported instead of rendering
   nonsense.** `format_bytes(used, 'gb')` used to render `1.27055e-10` because
   the unit comparison was case sensitive, and any misspelled unit rendered

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -32,6 +32,33 @@ page tracks those in one place. Full per-release detail lives in each
   migrate) now keeps a placeholder you pass it as-is in `boot.ini` while
   migrating into the expanded per-host file, so the template survives on a
   fleet-managed machine.
+- **Check messages can now be told how to render their numbers.** Every filter
+  check gained four options - `decimals`, `byte-unit`, `decimal-separator` and
+  `thousands-separator` - so `check_drivesize` can report
+  `141.06GB/1006.85GB` (or `141,06GB/1.006,85GB`) instead of
+  `140.293GB/0.983TB`. The defaults are unchanged, so an installation that does
+  not set them renders exactly what it rendered before. The options only touch
+  the message: performance data keeps its full precision and its `.` radix, and
+  so do the numbers you write in a filter or a threshold. Real-time filters take
+  the same settings as `decimals`, `byte unit`, `decimal separator` and
+  `thousands separator` keys, inheritable from the default template.
+- **An unknown unit in `format_bytes()` is now reported instead of rendering
+  nonsense.** `format_bytes(used, 'gb')` used to render `1.27055e-10` because
+  the unit comparison was case sensitive, and any misspelled unit rendered
+  `value/1024^7`. Lowercase units now work, and a unit that names nothing (say
+  `'ZB'`) makes the check report `Filter processing failed: format_bytes
+  failed: Unknown byte unit: ZB`. A syntax string with such a typo returns
+  UNKNOWN rather than a quietly wrong number - fix the unit, or the check will
+  stay UNKNOWN.
+- **A `unit:` in `perf-config` that names no unit no longer divides the metric
+  by 1024⁷.** An unrecognised unit now leaves the value alone. If a graph of
+  yours has been flat at a near-zero value, check the `unit:` spelling in its
+  `perf-config`: the metric will jump to its real magnitude on upgrade.
+- **Errors raised while a template renders are now reported.** A function that
+  failed inside `detail-syntax` or `top-syntax` used to leave the placeholder
+  empty and say nothing; the check now returns UNKNOWN with `Filter processing
+  failed: …`. This surfaces template mistakes that have been silently producing
+  incomplete messages.
 - **Syslog submission works again, so a configured syslog server will start
   receiving traffic.** `SyslogClient` read its connection settings from the
   wrong place, so the target's address, port, facility, severity and templates

--- a/docs/reference/CheckDisk.yaml
+++ b/docs/reference/CheckDisk.yaml
@@ -68,10 +68,13 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: (has_space = 1 and free_pct < 10) or percent_disk_time > 95 or (has_device = 1 and (health_status
           = 'Unhealthy' or is_offline = 1))
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${free_pct} free, ${percent_disk_time}% busy, q=${queue_length} iops=${iops}'
         empty-state: critical
         empty-syntax: ''
@@ -87,6 +90,7 @@ common:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: (has_space = 1 and free_pct < 20) or percent_disk_time > 80 or (has_device = 1 and health_status
@@ -255,9 +259,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: percent_disk_time > 95
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${percent_disk_time}% busy, read=${read_bytes_per_sec}B/s write=${write_bytes_per_sec}B/s
           q=${queue_length}'
         empty-state: critical
@@ -274,6 +281,7 @@ common:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: percent_disk_time > 80
@@ -374,9 +382,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: has_issues = 1
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '%(path): %(message)'
         empty-state: unknown
         empty-syntax: No write test performed
@@ -392,6 +403,7 @@ common:
         perf-syntax: '%(path)'
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -476,9 +488,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name}
         empty-state: unknown
         empty-syntax: No files found
@@ -494,6 +509,7 @@ common:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_count}/${count} files (${problem_list})'
         warn: ''
         warning: ''
@@ -703,9 +719,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: newest > 50h
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${volume}: ${copies} copies, newest ${newest_date}'
         empty-state: ok
         empty-syntax: '%(status): No shadow copies found'
@@ -721,6 +740,7 @@ common:
         perf-syntax: ${volume}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: newest > 26h
@@ -798,9 +818,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: not exists
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} (type=${type}, path=${path}, exists=${exists})
         empty-state: ok
         empty-syntax: '%(status): No shares found'
@@ -816,6 +839,7 @@ common:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -875,9 +899,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '%(filename) (size=%(size), age=%(age))'
         empty-state: ok
         empty-syntax: No file inspected
@@ -893,6 +920,7 @@ common:
         perf-syntax: '%(filename)'
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '%(status): %(list)'
         warn: ''
         warning: ''
@@ -1062,9 +1090,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: health_status = 'Unhealthy' or free_pct < 10
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${health_status}, ${used}/${capacity} used'
         empty-state: ok
         empty-syntax: '%(status): No storage pools found'
@@ -1080,6 +1111,7 @@ common:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: health_status = 'Warning' or free_pct < 20
@@ -1160,9 +1192,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: used_pct > 90
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${path}: ${used}/${size} used (${free} free)'
         empty-state: unknown
         empty-syntax: '%(status): No paths checked'
@@ -1178,6 +1213,7 @@ common:
         perf-syntax: ${path}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: used_pct > 80
@@ -1281,9 +1317,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: used > 90%
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${drive_or_name}: ${used}/${size} used'
         empty-state: unknown
         empty-syntax: '%(status): No drives found'
@@ -1299,6 +1338,7 @@ unix:
         perf-syntax: ${drive_or_id}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: ${status} ${problem_list}
         warn: ''
         warning: used > 80%
@@ -1535,9 +1575,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: issues like 'not mounted'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: mount ${mount} ${issues}
         empty-state: unknown
         empty-syntax: check_mount found nothing matching this filter
@@ -1553,6 +1596,7 @@ unix:
         perf-syntax: ${mount}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: has_issues = 1
@@ -1627,9 +1671,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: used > 90%
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${drive_or_name}: ${used}/${size} used'
         empty-state: unknown
         empty-syntax: '%(status): No drives found'
@@ -1645,6 +1692,7 @@ windows:
         perf-syntax: ${drive_or_id}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: ${status} ${problem_list}
         warn: ''
         warning: used > 80%

--- a/docs/reference/CheckDocker.yaml
+++ b/docs/reference/CheckDocker.yaml
@@ -47,9 +47,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: container_state != 'running'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${names}=${container_state}
         empty-state: warning
         empty-syntax: No containers found
@@ -65,6 +68,7 @@ unix:
         perf-syntax: ${names}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -180,9 +184,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${message}
         empty-state: unknown
         empty-syntax: '%(status): No disk usage information returned'
@@ -198,6 +205,7 @@ unix:
         perf-syntax: docker
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -306,9 +314,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: 'docker ${version} on ${name}: ${running} running, ${paused} paused, ${stopped}
           stopped containers, ${images} images'
         empty-state: unknown
@@ -325,6 +336,7 @@ unix:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -397,9 +409,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: oom_killed = 1
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${names}: ${restart_count} restarts, ${container_state}'
         empty-state: ok
         empty-syntax: No containers found
@@ -415,6 +430,7 @@ unix:
         perf-syntax: ${names}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: restart_count > 3 and started < 15m and started >= 0
@@ -493,9 +509,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${names}: cpu ${cpu_pct}%, memory ${memory} (${memory_pct}%)'
         empty-state: ok
         empty-syntax: No running containers
@@ -511,6 +530,7 @@ unix:
         perf-syntax: ${names}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -614,9 +634,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: container_state != 'running'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${names}=${container_state}
         empty-state: warning
         empty-syntax: No containers found
@@ -632,6 +655,7 @@ windows:
         perf-syntax: ${names}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -747,9 +771,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${message}
         empty-state: unknown
         empty-syntax: '%(status): No disk usage information returned'
@@ -765,6 +792,7 @@ windows:
         perf-syntax: docker
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -873,9 +901,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: 'docker ${version} on ${name}: ${running} running, ${paused} paused, ${stopped}
           stopped containers, ${images} images'
         empty-state: unknown
@@ -892,6 +923,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -964,9 +996,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: oom_killed = 1
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${names}: ${restart_count} restarts, ${container_state}'
         empty-state: ok
         empty-syntax: No containers found
@@ -982,6 +1017,7 @@ windows:
         perf-syntax: ${names}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: restart_count > 3 and started < 15m and started >= 0
@@ -1060,9 +1096,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${names}: cpu ${cpu_pct}%, memory ${memory} (${memory_pct}%)'
         empty-state: ok
         empty-syntax: No running containers
@@ -1078,6 +1117,7 @@ windows:
         perf-syntax: ${names}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''

--- a/docs/reference/CheckEventLog.yaml
+++ b/docs/reference/CheckEventLog.yaml
@@ -250,9 +250,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: level in ('error', 'critical')
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${file} ${source} (${message})
         empty-state: ok
         empty-syntax: '%(status): No entries found'
@@ -268,6 +271,7 @@ windows:
         perf-syntax: ${file}_${source}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${count} message(s) ${problem_list}'
         unique-index: ''
         warn: ''

--- a/docs/reference/CheckHelpers.yaml
+++ b/docs/reference/CheckHelpers.yaml
@@ -359,9 +359,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: "%(key)\t%(value)\t%(unit)\t%(warn)\t%(crit)\t%(min)\t%(max)\n"
         empty-state: unknown
         empty-syntax: ''
@@ -377,6 +380,7 @@ common:
         perf-syntax: '%(key)'
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '%(status): %(message) %(list)'
         warn: ''
         warning: ''

--- a/docs/reference/CheckLogFile.yaml
+++ b/docs/reference/CheckLogFile.yaml
@@ -212,9 +212,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${column1}
         empty-state: ignored
         empty-syntax: '%(status): Nothing found'
@@ -230,6 +233,7 @@ common:
         perf-syntax: ${column1}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: ${count}/${total} (${problem_list})
         warn: ''
         warning: ''

--- a/docs/reference/CheckMSSQL.yaml
+++ b/docs/reference/CheckMSSQL.yaml
@@ -83,9 +83,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${server_name}: SQL Server ${version} ${product_level} ${edition}, uptime ${uptime}s'
         empty-state: unknown
         empty-syntax: '%(status): No server information returned'
@@ -101,6 +104,7 @@ windows:
         perf-syntax: ${server_name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -229,9 +233,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: full_age < 0 or full_age > 7d
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: last full backup ${full_age}s ago'
         empty-state: unknown
         empty-syntax: '%(status): No databases found'
@@ -247,6 +254,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_count}/${count} databases (${problem_list})'
         warn: ''
         warning: full_age > 3d
@@ -399,9 +407,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: state = 'SUSPECT' or state = 'EMERGENCY' or state = 'RECOVERY_PENDING'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${state}'
         empty-state: unknown
         empty-syntax: '%(status): No databases found'
@@ -417,6 +428,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_count}/${count} databases (${problem_list})'
         warn: ''
         warning: state = 'RESTORING' or state = 'RECOVERING' or state = 'OFFLINE'
@@ -554,9 +566,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: last_run_status = 'failed'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${last_run_status}'
         empty-state: ok
         empty-syntax: '%(status): No enabled SQL Agent jobs found'
@@ -572,6 +587,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_count}/${count} jobs (${problem_list})'
         warn: ''
         warning: last_run_status = 'canceled' or last_run_status = 'retry'
@@ -705,9 +721,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '%(line)'
         empty-state: ignored
         empty-syntax: ''
@@ -723,6 +742,7 @@ windows:
         perf-syntax: ''
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: ${list}
         warn: ''
         warning: ''

--- a/docs/reference/CheckMySQL.yaml
+++ b/docs/reference/CheckMySQL.yaml
@@ -97,9 +97,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${flavor} ${version}, uptime ${uptime}s, connections ${threads_connected}/${max_connections}
           (${connections_pct}%)
         empty-state: unknown
@@ -116,6 +119,7 @@ common:
         perf-syntax: ${flavor}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -260,9 +264,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '%(line)'
         empty-state: ignored
         empty-syntax: ''
@@ -278,6 +285,7 @@ common:
         perf-syntax: ''
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: ${list}
         warn: ''
         warning: ''

--- a/docs/reference/CheckNSCP.yaml
+++ b/docs/reference/CheckNSCP.yaml
@@ -83,9 +83,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: update_available = 1
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${version} (latest: ${latest_version})'
         empty-state: ignored
         empty-syntax: ''
@@ -101,6 +104,7 @@ common:
         perf-syntax: version
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: update_available = 1
@@ -195,9 +199,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${version} (${date})
         empty-state: ignored
         empty-syntax: ''
@@ -213,6 +220,7 @@ common:
         perf-syntax: version
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''

--- a/docs/reference/CheckNet.yaml
+++ b/docs/reference/CheckNet.yaml
@@ -21,9 +21,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: total_connections > 2000
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${protocol}/${state}: ${connections}'
         empty-state: ignored
         empty-syntax: No connection data
@@ -39,6 +42,7 @@ common:
         perf-syntax: ${protocol}_${state}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: total_connections > 1000
@@ -122,9 +126,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: result != 'ok'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${host} -> ${addresses} (${records}) in ${time}ms [${result}]
         empty-state: ignored
         empty-syntax: No DNS lookup performed
@@ -140,6 +147,7 @@ common:
         perf-syntax: ${host}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: time > 1000
@@ -278,9 +286,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: code < 200 or code >= 400 or result != 'ok'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${url} -> ${code} ${result} (${size}B in ${time}ms)
         empty-state: ignored
         empty-syntax: No URL checked
@@ -296,6 +307,7 @@ common:
         perf-syntax: ${url}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: time > 5000
@@ -571,9 +583,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: offset > 100 or stratum >= 16 or result != 'ok'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${server} offset=${offset_signed}ms stratum=${stratum}
         empty-state: ignored
         empty-syntax: No NTP server checked
@@ -589,6 +604,7 @@ common:
         perf-syntax: ${server}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: offset > 50 or stratum >= 16
@@ -714,9 +730,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: time > 100 or loss > 10%
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${ip} Packet loss = ${loss}%, RTA = ${time}ms
         empty-state: unknown
         empty-syntax: No hosts found
@@ -732,6 +751,7 @@ common:
         perf-syntax: ${host}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${ok_count}/${count} (${problem_list})'
         warn: ''
         warning: time > 60 or loss > 5%
@@ -876,9 +896,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: time > 5000 or result != 'ok'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${host}:${port} ${result} in ${time}ms
         empty-state: ignored
         empty-syntax: No hosts checked
@@ -894,6 +917,7 @@ common:
         perf-syntax: ${host}_${port}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: time > 1000
@@ -1073,9 +1097,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: time > 5000 or result != 'ok'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${host}:${port} ${result} in ${time}ms
         empty-state: ignored
         empty-syntax: No hosts checked
@@ -1091,6 +1118,7 @@ common:
         perf-syntax: ${host}_${port}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: time > 1000

--- a/docs/reference/CheckSecurity.yaml
+++ b/docs/reference/CheckSecurity.yaml
@@ -21,9 +21,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: licensed = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${activation_status} (${genuine_state}, grace ${grace_days}d)'
         empty-state: unknown
         empty-syntax: '%(status): No licensing information found (Software Licensing service unavailable?)'
@@ -39,6 +42,7 @@ common:
         perf-syntax: license
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: grace_days > 0 and grace_days < 30
@@ -144,9 +148,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: enabled = 0 or up_to_date = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} (enabled=${enabled} up_to_date=${up_to_date})
         empty-state: unknown
         empty-syntax: No antivirus product registered
@@ -162,6 +169,7 @@ common:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -202,9 +210,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: protected = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${drive} protected=${protected}
         empty-state: unknown
         empty-syntax: No encryptable volumes found
@@ -220,6 +231,7 @@ common:
         perf-syntax: ${drive}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -259,9 +271,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: expires_in < 10
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${subject} expires in ${expires_in}d (${valid_to})
         empty-state: unknown
         empty-syntax: No certificates found
@@ -277,6 +292,7 @@ common:
         perf-syntax: ${subject}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: expires_in < 30
@@ -451,9 +467,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: enabled = 0 or realtime_enabled = 0 or signature_age > 7
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: Defender enabled=${enabled} realtime=${realtime_enabled} tamper=${tamper_protection}
           sig_age=${signature_age}d sig=${signature_version} engine=${engine_version}
         empty-state: unknown
@@ -471,6 +490,7 @@ common:
         perf-syntax: defender
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: signature_age > 3
@@ -531,9 +551,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: exists = 0 or readable = 0 or owner_expected = 0 or world_writable = 1
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${path}: ${state}'
         empty-state: unknown
         empty-syntax: '%(status): No paths checked'
@@ -549,6 +572,7 @@ common:
         perf-syntax: ${path}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: unexpected_write = 1
@@ -688,9 +712,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: enabled = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${profile}=${enabled}
         empty-state: unknown
         empty-syntax: No firewall profiles found
@@ -706,6 +733,7 @@ common:
         perf-syntax: ${profile}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: ''
@@ -756,9 +784,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: present = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${state}'
         empty-state: ok
         empty-syntax: '%(status): No firewall rules matched'
@@ -774,6 +805,7 @@ common:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: ''
@@ -902,9 +934,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: expected = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${member} (${type})
         empty-state: ok
         empty-syntax: '%(status): Group is empty'
@@ -920,6 +955,7 @@ common:
         perf-syntax: ${member}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -991,9 +1027,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: enabled = 1 and password_required = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} (enabled=${enabled}, pw_req=${password_required}, pw_exp=${password_expires},
           locked=${locked})
         empty-state: ok
@@ -1010,6 +1049,7 @@ common:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: enabled = 1 and is_builtin_guest = 1
@@ -1070,9 +1110,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${network}=${category}
         empty-state: ok
         empty-syntax: No networks found
@@ -1088,6 +1131,7 @@ common:
         perf-syntax: ${network}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -1124,9 +1168,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: enabled = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: secure boot enabled=${enabled} supported=${supported}
         empty-state: unknown
         empty-syntax: No Secure Boot state
@@ -1142,6 +1189,7 @@ common:
         perf-syntax: secureboot
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -1174,9 +1222,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${user}
         empty-state: ok
         empty-syntax: No users logged on
@@ -1192,6 +1243,7 @@ common:
         perf-syntax: ${user}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${count} user(s) logged on: ${list}'
         warn: ''
         warning: ''

--- a/docs/reference/CheckSystem.yaml
+++ b/docs/reference/CheckSystem.yaml
@@ -91,9 +91,12 @@ common:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: uptime < 1d
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: 'uptime: ${uptime}h, boot: ${boot} (${tz})'
         empty-state: ignored
         empty-syntax: ''
@@ -109,6 +112,7 @@ common:
         perf-syntax: uptime
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: uptime < 2d
@@ -659,9 +663,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: charge < 10
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${charge}% (${power_source}, ${battery_status})'
         empty-state: warning
         empty-syntax: No battery found
@@ -677,6 +684,7 @@ unix:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: charge < 20
@@ -752,9 +760,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: load > 90
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${time}: ${load}%'
         empty-state: ignored
         empty-syntax: ''
@@ -770,6 +781,7 @@ unix:
         perf-syntax: ${core} ${time}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: load > 80
@@ -851,9 +863,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: usage > 95
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: 'user: ${user}% system: ${system}% iowait: ${iowait}% steal: ${steal}% idle: ${idle}%'
         empty-state: ignored
         empty-syntax: ''
@@ -869,6 +884,7 @@ unix:
         perf-syntax: cpu
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: usage > 90
@@ -932,9 +948,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${hostname} (${fqdn}), domain=${domain}
         empty-state: ignored
         empty-syntax: ''
@@ -950,6 +969,7 @@ unix:
         perf-syntax: hostname
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -991,9 +1011,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} ${version} (${publisher})
         empty-state: ok
         empty-syntax: '%(status): No installed software found'
@@ -1009,6 +1032,7 @@ unix:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: ''
@@ -1070,9 +1094,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: slab ${slab} (${slab_unreclaimable} unreclaimable), cache ${cache}, ${major_faults_per_sec}
           major faults/s
         empty-state: ignored
@@ -1089,6 +1116,7 @@ unix:
         perf-syntax: kernel
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -1140,9 +1168,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: name = 'threads' and current > 10000
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${label} ${human}
         empty-state: ignored
         empty-syntax: ''
@@ -1158,6 +1189,7 @@ unix:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: ${status} - ${list}
         warn: ''
         warning: name = 'threads' and current > 8000
@@ -1212,9 +1244,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${type} load average: ${load1}, ${load5}, ${load15}'
         empty-state: ignored
         empty-syntax: ''
@@ -1230,6 +1265,7 @@ unix:
         perf-syntax: ${type}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -1292,9 +1328,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: used > 90%
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${type} = ${used}
         empty-state: ignored
         empty-syntax: ''
@@ -1310,6 +1349,7 @@ unix:
         perf-syntax: ${type}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: used > 80%
@@ -1360,9 +1400,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: throughput > 100000
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} >${sent_human}/s <${received_human}/s
         empty-state: critical
         empty-syntax: ''
@@ -1378,6 +1421,7 @@ unix:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: throughput > 10000
@@ -1493,9 +1537,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: security > 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${updates} updates available (${security} security) via ${manager}
         empty-state: ok
         empty-syntax: ''
@@ -1511,6 +1558,7 @@ unix:
         perf-syntax: updates
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: updates > 0
@@ -1550,9 +1598,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${os} (kernel ${kernel_release})
         empty-state: ignored
         empty-syntax: ''
@@ -1568,6 +1619,7 @@ unix:
         perf-syntax: kernel_release
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -1635,9 +1687,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: used > 80%
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} ${used} (${size})
         empty-state: ignored
         empty-syntax: ''
@@ -1653,6 +1708,7 @@ unix:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: used > 60%
@@ -1692,9 +1748,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: state = 'stopped', count = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${exe}=${state}
         empty-state: unknown
         empty-syntax: 'UNKNOWN: No processes found'
@@ -1710,6 +1769,7 @@ unix:
         perf-syntax: ${exe}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: state not in ('started')
@@ -1871,9 +1931,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${exe} (${running})
         empty-state: ok
         empty-syntax: ''
@@ -1889,6 +1952,7 @@ unix:
         perf-syntax: ${exe}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: ''
@@ -1948,9 +2012,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${exe} (first seen: ${first_seen})'
         empty-state: ok
         empty-syntax: ''
@@ -1966,6 +2033,7 @@ unix:
         perf-syntax: ${exe}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -2025,10 +2093,13 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ( state not in ('running', 'oneshot', 'static') or active = 'failed' ) and preset !=
           'disabled'
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name}=${state}
         empty-state: unknown
         empty-syntax: '%(status): No services found'
@@ -2044,6 +2115,7 @@ unix:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${crit_list}'
         warn: ''
         warning: ''
@@ -2169,9 +2241,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${swap_count} swap device(s) in ${swap_in} pages/s, out ${swap_out} pages/s
         empty-state: ignored
         empty-syntax: ''
@@ -2187,6 +2262,7 @@ unix:
         perf-syntax: io
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -2234,9 +2310,12 @@ unix:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: temperature > 90
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${temperature}C'
         empty-state: critical
         empty-syntax: ''
@@ -2252,6 +2331,7 @@ unix:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: temperature > 70
@@ -3051,9 +3131,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: charge < 10
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${charge}% (${power_source}, ${battery_status})'
         empty-state: warning
         empty-syntax: No battery found
@@ -3069,6 +3152,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: charge < 20
@@ -3141,9 +3225,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: load > 90
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${time}: ${load}%'
         empty-state: ignored
         empty-syntax: ''
@@ -3159,6 +3246,7 @@ windows:
         perf-syntax: ${core} ${time}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: load > 80
@@ -3247,9 +3335,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${current_mhz}/${max_mhz} MHz (${frequency_pct}%)'
         empty-state: ignored
         empty-syntax: ''
@@ -3265,6 +3356,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -3337,9 +3429,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${vendor} ${model} (${chassis}), serial=${serial}, ${modules} memory module(s),
           ${memory}
         empty-state: ignored
@@ -3356,6 +3451,7 @@ windows:
         perf-syntax: hardware
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -3432,9 +3528,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${hostname} (${fqdn}), ${join}=${join_name}
         empty-state: ignored
         empty-syntax: ''
@@ -3450,6 +3549,7 @@ windows:
         perf-syntax: hostname
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -3508,9 +3608,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} ${version} (${publisher})
         empty-state: ok
         empty-syntax: '%(status): No installed software found'
@@ -3526,6 +3629,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: ''
@@ -3608,9 +3712,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: paged pool ${pool_paged}, nonpaged pool ${pool_nonpaged}, cache ${cache}, ${hard_faults_per_sec}
           hard faults/s
         empty-state: ignored
@@ -3627,6 +3734,7 @@ windows:
         perf-syntax: kernel
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -3682,9 +3790,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: name = 'threads' and current > 10000
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${label} ${human}
         empty-state: ignored
         empty-syntax: ''
@@ -3700,6 +3811,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: ${status} - ${list}
         warn: ''
         warning: name = 'threads' and current > 8000
@@ -3760,9 +3872,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: used > 90%
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${type}: ${used}/${size}'
         empty-state: ignored
         empty-syntax: ''
@@ -3778,6 +3893,7 @@ windows:
         perf-syntax: ${type}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: used > 80%
@@ -3836,9 +3952,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: throughput > 100000
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} >${sent_human}/s <${received_human}/s
         empty-state: critical
         empty-syntax: ''
@@ -3854,6 +3973,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: throughput > 10000
@@ -4016,9 +4136,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: security > 0 or critical > 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${updates} updates available (${security} security, ${critical} critical)
         empty-state: ok
         empty-syntax: ''
@@ -4034,6 +4157,7 @@ windows:
         perf-syntax: updates
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: updates > 0
@@ -4113,9 +4237,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: version <= 50
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${version} (${kernel_version}) ${arch}
         empty-state: ignored
         empty-syntax: ''
@@ -4131,6 +4258,7 @@ windows:
         perf-syntax: version
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: version <= 50
@@ -4207,9 +4335,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: used > 80%
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name} ${used} (${size})
         empty-state: ignored
         empty-syntax: ''
@@ -4225,6 +4356,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: used > 60%
@@ -4280,9 +4412,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: missing > 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${message}
         empty-state: ignored
         empty-syntax: ''
@@ -4298,6 +4433,7 @@ windows:
         perf-syntax: patch
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -4370,9 +4506,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${alias} = ${value}
         empty-state: unknown
         empty-syntax: ''
@@ -4388,6 +4527,7 @@ windows:
         perf-syntax: ${alias}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -4564,9 +4704,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${message}
         empty-state: ignored
         empty-syntax: ''
@@ -4582,6 +4725,7 @@ windows:
         perf-syntax: reboot
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: pending = 1
@@ -4647,9 +4791,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: error = 1 or blocked = 1 or user_intervention = 1
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${printer}: ''${document}'' by ${owner} (${job_status}, ${age}s)'
         empty-state: ok
         empty-syntax: '%(status): No print jobs queued'
@@ -4665,6 +4812,7 @@ windows:
         perf-syntax: ${printer}_${id}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: age > 600
@@ -4771,9 +4919,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: error = 1
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${printer}: ${printer_status}, ${jobs} job(s)'
         empty-state: ok
         empty-syntax: '%(status): No printers found'
@@ -4789,6 +4940,7 @@ windows:
         perf-syntax: ${printer}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: jobs > 10
@@ -4878,9 +5030,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: state = 'stopped', count = 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${exe}=${state}
         empty-state: unknown
         empty-syntax: 'UNKNOWN: No processes found'
@@ -4896,6 +5051,7 @@ windows:
         perf-syntax: ${exe}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: state not in ('started')
@@ -5109,9 +5265,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${exe} (${running})
         empty-state: ok
         empty-syntax: ''
@@ -5127,6 +5286,7 @@ windows:
         perf-syntax: ${exe}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: ''
@@ -5186,9 +5346,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${exe} (first seen: ${first_seen})'
         empty-state: ok
         empty-syntax: ''
@@ -5204,6 +5367,7 @@ windows:
         perf-syntax: ${exe}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -5263,9 +5427,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: not exists
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${path}: exists=${exists}, subkeys=${subkey_count}, values=${value_count}'
         empty-state: unknown
         empty-syntax: '${status}: No registry keys found'
@@ -5281,6 +5448,7 @@ windows:
         perf-syntax: ${path}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: ''
@@ -5402,9 +5570,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: not exists
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${path}: ${string_value} (type=${type})'
         empty-state: unknown
         empty-syntax: '${status}: No registry values found'
@@ -5420,6 +5591,7 @@ windows:
         perf-syntax: ${path}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: ''
@@ -5551,9 +5723,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: not state_is_ok()
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${name}=${state}, exit=%(exit_code), type=%(start_type)
         empty-state: unknown
         empty-syntax: '%(status): No services found'
@@ -5569,6 +5744,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${crit_list}, delayed (${warn_list})'
         warn: ''
         warning: not state_is_perfect()
@@ -5748,9 +5924,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${swap_count} page file(s), in ${swap_in} pages/s, out ${swap_out} pages/s
         empty-state: ignored
         empty-syntax: ''
@@ -5766,6 +5945,7 @@ windows:
         perf-syntax: io
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -5814,9 +5994,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: temperature > 90
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${name}: ${temperature} C'
         empty-state: critical
         empty-syntax: ''
@@ -5832,6 +6015,7 @@ windows:
         perf-syntax: ${name}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: temperature > 70
@@ -5871,9 +6055,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: synchronized = 0 or offset > 30000
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${state}
         empty-state: ignored
         empty-syntax: ''
@@ -5889,6 +6076,7 @@ windows:
         perf-syntax: w32time
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: offset > 1000

--- a/docs/reference/CheckTaskSched.yaml
+++ b/docs/reference/CheckTaskSched.yaml
@@ -24,9 +24,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: exit_code < 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${folder}/${title}: ${exit_code} != 0'
         empty-state: warning
         empty-syntax: '%(status): No tasks found'
@@ -42,6 +45,7 @@ windows:
         perf-syntax: ${title}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${problem_list}'
         warn: ''
         warning: exit_code != 0

--- a/docs/reference/CheckWMI.yaml
+++ b/docs/reference/CheckWMI.yaml
@@ -34,9 +34,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '%(line)'
         empty-state: ignored
         empty-syntax: ''
@@ -52,6 +55,7 @@ windows:
         perf-syntax: ''
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: ${list}
         warn: ''
         warning: ''

--- a/docs/reference/CheckWindowsApps.yaml
+++ b/docs/reference/CheckWindowsApps.yaml
@@ -26,9 +26,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: state != 'running' and auto_start != 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${pool}: ${state}, uptime ${uptime}s, ${recycles} recycles'
         empty-state: unknown
         empty-syntax: No application pools found
@@ -44,6 +47,7 @@ windows:
         perf-syntax: ${pool}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -93,9 +97,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: queue_length > 1000
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${queue}: ${queue_length} queued, ${rejected} rejected'
         empty-state: ok
         empty-syntax: No HTTP.sys request queues found
@@ -111,6 +118,7 @@ windows:
         perf-syntax: ${queue}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: queue_length > 800
@@ -150,9 +158,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: state = 'stopped' and auto_start != 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${site}: ${state}, ${connections} connections, uptime ${uptime}s'
         empty-state: unknown
         empty-syntax: No web sites found
@@ -168,6 +179,7 @@ windows:
         perf-syntax: ${site}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -231,9 +243,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${pool} (pid ${pid}): ${active_requests} active requests'
         empty-state: ok
         empty-syntax: No IIS worker processes running
@@ -249,6 +264,7 @@ windows:
         perf-syntax: ${pool}_${pid}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -292,9 +308,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${label} = ${value}
         empty-state: unknown
         empty-syntax: No Connection Broker counters found
@@ -310,6 +329,7 @@ windows:
         perf-syntax: ${label}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -359,9 +379,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: available = 0 and total_licenses > 0
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${description}: ${issued}/${total_licenses} issued, ${available} available'
         empty-state: unknown
         empty-syntax: No license key packs found
@@ -377,6 +400,7 @@ windows:
         perf-syntax: ${description}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: available < 10 and total_licenses > 0
@@ -432,9 +456,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: '${session}: ${cpu}% cpu, ${working_set}B working set'
         empty-state: ok
         empty-syntax: No sessions found
@@ -450,6 +477,7 @@ windows:
         perf-syntax: ${session}
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''
@@ -509,9 +537,12 @@ windows:
       - warn_count
       - warn_list
       common_options:
+        byte-unit: ''
         crit: ''
         critical: ''
         debug: 'false'
+        decimal-separator: ''
+        decimals: '-1'
         detail-syntax: ${active} active, ${inactive} inactive (${total_sessions} total)
         empty-state: unknown
         empty-syntax: No session counters found
@@ -527,6 +558,7 @@ windows:
         perf-syntax: sessions
         show-all: 'false'
         show-default: ''
+        thousands-separator: ''
         top-syntax: '${status}: ${list}'
         warn: ''
         warning: ''

--- a/docs/reference/common-options.yaml
+++ b/docs/reference/common-options.yaml
@@ -22,6 +22,15 @@ fields:
   warn_count: Number of items matched the warning criteria.
   warn_list: A list of all items which matched the warning criteria.
 options:
+  byte-unit:
+    content_type: 2
+    description: 'Unit to render every byte value of the message in: B, KB, MB, GB, TB, PB or EB.
+
+      By default each value scales on its own, which is why a single line can read "140.293GB/0.983TB";
+      pinning the unit makes the values comparable ("140.29GB/1006.85GB").
+
+      Performance data is unaffected - its unit is chosen separately and can be set with perf-config.'
+    group: filter
   crit:
     content_type: 2
     description: Short alias for critical.
@@ -37,6 +46,25 @@ options:
   debug:
     content_type: 2
     description: Show debugging information in the log
+    group: filter
+  decimal-separator:
+    content_type: 2
+    description: 'Character to use as the decimal separator of the message, for instance "," for the European
+      rendering (default ".").
+
+      Only the message is affected: performance data and the numbers you write in a filter or threshold
+      always use ".", as their consumers require.'
+    group: filter
+  decimals:
+    content_type: 2
+    description: 'Number of decimals to render the numbers of the message with, for instance 1 to turn
+      "25.191GB" into "25.2GB".
+
+      Applies to the byte and percentage keywords and to format_bytes()/format_number(); -1 (the default)
+      keeps the historical rendering of up to three decimals with the trailing zeros stripped.
+
+      Performance data is unaffected - it is generated from the raw values so that graphs keep their full
+      precision.'
     group: filter
   detail-syntax:
     content_type: 2
@@ -135,6 +163,14 @@ options:
     content_type: 4
     description: Show default values for a given command
     group: standard
+  thousands-separator:
+    content_type: 2
+    description: 'Character to group the thousands of the message with, for instance "." to render 1006.85
+      GB as "1.006,85" (together with decimal-separator=,). Empty (the default) means no grouping.
+
+      Only the message is affected: performance data and the numbers you write in a filter or threshold
+      are never grouped.'
+    group: filter
   top-syntax:
     content_type: 2
     description: 'Top level syntax.

--- a/include/nscapi/settings/filter.cpp
+++ b/include/nscapi/settings/filter.cpp
@@ -30,6 +30,23 @@ void filter_object::read_object(settings_helper::path_extension& path, const boo
                   "render one item per line (most Nagios compatible frontends show everything after the first line as long output). Reference it as %(sep) in "
                   "the top syntax to also break before the first item.",
                   true)
+      // Number rendering, mirroring the same-named options of a queried check
+      // (#1428). Unset means "leave it alone" so apply_parent can inherit.
+      .add_int("decimals", sh::int_key(&decimals, -1), "DECIMALS",
+               "Number of decimals to render the numbers of the message with (-1 keeps the historical rendering of up to three decimals with the trailing "
+               "zeros stripped). Performance data is unaffected.",
+               true)
+      .add_string("byte unit", sh::string_key(&byte_unit), "BYTE UNIT",
+                  "Unit to render every byte value of the message in: B, KB, MB, GB, TB, PB or EB. Empty (the default) scales each value on its own. "
+                  "Performance data is unaffected.",
+                  true)
+      .add_string("decimal separator", sh::string_key(&decimal_separator), "DECIMAL SEPARATOR",
+                  "Character to use as the decimal separator of the message, for instance ',' for the European rendering. Only the message is affected: "
+                  "performance data and the numbers written in a filter always use '.'.",
+                  true)
+      .add_string("thousands separator", sh::string_key(&thousands_separator), "THOUSANDS SEPARATOR",
+                  "Character to group the thousands of the message with. Empty (the default) means no grouping. Only the message is affected.", true)
+
       .add_string("perf config", sh::string_key(&perf_config), "PERF CONFIG", "Performance data configuration", true)
 
       .add_bool("debug", sh::bool_key(&debug), "DEBUG", "Enable this to display debug information for this match filter", true)
@@ -72,6 +89,10 @@ void filter_object::apply_parent(const filter_object& parent) {
   import_string(syntax_detail, parent.syntax_detail);
   import_string(syntax_top, parent.syntax_top);
   import_string(list_separator, parent.list_separator);
+  if (decimals == -1) decimals = parent.decimals;
+  import_string(byte_unit, parent.byte_unit);
+  import_string(decimal_separator, parent.decimal_separator);
+  import_string(thousands_separator, parent.thousands_separator);
   import_string(filter_string_, parent.filter_string_);
   import_string(filter_warn, parent.filter_warn);
   import_string(filter_crit, parent.filter_crit);

--- a/include/nscapi/settings/filter.hpp
+++ b/include/nscapi/settings/filter.hpp
@@ -8,6 +8,7 @@
 #include <nscapi/nscapi_helper.hpp>
 #include <nscapi/settings/helper.hpp>
 #include <nscapi/settings/proxy.hpp>
+#include <str/format.hpp>
 #include <str/number_format.hpp>
 #ifdef WIN32
 #pragma warning(disable : 4251)
@@ -110,6 +111,17 @@ struct NSCAPI_EXPORT filter_object {
     if (!decimal_separator.empty()) fmt.decimal_separator = decimal_separator;
     fmt.thousands_separator = thousands_separator;
     return fmt;
+  }
+
+  // Whether the `byte unit` key names a unit we know about. The query path
+  // rejects an unknown one outright; a real-time filter is persistent
+  // monitoring, so it warns and falls back to auto-scaling rather than
+  // dropping the filter - but either way an invalid unit is no longer silent.
+  // Returns an error message, or "" when the unit is empty or valid.
+  std::string invalid_byte_unit() const {
+    if (!byte_unit.empty() && str::format::byte_unit_index(byte_unit) < 0)
+      return "Invalid byte unit: " + byte_unit + " (expected one of B, KB, MB, GB, TB, PB, EB)";
+    return "";
   }
 
   void read_object(settings_helper::path_extension &path, bool is_default);

--- a/include/nscapi/settings/filter.hpp
+++ b/include/nscapi/settings/filter.hpp
@@ -8,6 +8,7 @@
 #include <nscapi/nscapi_helper.hpp>
 #include <nscapi/settings/helper.hpp>
 #include <nscapi/settings/proxy.hpp>
+#include <str/number_format.hpp>
 #ifdef WIN32
 #pragma warning(disable : 4251)
 #endif
@@ -30,6 +31,14 @@ struct NSCAPI_EXPORT filter_object {
   // What joins the items of %(list) and friends; accepts \n, \r, \t and \\.
   // Mirrors the `list-separator` option of a queried check (issue #1370).
   std::string list_separator;
+  // How the numbers of the message are rendered, mirroring the `decimals`,
+  // `byte-unit`, `decimal-separator` and `thousands-separator` options of a
+  // queried check (issue #1428). -1 decimals and empty strings mean "unset",
+  // so apply_parent can inherit them from the default template.
+  int decimals;
+  std::string byte_unit;
+  std::string decimal_separator;
+  std::string thousands_separator;
 
  private:
   std::string filter_string_;
@@ -50,7 +59,13 @@ struct NSCAPI_EXPORT filter_object {
   std::string timeout_msg;
 
   filter_object(std::string syntax_top, std::string syntax_detail, std::string target)
-      : debug(false), escape_html(false), syntax_top(std::move(syntax_top)), syntax_detail(std::move(syntax_detail)), target(std::move(target)), severity(-1) {}
+      : debug(false),
+        escape_html(false),
+        syntax_top(std::move(syntax_top)),
+        syntax_detail(std::move(syntax_detail)),
+        target(std::move(target)),
+        decimals(-1),
+        severity(-1) {}
 
   filter_object(const filter_object &other) = default;
 
@@ -82,6 +97,16 @@ struct NSCAPI_EXPORT filter_object {
   }
   void set_silent_period(const std::string &age) {
     if (age != "none" && age != "infinite" && age != "false" && age != "off") silent_period = parse_time(age);
+  }
+
+  // The number format these keys describe; unset keys keep their defaults.
+  str::number_format number_format() const {
+    str::number_format fmt;
+    fmt.decimals = decimals;
+    fmt.byte_unit = byte_unit;
+    if (!decimal_separator.empty()) fmt.decimal_separator = decimal_separator;
+    fmt.thousands_separator = thousands_separator;
+    return fmt;
   }
 
   void read_object(settings_helper::path_extension &path, bool is_default);

--- a/include/nscapi/settings/filter.hpp
+++ b/include/nscapi/settings/filter.hpp
@@ -100,9 +100,12 @@ struct NSCAPI_EXPORT filter_object {
   }
 
   // The number format these keys describe; unset keys keep their defaults.
+  // Unlike the query path this has no error channel, so a nonsensical decimals
+  // is clamped rather than rejected - the point is only to keep a config typo
+  // from handing render_fixed an unbounded width and crashing the check.
   str::number_format number_format() const {
     str::number_format fmt;
-    fmt.decimals = decimals;
+    fmt.decimals = decimals < -1 ? -1 : (decimals > str::max_decimals ? str::max_decimals : decimals);
     fmt.byte_unit = byte_unit;
     if (!decimal_separator.empty()) fmt.decimal_separator = decimal_separator;
     fmt.thousands_separator = thousands_separator;

--- a/include/nscapi/settings/filter_test.cpp
+++ b/include/nscapi/settings/filter_test.cpp
@@ -314,6 +314,50 @@ TEST(FilterObjectTest, ApplyParentPreservesOwnListSeparator) {
 }
 
 // ============================================================================
+// number formatting (issue #1428)
+// ============================================================================
+
+TEST(FilterObjectTest, NumberFormatDefaultsToUnset) {
+  const filter_object obj("top", "detail", "target");
+  const str::number_format fmt = obj.number_format();
+  EXPECT_TRUE(fmt.is_default());
+}
+
+TEST(FilterObjectTest, NumberFormatCarriesTheConfiguredKeys) {
+  filter_object obj("top", "detail", "target");
+  obj.decimals = 2;
+  obj.byte_unit = "GB";
+  obj.decimal_separator = ",";
+  obj.thousands_separator = ".";
+  const str::number_format fmt = obj.number_format();
+  EXPECT_EQ(2, fmt.decimals);
+  EXPECT_EQ("GB", fmt.byte_unit);
+  EXPECT_EQ(",", fmt.decimal_separator);
+  EXPECT_EQ(".", fmt.thousands_separator);
+}
+
+// A config typo must not hand render_fixed an unbounded width; the settings
+// path has no error channel, so it clamps rather than rejects.
+TEST(FilterObjectTest, NumberFormatClampsRunawayDecimals) {
+  filter_object obj("top", "detail", "target");
+  obj.decimals = 1000000000;
+  EXPECT_EQ(str::max_decimals, obj.number_format().decimals);
+  obj.decimals = -5;
+  EXPECT_EQ(-1, obj.number_format().decimals);
+}
+
+TEST(FilterObjectTest, InvalidByteUnitIsReportedButEmptyAndValidAreNot) {
+  filter_object obj("top", "detail", "target");
+  EXPECT_EQ("", obj.invalid_byte_unit());
+  obj.byte_unit = "GB";
+  EXPECT_EQ("", obj.invalid_byte_unit());
+  obj.byte_unit = "gb";  // case insensitive, like the query path
+  EXPECT_EQ("", obj.invalid_byte_unit());
+  obj.byte_unit = "ZB";
+  EXPECT_NE(std::string::npos, obj.invalid_byte_unit().find("Invalid byte unit"));
+}
+
+// ============================================================================
 // apply_parent tests
 // ============================================================================
 

--- a/include/parsers/filter/cli_helper.hpp
+++ b/include/parsers/filter/cli_helper.hpp
@@ -49,6 +49,11 @@ struct data_container {
       return "Invalid byte-unit: " + byte_unit + " (expected one of B, KB, MB, GB, TB, PB, EB)";
     }
     if (decimals < -1) return "Invalid decimals: " + str::xtos(decimals) + " (expected 0 or more, or -1 to leave the rendering alone)";
+    // An unbounded decimals would make render_fixed allocate a huge string and
+    // crash the check; past max_decimals the digits are noise anyway.
+    if (decimals > str::max_decimals) {
+      return "Invalid decimals: " + str::xtos(decimals) + " (expected at most " + str::xtos(str::max_decimals) + ")";
+    }
     return "";
   }
 };

--- a/include/parsers/filter/cli_helper.hpp
+++ b/include/parsers/filter/cli_helper.hpp
@@ -11,6 +11,7 @@
 #include <nscapi/protobuf/functions_exec.hpp>
 #include <nscapi/protobuf/functions_response.hpp>
 #include <parsers/filter/modern_filter.hpp>
+#include <str/format.hpp>
 #include <str/utils_no_boost.hpp>
 
 namespace modern_filter {
@@ -26,10 +27,30 @@ struct data_container {
   std::vector<std::string> filter_string, warn_string, crit_string, ok_string;
   std::string syntax_empty, syntax_ok, syntax_top, syntax_detail, syntax_perf, perf_config, empty_state, syntax_unique, list_separator;
   bool debug, escape_html;
+  // How the numbers of the message are rendered (issue #1428); -1 decimals is
+  // "leave the rendering alone". These only ever touch the message: the
+  // performance data is built from the raw values and stays locale neutral.
+  int decimals;
+  std::string byte_unit, decimal_separator, thousands_separator;
   // list_separator carries its default here as well as on the option, so a
   // check that builds a filter without registering the misc options still
   // joins lists with ", " instead of with nothing.
-  data_container() : list_separator(", "), debug(false), escape_html(false) {}
+  data_container() : list_separator(", "), debug(false), escape_html(false), decimals(-1), decimal_separator(".") {}
+
+  // The number format these options describe, or an error message when the
+  // pinned unit is not one we know about.
+  std::string build_number_format(str::number_format &fmt) const {
+    fmt.decimals = decimals;
+    fmt.byte_unit = byte_unit;
+    // An explicitly emptied separator means "the default radix character".
+    fmt.decimal_separator = decimal_separator.empty() ? "." : decimal_separator;
+    fmt.thousands_separator = thousands_separator;
+    if (!byte_unit.empty() && str::format::byte_unit_index(byte_unit) < 0) {
+      return "Invalid byte-unit: " + byte_unit + " (expected one of B, KB, MB, GB, TB, PB, EB)";
+    }
+    if (decimals < -1) return "Invalid decimals: " + str::xtos(decimals) + " (expected 0 or more, or -1 to leave the rendering alone)";
+    return "";
+  }
 };
 
 struct perf_writer final : perf_writer_interface {
@@ -202,6 +223,27 @@ struct cli_helper : boost::noncopyable {
 	"Set to \\n to render one item per line, which most Nagios compatible frontends show as long output below the summary line.\n"
 	"The top-syntax decides what precedes the first item; templates are never escape-decoded, so reference the decoded separator as %(sep) to break "
 	"before it too: --top-syntax \"%(status): %(count) items:%(sep)%(list)\".") + common_option_marker).c_str())
+      ("decimals", boost::program_options::value<int>(&data.decimals)->default_value(-1),
+	(std::string("Number of decimals to render the numbers of the message with, for instance 1 to turn \"25.191GB\" into \"25.2GB\".\n"
+	"Applies to the byte and percentage keywords and to format_bytes()/format_number(); -1 (the default) keeps the historical rendering of up to three "
+	"decimals with the trailing zeros stripped.\n"
+	"Performance data is unaffected - it is generated from the raw values so that graphs keep their full precision.") + common_option_marker).c_str())
+      ("byte-unit", boost::program_options::value<std::string>(&data.byte_unit),
+	(std::string("Unit to render every byte value of the message in: B, KB, MB, GB, TB, PB or EB.\n"
+	"By default each value scales on its own, which is why a single line can read \"140.293GB/0.983TB\"; pinning the unit makes the values comparable "
+	"(\"140.29GB/1006.85GB\").\n"
+	"Performance data is unaffected - its unit is chosen separately and can be set with perf-config.") + common_option_marker).c_str())
+      // No program_options default: the "." lives on data_container instead, so
+      // that the docs extractor does not unexpand the literal "." into the
+      // ${data-path} token when it resolves path variables in defaults.
+      ("decimal-separator", boost::program_options::value<std::string>(&data.decimal_separator),
+	(std::string("Character to use as the decimal separator of the message, for instance \",\" for the European rendering (default \".\").\n"
+	"Only the message is affected: performance data and the numbers you write in a filter or threshold always use \".\", as their consumers require.") +
+	common_option_marker).c_str())
+      ("thousands-separator", boost::program_options::value<std::string>(&data.thousands_separator),
+	(std::string("Character to group the thousands of the message with, for instance \".\" to render 1006.85 GB as \"1.006,85\" (together with "
+	"decimal-separator=,). Empty (the default) means no grouping.\n"
+	"Only the message is affected: performance data and the numbers you write in a filter or threshold are never grouped.") + common_option_marker).c_str())
       ;
     // clang-format on
     nscapi::program_options::add_help(desc);
@@ -276,6 +318,16 @@ struct cli_helper : boost::noncopyable {
     // The separator joins list items as they are collected, so it has to be in
     // place before the first match is recorded (start_match, below).
     filter.summary.list_separator = str::utils::unescape(data.list_separator);
+    // Same story for the number format: every keyword getter reads it off the
+    // evaluation context while the rows are rendered.
+    str::number_format number_format;
+    const std::string number_format_error = data.build_number_format(number_format);
+    if (!number_format_error.empty()) {
+      nscapi::protobuf::functions::set_response_bad(*response, number_format_error);
+      return false;
+    }
+    filter.context->set_number_format(number_format);
+    filter.set_human_number_format(!number_format.is_default());
     data.filter_string.erase(std::remove(data.filter_string.begin(), data.filter_string.end(), "none"), data.filter_string.end());
     data.ok_string.erase(std::remove(data.ok_string.begin(), data.ok_string.end(), "none"), data.ok_string.end());
     data.warn_string.erase(std::remove(data.warn_string.begin(), data.warn_string.end(), "none"), data.warn_string.end());

--- a/include/parsers/filter/cli_helper_test.cpp
+++ b/include/parsers/filter/cli_helper_test.cpp
@@ -785,7 +785,18 @@ struct SeparatorFilter {
   struct {
     std::string list_separator = ", ";
   } summary;
+  // build_filter sets the number format on the context and tells the renderers
+  // whether they have one to honour; both are recorded here so the tests can
+  // read them back.
+  struct fake_context {
+    str::number_format number_format;
+    void set_number_format(const str::number_format &fmt) { number_format = fmt; }
+  };
+  std::shared_ptr<fake_context> context = std::make_shared<fake_context>();
+  bool human_numbers = false;
   bool started = false;
+
+  void set_human_number_format(const bool human) { human_numbers = human; }
 
   bool build_syntax(bool, const std::string &, const std::string &, const std::string &, const std::string &, const std::string &, const std::string &) {
     return true;
@@ -847,6 +858,87 @@ TEST_F(CliHelperTest, BuildFilterKeepsAPlainSeparatorVerbatim) {
   ASSERT_TRUE(helper.build_filter(filter));
 
   EXPECT_EQ(" | ", filter.summary.list_separator);
+}
+
+// ============================================================================
+// cli_helper — number formatting (issue #1428)
+// ============================================================================
+
+TEST_F(CliHelperTest, NumberFormatDefaultsToTheHistoricalRendering) {
+  modern_filter::cli_helper<SeparatorFilter> helper(request_, response_, data_);
+  helper.add_misc_options();
+
+  boost::program_options::variables_map vm;
+  const std::vector<std::string> empty_args;
+  boost::program_options::store(boost::program_options::command_line_parser(empty_args).options(helper.get_desc()).run(), vm);
+  boost::program_options::notify(vm);
+
+  SeparatorFilter filter;
+  ASSERT_TRUE(helper.build_filter(filter));
+
+  EXPECT_TRUE(filter.context->number_format.is_default());
+  // Nothing configured, so the templates keep rendering their floats the way
+  // they always did.
+  EXPECT_FALSE(filter.human_numbers);
+}
+
+TEST_F(CliHelperTest, NumberFormatOptionsReachTheContext) {
+  modern_filter::cli_helper<SeparatorFilter> helper(request_, response_, data_);
+  helper.add_misc_options();
+
+  boost::program_options::variables_map vm;
+  const std::vector<std::string> args{"--decimals", "2", "--byte-unit", "GB", "--decimal-separator", ",", "--thousands-separator", "."};
+  boost::program_options::store(boost::program_options::command_line_parser(args).options(helper.get_desc()).run(), vm);
+  boost::program_options::notify(vm);
+
+  SeparatorFilter filter;
+  ASSERT_TRUE(helper.build_filter(filter));
+
+  EXPECT_EQ(2, filter.context->number_format.decimals);
+  EXPECT_EQ("GB", filter.context->number_format.byte_unit);
+  EXPECT_EQ(",", filter.context->number_format.decimal_separator);
+  EXPECT_EQ(".", filter.context->number_format.thousands_separator);
+  EXPECT_TRUE(filter.human_numbers);
+}
+
+// REST passes each option as the single token `key=value`, which is the
+// transport the request came in over for most of these checks.
+TEST_F(CliHelperTest, NumberFormatOptionsAcceptTheValuedForm) {
+  modern_filter::cli_helper<SeparatorFilter> helper(request_, response_, data_);
+  helper.add_misc_options();
+
+  boost::program_options::variables_map vm;
+  const std::vector<std::string> args{"--decimals=1", "--byte-unit=MB"};
+  boost::program_options::store(boost::program_options::command_line_parser(args).options(helper.get_desc()).run(), vm);
+  boost::program_options::notify(vm);
+
+  SeparatorFilter filter;
+  ASSERT_TRUE(helper.build_filter(filter));
+
+  EXPECT_EQ(1, filter.context->number_format.decimals);
+  EXPECT_EQ("MB", filter.context->number_format.byte_unit);
+}
+
+TEST_F(CliHelperTest, BuildFilterRejectsAnUnknownByteUnit) {
+  modern_filter::cli_helper<SeparatorFilter> helper(request_, response_, data_);
+  data_.byte_unit = "ZB";
+
+  SeparatorFilter filter;
+  EXPECT_FALSE(helper.build_filter(filter));
+  ASSERT_GT(response_->lines_size(), 0);
+  EXPECT_NE(std::string::npos, response_->lines(0).message().find("Invalid byte-unit"));
+  // A rejected option must not leave the filter half-built.
+  EXPECT_FALSE(filter.started);
+}
+
+TEST_F(CliHelperTest, BuildFilterRejectsNegativeDecimals) {
+  modern_filter::cli_helper<SeparatorFilter> helper(request_, response_, data_);
+  data_.decimals = -2;
+
+  SeparatorFilter filter;
+  EXPECT_FALSE(helper.build_filter(filter));
+  ASSERT_GT(response_->lines_size(), 0);
+  EXPECT_NE(std::string::npos, response_->lines(0).message().find("Invalid decimals"));
 }
 
 // ============================================================================

--- a/include/parsers/filter/cli_helper_test.cpp
+++ b/include/parsers/filter/cli_helper_test.cpp
@@ -941,6 +941,20 @@ TEST_F(CliHelperTest, BuildFilterRejectsNegativeDecimals) {
   EXPECT_NE(std::string::npos, response_->lines(0).message().find("Invalid decimals"));
 }
 
+// An unbounded decimals would make render_fixed allocate a multi-megabyte
+// string and crash the check, so a value past max_decimals is rejected up
+// front rather than reaching the renderer.
+TEST_F(CliHelperTest, BuildFilterRejectsRunawayDecimals) {
+  modern_filter::cli_helper<SeparatorFilter> helper(request_, response_, data_);
+  data_.decimals = 1000000000;
+
+  SeparatorFilter filter;
+  EXPECT_FALSE(helper.build_filter(filter));
+  ASSERT_GT(response_->lines_size(), 0);
+  EXPECT_NE(std::string::npos, response_->lines(0).message().find("Invalid decimals"));
+  EXPECT_FALSE(filter.started);
+}
+
 // ============================================================================
 // cli_helper — valued booleans (REST passes `x=true` as a single token, which
 // bool_switch would reject with "does not take any arguments")

--- a/include/parsers/filter/modern_filter.hpp
+++ b/include/parsers/filter/modern_filter.hpp
@@ -52,8 +52,14 @@ struct filter_text_renderer {
 
   typedef std::list<my_entry> entry_list;
   entry_list entries;
-  filter_text_renderer() {}
+  // True for the renderers whose output a human reads (top/detail/ok/empty),
+  // which is where the check's number format applies. The perf, unique and
+  // hash renderers keep the plain rendering: their output is a label or a key,
+  // and a decimal comma in either would travel straight into a metric store.
+  bool human_numbers;
+  filter_text_renderer() : human_numbers(false) {}
 
+  void set_human_numbers(const bool human) { human_numbers = human; }
   bool empty() const { return entries.empty(); }
   bool parse(std::shared_ptr<TFactory> context, const std::string &str, const error_handler &error) {
     if (str.empty() || str == "none") return true;
@@ -107,9 +113,10 @@ struct filter_text_renderer {
         ret += e.origin.name;
       else if (e.node->is_int())
         ret += str::xtos_non_sci(e.node->get_int_value(context));
-      else if (e.node->is_float())
-        ret += str::xtos(e.node->get_float_value(context));
-      else
+      else if (e.node->is_float()) {
+        const double value = e.node->get_float_value(context);
+        ret += human_numbers ? str::render_number(value, context->get_number_format()) : str::xtos(value);
+      } else
         ret += e.node->get_string_value(context);
     }
     return ret;
@@ -328,6 +335,16 @@ struct modern_filters {
 
   modern_filters() : has_matched(false), context(new TFactory()), fetch_hash_(false), has_unique_index(false) { context->set_summary(&summary); }
 
+  // Route the floats of the human readable templates through the number format
+  // set on the context. Off by default so an unconfigured check renders byte
+  // for byte what it always did.
+  void set_human_number_format(const bool human) {
+    renderer_top.set_human_numbers(human);
+    renderer_detail.set_human_numbers(human);
+    renderer_ok.set_human_numbers(human);
+    renderer_empty.set_human_numbers(human);
+  }
+
   std::map<std::string, std::string> get_filter_syntax() const {
     std::map<std::string, std::string> ret;
     std::map<std::string, std::string> m1 = summary.get_filter_syntax();
@@ -387,6 +404,18 @@ struct modern_filters {
     std::vector<std::string> crit_;
     if (!crit.empty()) crit_.push_back(crit);
     return build_engines(debug, filter_, ok_, warn_, crit_);
+  }
+
+  // A function that fails while a template is rendered - a misspelled unit in
+  // format_bytes, say - reports through the evaluation context, and nothing
+  // used to read that on the rendering path: the placeholder simply came out
+  // empty and left the operator guessing. Drain it into the error handler the
+  // checks already report through (#1428). The engines clear the context after
+  // logging their own errors, so nothing is reported twice.
+  void drain_render_errors() {
+    if (!context->has_error()) return;
+    if (error_handler_) error_handler_->log_error(context->get_error());
+    context->clear();
   }
 
   error_type get_error_handler(bool debug) {
@@ -521,6 +550,7 @@ struct modern_filters {
       }
       std::string current = renderer_detail.render(context);
       std::string perf_alias = renderer_perf.render(context);
+      drain_render_errors();
       bool second_unique_match = false;
       if (has_unique_index) {
         std::string tmp = renderer_unique.render(context);
@@ -686,9 +716,15 @@ struct modern_filters {
     }
   }
   std::string get_message() {
-    if (!summary.has_matched() && !renderer_empty.empty()) return renderer_empty.render(context);
-    if (summary.returnCode == NSCAPI::query_return_codes::returnOK && !renderer_ok.empty()) return renderer_ok.render(context);
-    return renderer_top.render(context);
+    std::string message;
+    if (!summary.has_matched() && !renderer_empty.empty())
+      message = renderer_empty.render(context);
+    else if (summary.returnCode == NSCAPI::query_return_codes::returnOK && !renderer_ok.empty())
+      message = renderer_ok.render(context);
+    else
+      message = renderer_top.render(context);
+    drain_render_errors();
+    return message;
   }
 };
 }  // namespace modern_filter

--- a/include/parsers/filter/realtime_helper.hpp
+++ b/include/parsers/filter/realtime_helper.hpp
@@ -96,6 +96,14 @@ struct realtime_filter_helper {
       // "inherit" here (as it does for every other filter_object string), so
       // the summary keeps its own ", " default.
       if (!config.list_separator.empty()) filter.summary.list_separator = str::utils::unescape(config.list_separator);
+      // Same story for the number format (#1428): set before the first row is
+      // rendered, and left alone entirely while nothing has been configured so
+      // an untouched filter renders exactly what it always did.
+      const str::number_format number_format = config.number_format();
+      if (!number_format.is_default()) {
+        filter.context->set_number_format(number_format);
+        filter.set_human_number_format(true);
+      }
       if (!filter.build_syntax(config.debug, config.syntax_top, config.syntax_detail, config.perf_data, config.perf_config, config.syntax_ok,
                                config.syntax_empty)) {
         error = "Failed to build strings " + alias;

--- a/include/parsers/filter/realtime_helper.hpp
+++ b/include/parsers/filter/realtime_helper.hpp
@@ -99,6 +99,13 @@ struct realtime_filter_helper {
       // Same story for the number format (#1428): set before the first row is
       // rendered, and left alone entirely while nothing has been configured so
       // an untouched filter renders exactly what it always did.
+      const std::string byte_unit_error = config.invalid_byte_unit();
+      if (!byte_unit_error.empty()) {
+        // A one-shot query would be rejected here; a real-time filter keeps
+        // running (auto-scaling the value) so a formatting typo cannot take
+        // down persistent monitoring, but the misconfiguration is logged.
+        NSC_LOG_ERROR(byte_unit_error + " in real-time filter '" + alias + "'; falling back to auto-scaling");
+      }
       const str::number_format number_format = config.number_format();
       if (!number_format.is_default()) {
         filter.context->set_number_format(number_format);

--- a/include/parsers/where/format_functions.hpp
+++ b/include/parsers/where/format_functions.hpp
@@ -55,6 +55,9 @@ inline str::number_format with_decimals(const str::number_format &base, const ev
   str::number_format fmt = base;
   fmt.decimals = static_cast<int>(node->get_int_value(context));
   if (fmt.decimals < 0) throw std::invalid_argument("decimals must not be negative");
+  // Bound it: an unlimited number of decimals would make render_fixed allocate
+  // a huge string and crash, and past max_decimals a double has no digits left.
+  if (fmt.decimals > str::max_decimals) throw std::invalid_argument("decimals must not exceed " + str::xtos(str::max_decimals));
   return fmt;
 }
 

--- a/include/parsers/where/format_functions.hpp
+++ b/include/parsers/where/format_functions.hpp
@@ -19,10 +19,18 @@
 // Usage examples (all valid in both filter expressions and detail-syntax):
 //   detail-syntax = "%(name): %(format_bytes(total_bytes_per_sec))/s"
 //   detail-syntax = "%(format_bytes(used, 'GB')) used"
+//   detail-syntax = "%(format_bytes(used, 'GB', 1)) GB used"
+//   detail-syntax = "%(format_number(used_pct, 1))% used"
 //   warning       = "convert_bytes(write_bytes_per_sec, 'MB') > 100"
 //   detail-syntax = "%(scale(value, 1000000)) Mbps"
 //
-// Originally added for check_pdh (issue #281) and generalised in #1392.
+// Everything rendered here follows the check's number format (the `decimals`,
+// `byte-unit`, `decimal-separator` and `thousands-separator` options), so a
+// check configured for two decimals and a decimal comma keeps them here too;
+// an explicit `decimals` argument wins over the option.
+//
+// Originally added for check_pdh (issue #281), generalised in #1392 and given
+// configurable precision and separators in #1428.
 
 namespace parsers {
 namespace where {
@@ -42,26 +50,65 @@ inline bool has_no_value(const evaluation_context &context, const node_type &nod
   return node->get_value(context, numeric_type).is_no_value;
 }
 
+// Read the optional trailing `decimals` argument of a format function.
+inline str::number_format with_decimals(const str::number_format &base, const evaluation_context &context, const node_type &node) {
+  str::number_format fmt = base;
+  fmt.decimals = static_cast<int>(node->get_int_value(context));
+  if (fmt.decimals < 0) throw std::invalid_argument("decimals must not be negative");
+  return fmt;
+}
+
 // Format a number as a human-readable byte string: format_bytes(value) auto-
-// scales, format_bytes(value, unit) pins the unit.
+// scales and appends the unit, format_bytes(value, unit) pins the unit and
+// leaves it out of the result (the syntax string spells it out), and a third
+// argument overrides the number of decimals.
 inline node_type fn_format_bytes(value_type, evaluation_context context, const node_type subject) {
   try {
     const std::list<node_type> args = subject->get_list_value(context);
-    if (args.empty() || args.size() > 2) {
-      context->error("format_bytes expects 1 or 2 arguments: format_bytes(value) or format_bytes(value, unit)");
+    if (args.empty() || args.size() > 3) {
+      context->error("format_bytes expects 1 to 3 arguments: format_bytes(value), format_bytes(value, unit) or format_bytes(value, unit, decimals)");
       return factory::create_false();
     }
     auto it = args.begin();
     if (has_no_value(context, *it, type_int)) return *it;
     const long long v = (*it)->get_int_value(context);
+    str::number_format fmt = context->get_number_format();
     if (args.size() == 1) {
-      return factory::create_string(str::format::format_byte_units(v));
+      return factory::create_string(str::format::format_byte_units(v, fmt));
     }
     ++it;
     const std::string unit = (*it)->get_string_value(context);
-    return factory::create_string(str::format::format_byte_units(v, unit));
+    if (args.size() == 3) {
+      ++it;
+      fmt = with_decimals(fmt, context, *it);
+    }
+    return factory::create_string(str::format::format_byte_units(v, unit, fmt));
   } catch (const std::exception &e) {
     context->error(std::string("format_bytes failed: ") + e.what());
+    return factory::create_false();
+  }
+}
+
+// Render any number with a fixed number of decimals, honouring the check's
+// separators: format_number(used_pct, 1) turns 13.9333 into "13.9".
+inline node_type fn_format_number(value_type, evaluation_context context, const node_type subject) {
+  try {
+    const std::list<node_type> args = subject->get_list_value(context);
+    if (args.empty() || args.size() > 2) {
+      context->error("format_number expects 1 or 2 arguments: format_number(value) or format_number(value, decimals)");
+      return factory::create_false();
+    }
+    auto it = args.begin();
+    if (has_no_value(context, *it, type_float)) return *it;
+    const double v = (*it)->get_float_value(context);
+    str::number_format fmt = context->get_number_format();
+    if (args.size() == 2) {
+      ++it;
+      fmt = with_decimals(fmt, context, *it);
+    }
+    return factory::create_string(str::render_number(v, fmt));
+  } catch (const std::exception &e) {
+    context->error(std::string("format_number failed: ") + e.what());
     return factory::create_false();
   }
 }
@@ -118,8 +165,15 @@ void register_format_functions(TRegistry &registry) {
   registry
       .add_string_fun("format_bytes", &fn_format_bytes,
                       "Format a number as a human-readable byte string.\n"
-                      "Syntax: format_bytes(value) auto-scales to B/KB/MB/GB/... (1024-based).\n"
-                      "        format_bytes(value, unit) formats to a fixed unit (\"B\", \"K\"/\"KB\", \"M\"/\"MB\", \"G\"/\"GB\", \"T\"/\"TB\").")
+                      "Syntax: format_bytes(value) auto-scales to B/KB/MB/GB/... (1024-based) and appends the unit.\n"
+                      "        format_bytes(value, unit) formats to a fixed unit (\"B\", \"K\"/\"KB\", \"M\"/\"MB\", \"G\"/\"GB\", \"T\"/\"TB\") "
+                      "and does not append it; an empty unit renders the raw byte count.\n"
+                      "        format_bytes(value, unit, decimals) does the same with a fixed number of decimals.\n"
+                      "Without an explicit decimals argument the decimals, byte-unit, decimal-separator and thousands-separator options apply.")
+      .add_string_fun("format_number", &fn_format_number,
+                      "Render a number with a fixed number of decimals, using the check's decimal and thousands separators.\n"
+                      "Syntax: format_number(value) uses the decimals option; format_number(value, decimals) overrides it.\n"
+                      "Useful for percentages and other non-byte values: format_number(used_pct, 1).")
       .add_custom_fun("convert_bytes", parsers::where::type_float, &fn_convert_bytes,
                       "Convert a byte count to a specific unit and return the numeric value (1024-based). Useful in thresholds.\n"
                       "Syntax: convert_bytes(value, unit) where unit is \"B\", \"K\"/\"KB\", \"M\"/\"MB\", \"G\"/\"GB\", \"T\"/\"TB\".")

--- a/include/parsers/where/node.hpp
+++ b/include/parsers/where/node.hpp
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <parsers/where/dll_defines.hpp>
+#include <str/number_format.hpp>
 #include <string>
 #include <utility>
 #ifdef WIN32
@@ -225,6 +226,17 @@ struct evaluation_context_interface {
   virtual bool debug_enabled() = 0;
   virtual std::string get_debug() const = 0;
   virtual void debug(object_match reason) = 0;
+
+  // How the human readable numbers of this evaluation are rendered (#1428).
+  // Lives on the context because that is the one thing every keyword getter
+  // and every format function is already handed; the check's options set it
+  // once, before the first row is evaluated. It never reaches performance
+  // data, which is rendered from the raw values further down.
+  const str::number_format &get_number_format() const { return number_format_; }
+  void set_number_format(const str::number_format &fmt) { number_format_ = fmt; }
+
+ protected:
+  str::number_format number_format_;
 };
 typedef std::shared_ptr<evaluation_context_interface> evaluation_context;
 

--- a/include/str/format.hpp
+++ b/include/str/format.hpp
@@ -13,6 +13,7 @@
 #include <locale>
 #include <sstream>
 #include <stdexcept>
+#include <str/number_format.hpp>
 #include <str/utils.hpp>
 #include <str/xtos.hpp>
 #include <string>
@@ -111,6 +112,18 @@ inline std::string format_pct(unsigned long long value, unsigned long long total
   return format_pct(calc_pct_double(value, total), decimals);
 }
 inline std::string format_pct(long long value, long long total, int decimals = 2) { return format_pct(calc_pct_double(value, total), decimals); }
+
+// Percentages have always rendered with two decimals; `decimals` on the number
+// format overrides that, and the separators apply either way.
+inline std::string format_pct(const double pct, const number_format &fmt) {
+  number_format pct_fmt = fmt;
+  if (pct_fmt.decimals < 0) pct_fmt.decimals = 2;
+  return render_number(pct, pct_fmt);
+}
+inline std::string format_pct(unsigned long long value, unsigned long long total, const number_format &fmt) {
+  return format_pct(calc_pct_double(value, total), fmt);
+}
+inline std::string format_pct(long long value, long long total, const number_format &fmt) { return format_pct(calc_pct_double(value, total), fmt); }
 
 //
 // Padding
@@ -390,104 +403,79 @@ inline long long decode_byte_units(const std::string &s) {
 constexpr char BKMG_RANGE[] = "BKMGTPE?";
 constexpr std::size_t BKMG_SIZE = 7;
 
-inline std::string format_byte_units(const long long i) {
-  auto cpy = static_cast<double>(i);
+// Number of times `value` has to be divided by 1024 to land in the unit the
+// auto-scaler picks for it.
+inline std::size_t auto_scale_index(const double value) {
+  double rest = value < 0 ? -value : value;
   std::size_t idx = 0;
-  double acpy = cpy < 0 ? -cpy : cpy;
-  while ((acpy > 999) && (idx < BKMG_SIZE)) {
-    cpy /= 1024;
-    acpy = cpy < 0 ? -cpy : cpy;
+  while ((rest > 999) && (idx < BKMG_SIZE)) {
+    rest /= 1024;
     idx++;
   }
-  std::stringstream ss;
-  ss << std::setiosflags(std::ios::fixed) << std::setprecision(3) << cpy;
-  std::string ret = ss.str();
-  std::string::size_type pos = ret.find_last_not_of('0');
-  if (pos != std::string::npos) {
-    if (ret[pos] == '.') pos--;
-    ret = ret.substr(0, pos + 1);
+  return idx;
+}
+
+// Index of the unit named by `unit` ("g", "GB", "gb", ...), or -1 when it
+// names no unit we know of. Case insensitive, like decode_byte_units and
+// convert_to_byte_units: format_byte_units used to be the odd one out and
+// silently rendered value/1024^7 for a lowercase or misspelled unit (#1428).
+inline int byte_unit_index(const std::string &unit) {
+  if (unit.empty()) return -1;
+  const char c = static_cast<char>(std::toupper(static_cast<unsigned char>(unit[0])));
+  for (std::size_t i = 0; i < BKMG_SIZE; i++) {
+    if (BKMG_RANGE[i] == c) return static_cast<int>(i);
   }
-  ret += BKMG_RANGE[idx];
+  return -1;
+}
+
+// Name of the unit at `idx` ("B", "KB", "MB", ...).
+inline std::string byte_unit_name(const std::size_t idx) {
+  auto ret = std::string(1, BKMG_RANGE[idx > BKMG_SIZE ? BKMG_SIZE : idx]);
   if (idx > 0) ret += "B";
   return ret;
 }
-inline std::string format_byte_units(const unsigned long long i) {
-  auto cpy = static_cast<double>(i);
-  std::size_t idx = 0;
-  while ((cpy > 999) && (idx < BKMG_SIZE)) {
-    cpy /= 1024;
-    idx++;
-  }
-  std::stringstream ss;
-  ss << std::setiosflags(std::ios::fixed) << std::setprecision(3) << cpy;
-  std::string ret = ss.str();
-  std::string::size_type pos = ret.find_last_not_of('0');
-  if (pos != std::string::npos) {
-    if (ret[pos] == '.') pos--;
-    ret = ret.substr(0, pos + 1);
-  }
-  ret += BKMG_RANGE[idx];
-  if (idx > 0) ret += "B";
-  return ret;
+
+// Render a byte count as a human readable string with the unit appended
+// ("25.19GB"). `fmt.byte_unit` pins the unit; an empty one scales the value on
+// its own. An unparsable pinned unit falls back to auto-scaling - the option
+// parser rejects those up front, so reaching here means an internal caller.
+inline std::string format_byte_units(const double value, const number_format &fmt) {
+  const int pinned = byte_unit_index(fmt.byte_unit);
+  const std::size_t idx = pinned >= 0 ? static_cast<std::size_t>(pinned) : auto_scale_index(value);
+  double scaled = value;
+  for (std::size_t i = 0; i < idx; i++) scaled /= 1024;
+  return render_number(scaled, fmt) + byte_unit_name(idx);
 }
+inline std::string format_byte_units(const long long i) { return format_byte_units(static_cast<double>(i), number_format()); }
+inline std::string format_byte_units(const unsigned long long i) { return format_byte_units(static_cast<double>(i), number_format()); }
+inline std::string format_byte_units(const long long i, const number_format &fmt) { return format_byte_units(static_cast<double>(i), fmt); }
+inline std::string format_byte_units(const unsigned long long i, const number_format &fmt) { return format_byte_units(static_cast<double>(i), fmt); }
+
+// Convert a byte count into `unit`. An empty or unknown unit leaves the value
+// alone; dividing seven times for a unit nobody recognised (what this used to
+// do) turns a typo in perf-config into a metric off by 1024^7.
 template <class T>
 double convert_to_byte_units(T i, const std::string &unit) {
-  const std::string unit_uc = boost::to_upper_copy(unit);
-  std::size_t idx = 0;
-  if (unit_uc.empty()) {
-    return static_cast<double>(i);
-  }
+  const int idx = byte_unit_index(unit);
+  if (idx <= 0) return static_cast<double>(i);
   auto cpy = static_cast<double>(i);
-  while (idx < BKMG_SIZE) {
-    if (unit_uc[0] == BKMG_RANGE[idx]) {
-      return cpy;
-    }
-    cpy /= 1024.0;
-    idx++;
-  }
+  for (int n = 0; n < idx; n++) cpy /= 1024.0;
   return cpy;
 }
-template <class T>
-std::string format_byte_units(T value, std::string unit) {
-  std::stringstream ss;
-  auto cpy = static_cast<double>(value);
-  if (unit.empty()) {
-    ss << cpy;
-    return ss.str();
-  }
-  for (std::size_t i = 0; i < BKMG_SIZE; i++) {
-    if (unit[0] == BKMG_RANGE[i]) {
-      ss << std::setiosflags(std::ios::fixed) << std::setprecision(3) << cpy;
-      std::string s = ss.str();
-      std::string::size_type pos = s.find_last_not_of('0');
-      if (pos != std::string::npos) {
-        if (s[pos] == '.') {
-          if (pos == 0) {
-            // Handle strings like ".000" by normalizing to "0"
-            s = "0";
-            return s;
-          }
-          --pos;
-        }
-        s = s.substr(0, pos + 1);
-      }
-      return s;
-    }
-    cpy /= 1024;
-  }
-  ss << cpy;
-  return ss.str();
+
+// Render a byte count in `unit` *without* appending the unit - the caller
+// spells the unit out in its syntax string. An empty unit renders the raw
+// number; an unknown one throws, so a typo is reported rather than silently
+// rendering value/1024^7 (#1428).
+template <class T> std::string format_byte_units(T value, const std::string &unit, const number_format &fmt = number_format()) {
+  if (unit.empty()) return render_number(static_cast<double>(value), fmt);
+  const int idx = byte_unit_index(unit);
+  if (idx < 0) throw std::invalid_argument("Unknown byte unit: " + unit);
+  double scaled = static_cast<double>(value);
+  for (int n = 0; n < idx; n++) scaled /= 1024;
+  return render_number(scaled, fmt);
 }
-inline std::string find_proper_unit_BKMG(unsigned long long i) {
-  auto cpy = static_cast<double>(i);
-  std::size_t idx = 0;
-  while ((cpy > 999) && (idx < BKMG_SIZE)) {
-    cpy /= 1024;
-    idx++;
-  }
-  auto ret = std::string(1, BKMG_RANGE[idx]);
-  if (idx > 0) ret += "B";
-  return ret;
-}
+
+inline std::string find_proper_unit_BKMG(unsigned long long i) { return byte_unit_name(auto_scale_index(static_cast<double>(i))); }
 }  // namespace format
 }  // namespace str

--- a/include/str/format_test.cpp
+++ b/include/str/format_test.cpp
@@ -364,9 +364,54 @@ TEST(format, format_byte_units_with_empty_unit) {
 }
 
 TEST(format, format_byte_units_with_unknown_unit) {
-  // Unknown unit not in BKMG_RANGE: falls through the loop dividing by 1024 each time
-  std::string result = str::format::format_byte_units(0LL, "Z");
-  EXPECT_FALSE(result.empty());
+  // A unit nobody recognises is a typo in a syntax string, not a request to
+  // divide by 1024 seven times (#1428).
+  EXPECT_THROW(str::format::format_byte_units(1024LL, "Z"), std::invalid_argument);
+}
+
+TEST(format, format_byte_units_unit_is_case_insensitive) {
+  // decode_byte_units and convert_to_byte_units have always accepted "gb";
+  // format_byte_units used to silently render 1.27055e-10 for it.
+  EXPECT_EQ(str::format::format_byte_units(1024LL * 1024LL * 1024LL, "gb"), "1");
+  EXPECT_EQ(str::format::format_byte_units(1024LL * 1024LL * 1024LL, "g"), "1");
+  EXPECT_EQ(str::format::format_byte_units(2048LL, "kb"), "2");
+}
+
+TEST(format, format_byte_units_with_decimals) {
+  str::number_format fmt;
+  fmt.decimals = 2;
+  // Exactly two decimals, trailing zeros kept - a stable width is the point.
+  EXPECT_EQ(str::format::format_byte_units(1024LL * 1024LL * 1024LL, fmt), "1.00GB");
+  EXPECT_EQ(str::format::format_byte_units(5734563876LL, fmt), "5.34GB");
+  EXPECT_EQ(str::format::format_byte_units(5734563876LL, "G", fmt), "5.34");
+}
+
+TEST(format, format_byte_units_with_pinned_unit) {
+  str::number_format fmt;
+  fmt.decimals = 2;
+  fmt.byte_unit = "GB";
+  // Without a pinned unit these two land in different units, which is what
+  // makes "140.293GB/0.983TB" so hard to read (#1428).
+  EXPECT_EQ(str::format::format_byte_units(1006LL * 1024LL * 1024LL * 1024LL, fmt), "1006.00GB");
+  EXPECT_EQ(str::format::format_byte_units(140LL * 1024LL * 1024LL * 1024LL, fmt), "140.00GB");
+}
+
+TEST(format, format_byte_units_with_separators) {
+  str::number_format fmt;
+  fmt.decimals = 2;
+  fmt.byte_unit = "GB";
+  fmt.decimal_separator = ",";
+  fmt.thousands_separator = ".";
+  EXPECT_EQ(str::format::format_byte_units(1006LL * 1024LL * 1024LL * 1024LL, fmt), "1.006,00GB");
+}
+
+TEST(format, format_pct_with_number_format) {
+  str::number_format fmt;
+  EXPECT_EQ(str::format::format_pct(1LL, 3LL, fmt), "33.33");
+  fmt.decimals = 1;
+  EXPECT_EQ(str::format::format_pct(1LL, 3LL, fmt), "33.3");
+  fmt.decimal_separator = ",";
+  EXPECT_EQ(str::format::format_pct(1LL, 3LL, fmt), "33,3");
 }
 
 TEST(format, format_byte_units_zero_with_unit) {
@@ -376,10 +421,14 @@ TEST(format, format_byte_units_zero_with_unit) {
 }
 
 TEST(format, convert_to_byte_units_unknown_unit) {
-  // Unknown unit: divides through all BKMG_SIZE iterations
-  double result = str::format::convert_to_byte_units(1024LL, "Z");
-  // After 7 divisions by 1024, result is 1024 / 1024^7
-  EXPECT_GT(result, 0.0);
+  // A unit nobody recognises leaves the value alone; dividing seven times (what
+  // this used to do) turns a typo in perf-config into a metric off by 1024^7.
+  EXPECT_DOUBLE_EQ(str::format::convert_to_byte_units(1024LL, "Z"), 1024.0);
+}
+
+TEST(format, convert_to_byte_units_is_case_insensitive) {
+  EXPECT_DOUBLE_EQ(str::format::convert_to_byte_units(2048LL, "kb"), 2.0);
+  EXPECT_DOUBLE_EQ(str::format::convert_to_byte_units(1024LL * 1024LL, "m"), 1.0);
 }
 
 TEST(format, decode_time_with_long_type) {
@@ -539,11 +588,9 @@ TEST(format, convert_to_byte_units_int_type) {
 
 // format_byte_units<T>(value, unit) with non-zero unknown unit (falls through loop)
 TEST(format, format_byte_units_with_unit_unknown_nonzero) {
-  std::string result = str::format::format_byte_units(1024LL, "Z");
-  EXPECT_FALSE(result.empty());
-  // After dividing by 1024 seven times: 1024 / 1024^7 → very small number
-  double val = std::stod(result);
-  EXPECT_GT(val, 0.0);
+  // See format_byte_units_with_unknown_unit: an unknown unit is reported, not
+  // quietly rendered as value/1024^7 (#1428).
+  EXPECT_THROW(str::format::format_byte_units(1024LL, "Z"), std::invalid_argument);
 }
 
 // format_byte_units<T>(value, unit) with T (terabyte) unit

--- a/include/str/number_format.hpp
+++ b/include/str/number_format.hpp
@@ -10,6 +10,15 @@
 
 namespace str {
 
+// The largest number of decimals that is ever meaningful: a double carries at
+// most ~17 significant digits, so anything past this is noise. It also bounds
+// the width of a rendered number - std::setprecision(N) makes the stream build
+// an N-digit fraction, so an unbounded N (a config typo, or a hostile REST
+// argument) would try to allocate a huge string and crash the check. Callers
+// that take a decimals value from outside reject anything larger; render_fixed
+// clamps to it as a last-resort backstop so no path can trigger that.
+constexpr int max_decimals = 15;
+
 // How the human readable numbers of a check message are rendered (issue #1428).
 //
 // This describes the *message* and nothing else. Performance data is rendered
@@ -20,8 +29,8 @@ namespace str {
 struct number_format {
   // Decimals to render. -1 keeps the historical rendering: up to three
   // decimals with the trailing zeros stripped ("1KB", "70.874GB"). Anything
-  // >= 0 renders exactly that many ("25.19GB"), because a stable width is the
-  // whole point of asking for two decimals.
+  // in [0, max_decimals] renders exactly that many ("25.19GB"), because a
+  // stable width is the whole point of asking for two decimals.
   int decimals;
   // Unit to pin byte values to ("GB"); empty lets every value scale on its
   // own, which is why one drive reads "140.293GB/0.983TB" by default.
@@ -43,9 +52,13 @@ struct number_format {
 // three, trailing zeros stripped" - the rendering every byte value has used
 // since forever.
 inline std::string render_fixed(const double value, const int decimals) {
+  // Clamp as a backstop: the option and function-argument parsers already
+  // reject anything above max_decimals, but a settings key or an internal
+  // caller must never be able to hand setprecision an unbounded width.
+  const int precision = decimals < 0 ? 3 : (decimals > max_decimals ? max_decimals : decimals);
   std::ostringstream ss;
   ss.imbue(std::locale::classic());
-  ss << std::fixed << std::setprecision(decimals < 0 ? 3 : decimals) << value;
+  ss << std::fixed << std::setprecision(precision) << value;
   std::string ret = ss.str();
   if (decimals >= 0) return ret;
   const std::string::size_type pos = ret.find_last_not_of('0');

--- a/include/str/number_format.hpp
+++ b/include/str/number_format.hpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <iomanip>
+#include <locale>
+#include <sstream>
+#include <string>
+
+namespace str {
+
+// How the human readable numbers of a check message are rendered (issue #1428).
+//
+// This describes the *message* and nothing else. Performance data is rendered
+// separately (nscapi/protobuf/functions_perfdata.cpp) and has to stay locale
+// neutral, and so does every number the filter grammar parses back out of a
+// threshold - a decimal comma in either would break the consumers rather than
+// please them.
+struct number_format {
+  // Decimals to render. -1 keeps the historical rendering: up to three
+  // decimals with the trailing zeros stripped ("1KB", "70.874GB"). Anything
+  // >= 0 renders exactly that many ("25.19GB"), because a stable width is the
+  // whole point of asking for two decimals.
+  int decimals;
+  // Unit to pin byte values to ("GB"); empty lets every value scale on its
+  // own, which is why one drive reads "140.293GB/0.983TB" by default.
+  std::string byte_unit;
+  // Radix character; "," gives the European rendering.
+  std::string decimal_separator;
+  // Digit grouping for the integer part; empty means no grouping.
+  std::string thousands_separator;
+
+  number_format() : decimals(-1), decimal_separator(".") {}
+
+  // True while nothing has been overridden. Callers use it to take the exact
+  // legacy code path rather than a reimplementation of it, so an unconfigured
+  // check renders byte for byte what it always did.
+  bool is_default() const { return decimals == -1 && byte_unit.empty() && decimal_separator == "." && thousands_separator.empty(); }
+};
+
+// Render `value` with `decimals` decimals. A negative `decimals` means "up to
+// three, trailing zeros stripped" - the rendering every byte value has used
+// since forever.
+inline std::string render_fixed(const double value, const int decimals) {
+  std::ostringstream ss;
+  ss.imbue(std::locale::classic());
+  ss << std::fixed << std::setprecision(decimals < 0 ? 3 : decimals) << value;
+  std::string ret = ss.str();
+  if (decimals >= 0) return ret;
+  const std::string::size_type pos = ret.find_last_not_of('0');
+  if (pos == std::string::npos) return ret;
+  if (ret[pos] != '.') return ret.substr(0, pos + 1);
+  // Everything after the radix point was a zero: drop the point as well, and
+  // keep a leading "0" for a string that is nothing but the fraction.
+  return pos == 0 ? std::string("0") : ret.substr(0, pos);
+}
+
+// Swap in the configured separators. `plain` is a C-locale number, so the
+// radix character is a '.' and there is no grouping to undo.
+inline std::string apply_separators(const std::string &plain, const number_format &fmt) {
+  if (fmt.decimal_separator == "." && fmt.thousands_separator.empty()) return plain;
+  const std::string::size_type dot = plain.find('.');
+  std::string int_part = dot == std::string::npos ? plain : plain.substr(0, dot);
+  const std::string fraction = dot == std::string::npos ? std::string() : plain.substr(dot + 1);
+  if (!fmt.thousands_separator.empty()) {
+    const std::string::size_type first_digit = (!int_part.empty() && (int_part[0] == '-' || int_part[0] == '+')) ? 1 : 0;
+    for (std::string::size_type i = int_part.size(); i > first_digit + 3;) {
+      i -= 3;
+      int_part.insert(i, fmt.thousands_separator);
+    }
+  }
+  if (fraction.empty()) return int_part;
+  return int_part + (fmt.decimal_separator.empty() ? "." : fmt.decimal_separator) + fraction;
+}
+
+inline std::string render_number(const double value, const number_format &fmt) { return apply_separators(render_fixed(value, fmt.decimals), fmt); }
+
+}  // namespace str

--- a/include/str/number_format_test.cpp
+++ b/include/str/number_format_test.cpp
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include <gtest/gtest.h>
+
+#include <str/number_format.hpp>
+
+// The default has to render byte for byte what the checks always rendered, so
+// that a check nobody configured keeps its output (#1428).
+TEST(number_format, DefaultIsTheHistoricalRendering) {
+  const str::number_format fmt;
+  EXPECT_TRUE(fmt.is_default());
+  EXPECT_EQ(str::render_number(1.0, fmt), "1");
+  EXPECT_EQ(str::render_number(25.191, fmt), "25.191");
+  EXPECT_EQ(str::render_number(25.1915, fmt), "25.192");
+  EXPECT_EQ(str::render_number(0.0, fmt), "0");
+  EXPECT_EQ(str::render_number(-70.874, fmt), "-70.874");
+}
+
+TEST(number_format, FixedDecimalsKeepTrailingZeros) {
+  str::number_format fmt;
+  fmt.decimals = 2;
+  EXPECT_FALSE(fmt.is_default());
+  EXPECT_EQ(str::render_number(1.0, fmt), "1.00");
+  EXPECT_EQ(str::render_number(25.191, fmt), "25.19");
+  EXPECT_EQ(str::render_number(25.195, fmt), "25.20");
+}
+
+TEST(number_format, ZeroDecimalsRoundsToWhole) {
+  str::number_format fmt;
+  fmt.decimals = 0;
+  EXPECT_EQ(str::render_number(25.6, fmt), "26");
+  EXPECT_EQ(str::render_number(-25.6, fmt), "-26");
+}
+
+TEST(number_format, DecimalSeparator) {
+  str::number_format fmt;
+  fmt.decimals = 2;
+  fmt.decimal_separator = ",";
+  EXPECT_EQ(str::render_number(25.191, fmt), "25,19");
+  EXPECT_EQ(str::render_number(-25.191, fmt), "-25,19");
+}
+
+TEST(number_format, ThousandsSeparator) {
+  str::number_format fmt;
+  fmt.decimals = 2;
+  fmt.decimal_separator = ",";
+  fmt.thousands_separator = ".";
+  EXPECT_EQ(str::render_number(1006.85, fmt), "1.006,85");
+  EXPECT_EQ(str::render_number(1234567.5, fmt), "1.234.567,50");
+  EXPECT_EQ(str::render_number(-1234.5, fmt), "-1.234,50");
+  EXPECT_EQ(str::render_number(999.5, fmt), "999,50");
+}
+
+TEST(number_format, ThousandsSeparatorWithoutDecimals) {
+  str::number_format fmt;
+  fmt.decimals = 0;
+  fmt.thousands_separator = " ";
+  EXPECT_EQ(str::render_number(1234567.0, fmt), "1 234 567");
+}
+
+TEST(number_format, MultiCharacterSeparators) {
+  str::number_format fmt;
+  fmt.decimals = 1;
+  fmt.thousands_separator = "'";
+  fmt.decimal_separator = "::";
+  EXPECT_EQ(str::render_number(12345.6, fmt), "12'345::6");
+}
+
+TEST(number_format, ApplySeparatorsIsANoOpForTheDefault) {
+  const str::number_format fmt;
+  EXPECT_EQ(str::apply_separators("1234.5", fmt), "1234.5");
+}
+
+TEST(number_format, RenderFixedStripsTrailingZerosOnlyWhenAsked) {
+  EXPECT_EQ(str::render_fixed(1.5, -1), "1.5");
+  EXPECT_EQ(str::render_fixed(1.5, 3), "1.500");
+  EXPECT_EQ(str::render_fixed(1.0, -1), "1");
+  EXPECT_EQ(str::render_fixed(1.0, 0), "1");
+}

--- a/include/str/number_format_test.cpp
+++ b/include/str/number_format_test.cpp
@@ -78,3 +78,16 @@ TEST(number_format, RenderFixedStripsTrailingZerosOnlyWhenAsked) {
   EXPECT_EQ(str::render_fixed(1.0, -1), "1");
   EXPECT_EQ(str::render_fixed(1.0, 0), "1");
 }
+
+// A huge decimals count used to make setprecision build a multi-megabyte
+// string and crash the process; render_fixed clamps to max_decimals as a
+// backstop so no caller (a config typo, a hostile REST argument) can trigger
+// that. The clamp caps the width, not the value.
+TEST(number_format, RenderFixedClampsRunawayDecimals) {
+  const std::string clamped = str::render_fixed(1.5, 1000000000);
+  EXPECT_EQ(clamped.size(), std::string("1.").size() + str::max_decimals);
+  EXPECT_EQ(clamped, "1.500000000000000");
+  str::number_format fmt;
+  fmt.decimals = 1000000000;
+  EXPECT_EQ(str::render_number(1.5, fmt), "1.500000000000000");
+}

--- a/include/win/processes.hpp
+++ b/include/win/processes.hpp
@@ -5,6 +5,7 @@
 
 #include <list>
 #include <memory>
+#include <parsers/where/node.hpp>
 #include <str/format.hpp>
 #include <str/xtos.hpp>
 #include <string>
@@ -74,8 +75,10 @@ struct string_var {
   long long get_##name() const { return (name).get(); }
 #define BOL_GETTER(name) \
   bool get_##name() const { return (name).get(); }
-#define HUMAN_SIZE_GETTER(name) \
-  std::string get_##name##_human() const { return str::format::format_byte_units((name).get()); }
+#define HUMAN_SIZE_GETTER(name)                                                                                \
+  std::string get_##name##_human(parsers::where::evaluation_context context) const {                           \
+    return str::format::format_byte_units(static_cast<long long>((name).get()), context->get_number_format()); \
+  }
 
 struct process_info {
   string_var filename;

--- a/modules/CheckDisk/check_disk_health.cpp
+++ b/modules/CheckDisk/check_disk_health.cpp
@@ -129,10 +129,10 @@ std::function<boost::optional<long long>(std::shared_ptr<filter_obj>)> space_val
 
 // Rendering counterpart of the above: bytes as a human-readable string,
 // percentages with their sign, and a dash where there is no space data.
-std::function<std::string(std::shared_ptr<filter_obj>)> space_bytes_human(const space_getter getter) {
-  return [getter](const std::shared_ptr<filter_obj> obj) -> std::string {
+std::function<std::string(std::shared_ptr<filter_obj>, parsers::where::evaluation_context)> space_bytes_human(const space_getter getter) {
+  return [getter](const std::shared_ptr<filter_obj> obj, const parsers::where::evaluation_context context) -> std::string {
     if (!obj->has_space) return "-";
-    return str::format::format_byte_units(((*obj).*getter)());
+    return str::format::format_byte_units(((*obj).*getter)(), context->get_number_format());
   };
 }
 
@@ -231,11 +231,11 @@ filter_obj_handler::filter_obj_handler() {
   // a raw byte count, and a row with no filesystem prints `-` instead of a
   // fabricated zero. Thresholds and perfdata keep using the numeric variables
   // above, exactly as in check_drivesize.
-  registry_.add_human_string("size", space_bytes_human(&filter_obj::get_total), "")
-      .add_human_string("total", space_bytes_human(&filter_obj::get_total), "")  // deprecated alias for size
-      .add_human_string("free", space_bytes_human(&filter_obj::get_free), "")
-      .add_human_string("used", space_bytes_human(&filter_obj::get_used), "")
-      .add_human_string("user_free", space_bytes_human(&filter_obj::get_user_free), "")
+  registry_.add_human_string_context("size", space_bytes_human(&filter_obj::get_total), "")
+      .add_human_string_context("total", space_bytes_human(&filter_obj::get_total), "")  // deprecated alias for size
+      .add_human_string_context("free", space_bytes_human(&filter_obj::get_free), "")
+      .add_human_string_context("used", space_bytes_human(&filter_obj::get_used), "")
+      .add_human_string_context("user_free", space_bytes_human(&filter_obj::get_user_free), "")
       .add_human_string("free_pct", space_pct_human(&filter_obj::get_free_pct), "")
       .add_human_string("used_pct", space_pct_human(&filter_obj::get_used_pct), "");
 

--- a/modules/CheckDisk/check_drive_unix.cpp
+++ b/modules/CheckDisk/check_drive_unix.cpp
@@ -5,15 +5,13 @@
 // query space via statvfs. Field registration / derived math / filter
 // scaffolding mirror check_drive_win.cpp so queries are portable.
 
-#include "check_drive.hpp"
-
 #include <mntent.h>
 #include <sys/statvfs.h>
 
 #include <algorithm>
-#include <ctime>
 #include <boost/algorithm/string.hpp>
 #include <boost/program_options.hpp>
+#include <ctime>
 #include <list>
 #include <memory>
 #include <nscapi/macros.hpp>
@@ -22,6 +20,7 @@
 #include <parsers/filter/cli_helper.hpp>
 #include <parsers/filter/modern_filter.hpp>
 #include <parsers/where/filter_handler_impl.hpp>
+#include <parsers/where/format_functions.hpp>
 #include <parsers/where/helpers.hpp>
 #include <set>
 #include <str/format.hpp>
@@ -29,6 +28,7 @@
 #include <utility>
 #include <vector>
 
+#include "check_drive.hpp"
 #include "drive_trend.hpp"
 
 namespace po = boost::program_options;
@@ -257,25 +257,35 @@ struct filter_obj {
 
   std::string get_user_free_pct_human(parsers::where::evaluation_context context) {
     get_size(context);
-    return str::format::format_pct(user_free, drive_size);
+    return str::format::format_pct(user_free, drive_size, context->get_number_format());
   }
   std::string get_total_free_pct_human(parsers::where::evaluation_context context) {
     get_size(context);
-    return str::format::format_pct(total_free, drive_size);
+    return str::format::format_pct(total_free, drive_size, context->get_number_format());
   }
   std::string get_user_used_pct_human(parsers::where::evaluation_context context) {
     get_size(context);
-    return str::format::format_pct(drive_size - user_free, drive_size);
+    return str::format::format_pct(drive_size - user_free, drive_size, context->get_number_format());
   }
   std::string get_total_used_pct_human(parsers::where::evaluation_context context) {
     get_size(context);
-    return str::format::format_pct(drive_size - total_free, drive_size);
+    return str::format::format_pct(drive_size - total_free, drive_size, context->get_number_format());
   }
-  std::string get_user_free_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_user_free(context)); }
-  std::string get_total_free_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_total_free(context)); }
-  std::string get_drive_size_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_drive_size(context)); }
-  std::string get_total_used_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_total_used(context)); }
-  std::string get_user_used_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_user_used(context)); }
+  std::string get_user_free_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_user_free(context), context->get_number_format());
+  }
+  std::string get_total_free_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_total_free(context), context->get_number_format());
+  }
+  std::string get_drive_size_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_drive_size(context), context->get_number_format());
+  }
+  std::string get_total_used_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_total_used(context), context->get_number_format());
+  }
+  std::string get_user_used_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_user_used(context), context->get_number_format());
+  }
 
   long long get_type(parsers::where::evaluation_context) const { return drive.type; }
   std::string get_type_as_string(parsers::where::evaluation_context context) { return type_to_string(get_type(context)); }
@@ -300,7 +310,7 @@ struct filter_obj {
   long long get_trend_span() const { return is_total_ ? trend_total_.span : trend_.span; }
   long long get_trend_samples() const { return is_total_ ? trend_total_.samples : trend_.samples; }
   std::string get_full_in_human(parsers::where::evaluation_context context) { return drive_trend::format_full_in(get_full_in(context)); }
-  std::string get_rate_human(parsers::where::evaluation_context) const { return drive_trend::format_rate(get_rate()); }
+  std::string get_rate_human(parsers::where::evaluation_context context) const { return drive_trend::format_rate(get_rate(), context->get_number_format()); }
 
   void append(const std::shared_ptr<filter_obj> &other) {
     user_free += other->user_free;
@@ -473,6 +483,11 @@ struct filter_obj_handler : public native_context {
                          return drive_trend::parse_time_node(context, subject);
                        })
         .add_converter(type_custom_type, &convert_type);
+
+    // Byte-valued keywords with no arithmetic in the grammar: without these a
+    // template can only print the raw count, and there is no way at all to ask
+    // for a fixed unit or a different precision (#1392, #1428).
+    parsers::where::format_functions::register_format_functions(registry_);
   }
 };
 

--- a/modules/CheckDisk/check_drive_win.cpp
+++ b/modules/CheckDisk/check_drive_win.cpp
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: 2004-2026 Michael Medin
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 
-#include "check_drive.hpp"
-
 #include <boost/program_options.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <bytes/char_buffer.hpp>
@@ -17,11 +15,13 @@
 #include <parsers/filter/cli_helper.hpp>
 #include <parsers/filter/modern_filter.hpp>
 #include <parsers/where/filter_handler_impl.hpp>
+#include <parsers/where/format_functions.hpp>
 #include <parsers/where/helpers.hpp>
 #include <str/format.hpp>
 #include <str/xtos.hpp>
 #include <utility>
 
+#include "check_drive.hpp"
 #include "drive_trend.hpp"
 
 #ifdef WIN32
@@ -172,26 +172,36 @@ struct filter_obj {
 
   std::string get_user_free_pct_human(parsers::where::evaluation_context context) {
     get_size(context);
-    return str::format::format_pct(user_free, drive_size);
+    return str::format::format_pct(user_free, drive_size, context->get_number_format());
   }
   std::string get_total_free_pct_human(parsers::where::evaluation_context context) {
     get_size(context);
-    return str::format::format_pct(total_free, drive_size);
+    return str::format::format_pct(total_free, drive_size, context->get_number_format());
   }
   std::string get_user_used_pct_human(parsers::where::evaluation_context context) {
     get_size(context);
-    return str::format::format_pct(drive_size - user_free, drive_size);
+    return str::format::format_pct(drive_size - user_free, drive_size, context->get_number_format());
   }
   std::string get_total_used_pct_human(parsers::where::evaluation_context context) {
     get_size(context);
-    return str::format::format_pct(drive_size - total_free, drive_size);
+    return str::format::format_pct(drive_size - total_free, drive_size, context->get_number_format());
   }
 
-  std::string get_user_free_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_user_free(context)); }
-  std::string get_total_free_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_total_free(context)); }
-  std::string get_drive_size_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_drive_size(context)); }
-  std::string get_total_used_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_total_used(context)); }
-  std::string get_user_used_human(parsers::where::evaluation_context context) { return str::format::format_byte_units(get_user_used(context)); }
+  std::string get_user_free_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_user_free(context), context->get_number_format());
+  }
+  std::string get_total_free_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_total_free(context), context->get_number_format());
+  }
+  std::string get_drive_size_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_drive_size(context), context->get_number_format());
+  }
+  std::string get_total_used_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_total_used(context), context->get_number_format());
+  }
+  std::string get_user_used_human(parsers::where::evaluation_context context) {
+    return str::format::format_byte_units(get_user_used(context), context->get_number_format());
+  }
 
   std::string get_type_as_string(parsers::where::evaluation_context context) { return type_to_string(get_type(context)); }
 
@@ -294,7 +304,7 @@ struct filter_obj {
   long long get_trend_span() const { return is_total_ ? trend_total_.span : trend_.span; }
   long long get_trend_samples() const { return is_total_ ? trend_total_.samples : trend_.samples; }
   std::string get_full_in_human(parsers::where::evaluation_context context) { return drive_trend::format_full_in(get_full_in(context)); }
-  std::string get_rate_human(parsers::where::evaluation_context) const { return drive_trend::format_rate(get_rate()); }
+  std::string get_rate_human(parsers::where::evaluation_context context) const { return drive_trend::format_rate(get_rate(), context->get_number_format()); }
 
   void append(std::shared_ptr<filter_obj> other) {
     user_free += other->user_free;
@@ -490,6 +500,11 @@ struct filter_obj_handler : public native_context {
                          return drive_trend::parse_time_node(context, subject);
                        })
         .add_converter(type_custom_type, &convert_type);
+
+    // Byte-valued keywords with no arithmetic in the grammar: without these a
+    // template can only print the raw count, and there is no way at all to ask
+    // for a fixed unit or a different precision (#1392, #1428).
+    parsers::where::format_functions::register_format_functions(registry_);
   }
 };
 

--- a/modules/CheckDisk/check_uncpath.cpp
+++ b/modules/CheckDisk/check_uncpath.cpp
@@ -27,9 +27,15 @@ namespace po = boost::program_options;
 
 namespace uncpath_check {
 
-std::string unc_obj::get_free_human() const { return str::format::format_byte_units(free); }
-std::string unc_obj::get_used_human() const { return str::format::format_byte_units(get_used()); }
-std::string unc_obj::get_size_human() const { return str::format::format_byte_units(size); }
+std::string unc_obj::get_free_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(free, context->get_number_format());
+}
+std::string unc_obj::get_used_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(get_used(), context->get_number_format());
+}
+std::string unc_obj::get_size_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(size, context->get_number_format());
+}
 
 #ifdef WIN32
 unc_obj query(const std::string &path, const std::string &user, const std::string &password) {
@@ -116,9 +122,9 @@ filter_obj_handler::filter_obj_handler() {
       .add_int_var("used_pct", &filter_obj::get_used_pct, "Percentage of used space")
       .add_int_perf("%", "", "_used_pct");
 
-  registry_.add_human_string("size", &filter_obj::get_size_human, "")
-      .add_human_string("free", &filter_obj::get_free_human, "")
-      .add_human_string("used", &filter_obj::get_used_human, "");
+  registry_.add_human_string_context("size", &filter_obj::get_size_human, "")
+      .add_human_string_context("free", &filter_obj::get_free_human, "")
+      .add_human_string_context("used", &filter_obj::get_used_human, "");
 
   // The human strings above auto-scale; these let a template or a threshold
   // pick the unit (and cover user_free, which has no human form).

--- a/modules/CheckDisk/check_uncpath.hpp
+++ b/modules/CheckDisk/check_uncpath.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <nscapi/protobuf/command.hpp>
+#include <parsers/where/node.hpp>
 #include <string>
 
 namespace uncpath_check {
@@ -28,9 +29,9 @@ struct unc_obj {
   long long get_user_free() const { return user_free; }
   long long get_free_pct() const { return size == 0 ? 0 : (free * 100 / size); }
   long long get_used_pct() const { return size == 0 ? 0 : ((size - free) * 100 / size); }
-  std::string get_free_human() const;
-  std::string get_used_human() const;
-  std::string get_size_human() const;
+  std::string get_free_human(parsers::where::evaluation_context context) const;
+  std::string get_used_human(parsers::where::evaluation_context context) const;
+  std::string get_size_human(parsers::where::evaluation_context context) const;
 
   std::string show() const { return path; }
 };

--- a/modules/CheckDisk/drive_trend.hpp
+++ b/modules/CheckDisk/drive_trend.hpp
@@ -100,10 +100,10 @@ inline std::string format_full_in(const boost::optional<long long> &v) {
   return str::format::itos_as_time(static_cast<unsigned long long>(*v < 0 ? 0 : *v) * 1000);
 }
 
-inline std::string format_rate(const boost::optional<long long> &v) {
+inline std::string format_rate(const boost::optional<long long> &v, const str::number_format &fmt = str::number_format()) {
   if (!v) return "unknown";
-  if (*v < 0) return "-" + str::format::format_byte_units(-*v) + "/day";
-  return str::format::format_byte_units(*v) + "/day";
+  if (*v < 0) return "-" + str::format::format_byte_units(-*v, fmt) + "/day";
+  return str::format::format_byte_units(*v, fmt) + "/day";
 }
 
 // Duration literal ("12h", or the tokenized [12, h] list form) to seconds, as

--- a/modules/CheckDocker/check_docker_stats.cpp
+++ b/modules/CheckDocker/check_docker_stats.cpp
@@ -36,7 +36,10 @@ struct stats_obj {
   long long get_memory_used() const { return memory_used; }
   long long get_memory_limit() const { return memory_limit; }
   long long get_memory_pct() const { return memory_limit > 0 ? memory_used * 100 / memory_limit : 0; }
-  std::string get_memory_human() const { return str::format::format_byte_units(memory_used) + " of " + str::format::format_byte_units(memory_limit); }
+  std::string get_memory_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(memory_used, context->get_number_format()) + " of " +
+           str::format::format_byte_units(memory_limit, context->get_number_format());
+  }
 };
 
 // One /containers/{id}/stats?stream=false sample -> cpu% and memory usage.
@@ -76,8 +79,8 @@ struct stats_obj_handler : public stats_context {
   stats_obj_handler() {
     registry_.add_string_var("names", &stats_obj::get_names, "Container name(s), comma separated")
         .add_string_var("image", &stats_obj::get_image, "Image the container was created from")
-        .add_string_var("memory", &stats_obj::get_memory_human,
-                        "Memory usage as human readable text, e.g. 45.2M of 512M (display only; threshold on memory_used or memory_pct)");
+        .add_string_var_w_context("memory", &stats_obj::get_memory_human,
+                                  "Memory usage as human readable text, e.g. 45.2M of 512M (display only; threshold on memory_used or memory_pct)");
     registry_.add_int_var("cpu_pct", &stats_obj::get_cpu_pct, "CPU usage in percent of the host (like docker stats)")
         .add_int_perf("%", "", " cpu")
         .add_int_var("memory_pct", &stats_obj::get_memory_pct, "Memory usage in percent of the container's limit")

--- a/modules/CheckSystem/check_cpu_frequency.cpp
+++ b/modules/CheckSystem/check_cpu_frequency.cpp
@@ -65,8 +65,12 @@ void cpu_frequency::read_wmi(const wmi_impl::row &r) {
   architecture = arch ? architecture_to_string(*arch) : "unknown";
 }
 
-std::string cpu_frequency::get_l2_cache_human() const { return str::format::format_byte_units(l2_cache); }
-std::string cpu_frequency::get_l3_cache_human() const { return str::format::format_byte_units(l3_cache); }
+std::string cpu_frequency::get_l2_cache_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(l2_cache, context->get_number_format());
+}
+std::string cpu_frequency::get_l3_cache_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(l3_cache, context->get_number_format());
+}
 
 void cpu_frequency::build_metrics(PB::Metrics::MetricsBundle *section) const {
   using namespace nscapi::metrics;
@@ -159,8 +163,8 @@ filter_obj_handler::filter_obj_handler() {
   registry_.add_string_var("architecture", &filter_obj::get_architecture, "Processor architecture (x86, x64, ARM64, ...)");
 
   // Render the cache sizes human-readable; expressions keep comparing bytes.
-  registry_.add_human_string("l2_cache", &filter_obj::get_l2_cache_human, "L2 cache as a human-readable size")
-      .add_human_string("l3_cache", &filter_obj::get_l3_cache_human, "L3 cache as a human-readable size");
+  registry_.add_human_string_context("l2_cache", &filter_obj::get_l2_cache_human, "L2 cache as a human-readable size")
+      .add_human_string_context("l3_cache", &filter_obj::get_l3_cache_human, "L3 cache as a human-readable size");
 }
 
 void check_cpu_frequency(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,

--- a/modules/CheckSystem/check_cpu_frequency.hpp
+++ b/modules/CheckSystem/check_cpu_frequency.hpp
@@ -8,6 +8,7 @@
 #include <list>
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/protobuf/metrics.hpp>
+#include <parsers/where/node.hpp>
 #include <string>
 #include <win/wmi/wmi_query.hpp>
 
@@ -58,8 +59,8 @@ struct cpu_frequency {
   long long get_frequency_pct() const { return max_mhz == 0 ? 0 : (current_mhz * 100 / max_mhz); }
   long long get_l2_cache() const { return l2_cache; }
   long long get_l3_cache() const { return l3_cache; }
-  std::string get_l2_cache_human() const;
-  std::string get_l3_cache_human() const;
+  std::string get_l2_cache_human(parsers::where::evaluation_context context) const;
+  std::string get_l3_cache_human(parsers::where::evaluation_context context) const;
   std::string get_architecture() const { return architecture; }
 
   std::string show() const { return name; }

--- a/modules/CheckSystem/check_cpu_frequency_test.cpp
+++ b/modules/CheckSystem/check_cpu_frequency_test.cpp
@@ -10,8 +10,36 @@
 #include "check_cpu_frequency.hpp"
 
 #include <algorithm>
+#include <parsers/where/node.hpp>
+#include <str/number_format.hpp>
 #include <string>
 #include <vector>
+
+namespace {
+
+// Minimal evaluation context carrying the number format the human readable
+// getters render through (#1428).
+struct mock_evaluation_context final : parsers::where::evaluation_context_interface {
+  bool has_error() const override { return false; }
+  std::string get_error() const override { return ""; }
+  void error(std::string) override {}
+  bool has_warn() const override { return false; }
+  std::string get_warn() const override { return ""; }
+  void warn(std::string) override {}
+  void clear() override {}
+  void enable_debug(bool) override {}
+  bool debug_enabled() override { return false; }
+  std::string get_debug() const override { return ""; }
+  void debug(parsers::where::object_match) override {}
+};
+
+parsers::where::evaluation_context make_context(const str::number_format &fmt = str::number_format()) {
+  auto ctx = std::make_shared<mock_evaluation_context>();
+  ctx->set_number_format(fmt);
+  return ctx;
+}
+
+}  // namespace
 
 // ============================================================================
 // cpu_frequency struct tests
@@ -153,11 +181,19 @@ TEST(CpuFrequency, CacheAccessorsAndHumanRendering) {
   c.l3_cache = 16LL * 1024 * 1024;
   EXPECT_EQ(c.get_l2_cache(), 512LL * 1024);
   EXPECT_EQ(c.get_l3_cache(), 16LL * 1024 * 1024);
-  EXPECT_EQ(c.get_l2_cache_human(), "512KB");
-  EXPECT_EQ(c.get_l3_cache_human(), "16MB");
+  EXPECT_EQ(c.get_l2_cache_human(make_context()), "512KB");
+  EXPECT_EQ(c.get_l3_cache_human(make_context()), "16MB");
   // Unreported caches render as 0B rather than failing.
   const cpu_frequency_check::cpu_frequency empty;
-  EXPECT_EQ(empty.get_l2_cache_human(), "0B");
+  EXPECT_EQ(empty.get_l2_cache_human(make_context()), "0B");
+
+  // The context carries the check's rendering options (#1428).
+  str::number_format fmt;
+  fmt.decimals = 2;
+  fmt.byte_unit = "KB";
+  const parsers::where::evaluation_context pinned = make_context(fmt);
+  EXPECT_EQ(c.get_l2_cache_human(pinned), "512.00KB");
+  EXPECT_EQ(c.get_l3_cache_human(pinned), "16384.00KB");
 }
 
 TEST(CpuFrequency, SocketAndLoadAccessors) {

--- a/modules/CheckSystem/check_hardware.cpp
+++ b/modules/CheckSystem/check_hardware.cpp
@@ -113,7 +113,9 @@ void hardware_info::recompute() {
   }
 }
 
-std::string hardware_info::get_memory_human() const { return str::format::format_byte_units(memory); }
+std::string hardware_info::get_memory_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(memory, context->get_number_format());
+}
 
 filter_obj_handler::filter_obj_handler() {
   // clang-format off
@@ -133,7 +135,7 @@ filter_obj_handler::filter_obj_handler() {
                    "Total installed memory (supports size units, e.g. 'memory < 64G'); renders human-readable")
       .add_int_var("memory_speed", &hardware_info::get_memory_speed, "Slowest populated module's configured clock in MHz (0 when unknown)");
   // Render ${memory} human-readable (64GB) while expressions keep comparing bytes.
-  registry_.add_human_string("memory", &hardware_info::get_memory_human, "Total installed memory as a human-readable size");
+  registry_.add_human_string_context("memory", &hardware_info::get_memory_human, "Total installed memory as a human-readable size");
   // clang-format on
 }
 

--- a/modules/CheckSystem/check_hardware.hpp
+++ b/modules/CheckSystem/check_hardware.hpp
@@ -67,7 +67,7 @@ struct hardware_info {
   long long get_slots() const { return slots; }
   long long get_modules() const { return modules; }
   long long get_memory() const { return memory; }
-  std::string get_memory_human() const;
+  std::string get_memory_human(parsers::where::evaluation_context context) const;
   long long get_memory_speed() const { return memory_speed; }
   std::string get_module_list() const { return module_list; }
 

--- a/modules/CheckSystem/check_hardware_test.cpp
+++ b/modules/CheckSystem/check_hardware_test.cpp
@@ -12,6 +12,23 @@ using hardware_check::parse_first_array_int;
 
 namespace {
 
+// Minimal evaluation context carrying the default number format.
+struct mock_evaluation_context final : parsers::where::evaluation_context_interface {
+  bool has_error() const override { return false; }
+  std::string get_error() const override { return ""; }
+  void error(std::string) override {}
+  bool has_warn() const override { return false; }
+  std::string get_warn() const override { return ""; }
+  void warn(std::string) override {}
+  void clear() override {}
+  void enable_debug(bool) override {}
+  bool debug_enabled() override { return false; }
+  std::string get_debug() const override { return ""; }
+  void debug(parsers::where::object_match) override {}
+};
+
+parsers::where::evaluation_context make_context() { return std::make_shared<mock_evaluation_context>(); }
+
 std::string join_lines(const PB::Commands::QueryResponseMessage::Response &r) {
   std::string out;
   for (int i = 0; i < r.lines_size(); ++i) {
@@ -90,7 +107,7 @@ TEST(CheckHardware, RecomputeAggregatesModules) {
   EXPECT_EQ(h.memory, 64LL * 1024 * 1024 * 1024);
   EXPECT_EQ(h.memory_speed, 4400);  // slowest module
   EXPECT_EQ(h.module_list, "DIMM_A1: 32GB@4800MHz; DIMM_B1: 32GB@4400MHz");
-  EXPECT_EQ(h.get_memory_human(), "64GB");
+  EXPECT_EQ(h.get_memory_human(make_context()), "64GB");
 }
 
 // --- rendering / thresholds ------------------------------------------------------

--- a/modules/CheckSystem/check_kernel_memory.cpp
+++ b/modules/CheckSystem/check_kernel_memory.cpp
@@ -15,12 +15,21 @@ namespace kernel_memory_check {
 
 using parsers::where::type_size;
 
-std::string kernel_memory_obj::get_pool_paged_human() const { return str::format::format_byte_units(pool_paged); }
-std::string kernel_memory_obj::get_pool_nonpaged_human() const { return str::format::format_byte_units(pool_nonpaged); }
-std::string kernel_memory_obj::get_cache_human() const { return str::format::format_byte_units(cache); }
+std::string kernel_memory_obj::get_pool_paged_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(pool_paged, context->get_number_format());
+}
+std::string kernel_memory_obj::get_pool_nonpaged_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(pool_nonpaged, context->get_number_format());
+}
+std::string kernel_memory_obj::get_cache_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(cache, context->get_number_format());
+}
 
 std::string kernel_memory_obj::show() const {
-  return "paged pool " + get_pool_paged_human() + ", nonpaged pool " + get_pool_nonpaged_human() + ", cache " + get_cache_human();
+  // Debug output, so the plain rendering rather than the check's number format
+  // (which lives on the evaluation context and is not in reach here).
+  return "paged pool " + str::format::format_byte_units(pool_paged) + ", nonpaged pool " + str::format::format_byte_units(pool_nonpaged) + ", cache " +
+         str::format::format_byte_units(cache);
 }
 
 kernel_memory_obj make_kernel_memory_obj(const long long pool_paged, const long long pool_nonpaged, const long long cache, const double page_faults,
@@ -50,9 +59,9 @@ filter_obj_handler::filter_obj_handler() {
       .add_float("hard_faults_per_sec", &kernel_memory_obj::get_hard_faults,
                  "Hard faults per second (Page Reads/sec): faults that had to read from disk — the fault-storm signal");
   // Render the three byte gauges human-readable; expressions keep comparing bytes.
-  registry_.add_human_string("pool_paged", &kernel_memory_obj::get_pool_paged_human, "Paged pool as a human-readable size")
-      .add_human_string("pool_nonpaged", &kernel_memory_obj::get_pool_nonpaged_human, "Nonpaged pool as a human-readable size")
-      .add_human_string("cache", &kernel_memory_obj::get_cache_human, "File cache as a human-readable size");
+  registry_.add_human_string_context("pool_paged", &kernel_memory_obj::get_pool_paged_human, "Paged pool as a human-readable size")
+      .add_human_string_context("pool_nonpaged", &kernel_memory_obj::get_pool_nonpaged_human, "Nonpaged pool as a human-readable size")
+      .add_human_string_context("cache", &kernel_memory_obj::get_cache_human, "File cache as a human-readable size");
   // clang-format on
 }
 

--- a/modules/CheckSystem/check_kernel_memory.hpp
+++ b/modules/CheckSystem/check_kernel_memory.hpp
@@ -30,9 +30,9 @@ struct kernel_memory_obj {
   long long get_pool_paged() const { return pool_paged; }
   long long get_pool_nonpaged() const { return pool_nonpaged; }
   long long get_cache() const { return cache; }
-  std::string get_pool_paged_human() const;
-  std::string get_pool_nonpaged_human() const;
-  std::string get_cache_human() const;
+  std::string get_pool_paged_human(parsers::where::evaluation_context context) const;
+  std::string get_pool_nonpaged_human(parsers::where::evaluation_context context) const;
+  std::string get_cache_human(parsers::where::evaluation_context context) const;
   double get_page_faults() const { return page_faults; }
   double get_transition_faults() const { return transition_faults; }
   double get_hard_faults() const { return hard_faults; }

--- a/modules/CheckSystem/check_memory.cpp
+++ b/modules/CheckSystem/check_memory.cpp
@@ -9,6 +9,7 @@
 #include <parsers/filter/modern_filter.hpp>
 #include <parsers/filter/realtime_helper.hpp>
 #include <parsers/where/filter_handler_impl.hpp>
+#include <parsers/where/format_functions.hpp>
 #include <parsers/where/node.hpp>
 #include <str/format.hpp>
 #include <string>
@@ -33,13 +34,23 @@ struct filter_obj {
   long long get_free() const { return total - used; }
   long long get_used_pct() const { return str::format::calc_pct_round(get_used(), get_total()); }
   long long get_free_pct() const { return str::format::calc_pct_round(get_free(), get_total()); }
-  std::string get_used_pct_human() const { return str::format::format_pct(get_used(), get_total()); }
-  std::string get_free_pct_human() const { return str::format::format_pct(get_free(), get_total()); }
+  std::string get_used_pct_human(parsers::where::evaluation_context context) const {
+    return str::format::format_pct(get_used(), get_total(), context->get_number_format());
+  }
+  std::string get_free_pct_human(parsers::where::evaluation_context context) const {
+    return str::format::format_pct(get_free(), get_total(), context->get_number_format());
+  }
   std::string get_type() const { return type; }
 
-  std::string get_total_human() const { return str::format::format_byte_units(get_total()); }
-  std::string get_used_human() const { return str::format::format_byte_units(get_used()); }
-  std::string get_free_human() const { return str::format::format_byte_units(get_free()); }
+  std::string get_total_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_total(), context->get_number_format());
+  }
+  std::string get_used_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_used(), context->get_number_format());
+  }
+  std::string get_free_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_free(), context->get_number_format());
+  }
 };
 
 parsers::where::node_type calculate_free(std::shared_ptr<filter_obj> object, parsers::where::evaluation_context context, parsers::where::node_type subject) {
@@ -77,14 +88,17 @@ struct filter_obj_handler : public native_context {
       ("used_pct", [](auto obj, auto context) { return obj->get_used_pct(); }, "% used memory")
       ;
     // clang-format on
-    registry_.add_human_string("size", &filter_obj::get_total_human, "")
-        .add_human_string("free", &filter_obj::get_free_human, "")
-        .add_human_string("used", &filter_obj::get_used_human, "")
+    registry_.add_human_string_context("size", &filter_obj::get_total_human, "")
+        .add_human_string_context("free", &filter_obj::get_free_human, "")
+        .add_human_string_context("used", &filter_obj::get_used_human, "")
         // Issue #595: render percentages with two decimals via human-string
-        .add_human_string("used_pct", &filter_obj::get_used_pct_human, "")
-        .add_human_string("free_pct", &filter_obj::get_free_pct_human, "");
+        .add_human_string_context("used_pct", &filter_obj::get_used_pct_human, "")
+        .add_human_string_context("free_pct", &filter_obj::get_free_pct_human, "");
 
     registry_.add_converter(type_custom_free, &calculate_free).add_converter(type_custom_used, &calculate_free);
+
+    // Byte-valued keywords with no arithmetic in the grammar (#1392, #1428).
+    parsers::where::format_functions::register_format_functions(registry_);
   }
 };
 typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;

--- a/modules/CheckSystem/check_network.cpp
+++ b/modules/CheckSystem/check_network.cpp
@@ -445,14 +445,14 @@ filter_obj_handler::filter_obj_handler() {
   // `received` so perfdata stays numeric. format_byte_units auto-scales
   // to B/KB/MB/GB/... base-1024.
   registry_
-      .add_string_var(
-          "sent_human", [](auto obj) { return str::format::format_byte_units(obj->getBytesSentPersec()); },
+      .add_string_var_w_context(
+          "sent_human", [](auto obj, auto context) { return str::format::format_byte_units(obj->getBytesSentPersec(), context->get_number_format()); },
           "Bytes sent per second, formatted as a human-readable string (auto-scaled).")
-      .add_string_var(
-          "received_human", [](auto obj) { return str::format::format_byte_units(obj->getBytesReceivedPersec()); },
+      .add_string_var_w_context(
+          "received_human", [](auto obj, auto context) { return str::format::format_byte_units(obj->getBytesReceivedPersec(), context->get_number_format()); },
           "Bytes received per second, formatted as a human-readable string (auto-scaled).")
-      .add_string_var(
-          "total_human", [](auto obj) { return str::format::format_byte_units(obj->getBytesTotalPersec()); },
+      .add_string_var_w_context(
+          "total_human", [](auto obj, auto context) { return str::format::format_byte_units(obj->getBytesTotalPersec(), context->get_number_format()); },
           "Bytes total per second, formatted as a human-readable string (auto-scaled).");
 
   // The *_human strings above auto-scale; these let a template or a threshold

--- a/modules/CheckSystem/check_pdh.cpp
+++ b/modules/CheckSystem/check_pdh.cpp
@@ -59,8 +59,8 @@ filter_obj_handler::filter_obj_handler() {
   // for the common units; for arbitrary scaling use the scale() / format_bytes()
   // functions registered below.
   registry_
-      .add_string_var(
-          "value_human", [](auto obj) { return str::format::format_byte_units(obj->get_value_i()); },
+      .add_string_var_w_context(
+          "value_human", [](auto obj, auto context) { return str::format::format_byte_units(obj->get_value_i(), context->get_number_format()); },
           "Counter value formatted as a human-readable byte string, auto-scaled to B/KB/MB/GB/...")
       .add_float(
           "value_kb", [](auto obj) { return obj->get_value_f() / 1024.0; }, "Counter value in KB (1024-based).")

--- a/modules/CheckSystem/check_process.cpp
+++ b/modules/CheckSystem/check_process.cpp
@@ -76,13 +76,13 @@ filter_obj_handler::filter_obj_handler() {
   // clang-format on
 
   registry_.add_human_string("state", &filter_obj::get_state_s, "The current state (started, stopped, hung)");
-  registry_.add_human_string("peak_virtual", &filter_obj::get_PeakVirtualSize_human, "");
-  registry_.add_human_string("virtual", &filter_obj::get_VirtualSize_human, "");
-  registry_.add_human_string("peak_working_set", &filter_obj::get_PeakWorkingSetSize_human, "");
-  registry_.add_human_string("working_set", &filter_obj::get_WorkingSetSize_human, "");
-  registry_.add_human_string("rss", &filter_obj::get_WorkingSetSize_human, "");
-  registry_.add_human_string("peak_pagefile", &filter_obj::get_PageFileUsage_human, "");
-  registry_.add_human_string("pagefile", &filter_obj::get_PeakPageFileUsage_human, "");
+  registry_.add_human_string_context("peak_virtual", &filter_obj::get_PeakVirtualSize_human, "");
+  registry_.add_human_string_context("virtual", &filter_obj::get_VirtualSize_human, "");
+  registry_.add_human_string_context("peak_working_set", &filter_obj::get_PeakWorkingSetSize_human, "");
+  registry_.add_human_string_context("working_set", &filter_obj::get_WorkingSetSize_human, "");
+  registry_.add_human_string_context("rss", &filter_obj::get_WorkingSetSize_human, "");
+  registry_.add_human_string_context("peak_pagefile", &filter_obj::get_PageFileUsage_human, "");
+  registry_.add_human_string_context("pagefile", &filter_obj::get_PeakPageFileUsage_human, "");
 
   registry_.add_converter(type_custom_state, &parse_state);
 }

--- a/modules/CheckSystem/filter.cpp
+++ b/modules/CheckSystem/filter.cpp
@@ -89,14 +89,14 @@ filter_obj_handler::filter_obj_handler() {
       .add_int("peak_used", &filter_obj::get_peak, "Peak used memory in bytes (g,m,k,b) since boot")
       .add_scaled_byte([](auto obj, auto context) { return get_zero(); }, [](auto obj, auto context) { return obj->get_total(); })
       .add_int("peak_used_pct", &filter_obj::get_peak_used_pct, "% peak used memory since boot");
-  registry_.add_human_string("size", &filter_obj::get_total_human, "")
-      .add_human_string("free", &filter_obj::get_free_human, "")
-      .add_human_string("used", &filter_obj::get_used_human, "")
+  registry_.add_human_string_context("size", &filter_obj::get_total_human, "")
+      .add_human_string_context("free", &filter_obj::get_free_human, "")
+      .add_human_string_context("used", &filter_obj::get_used_human, "")
       // Issue #595: render percentages with two decimals via human-string
-      .add_human_string("used_pct", &filter_obj::get_used_pct_human, "")
-      .add_human_string("free_pct", &filter_obj::get_free_pct_human, "")
-      .add_human_string("peak_used", &filter_obj::get_peak_human, "")
-      .add_human_string("peak_used_pct", &filter_obj::get_peak_used_pct_human, "");
+      .add_human_string_context("used_pct", &filter_obj::get_used_pct_human, "")
+      .add_human_string_context("free_pct", &filter_obj::get_free_pct_human, "")
+      .add_human_string_context("peak_used", &filter_obj::get_peak_human, "")
+      .add_human_string_context("peak_used_pct", &filter_obj::get_peak_used_pct_human, "");
 
   registry_.add_converter(type_custom_free, &calculate_free).add_converter(type_custom_used, &calculate_free);
 }

--- a/modules/CheckSystem/filter.hpp
+++ b/modules/CheckSystem/filter.hpp
@@ -66,15 +66,29 @@ struct filter_obj {
   long long get_used_pct() const { return str::format::calc_pct_round(get_used(), get_total()); }
   long long get_free_pct() const { return str::format::calc_pct_round(get_free(), get_total()); }
   long long get_peak_used_pct() const { return str::format::calc_pct_round(get_peak(), get_total()); }
-  std::string get_peak_human() const { return str::format::format_byte_units(get_peak()); }
-  std::string get_peak_used_pct_human() const { return str::format::format_pct(get_peak(), get_total()); }
-  std::string get_used_pct_human() const { return str::format::format_pct(get_used(), get_total()); }
-  std::string get_free_pct_human() const { return str::format::format_pct(get_free(), get_total()); }
+  std::string get_peak_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_peak(), context->get_number_format());
+  }
+  std::string get_peak_used_pct_human(parsers::where::evaluation_context context) const {
+    return str::format::format_pct(get_peak(), get_total(), context->get_number_format());
+  }
+  std::string get_used_pct_human(parsers::where::evaluation_context context) const {
+    return str::format::format_pct(get_used(), get_total(), context->get_number_format());
+  }
+  std::string get_free_pct_human(parsers::where::evaluation_context context) const {
+    return str::format::format_pct(get_free(), get_total(), context->get_number_format());
+  }
   std::string get_name() const { return info.name; }
 
-  std::string get_total_human() const { return str::format::format_byte_units(get_total()); }
-  std::string get_used_human() const { return str::format::format_byte_units(get_used()); }
-  std::string get_free_human() const { return str::format::format_byte_units(get_free()); }
+  std::string get_total_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_total(), context->get_number_format());
+  }
+  std::string get_used_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_used(), context->get_number_format());
+  }
+  std::string get_free_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_free(), context->get_number_format());
+  }
 };
 
 typedef parsers::where::filter_handler_impl<std::shared_ptr<filter_obj> > native_context;

--- a/modules/CheckSystemUnix/check_kernel_memory.cpp
+++ b/modules/CheckSystemUnix/check_kernel_memory.cpp
@@ -30,12 +30,21 @@ double rate_of(const unsigned long long cur, const unsigned long long prev, cons
 }
 }  // namespace
 
-std::string kernel_memory_obj::get_slab_human() const { return str::format::format_byte_units(slab); }
-std::string kernel_memory_obj::get_slab_unreclaimable_human() const { return str::format::format_byte_units(slab_unreclaimable); }
-std::string kernel_memory_obj::get_cache_human() const { return str::format::format_byte_units(cache); }
+std::string kernel_memory_obj::get_slab_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(slab, context->get_number_format());
+}
+std::string kernel_memory_obj::get_slab_unreclaimable_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(slab_unreclaimable, context->get_number_format());
+}
+std::string kernel_memory_obj::get_cache_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(cache, context->get_number_format());
+}
 
 std::string kernel_memory_obj::show() const {
-  return "slab " + get_slab_human() + " (" + get_slab_unreclaimable_human() + " unreclaimable), cache " + get_cache_human();
+  // Debug output, so the plain rendering rather than the check's number format
+  // (which lives on the evaluation context and is not in reach here).
+  return "slab " + str::format::format_byte_units(slab) + " (" + str::format::format_byte_units(slab_unreclaimable) + " unreclaimable), cache " +
+         str::format::format_byte_units(cache);
 }
 
 // /proc/meminfo lines look like "Slab:  123456 kB".
@@ -114,9 +123,9 @@ filter_obj_handler::filter_obj_handler() {
       .add_float("major_faults_per_sec", &kernel_memory_obj::get_major_faults,
                  "Major (hard) faults per second (pgmajfault in /proc/vmstat): faults that had to read from disk — the fault-storm signal");
   // Render the byte gauges human-readable; expressions keep comparing bytes.
-  registry_.add_human_string("slab", &kernel_memory_obj::get_slab_human, "Total slab as a human-readable size")
-      .add_human_string("slab_unreclaimable", &kernel_memory_obj::get_slab_unreclaimable_human, "Unreclaimable slab as a human-readable size")
-      .add_human_string("cache", &kernel_memory_obj::get_cache_human, "Page cache as a human-readable size");
+  registry_.add_human_string_context("slab", &kernel_memory_obj::get_slab_human, "Total slab as a human-readable size")
+      .add_human_string_context("slab_unreclaimable", &kernel_memory_obj::get_slab_unreclaimable_human, "Unreclaimable slab as a human-readable size")
+      .add_human_string_context("cache", &kernel_memory_obj::get_cache_human, "Page cache as a human-readable size");
   // clang-format on
 }
 

--- a/modules/CheckSystemUnix/check_kernel_memory.h
+++ b/modules/CheckSystemUnix/check_kernel_memory.h
@@ -31,9 +31,9 @@ struct kernel_memory_obj {
   long long get_slab_reclaimable() const { return slab_reclaimable; }
   long long get_slab_unreclaimable() const { return slab_unreclaimable; }
   long long get_cache() const { return cache; }
-  std::string get_slab_human() const;
-  std::string get_slab_unreclaimable_human() const;
-  std::string get_cache_human() const;
+  std::string get_slab_human(parsers::where::evaluation_context context) const;
+  std::string get_slab_unreclaimable_human(parsers::where::evaluation_context context) const;
+  std::string get_cache_human(parsers::where::evaluation_context context) const;
   double get_page_faults() const { return page_faults; }
   double get_major_faults() const { return major_faults; }
 

--- a/modules/CheckSystemUnix/check_memory.cpp
+++ b/modules/CheckSystemUnix/check_memory.cpp
@@ -51,9 +51,9 @@ filter_obj_handler::filter_obj_handler() {
           .add_percentage([] (auto obj, auto context) { return obj->get_total(); }, "", " %")
       ;
   // clang-format on
-  registry_.add_human_string("size", &filter_obj::get_total_human, "")
-      .add_human_string("free", &filter_obj::get_free_human, "")
-      .add_human_string("used", &filter_obj::get_used_human, "");
+  registry_.add_human_string_context("size", &filter_obj::get_total_human, "")
+      .add_human_string_context("free", &filter_obj::get_free_human, "")
+      .add_human_string_context("used", &filter_obj::get_used_human, "");
 
   registry_.add_converter(type_custom_free, &calculate_free).add_converter(type_custom_used, &calculate_free);
 }

--- a/modules/CheckSystemUnix/check_memory.h
+++ b/modules/CheckSystemUnix/check_memory.h
@@ -33,9 +33,15 @@ struct filter_obj {
   long long get_free() const { return free; }
   std::string get_type() const { return type; }
 
-  std::string get_total_human() const { return str::format::format_byte_units(get_total()); }
-  std::string get_used_human() const { return str::format::format_byte_units(get_used()); }
-  std::string get_free_human() const { return str::format::format_byte_units(get_free()); }
+  std::string get_total_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_total(), context->get_number_format());
+  }
+  std::string get_used_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_used(), context->get_number_format());
+  }
+  std::string get_free_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_free(), context->get_number_format());
+  }
 };
 
 typedef parsers::where::filter_handler_impl<std::shared_ptr<filter_obj> > native_context;

--- a/modules/CheckSystemUnix/check_network.cpp
+++ b/modules/CheckSystemUnix/check_network.cpp
@@ -24,9 +24,15 @@ namespace po = boost::program_options;
 
 namespace network_check {
 
-std::string network_interface::get_received_human() const { return str::format::format_byte_units(rx_bytes_per_sec); }
-std::string network_interface::get_sent_human() const { return str::format::format_byte_units(tx_bytes_per_sec); }
-std::string network_interface::get_total_human() const { return str::format::format_byte_units(get_total()); }
+std::string network_interface::get_received_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(rx_bytes_per_sec, context->get_number_format());
+}
+std::string network_interface::get_sent_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(tx_bytes_per_sec, context->get_number_format());
+}
+std::string network_interface::get_total_human(parsers::where::evaluation_context context) const {
+  return str::format::format_byte_units(get_total(), context->get_number_format());
+}
 
 typedef network_interface filter_obj;
 
@@ -67,9 +73,9 @@ filter_obj_handler::filter_obj_handler() {
       .add_int_var("usage_total", &filter_obj::get_usage_total, "Percent of link speed used by total traffic (0 when speed unknown)")
       .add_int_perf("%", "", "_usage_total");
 
-  registry_.add_string_var("received_human", &filter_obj::get_received_human, "Bytes received per second (human readable, auto-scaled)")
-      .add_string_var("sent_human", &filter_obj::get_sent_human, "Bytes sent per second (human readable, auto-scaled)")
-      .add_string_var("total_human", &filter_obj::get_total_human, "Bytes total per second (human readable, auto-scaled)");
+  registry_.add_string_var_w_context("received_human", &filter_obj::get_received_human, "Bytes received per second (human readable, auto-scaled)")
+      .add_string_var_w_context("sent_human", &filter_obj::get_sent_human, "Bytes sent per second (human readable, auto-scaled)")
+      .add_string_var_w_context("total_human", &filter_obj::get_total_human, "Bytes total per second (human readable, auto-scaled)");
 
   // The *_human strings above auto-scale; these let a template or a threshold
   // pick the unit, e.g. `convert_bytes(throughput, 'MB') > 100` (#1392).

--- a/modules/CheckSystemUnix/check_network.h
+++ b/modules/CheckSystemUnix/check_network.h
@@ -8,6 +8,7 @@
 #include <memory>
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/protobuf/metrics.hpp>
+#include <parsers/where/node.hpp>
 #include <string>
 
 class pdh_thread;
@@ -67,9 +68,9 @@ struct network_interface {
   long long get_usage_out() const { return speed_bps <= 0 ? 0 : (tx_bytes_per_sec * 8 * 100) / speed_bps; }
   long long get_usage_total() const { return speed_bps <= 0 ? 0 : (get_total() * 8 * 100) / speed_bps; }
 
-  std::string get_received_human() const;
-  std::string get_sent_human() const;
-  std::string get_total_human() const;
+  std::string get_received_human(parsers::where::evaluation_context context) const;
+  std::string get_sent_human(parsers::where::evaluation_context context) const;
+  std::string get_total_human(parsers::where::evaluation_context context) const;
 
   std::string show() const { return name; }
 };

--- a/modules/CheckSystemUnix/check_pagefile.cpp
+++ b/modules/CheckSystemUnix/check_pagefile.cpp
@@ -51,9 +51,9 @@ filter_obj_handler::filter_obj_handler() {
           .add_percentage([] (auto obj, auto context) { return obj->get_total(); }, "", " %")
       ;
   // clang-format on
-  registry_.add_human_string("size", &filter_obj::get_total_human, "")
-      .add_human_string("free", &filter_obj::get_free_human, "")
-      .add_human_string("used", &filter_obj::get_used_human, "");
+  registry_.add_human_string_context("size", &filter_obj::get_total_human, "")
+      .add_human_string_context("free", &filter_obj::get_free_human, "")
+      .add_human_string_context("used", &filter_obj::get_used_human, "");
 
   registry_.add_converter(type_custom_free, &calculate_free).add_converter(type_custom_used, &calculate_free);
 }

--- a/modules/CheckSystemUnix/check_pagefile.h
+++ b/modules/CheckSystemUnix/check_pagefile.h
@@ -30,13 +30,23 @@ struct filter_obj {
   long long get_free() const { return total > used ? total - used : 0; }
   long long get_used_pct() const { return str::format::calc_pct_round(get_used(), get_total()); }
   long long get_free_pct() const { return str::format::calc_pct_round(get_free(), get_total()); }
-  std::string get_used_pct_human() const { return str::format::format_pct(get_used(), get_total()); }
-  std::string get_free_pct_human() const { return str::format::format_pct(get_free(), get_total()); }
+  std::string get_used_pct_human(parsers::where::evaluation_context context) const {
+    return str::format::format_pct(get_used(), get_total(), context->get_number_format());
+  }
+  std::string get_free_pct_human(parsers::where::evaluation_context context) const {
+    return str::format::format_pct(get_free(), get_total(), context->get_number_format());
+  }
   std::string get_name() const { return name; }
 
-  std::string get_total_human() const { return str::format::format_byte_units(get_total()); }
-  std::string get_used_human() const { return str::format::format_byte_units(get_used()); }
-  std::string get_free_human() const { return str::format::format_byte_units(get_free()); }
+  std::string get_total_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_total(), context->get_number_format());
+  }
+  std::string get_used_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_used(), context->get_number_format());
+  }
+  std::string get_free_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(get_free(), context->get_number_format());
+  }
 };
 
 typedef parsers::where::filter_handler_impl<std::shared_ptr<filter_obj> > native_context;

--- a/modules/CheckSystemUnix/check_process.cpp
+++ b/modules/CheckSystemUnix/check_process.cpp
@@ -92,10 +92,11 @@ filter_obj_handler::filter_obj_handler() {
                              "Resident set size in bytes; alias for working_set, matching the Windows keyword set (g,m,k,b)")
       .add_scaled_byte(std::string(""), " rss");
 
-  registry_.add_human_string("virtual", &filter_obj::get_virtual_size_human, "").add_human_string("working_set", &filter_obj::get_working_set_human, "");
-  registry_.add_human_string("rss", &filter_obj::get_working_set_human, "");
-  registry_.add_human_string("peak_virtual", &filter_obj::get_peak_virtual_size_human, "")
-      .add_human_string("peak_working_set", &filter_obj::get_peak_working_set_human, "");
+  registry_.add_human_string_context("virtual", &filter_obj::get_virtual_size_human, "")
+      .add_human_string_context("working_set", &filter_obj::get_working_set_human, "");
+  registry_.add_human_string_context("rss", &filter_obj::get_working_set_human, "");
+  registry_.add_human_string_context("peak_virtual", &filter_obj::get_peak_virtual_size_human, "")
+      .add_human_string_context("peak_working_set", &filter_obj::get_peak_working_set_human, "");
 
   // Time counters. Perfdata mirrors Windows (no UOM): cumulative CPU seconds
   // normally, whole percentages of total CPU with delta=true. creation is the

--- a/modules/CheckSystemUnix/check_process.h
+++ b/modules/CheckSystemUnix/check_process.h
@@ -201,10 +201,18 @@ struct filter_obj {
   long long get_peak_working_set() const { return peak_working_set; }
   long long get_page_faults() const { return page_faults; }
 
-  std::string get_virtual_size_human() const { return str::format::format_byte_units(virtual_size); }
-  std::string get_peak_virtual_size_human() const { return str::format::format_byte_units(peak_virtual_size); }
-  std::string get_working_set_human() const { return str::format::format_byte_units(working_set); }
-  std::string get_peak_working_set_human() const { return str::format::format_byte_units(peak_working_set); }
+  std::string get_virtual_size_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(virtual_size, context->get_number_format());
+  }
+  std::string get_peak_virtual_size_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(peak_virtual_size, context->get_number_format());
+  }
+  std::string get_working_set_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(working_set, context->get_number_format());
+  }
+  std::string get_peak_working_set_human(parsers::where::evaluation_context context) const {
+    return str::format::format_byte_units(peak_working_set, context->get_number_format());
+  }
 
   // Time getters
   long long get_user_time() const { return user_time; }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ NSCP_CREATE_TEST(
     str_test
     SOURCES
         ${NSCP_INCLUDEDIR}/str/format_test.cpp
+        ${NSCP_INCLUDEDIR}/str/number_format_test.cpp
         ${NSCP_INCLUDEDIR}/str/xtos_test.cpp
         ${NSCP_INCLUDEDIR}/str/nscp_string_test.cpp
         ${NSCP_INCLUDEDIR}/str/utils_test.cpp

--- a/tests/checkdisk-unix.test.ts
+++ b/tests/checkdisk-unix.test.ts
@@ -422,4 +422,84 @@ onLinux("CheckDisk (Unix)", () => {
     const out = await query("check_disk_write", []);
     expect(out).toMatch(/No file specified/);
   });
+
+  // --- number formatting (issue #1428) -------------------------------------
+  //
+  // These go over the one-shot client-query path, which passes each option as
+  // the single token `key=value` exactly as REST does.
+
+  const formatArgs = (extra: string[]) => [
+    "drive=/",
+    "warning=used>99%",
+    "critical=used>99%",
+    "show-all=true",
+    "detail-syntax=%(used)/%(size)",
+    "top-syntax=${list}",
+    ...extra,
+  ];
+
+  it("renders byte values with up to three decimals by default", async () => {
+    const out = await query("check_drivesize", formatArgs([]));
+    expect(out).toMatch(/^-?[\d.]+(B|KB|MB|GB|TB)\/-?[\d.]+(B|KB|MB|GB|TB)/m);
+  });
+
+  it("honours decimals", async () => {
+    const out = await query("check_drivesize", formatArgs(["decimals=1"]));
+    // Exactly one decimal on both values, trailing zero kept.
+    expect(out).toMatch(/^\d+\.\d(B|KB|MB|GB|TB)\/\d+\.\d(B|KB|MB|GB|TB)/m);
+  });
+
+  it("honours byte-unit, so both values land in the same unit", async () => {
+    const out = await query("check_drivesize", formatArgs(["decimals=2", "byte-unit=GB"]));
+    expect(out).toMatch(/^\d+\.\d\dGB\/\d+\.\d\dGB/m);
+  });
+
+  it("honours the decimal and thousands separators", async () => {
+    const out = await query("check_drivesize", formatArgs(["decimals=2", "byte-unit=MB", "decimal-separator=,", "thousands-separator=."]));
+    expect(out).toMatch(/^\d{1,3}(\.\d{3})*,\d\dMB/m);
+  });
+
+  // The whole point of keeping the number format on the message side: whatever
+  // the operator does to the message, the metrics stay machine readable.
+  it("leaves performance data locale neutral", async () => {
+    const out = await query("check_drivesize", [
+      "drive=/",
+      "warning=used>99%",
+      "critical=used>99%",
+      "decimals=2",
+      "byte-unit=GB",
+      "decimal-separator=,",
+      "thousands-separator=.",
+    ]);
+    const perf = out.slice(out.indexOf("|") + 1);
+    expect(perf).toMatch(/'\/ used'=[\d.]+GB/);
+    expect(perf).not.toMatch(/,/);
+  });
+
+  it("rejects a byte-unit it does not know", async () => {
+    const out = await query("check_drivesize", ["drive=/", "byte-unit=ZB"]);
+    expect(out).toMatch(/Invalid byte-unit: ZB/);
+  });
+
+  it("exposes format_bytes and format_number to check_drivesize templates", async () => {
+    const out = await query("check_drivesize", [
+      "drive=/",
+      "warning=used>99%",
+      "critical=used>99%",
+      "show-all=true",
+      "detail-syntax=%(format_bytes(used,'GB',1)) of %(format_bytes(size,'GB',1)) GB (%(format_number(used_pct,1))%)",
+      "top-syntax=${list}",
+    ]);
+    expect(out).toMatch(/^\d+\.\d of \d+\.\d GB \(\d+\.\d%\)/m);
+  });
+
+  it("reports an unknown unit in format_bytes rather than rendering nonsense", async () => {
+    const out = await query("check_drivesize", [
+      "drive=/",
+      "show-all=true",
+      "detail-syntax=%(format_bytes(used,'ZB'))",
+      "top-syntax=${list}",
+    ]);
+    expect(out).toMatch(/Unknown byte unit: ZB/);
+  });
 });


### PR DESCRIPTION
Fixes #1428.

`check_drivesize` reports `140.293GB/0.983TB used`: two units and six decimals for one disk, with no way to change either. The issue asked for fewer decimals and a European decimal comma. The mixed units in that one line turn out to be the larger readability problem, and neither of the two checks the issue names (`check_drivesize`, `check_memory`) could even reach the existing `format_bytes()` workaround — `register_format_functions()` was never called from them.

## The options

Four options, added next to `list-separator` in `add_misc_options()`, so every filter check has them and they fold out of the per-command reference onto the shared common-options page:

| Option | Effect | Default |
|---|---|---|
| `decimals` | Exactly N decimals (`2` → `25.20`) | `-1` (up to 3, trailing zeros stripped) |
| `byte-unit` | Pin every byte value to one unit, `B`…`EB` | auto, per value |
| `decimal-separator` | Radix character | `.` |
| `thousands-separator` | Digit grouping for the integer part | none |

```
check_drivesize drive=/ show-all=true
OK /: 141.085GB/0.983TB used

check_drivesize drive=/ show-all=true decimals=2 byte-unit=GB
OK /: 141.09GB/1006.85GB used

check_drivesize drive=/ show-all=true decimals=2 byte-unit=GB decimal-separator=, thousands-separator=.
OK /: 141,09GB/1.006,85GB used
```

The format lives on the evaluation context — the one thing every keyword getter and every format function is already handed — so the check's options set it once before the first row is evaluated. Defaults are unchanged, so an installation that sets none of them renders byte for byte what it rendered before.

**Two constraints held throughout:**

- It reaches the *message* only. Performance data is built from the raw values and keeps its full precision and its `.` radix: `'/ used'=141.03804GB;805.48314;…` even with a decimal comma configured. An integration case asserts this.
- Threshold parsing is untouched. `warning=used>1.5g` means the same thing with `decimal-separator=,` in force.

Real-time filters take the same values as `decimals`, `byte unit`, `decimal separator` and `thousands separator` settings keys, inheritable from the default template.

## Formatter bugs found on the way

- `format_byte_units(v, unit)` compared the unit case-sensitively against an uppercase table, so `format_bytes(used, 'gb')` rendered `1.27055e-10` while `convert_bytes(used, 'gb')` — which upper-cases — worked. Units are now case insensitive everywhere.
- A unit that matched nothing fell out of the loop having divided seven times, so a typo rendered `value/1024^7`. An unknown unit is now reported.
- `convert_to_byte_units` had the same fallthrough, so a misspelled `unit:` in `perf-config` silently scaled the metric by 1024⁻⁷. It now leaves the value alone. **A graph that has been flat near zero will jump to its real magnitude on upgrade.**

Reporting the typo needed one more fix: a function that failed while a template rendered called `context->error()`, and nothing on the rendering path read it — the placeholder just came out empty. `modern_filters` now drains those into the error handler the checks already report through, so the check returns UNKNOWN with the reason instead of a quietly incomplete message.

## Functions

`format_bytes()` gained an optional `decimals` argument, and `format_number(value, decimals)` joins it for percentages and other non-byte values. Both follow the options above unless given an explicit argument.

`register_format_functions()` is now called from every check carrying byte-valued keywords that lacked it — `check_drivesize` and `check_memory` among them.

## Testing

- **Unit:** new `str/number_format_test.cpp` for the rendering primitives; `format_test.cpp` updated for the three fixed contracts; `cli_helper_test.cpp` covers the option plumbing, the valued (`--decimals=1`) form REST uses, and rejection of a bad `byte-unit`/`decimals`.
- **Integration:** 8 new cases in `checkdisk-unix.test.ts` driving the options over the one-shot client-query path (same `k=v` single-token parsing as REST), including the locale-neutral perfdata assertion and the `format_bytes`/`format_number` templates.
- Full unit suite passes locally except `lua_log_file_test`, which fails on this machine because `os.tmpname()` hands the Lua script a `/tmp` path the sandbox won't let it write — unrelated, and it fails the same way on a clean tree.
- The REST-based suites (`checkdisk-commands`, `checksystem-commands`, `checknet-commands`) could not run locally: no build dir in this checkout has `libWEBServer.so`, so nothing can bind :8443. They were unrunnable before this change too and need CI.

## Needs a Windows build before merge

The Windows-only sources (`check_drive_win.cpp`, `check_process.cpp`, `filter.hpp`, `check_kernel_memory`, `check_cpu_frequency`, `check_hardware`, `check_network`, `check_pdh`, `check_uncpath`, `win/processes.hpp`) follow the same mechanical pattern as their Linux counterparts — human getters take an `evaluation_context`, registrations move to `add_human_string_context` / `add_string_var_w_context` — but they are not compiled on this machine.

## Docs

`docs/reference/*.yaml` and the generated Markdown were regenerated, keeping only what this change causes. A "Number formatting" section was added to `concepts/checks.md`, and `setup/upgrading.md` carries four entries covering the behaviour changes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
