### PR TITLE
ci(winget): sync the bot fork before submitting to winget-pkgs

### DIFF
--- a/.github/workflows/publish-winget.yml
+++ b/.github/workflows/publish-winget.yml
@@ -116,6 +116,86 @@ jobs:
           path: dist/winget
           if-no-files-found: error
 
+      - name: Sync the bot's winget-pkgs fork with upstream
+        if: ${{ steps.ctx.outputs.dry_run != 'true' }}
+        shell: pwsh
+        env:
+          WINGET_PR_TOKEN: ${{ secrets.WINGET_PR_TOKEN }}
+        run: |
+          if ([string]::IsNullOrEmpty($env:WINGET_PR_TOKEN)) {
+              Write-Warning 'WINGET_PR_TOKEN secret is not configured. Skipping fork sync.'
+              exit 0
+          }
+
+          # wingetcreate pushes its branch to a fork of microsoft/winget-pkgs
+          # owned by the token's account, and fast-forwards that fork first.
+          # winget-pkgs takes hundreds of commits a day, so a fork left alone
+          # between releases drifts by tens of thousands of commits and the
+          # fast-forward inside wingetcreate gives up with nothing but "The
+          # forked repository could not be synced with the upstream commits."
+          # Sync it here instead: every release keeps the fork current, and a
+          # sync that genuinely cannot happen says so with the repo name.
+          $headers = @{
+              Authorization          = "Bearer $env:WINGET_PR_TOKEN"
+              Accept                 = 'application/vnd.github+json'
+              'X-GitHub-Api-Version' = '2022-11-28'
+          }
+
+          # Invoke-RestMethod turns any non-2xx into a terminating error, so
+          # wrap it to get the status back and decide per call.
+          function Invoke-GitHubApi {
+              param([string]$Method, [string]$Uri, [string]$Body)
+              try {
+                  $params = @{ Method = $Method; Uri = $Uri; Headers = $headers }
+                  if ($Body) {
+                      $params.Body        = $Body
+                      $params.ContentType = 'application/json'
+                  }
+                  return @{ status = 200; body = Invoke-RestMethod @params }
+              } catch {
+                  $status = 0
+                  if ($_.Exception.Response) { $status = [int]$_.Exception.Response.StatusCode }
+                  $detail = $_.ErrorDetails.Message
+                  if (-not $detail) { $detail = $_.Exception.Message }
+                  return @{ status = $status; body = $detail }
+              }
+          }
+
+          # The fork belongs to whichever account minted WINGET_PR_TOKEN, so
+          # ask the token rather than hard-coding the bot name.
+          $me = Invoke-GitHubApi GET 'https://api.github.com/user'
+          if ($me.status -ne 200) {
+              Write-Error "Could not identify the WINGET_PR_TOKEN account (HTTP $($me.status)): $($me.body)"
+              exit 1
+          }
+          $owner = $me.body.login
+          $fork  = "$owner/winget-pkgs"
+          Write-Host "WINGET_PR_TOKEN account: $owner"
+
+          $repo = Invoke-GitHubApi GET "https://api.github.com/repos/$fork"
+          if ($repo.status -eq 404) {
+              Write-Host "$fork does not exist yet; wingetcreate will create the fork."
+              exit 0
+          }
+          if ($repo.status -ne 200) {
+              Write-Error "Could not read $fork (HTTP $($repo.status)): $($repo.body)"
+              exit 1
+          }
+
+          $branch = $repo.body.default_branch
+          $sync = Invoke-GitHubApi POST "https://api.github.com/repos/$fork/merge-upstream" `
+              (@{ branch = $branch } | ConvertTo-Json)
+          if ($sync.status -eq 200) {
+              Write-Host "${fork}:${branch} is in sync with microsoft/winget-pkgs - $($sync.body.message)"
+              exit 0
+          }
+
+          Write-Host "Sign in as $owner and press 'Sync fork' on https://github.com/$fork."
+          Write-Host "If the fork has diverged, or is too far behind for GitHub to fast-forward, delete it instead:"
+          Write-Host "wingetcreate re-forks on the next run. Check for open PRs from the fork before deleting it."
+          Write-Error "Could not fast-forward ${fork}:${branch} from microsoft/winget-pkgs (HTTP $($sync.status)): $($sync.body)"
+          exit 1
+
       - name: Submit manifest to microsoft/winget-pkgs
         if: ${{ steps.ctx.outputs.dry_run != 'true' }}
         shell: pwsh

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -55,7 +55,7 @@ release.
    [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs). Using
    the maintainer's personal account works but is not recommended; a
    dedicated bot identity is cleaner.
-2. Create a classic Personal Access Token with the `public_repo` scope.
+2. Create a classic Personal Access Token with `public_repo` and `workflow`.
    `wingetcreate` never writes to `microsoft/winget-pkgs` directly — it forks
    it into the token's own account, pushes a branch there and opens the PR
    from that fork. So the token needs repository write access in *its own*

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -55,12 +55,26 @@ release.
    [`microsoft/winget-pkgs`](https://github.com/microsoft/winget-pkgs). Using
    the maintainer's personal account works but is not recommended; a
    dedicated bot identity is cleaner.
-2. Create a classic Personal Access Token with the `public_repo` scope (or a
-   fine-grained PAT with `Pull requests: write` on `microsoft/winget-pkgs`).
+2. Create a classic Personal Access Token with the `public_repo` scope.
+   `wingetcreate` never writes to `microsoft/winget-pkgs` directly — it forks
+   it into the token's own account, pushes a branch there and opens the PR
+   from that fork. So the token needs repository write access in *its own*
+   account, which a fine-grained PAT scoped to `microsoft/winget-pkgs` does
+   not grant. Adding the `workflow` scope is cheap insurance — `winget-pkgs`
+   carries files under `.github/workflows`, which some token types are barred
+   from writing.
 3. Store it as the `WINGET_PR_TOKEN` repository secret.
 4. The very first submission for `Mickem.NSClient` may need a manual
    `wingetcreate new` run to seed the package directory in `winget-pkgs`.
    Subsequent versions can use `wingetcreate submit` as the workflow does.
+
+The bot's fork of `winget-pkgs` has to be current before `wingetcreate` can
+push to it, and upstream takes hundreds of commits a day — a fork left alone
+between releases drifts far enough that the fast-forward stops working. The
+workflow syncs the fork itself before submitting, which keeps it current on
+every release. If that step still fails, sign in as the bot and press "Sync
+fork", or delete the fork outright (`wingetcreate` re-forks on the next run —
+check the fork has no open PRs first).
 
 ### Chocolatey (`publish-chocolatey.yml`)
 
@@ -86,7 +100,7 @@ release.
 
 | Secret               | Used by                  | Notes                                                                                   |
 | -------------------- | ------------------------ | --------------------------------------------------------------------------------------- |
-| `WINGET_PR_TOKEN`    | `publish-winget.yml`     | Classic PAT with `public_repo`, or fine-grained with `Pull requests: write` on winget-pkgs. |
+| `WINGET_PR_TOKEN`    | `publish-winget.yml`     | Classic PAT with `public_repo` + `workflow`. Not a fine-grained PAT — the fork lives in the token's own account. |
 | `CHOCOLATEY_API_KEY` | `publish-chocolatey.yml` | API key from `https://community.chocolatey.org/account`.                                |
 | `SCOOP_BUCKET_PAT`   | `publish-scoop.yml`      | PAT with write access to the Scoop bucket repository (`mickem/scoop-bucket` by default). |
 


