### PR TITLE
Pin schedules-from-includes against issue #636 and fix directory-include saves

### DIFF
--- a/include/settings/impl/settings_ini.hpp
+++ b/include/settings/impl/settings_ini.hpp
@@ -223,6 +223,13 @@ class INISettings : public settings_interface_impl {
   void save(bool re_save_all) override {
     settings_interface_impl::save(re_save_all);
 
+    // A directory include ([/includes] pointing at a folder) is a container
+    // store: the files inside it are its children, which the base save above
+    // already flushed. It has no file of its own, and handing the directory
+    // path to SaveFile fails with EISDIR - which, since child saves propagate,
+    // used to abort every settings write on an agent with a directory include.
+    if (boost::filesystem::is_directory(get_file_name())) return;
+
     const SI_Error rc = ini.SaveFile(get_file_name().string().c_str());
     if (rc < 0) throw_SI_error(rc, "Failed to save file");
   }
@@ -235,6 +242,9 @@ class INISettings : public settings_interface_impl {
   /// generated configs is for `[/modules]` to come first).
   void save_sorted() override {
     settings_interface_impl::save(true);
+
+    // Same as save(): a directory include has no file of its own to rewrite.
+    if (boost::filesystem::is_directory(get_file_name())) return;
 
     // Snapshot every (section, key) -> value/comment pair from the live
     // CSimpleIni then re-insert them in alphabetical order into a fresh

--- a/include/settings/impl/settings_ini_test.cpp
+++ b/include/settings/impl/settings_ini_test.cpp
@@ -683,3 +683,84 @@ TEST(settings_ini, get_changes_is_empty_after_a_deletion_is_saved) {
   EXPECT_EQ(settings_test::read_file(file).find("doomed"), std::string::npos);
   EXPECT_FALSE(s.get_string("/section", "key").has_value()) << "and it stays gone for readers";
 }
+
+// --- [/includes] value resolution (issue #636) -------------------------------
+// A key defined in an included file must resolve through the parent store both
+// ways: enumeration (get_keys) AND the value read (get_string). Issue #636 was
+// the halfway failure: the Scheduler saw the schedule keys from an included
+// file but every value came back empty, so each schedule lost its command.
+// These pin the full scenario from that report so it cannot quietly come back.
+
+TEST(settings_ini, include_file_keys_and_values_resolve_through_the_parent) {
+  temp_dir dir;
+  auto included = dir.file("checks.ini");
+  write_file(included,
+             "[/settings/scheduler/schedules]\n"
+             "test_swap=alias_swap2\n");
+  auto file = dir.file("nsclient.ini");
+  write_file(file, "[/includes]\nchecks=" + ini_context(included) + "\n");
+
+  ini_child_core core;
+  settings::INISettings s(&core, "master", ini_context(file));
+
+  const auto keys = s.get_keys("/settings/scheduler/schedules");
+  ASSERT_NE(std::find(keys.begin(), keys.end(), "test_swap"), keys.end()) << "the included key must be enumerated";
+  EXPECT_TRUE(s.has_key("/settings/scheduler/schedules", "test_swap"));
+  // The value read is what #636 lost: enumerated but empty.
+  EXPECT_EQ(s.get_string("/settings/scheduler/schedules", "test_swap", ""), "alias_swap2");
+}
+
+TEST(settings_ini, include_directory_keys_and_values_resolve_through_the_parent) {
+  // The exact #636 setup: [/includes] points at a *directory*, and the
+  // schedules live in a file inside it. That chains two stores (main ->
+  // directory -> file), so the value has to survive two child hops.
+  temp_dir dir;
+  boost::filesystem::path sub = dir.path() / "ini";
+  boost::filesystem::create_directories(sub);
+  write_file(sub / "checks.ini",
+             "[/settings/scheduler/schedules]\n"
+             "test_swap=alias_swap2\n"
+             "test_swap2=check_swap\n");
+  auto file = dir.file("nsclient.ini");
+  write_file(file,
+             "[/includes]\n"
+             "otherfiles=" + sub.generic_string() + "/\n"
+             "[/settings/scheduler/schedules]\n"
+             "uptime=check_uptime\n");
+
+  ini_child_core core;
+  settings::INISettings s(&core, "master", ini_context(file));
+
+  const auto keys = s.get_keys("/settings/scheduler/schedules");
+  EXPECT_NE(std::find(keys.begin(), keys.end(), "uptime"), keys.end());
+  ASSERT_NE(std::find(keys.begin(), keys.end(), "test_swap"), keys.end());
+  ASSERT_NE(std::find(keys.begin(), keys.end(), "test_swap2"), keys.end());
+
+  EXPECT_EQ(s.get_string("/settings/scheduler/schedules", "uptime", ""), "check_uptime");
+  EXPECT_EQ(s.get_string("/settings/scheduler/schedules", "test_swap", ""), "alias_swap2");
+  EXPECT_EQ(s.get_string("/settings/scheduler/schedules", "test_swap2", ""), "check_swap");
+}
+
+TEST(settings_ini, include_directory_sections_and_subkeys_resolve_through_the_parent) {
+  // A schedule written as its own section inside the included file: the object
+  // reader walks get_sections + get_keys + get_string on the sub-path, so all
+  // three have to fold the include in.
+  temp_dir dir;
+  boost::filesystem::path sub = dir.path() / "ini";
+  boost::filesystem::create_directories(sub);
+  write_file(sub / "sections.ini",
+             "[/settings/scheduler/schedules/fancy]\n"
+             "command=check_ok\n"
+             "interval=30s\n");
+  auto file = dir.file("nsclient.ini");
+  write_file(file, "[/includes]\notherfiles=" + sub.generic_string() + "/\n");
+
+  ini_child_core core;
+  settings::INISettings s(&core, "master", ini_context(file));
+
+  const auto sections = s.get_sections("/settings/scheduler/schedules");
+  ASSERT_NE(std::find(sections.begin(), sections.end(), "fancy"), sections.end());
+  EXPECT_EQ(s.get_keys("/settings/scheduler/schedules/fancy").size(), 2u);
+  EXPECT_EQ(s.get_string("/settings/scheduler/schedules/fancy", "command", ""), "check_ok");
+  EXPECT_EQ(s.get_string("/settings/scheduler/schedules/fancy", "interval", ""), "30s");
+}

--- a/include/settings/impl/settings_ini_test.cpp
+++ b/include/settings/impl/settings_ini_test.cpp
@@ -741,6 +741,30 @@ TEST(settings_ini, include_directory_keys_and_values_resolve_through_the_parent)
   EXPECT_EQ(s.get_string("/settings/scheduler/schedules", "test_swap2", ""), "check_swap");
 }
 
+TEST(settings_ini, save_survives_a_directory_include) {
+  // Found while pinning #636: the directory store has no file of its own, but
+  // save() handed the directory path to SaveFile anyway. The resulting EISDIR
+  // propagated out of the child save, so on an agent with a directory include
+  // every settings write (`nscp settings --set`, the web UI) failed and the
+  // main file was never written.
+  temp_dir dir;
+  boost::filesystem::path sub = dir.path() / "ini";
+  boost::filesystem::create_directories(sub);
+  write_file(sub / "checks.ini", "[/settings/scheduler/schedules]\ntest_swap=alias_swap2\n");
+  auto file = dir.file("nsclient.ini");
+  write_file(file, "[/includes]\notherfiles=" + sub.generic_string() + "/\n");
+
+  ini_child_core core;
+  settings::INISettings s(&core, "master", ini_context(file));
+  s.set_string("/settings/log", "level", "debug");
+  ASSERT_NO_THROW(s.save(false));
+
+  // The write must actually have landed in the main file.
+  EXPECT_NE(settings_test::read_file(file).find("level"), std::string::npos);
+  // ... and the included file must still be intact.
+  EXPECT_EQ(s.get_string("/settings/scheduler/schedules", "test_swap", ""), "alias_swap2");
+}
+
 TEST(settings_ini, include_directory_sections_and_subkeys_resolve_through_the_parent) {
   // A schedule written as its own section inside the included file: the object
   // reader walks get_sections + get_keys + get_string on the sub-path, so all

--- a/tests/scheduler-includes.test.ts
+++ b/tests/scheduler-includes.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Covers issue #636: schedules defined in a file pulled in via `[/includes]`
+ * lost their command — the Scheduler enumerated the keys from the included
+ * file but every value read came back empty, so it logged
+ * "Adding scheduled item: ... command: , ..." and submitted nothing useful.
+ *
+ * The setup mirrors the report: the main ini includes a *directory*, and the
+ * schedules live in a file inside it (that chains two child settings stores:
+ * main -> directory -> file). Three schedules are defined:
+ *
+ *   - localcheck    — in the main ini (control: this always worked)
+ *   - includedcheck — key=value in the included file (the #636 case)
+ *   - sectioncheck  — its own section in the included file
+ *
+ * All inherit `run on startup` from the default schedule, so each must report
+ * exactly once within seconds of boot. Results travel over GraphiteClient's
+ * carbon line protocol to a local TCP listener (no Docker, no network). A
+ * schedule whose command was lost reports UNKNOWN (status 3) — or nothing at
+ * all — so asserting `status 0` proves the command survived the include.
+ */
+import type { AddressInfo } from "net";
+import * as net from "net";
+
+import * as fs from "fs";
+import * as path from "path";
+
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(120_000);
+
+// Pin the status path so assertions match on a known prefix rather than on
+// whatever ${hostname} resolves to on the test machine.
+const STATUS_PATH = "nscp.inctest.${check_alias}.status";
+
+describe("Scheduler schedules from [/includes] files", () => {
+  let nscp: NscpInstance;
+  let server: net.Server;
+  let received = "";
+
+  /** Poll the captured carbon stream until `predicate` holds. */
+  async function waitForReceived(
+    predicate: (s: string) => boolean,
+    timeoutMs: number,
+  ): Promise<string> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (predicate(received)) return received;
+      await new Promise((r) => setTimeout(r, 250));
+    }
+    return received; // hand back whatever we have so expect() shows a useful diff
+  }
+
+  /** Carbon lines captured so far for one schedule alias. */
+  function linesFor(alias: string, data = received): string[] {
+    return data.split("\n").filter((l) => l.includes(`.${alias}.`));
+  }
+
+  beforeAll(async () => {
+    const port = await new Promise<number>((resolve) => {
+      server = net.createServer((sock) => {
+        sock.on("error", () => {});
+        sock.on("data", (chunk) => {
+          received += chunk.toString();
+        });
+      });
+      server.listen(0, "127.0.0.1", () => resolve((server.address() as AddressInfo).port));
+    });
+
+    nscp = new NscpInstance();
+
+    // The included directory, as in the issue's /etc/nsclient/ini/. Both the
+    // one-liner and the section variant live here; neither exists in the main
+    // ini, so a value that fails to resolve across the include chain cannot
+    // be masked by local configuration.
+    const confDir = nscp.scratch("conf.d");
+    fs.writeFileSync(
+      path.join(confDir, "schedules.ini"),
+      [
+        "[/settings/scheduler/schedules]",
+        "includedcheck = check_ok",
+        "",
+        "[/settings/scheduler/schedules/sectioncheck]",
+        "command = check_ok",
+        "",
+      ].join("\n"),
+    );
+
+    await nscp.configure({
+      "/modules": {
+        CheckHelpers: "enabled", // provides check_ok
+        Scheduler: "enabled",
+        GraphiteClient: "enabled",
+      },
+      // The trailing separator marks the include as a directory, like the
+      // `otherfiles=/etc/nsclient/ini/` line in the issue.
+      "/includes": { otherfiles: confDir + path.sep },
+      "/settings/graphite/client/targets/default": {
+        address: `127.0.0.1:${port}`,
+        "status path": STATUS_PATH,
+      },
+      // An interval far longer than the test plus `run on startup`: every
+      // schedule reports once right after boot and then stays silent, so a
+      // captured result can only mean the schedule was wired up correctly.
+      "/settings/scheduler/schedules/default": {
+        channel: "GRAPHITE",
+        interval: "1h",
+        report: "all", // check_ok returns OK, which is filtered out otherwise
+        "run on startup": "true",
+      },
+      // The control: same shape as includedcheck but defined locally.
+      "/settings/scheduler/schedules": { localcheck: "check_ok" },
+    });
+
+    nscp.start();
+  });
+
+  afterAll(async () => {
+    await nscp?.stop();
+    await new Promise<void>((resolve) => server?.close(() => resolve()));
+  });
+
+  it("runs a schedule defined in the main ini (control)", async () => {
+    const data = await waitForReceived((s) => linesFor("localcheck", s).length > 0, 60_000);
+    // Carbon line protocol: "<dotted.path> <value> <unix-timestamp>".
+    expect(data).toMatch(/^nscp\.inctest\.localcheck\.status 0 \d+$/m);
+  });
+
+  it("resolves the command of a key=value schedule from an included directory (#636)", async () => {
+    const data = await waitForReceived((s) => linesFor("includedcheck", s).length > 0, 60_000);
+    expect(data).toMatch(/^nscp\.inctest\.includedcheck\.status 0 \d+$/m);
+  });
+
+  it("resolves a section-based schedule from an included directory", async () => {
+    const data = await waitForReceived((s) => linesFor("sectioncheck", s).length > 0, 60_000);
+    expect(data).toMatch(/^nscp\.inctest\.sectioncheck\.status 0 \d+$/m);
+  });
+});


### PR DESCRIPTION
Investigation of #636 (schedules defined in `[/includes]` files were detected but lost their command). The reported failure no longer reproduces on the current codebase — the settings layer resolves both keys and values through include children, including the two-store chain a directory include creates — but nothing covered it, and validating the scenario end-to-end exposed a live bug in the same feature.

## What this PR does

### Regression tests for #636 (no product change needed)
- **`include/settings/impl/settings_ini_test.cpp`**: keys, values, sections and sub-keys resolve through a file include and a directory include — the exact layout from the report (`[/includes] otherfiles=<dir>/` with schedules in a file inside the directory).
- **`tests/scheduler-includes.test.ts`**: boots the real agent with schedules in an included directory (both `key=value` and section form) plus a local control schedule, and asserts each fires with its command intact via run-on-startup results over GraphiteClient's carbon protocol. A schedule whose command was lost reports UNKNOWN or nothing, so asserting `status 0` proves the command survived the include.

### Fix: a directory include failed every settings write
Running the end-to-end test surfaced this: with `[/includes]` pointing at a directory, any settings write (`nscp settings --set`, web-UI changes) failed with `Failed to save file '.../conf.d/': Is a directory` and the main file was never written. The directory store handed its own context — the directory path — to `SaveFile()`, and the EISDIR propagated out of the child-save chain, aborting the whole save.

The directory store is only a container: the files inside it are its children, and the base save already flushes those. `save()` and `save_sorted()` now skip the file write for a directory context. A unit test pins the scenario (write lands in the main file, included values survive).

## Validation
- All 72 C++ ctest targets pass.
- New `scheduler-includes` jest suite passes against the built binary (and reproduced the save failure before the fix).
- Adjacent suites `scheduler-run-on-startup` and `settings-host-placeholders` still pass.

Closes #636.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Pwp8URZsaqSn3Vo9tj8HZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012Pwp8URZsaqSn3Vo9tj8HZ)_