### PR TITLE
settings: make --use-samples work, pin the --add-defaults contract, fix test-less configure

### DIFF
--- a/include/settings/settings_core.hpp
+++ b/include/settings/settings_core.hpp
@@ -193,8 +193,12 @@ class settings_core {
   virtual settings::error_list validate() = 0;
 
   //////////////////////////////////////////////////////////////////////////
-  /// Overwrite the (current) settings store with default values.
-  virtual void update_defaults() = 0;
+  /// Fill the (current) settings store with the registered default values.
+  /// include_samples also materializes the keys registered as samples (the
+  /// sample schedules, targets and real-time filters modules register via
+  /// add_samples) - the CLI exposes it as `settings ... --use-samples`.
+  /// Existing values are never overwritten either way.
+  virtual void update_defaults(bool include_samples = false) = 0;
   virtual void remove_defaults() = 0;
 
   //////////////////////////////////////////////////////////////////////////

--- a/include/settings/test_helpers.hpp
+++ b/include/settings/test_helpers.hpp
@@ -105,7 +105,7 @@ class mock_settings_core : public settings::settings_core {
   void migrate_from(std::string, std::string) override {}
   void set_primary(std::string) override {}
   settings::error_list validate() override { return {}; }
-  void update_defaults() override {}
+  void update_defaults(bool = false) override {}
   void remove_defaults() override {}
   void boot(std::string = "boot.ini") override {}
   void set_ready(bool flag = true) override { ready_flag_ = flag; }

--- a/libs/settings_manager/settings_handler_impl.cpp
+++ b/libs/settings_manager/settings_handler_impl.cpp
@@ -19,10 +19,10 @@ settings::instance_ptr settings::settings_handler_impl::get_no_wait() {
   return instance_;
 }
 
-void settings::settings_handler_impl::update_defaults() {
-  for (const std::string &path : get_reg_sections("", false)) {
+void settings::settings_handler_impl::update_defaults(bool include_samples) {
+  for (const std::string &path : get_reg_sections("", include_samples)) {
     get()->add_path(path);
-    for (const std::string &key : get_reg_keys(path, false)) {
+    for (const std::string &key : get_reg_keys(path, include_samples)) {
       auto desc = get_registered_key(path, key);
       auto advanced = desc.has_value() && desc.value().advanced;
       auto default_value = desc.has_value() ? desc.value().default_value : "";
@@ -45,8 +45,12 @@ void settings::settings_handler_impl::update_defaults() {
 }
 
 void settings::settings_handler_impl::remove_defaults() {
-  for (std::string path : get_reg_sections("", false)) {
-    for (std::string key : get_reg_keys(path, false)) {
+  // Samples are included so this is the inverse of update_defaults(true): a
+  // sample section written by --use-samples holds only default-valued keys and
+  // is removed again here; one the operator has edited differs from the
+  // defaults and is kept, like any other key.
+  for (std::string path : get_reg_sections("", true)) {
+    for (std::string key : get_reg_keys(path, true)) {
       auto desc = get_registered_key(path, key);
       auto default_value = desc.has_value() ? desc.value().default_value : "";
       if (get()->has_key(path, key)) {

--- a/libs/settings_manager/settings_handler_impl.hpp
+++ b/libs/settings_manager/settings_handler_impl.hpp
@@ -71,7 +71,7 @@ class settings_handler_impl : public settings_core {
 
   instance_ptr get();
   instance_ptr get_no_wait();
-  void update_defaults();
+  void update_defaults(bool include_samples = false);
   void remove_defaults();
   // primary_context is what set_primary stores in boot.ini. It is passed
   // separately from `to` because an instance's context is the *expanded* one

--- a/libs/settings_manager/settings_manager_impl_test.cpp
+++ b/libs/settings_manager/settings_manager_impl_test.cpp
@@ -756,6 +756,43 @@ TEST_F(SettingsDefaultsTest, UpdateDefaultsIgnoresSamplePaths) {
   EXPECT_FALSE(impl_->get()->has_key("/sample", "k"));
 }
 
+TEST_F(SettingsDefaultsTest, UpdateDefaultsWithSamplesMaterialisesSampleKeys) {
+  // include_samples is what `--add-defaults --use-samples` runs: the sample
+  // objects (sample schedules, targets, real-time filters) are written out as
+  // a starting point to edit.
+  impl_->register_path(0xffff, "/sample", "S", "", false, /*is_sample=*/true, true);
+  impl_->register_key(0xffff, "/sample", "k", "string", "", "", "sample-default", false, /*is_sample=*/true, true);
+
+  impl_->update_defaults(true);
+
+  EXPECT_EQ(impl_->get()->get_string("/sample", "k", ""), "sample-default");
+}
+
+TEST_F(SettingsDefaultsTest, SampleDefaultsRoundTripLeavesNothingBehind) {
+  // remove_defaults includes samples, making it the inverse of
+  // update_defaults(true): an untouched sample section is stripped again.
+  impl_->register_path(0xffff, "/sample", "S", "", false, /*is_sample=*/true, true);
+  impl_->register_key(0xffff, "/sample", "k", "string", "", "", "sample-default", false, /*is_sample=*/true, true);
+
+  impl_->update_defaults(true);
+  impl_->remove_defaults();
+
+  EXPECT_FALSE(impl_->get()->has_key("/sample", "k"));
+  EXPECT_FALSE(impl_->get()->has_section("/sample"));
+}
+
+TEST_F(SettingsDefaultsTest, RemoveDefaultsKeepsAnEditedSampleKey) {
+  // A sample the operator has turned into real configuration differs from its
+  // default and must survive the cleanup like any other key.
+  impl_->register_path(0xffff, "/sample", "S", "", false, /*is_sample=*/true, true);
+  impl_->register_key(0xffff, "/sample", "k", "string", "", "", "sample-default", false, /*is_sample=*/true, true);
+  impl_->get()->set_string("/sample", "k", "operator-value");
+
+  impl_->remove_defaults();
+
+  EXPECT_EQ(impl_->get()->get_string("/sample", "k", ""), "operator-value");
+}
+
 TEST_F(SettingsDefaultsTest, RemoveDefaultsDropsKeysLeftAtTheirDefault) {
   impl_->register_path(0xffff, "/sec", "S", "", false, false, true);
   impl_->register_key(0xffff, "/sec", "k", "string", "", "", "the-default", false, false, true);

--- a/modules/WEBServer/CMakeLists.txt
+++ b/modules/WEBServer/CMakeLists.txt
@@ -243,39 +243,44 @@ NSCP_CREATE_TEST(
         ${MONGOOSE_CPP_DIR}
         ${NSCP_INCLUDEDIR}
 )
-if(NSCP_WEB_BACKEND STREQUAL "mongoose")
-    target_include_directories(
-        mongoose_wrapper_test
-        PRIVATE
-            ${MONGOOSE_INCLUDE_DIR}
-    )
-endif()
-if(OPENSSL_FOUND)
+# NSCP_CREATE_TEST is a no-op when NSCP_BUILD_TESTS is off, so everything that
+# decorates the target has to be guarded too (same pattern as CheckDisk /
+# CheckSecurity) - an unguarded call aborts the configure of a test-less build.
+if(TARGET mongoose_wrapper_test)
     if(NSCP_WEB_BACKEND STREQUAL "mongoose")
-        target_compile_definitions(
+        target_include_directories(
             mongoose_wrapper_test
             PRIVATE
-                MG_ENABLE_OPENSSL=1
-                MG_DISABLE_PFS=1
+                ${MONGOOSE_INCLUDE_DIR}
         )
     endif()
-    target_include_directories(
+    if(OPENSSL_FOUND)
+        if(NSCP_WEB_BACKEND STREQUAL "mongoose")
+            target_compile_definitions(
+                mongoose_wrapper_test
+                PRIVATE
+                    MG_ENABLE_OPENSSL=1
+                    MG_DISABLE_PFS=1
+            )
+        endif()
+        target_include_directories(
+            mongoose_wrapper_test
+            PRIVATE
+                ${OPENSSL_INCLUDE_DIR}
+        )
+        target_link_libraries(mongoose_wrapper_test ${OPENSSL_LIBRARIES})
+        if(WIN32)
+            target_link_libraries(mongoose_wrapper_test CRYPT32)
+        endif()
+    endif()
+    target_compile_definitions(
         mongoose_wrapper_test
         PRIVATE
-            ${OPENSSL_INCLUDE_DIR}
+            MG_ENABLE_HTTP_WEBSOCKET=0
+            MG_ENABLE_BROADCAST=1
+            MG_ENABLE_THREADS
     )
-    target_link_libraries(mongoose_wrapper_test ${OPENSSL_LIBRARIES})
-    if(WIN32)
-        target_link_libraries(mongoose_wrapper_test CRYPT32)
-    endif()
 endif()
-target_compile_definitions(
-    mongoose_wrapper_test
-    PRIVATE
-        MG_ENABLE_HTTP_WEBSOCKET=0
-        MG_ENABLE_BROADCAST=1
-        MG_ENABLE_THREADS
-)
 
 # Make sure the test process can locate runtime DLLs (gtest_main, nscp_mongoose,
 # boost, openssl, ...) regardless of how it is launched (ctest, IDE runner,

--- a/service/cli_parser.cpp
+++ b/service/cli_parser.cpp
@@ -83,7 +83,8 @@ cli_parser::cli_parser(const std::shared_ptr<NSClient> &core)
         ("list", "List all keys given a path.")
         ("add-defaults", "Same as --add-missing")
         ("remove-defaults", "Remove all keys which have default values (and empty sections)")
-        ("use-samples", "Add sample commands provided by some sections such as targets and real time filters")
+        ("use-samples", "Together with --add-missing/--add-defaults, also write the sample objects some sections provide "
+                        "(sample schedules, targets, real time filters) as a starting point to edit.")
         ("activate-module", po::value<std::vector<std::string> >()->multitoken(),
          "Add one or more modules (and their configuration options) to the configuration. "
          "Accepts several names in one go, e.g. --activate-module CheckHelpers CheckSystem CheckDisk")

--- a/service/settings_client.cpp
+++ b/service/settings_client.cpp
@@ -46,7 +46,7 @@ void nsclient_core::settings_client::startup() {
     return;
   }
   if (default_) {
-    get_core()->update_defaults();
+    get_core()->update_defaults(use_samples_);
   }
   if (remove_default_) {
     std::cout << "Removing default values" << std::endl;
@@ -333,7 +333,7 @@ int nsclient_core::settings_client::activate(const std::vector<std::string> &mod
   }
   core_->boot_start_plugins(false);
   if (default_) {
-    get_core()->update_defaults();
+    get_core()->update_defaults(use_samples_);
   }
   get_core()->get()->save(false);
   return ret;

--- a/tests/settings-update-defaults.test.ts
+++ b/tests/settings-update-defaults.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Verifies the contract of `nscp settings --update --add-defaults` (issue #542):
+ * filling in defaults must not fabricate configuration. Around 0.5.2 the
+ * generated file was polluted with placeholder values rendered as `UNKNOWN`
+ * and with sample/template sections, which every deployment then had to clean
+ * up by hand. Today defaults come from the settings registry, which excludes
+ * sample keys and advanced keys — this suite pins that behaviour.
+ *
+ * Each case runs one-shot `nscp settings ...` invocations against a throwaway
+ * settings file and inspects the resulting ini. No server/port/docker needed.
+ *
+ * The modules used (CheckHelpers, Scheduler) exist on both Linux and Windows,
+ * so the suite runs on both platforms.
+ */
+import * as fs from "fs";
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(120_000);
+
+/** Parse an nsclient.ini into {section -> {key -> value}} (comments dropped). */
+function parseIni(iniPath: string): Map<string, Map<string, string>> {
+  const sections = new Map<string, Map<string, string>>();
+  let current: Map<string, string> | undefined;
+  for (const raw of fs.readFileSync(iniPath, "utf8").split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line === "" || line.startsWith(";") || line.startsWith("#")) continue;
+    const header = line.match(/^\[(.+)\]$/);
+    if (header) {
+      const name = header[1];
+      current = sections.get(name) ?? new Map<string, string>();
+      sections.set(name, current);
+      continue;
+    }
+    if (!current) continue;
+    const eq = line.indexOf("=");
+    if (eq < 0) continue;
+    current.set(line.slice(0, eq).trim(), line.slice(eq + 1).trim());
+  }
+  return sections;
+}
+
+/** The module keys set to `enabled` in the [/modules] section. */
+function enabledModules(sections: Map<string, Map<string, string>>): Set<string> {
+  const out = new Set<string>();
+  for (const [key, value] of sections.get("/modules") ?? []) {
+    if (value === "enabled") out.add(key);
+  }
+  return out;
+}
+
+/** Every `path.key=value` whose value matches `pred`, for failure messages. */
+function valuesWhere(
+  sections: Map<string, Map<string, string>>,
+  pred: (value: string) => boolean,
+): string[] {
+  const hits: string[] = [];
+  for (const [section, keys] of sections) {
+    for (const [key, value] of keys) {
+      if (pred(value)) hits.push(`${section}.${key}=${value}`);
+    }
+  }
+  return hits;
+}
+
+describe("settings --update --add-defaults", () => {
+  it("adds registered defaults without fabricating placeholders or samples", async () => {
+    const nscp = new NscpInstance();
+    await nscp.run(["settings", "--activate-module", "CheckHelpers", "Scheduler"]);
+
+    const r = await nscp.run(["settings", "--update", "--add-defaults"]);
+    expect(r.exitCode).toBe(0);
+    const sections = parseIni(nscp.settingsFile);
+
+    // A real registered default is filled in: [/settings/log] level = info.
+    expect(sections.get("/settings/log")?.get("level")).toBe("info");
+
+    // The 0.5.2-era failure mode: keys without a usable default were written
+    // as the literal placeholder UNKNOWN and broke the agent until edited.
+    expect(valuesWhere(sections, (v) => v === "UNKNOWN")).toEqual([]);
+
+    // Sample/template objects (Scheduler's sample schedule, external script
+    // samples, ...) are registered as samples and must stay out of the file
+    // unless explicitly asked for.
+    const sampleSections = [...sections.keys()].filter((s) => s.endsWith("/sample"));
+    expect(sampleSections).toEqual([]);
+
+    // Adding defaults must not grow the module list: exactly the modules that
+    // were active before, nothing force-enabled.
+    expect(enabledModules(sections)).toEqual(new Set(["CheckHelpers", "Scheduler"]));
+  });
+
+  it("keeps a value the operator set over the registered default", async () => {
+    const nscp = new NscpInstance();
+    await nscp.run(["settings", "--activate-module", "CheckHelpers"]);
+    await nscp.run(["settings", "--path", "/settings/log", "--key", "level", "--set", "debug"]);
+
+    const r = await nscp.run(["settings", "--update", "--add-defaults"]);
+    expect(r.exitCode).toBe(0);
+    expect(parseIni(nscp.settingsFile).get("/settings/log")?.get("level")).toBe("debug");
+  });
+
+  it("--remove-defaults strips the default-valued keys again", async () => {
+    const nscp = new NscpInstance();
+    await nscp.run(["settings", "--activate-module", "CheckHelpers"]);
+    await nscp.run(["settings", "--update", "--add-defaults"]);
+    expect(parseIni(nscp.settingsFile).get("/settings/log")?.get("level")).toBe("info");
+
+    const r = await nscp.run(["settings", "--update", "--remove-defaults"]);
+    expect(r.exitCode).toBe(0);
+    expect(parseIni(nscp.settingsFile).get("/settings/log")?.get("level")).toBeUndefined();
+  });
+
+  it("the deprecated --generate spelling honours the same contract", async () => {
+    const nscp = new NscpInstance();
+    await nscp.run(["settings", "--activate-module", "CheckHelpers", "Scheduler"]);
+
+    const r = await nscp.run(["settings", "--generate", "--add-defaults"]);
+    expect(r.exitCode).toBe(0);
+    const sections = parseIni(nscp.settingsFile);
+
+    expect(sections.get("/settings/log")?.get("level")).toBe("info");
+    expect(valuesWhere(sections, (v) => v === "UNKNOWN")).toEqual([]);
+    expect([...sections.keys()].filter((s) => s.endsWith("/sample"))).toEqual([]);
+    expect(enabledModules(sections)).toEqual(new Set(["CheckHelpers", "Scheduler"]));
+  });
+});

--- a/tests/settings-update-defaults.test.ts
+++ b/tests/settings-update-defaults.test.ts
@@ -110,6 +110,26 @@ describe("settings --update --add-defaults", () => {
     expect(parseIni(nscp.settingsFile).get("/settings/log")?.get("level")).toBeUndefined();
   });
 
+  it("--use-samples writes the sample objects, and --remove-defaults strips them again", async () => {
+    const nscp = new NscpInstance();
+    await nscp.run(["settings", "--activate-module", "CheckHelpers", "Scheduler"]);
+
+    const r = await nscp.run(["settings", "--update", "--add-defaults", "--use-samples"]);
+    expect(r.exitCode).toBe(0);
+    let sections = parseIni(nscp.settingsFile);
+
+    // The Scheduler's sample schedule is materialized as a starting point...
+    expect([...sections.keys()]).toContain("/settings/scheduler/schedules/sample");
+    // ...with real defaults, not placeholders.
+    expect(valuesWhere(sections, (v) => v === "UNKNOWN")).toEqual([]);
+
+    // remove-defaults is the inverse: the untouched sample sections disappear.
+    const rm = await nscp.run(["settings", "--update", "--remove-defaults"]);
+    expect(rm.exitCode).toBe(0);
+    sections = parseIni(nscp.settingsFile);
+    expect([...sections.keys()].filter((s) => s.endsWith("/sample"))).toEqual([]);
+  });
+
   it("the deprecated --generate spelling honours the same contract", async () => {
     const nscp = new NscpInstance();
     await nscp.run(["settings", "--activate-module", "CheckHelpers", "Scheduler"]);


### PR DESCRIPTION
Three related changes around the settings CLI, grown out of verifying issue #542:

## settings: make `--use-samples` actually write the sample objects

The `--use-samples` flag was parsed and stored (`use_samples_`) but never read, so `settings --update --add-defaults --use-samples` behaved exactly like the plain invocation and the advertised sample commands (sample schedules, targets, real-time filters) were never written.

- `update_defaults()` takes an `include_samples` parameter that forwards to the registry enumeration (`get_reg_sections` / `get_reg_keys`); the CLI flag is passed through from both call sites (`--add-defaults` and `--activate-module`).
- Existing values are still never overwritten, and without the flag the behaviour is byte-for-byte unchanged.
- `remove_defaults()` now enumerates samples too, making it the inverse: a sample section still sitting at its defaults is stripped again, while one the operator edited survives like any other key.
- The `--use-samples` help text now says when the flag applies.

## test: pin the `settings --update --add-defaults` contract (#542)

Issue #542 reported that generating a configuration polluted the file: placeholder values written as the literal `UNKNOWN`, sample/template sections included, and modules enabled that the operator never asked for. The registry-driven defaults no longer do any of that, and a new integration suite (`tests/settings-update-defaults.test.ts`) locks the contract in against the real binary: registered defaults are filled in, no `UNKNOWN` placeholders and no `/sample` sections appear (without `--use-samples`), `[/modules]` is left untouched, operator values survive, `--remove-defaults` strips defaults again, and the deprecated `--generate` spelling behaves the same.

## build: guard `mongoose_wrapper_test` decoration for test-less builds

`NSCP_CREATE_TEST` is a no-op when `NSCP_BUILD_TESTS=OFF`, but the WEBServer CMakeLists decorated the test target unconditionally, so any configure with tests disabled aborted with `Cannot specify include directories for target "mongoose_wrapper_test"`. The decoration is now wrapped in the same `if(TARGET ...)` guard CheckDisk and CheckSecurity already use.

## Validation

- `settings_manager_test`: 83/83 pass, including three new cases (samples materialise with `update_defaults(true)`, sample round trip leaves nothing behind, an edited sample survives `--remove-defaults`).
- Integration: `settings-update-defaults.test.ts` 5/5 and `activate-module.test.ts` 3/3 against a Linux build (`NSCP_SKIP_DOCKER=1`).
- A fresh `cmake -DNSCP_BUILD_TESTS=OFF` configure with WEBServer enabled (the previously failing combination) completes cleanly.

Closes #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YCKSK7R7GSJjw5NXxdTRsQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCKSK7R7GSJjw5NXxdTRsQ)_