### PR DESCRIPTION
## Why

The [0.17.0 WinGet publish](https://github.com/mickem/nscp/actions/runs/32806439981) failed at the last step. Everything before it passed — manifests rendered, `winget validate` returned `Manifest validation succeeded: True`, hashes round-tripped. The whole failure was:

```
The forked repository could not be synced with the upstream commits.
Sync your fork manually and try again.
```

`wingetcreate` never pushes to `microsoft/winget-pkgs` directly. It forks the repo into the token account, fast-forwards that fork, pushes a branch there, and opens the PR from the fork. `mickem-gitbot/winget-pkgs` was last pushed on 2026-07-06 (the 0.14.1 submission) and had fallen **20,616 commits behind** upstream (`ahead_by: 0`, so a clean fast-forward — just an enormous one). `wingetcreate`'s internal sync gave up, and its message named neither the fork nor a status code.

## What this changes

A `Sync the bot's winget-pkgs fork with upstream` step before the submit step, under the same `dry_run` guard:

- Resolves the fork owner from the token (`GET /user`) rather than hard-coding `mickem-gitbot`, so rotating the bot account needs no workflow edit.
- Fork missing → logs that `wingetcreate` will create it, exits 0.
- `POST /repos/<owner>/winget-pkgs/merge-upstream` on the fork's default branch.
- On failure: prints the fork name, HTTP status and API message, plus both recovery paths (press *Sync fork*, or delete the fork and let `wingetcreate` re-fork), then fails the job.

Running this every release keeps the drift to one release's worth of commits instead of seven weeks'.

Also corrects `packaging/README.md`: it offered "a fine-grained PAT with `Pull requests: write` on `microsoft/winget-pkgs`" as an alternative token. That could never have worked — the fork lives in the token's *own* account, so the token needs write access there, not on `microsoft/winget-pkgs`. Adds a troubleshooting paragraph on fork staleness.

## This does not fix the current failure

`mickem-gitbot/winget-pkgs` is still 20,616 commits behind. The new step will attempt the same fast-forward and may fail too — just legibly. Before re-running 0.17.0, sign in as `mickem-gitbot` and either press **Sync fork**, or delete the fork (safe: its three PRs — 0.12.6, 0.14.0, 0.14.1 — are all closed and merged, and nothing is open).

Then: `gh workflow run publish-winget.yml -f version=0.17.0 -f dry_run=false`

Worth knowing: `microsoft/winget-pkgs` currently tops out at `Mickem.NSClient` **0.14.1** — 0.15.0 and 0.16.x never landed, so 0.17.0 is a sizeable jump for validation.

## Testing

YAML parses and the embedded PowerShell balances, but there is no `pwsh` on the dev box — the script is unverified until it runs on a `windows-latest` runner. A `workflow_dispatch` with `dry_run=true` will not exercise it (the step is `dry_run`-guarded), so the first real proof is a live submission.