### PR TITLE
Add "run on startup" option to real-time filters

### DIFF
--- a/docs/docs/scenarios/realtime-monitoring.md
+++ b/docs/docs/scenarios/realtime-monitoring.md
@@ -172,6 +172,7 @@ All filter families share these keys in the child section:
 | `silent period` | Suppress repeat notifications after a match                              |
 | `maximum age`   | Re-submit an OK/"empty" message when nothing has matched for this long   |
 | `empty message` | The text used for that OK re-submission                                  |
+| `run on startup` | Submit the OK/"empty" message once as soon as NSClient++ starts, so the destination (e.g. the SimpleCache behind `check_cache`) is primed before the first match or `maximum age` timeout |
 | `top syntax` / `detail syntax` | Message formatting, as in regular checks                   |
 
 ---

--- a/include/nscapi/settings/filter.cpp
+++ b/include/nscapi/settings/filter.cpp
@@ -63,6 +63,17 @@ void filter_object::read_object(settings_helper::path_extension& path, const boo
           "How long before a new alert is reported after an alert is reported. In other words whenever an alert is fired and a notification is sent the same "
           "notification will not be sent again until this period has ended.\nIf this is set to \"false\" no periodic ok messages will be reported only errors.")
 
+      // No default here: the value is inherited from the parent template via
+      // the clone-then-read flow (like the scheduler's same-named option), and
+      // a registered default would reset the cloned value whenever the key is
+      // absent. An explicit `false` on a child still overrides an inherited
+      // `true`.
+      .add_bool("run on startup", sh::bool_key(&run_on_startup), "RUN ON STARTUP",
+                "Submit the \"empty message\" (with an OK status) once as soon as NSClient++ has started instead of waiting for the first event or the "
+                "\"maximum age\" timeout. Use this to prime the destination (for instance the cache queried by check_cache) so checks made right after a "
+                "restart do not fail with \"Entry not found\". Inherited from the default filter unless set here.",
+                true)
+
       .add_string("empty message", sh::string_key(&timeout_msg, "eventlog found no records"), "EMPTY MESSAGE",
                   "The message to display if nothing matches the filter (generally considered the ok state).", !is_default)
 
@@ -98,6 +109,7 @@ void filter_object::apply_parent(const filter_object& parent) {
   import_string(filter_crit, parent.filter_crit);
   import_string(filter_ok, parent.filter_ok);
   if (parent.debug) debug = parent.debug;
+  if (parent.run_on_startup) run_on_startup = parent.run_on_startup;
   import_string(target, parent.target);
   import_string(target_id, parent.target_id);
   import_string(source_id, parent.source_id);

--- a/include/nscapi/settings/filter.cpp
+++ b/include/nscapi/settings/filter.cpp
@@ -109,6 +109,13 @@ void filter_object::apply_parent(const filter_object& parent) {
   import_string(filter_crit, parent.filter_crit);
   import_string(filter_ok, parent.filter_ok);
   if (parent.debug) debug = parent.debug;
+  // Like `debug` above, a plain bool cannot tell "explicitly false" from
+  // "unset", so this can only propagate a parent's true. That is fine because
+  // this function is not how filters inherit at runtime: the object handler
+  // clones the parent template and then reads the child's own keys over it
+  // (and `run on startup` is registered without a default exactly so an
+  // absent key keeps the cloned value while an explicit `false` overrides an
+  // inherited `true`).
   if (parent.run_on_startup) run_on_startup = parent.run_on_startup;
   import_string(target, parent.target);
   import_string(target_id, parent.target_id);

--- a/include/nscapi/settings/filter.hpp
+++ b/include/nscapi/settings/filter.hpp
@@ -24,6 +24,10 @@ namespace settings_filters {
 struct NSCAPI_EXPORT filter_object {
   bool debug;
   bool escape_html;
+  // Submit the filter's "empty message" once as soon as the module starts, so
+  // the destination (e.g. the cache behind check_cache) has an entry before
+  // the first data change or `maximum age` timeout fires (issue #584).
+  bool run_on_startup;
   std::string syntax_top;
   std::string syntax_detail;
   std::string target;
@@ -62,6 +66,7 @@ struct NSCAPI_EXPORT filter_object {
   filter_object(std::string syntax_top, std::string syntax_detail, std::string target)
       : debug(false),
         escape_html(false),
+        run_on_startup(false),
         syntax_top(std::move(syntax_top)),
         syntax_detail(std::move(syntax_detail)),
         target(std::move(target)),

--- a/include/nscapi/settings/filter_test.cpp
+++ b/include/nscapi/settings/filter_test.cpp
@@ -22,6 +22,7 @@ TEST(FilterObjectTest, ConstructorBasic) {
   EXPECT_EQ("target", obj.target);
   EXPECT_FALSE(obj.debug);
   EXPECT_FALSE(obj.escape_html);
+  EXPECT_FALSE(obj.run_on_startup);
   EXPECT_EQ(-1, obj.severity);
 }
 
@@ -36,6 +37,7 @@ TEST(FilterObjectTest, CopyConstructor) {
   filter_object original("top", "detail", "target");
   original.debug = true;
   original.escape_html = true;
+  original.run_on_startup = true;
   original.syntax_ok = "ok_syntax";
   original.filter_ok = "ok_filter";
   original.filter_warn = "warn_filter";
@@ -57,6 +59,7 @@ TEST(FilterObjectTest, CopyConstructor) {
   EXPECT_EQ(original.target, copy.target);
   EXPECT_EQ(original.debug, copy.debug);
   EXPECT_EQ(original.escape_html, copy.escape_html);
+  EXPECT_EQ(original.run_on_startup, copy.run_on_startup);
   EXPECT_EQ(original.syntax_ok, copy.syntax_ok);
   EXPECT_EQ(original.filter_ok, copy.filter_ok);
   EXPECT_EQ(original.filter_warn, copy.filter_warn);
@@ -472,6 +475,28 @@ TEST(FilterObjectTest, ApplyParentDoesNotOverwriteDebugFlagWhenChildIsTrue) {
   child.apply_parent(parent);
 
   EXPECT_TRUE(child.debug);
+}
+
+TEST(FilterObjectTest, ApplyParentCopiesRunOnStartupFlag) {
+  filter_object parent("", "", "");
+  parent.run_on_startup = true;
+
+  filter_object child("", "", "");
+  child.apply_parent(parent);
+
+  EXPECT_TRUE(child.run_on_startup);
+}
+
+TEST(FilterObjectTest, ApplyParentDoesNotOverwriteRunOnStartupWhenChildIsTrue) {
+  filter_object parent("", "", "");
+  parent.run_on_startup = false;
+
+  filter_object child("", "", "");
+  child.run_on_startup = true;
+
+  child.apply_parent(parent);
+
+  EXPECT_TRUE(child.run_on_startup);
 }
 
 TEST(FilterObjectTest, ApplyParentSeverityOnlyWhenChildIsUnset) {

--- a/include/parsers/filter/realtime_helper.hpp
+++ b/include/parsers/filter/realtime_helper.hpp
@@ -32,7 +32,7 @@ struct realtime_filter_helper {
   // startup` submissions are abandoned. The rounds are driven by the module's
   // real-time loop (sub-second to a few seconds apart), so this covers a slow
   // boot without retrying a genuinely broken destination forever.
-  static const int max_startup_attempts = 20;
+  static constexpr int max_startup_attempts = 20;
 
   typedef typename runtime_data::filter_type filter_type;
   typedef typename runtime_data::transient_data_type transient_data_type;
@@ -319,10 +319,10 @@ struct realtime_filter_helper {
   bool process_startup() {
     const boost::posix_time::ptime current_time = boost::posix_time::second_clock::local_time();
     bool pending = false;
+    nscapi::core_helper ch(core, plugin_id);
     for (const container_type &item : items) {
       if (item->broken || !item->startup_pending) continue;
       std::string response;
-      nscapi::core_helper ch(core, plugin_id);
       if (ch.submit_simple_message(item->get_target(), item->get_source_id(), item->get_target_id(), item->command, NSCAPI::query_return_codes::returnOK,
                                    item->timeout_msg, "", response)) {
         item->startup_pending = false;

--- a/include/parsers/filter/realtime_helper.hpp
+++ b/include/parsers/filter/realtime_helper.hpp
@@ -23,7 +23,16 @@ template <class runtime_data, class config_object>
 struct realtime_filter_helper {
   nscapi::core_wrapper *core;
   int plugin_id;
-  realtime_filter_helper(nscapi::core_wrapper *core, const int plugin_id) : core(core), plugin_id(plugin_id) {}
+  // Number of process_startup() rounds which still left something pending,
+  // bounding the retries (see max_startup_attempts).
+  int startup_attempts;
+  realtime_filter_helper(nscapi::core_wrapper *core, const int plugin_id) : core(core), plugin_id(plugin_id), startup_attempts(0) {}
+
+  // How many process_startup() rounds may fail before the remaining `run on
+  // startup` submissions are abandoned. The rounds are driven by the module's
+  // real-time loop (sub-second to a few seconds apart), so this covers a slow
+  // boot without retrying a genuinely broken destination forever.
+  static const int max_startup_attempts = 20;
 
   typedef typename runtime_data::filter_type filter_type;
   typedef typename runtime_data::transient_data_type transient_data_type;
@@ -53,6 +62,9 @@ struct realtime_filter_helper {
    public:
     bool debug;
     bool escape_html;
+    // Still needs its `run on startup` priming submitted, see
+    // process_startup(). Only touched from the module's real-time thread.
+    bool startup_pending;
     runtime_data data;
     std::atomic<long long> match_count;
     std::atomic<long long> error_count;
@@ -69,6 +81,7 @@ struct realtime_filter_helper {
           severity(0),
           debug(false),
           escape_html(false),
+          startup_pending(false),
           data(data),
           match_count(0),
           error_count(0),
@@ -170,6 +183,7 @@ struct realtime_filter_helper {
     item->silent_period = object->filter.silent_period;
     item->debug = object->filter.debug;
     item->escape_html = object->filter.escape_html;
+    item->startup_pending = object->filter.run_on_startup;
     if (!object->filter.command.empty()) item->command = object->filter.command;
     std::string message;
 
@@ -275,6 +289,55 @@ struct realtime_filter_helper {
       if (item->broken) continue;
       item->touch(current_time, false);
     }
+  }
+
+  // Whether any filter still has a `run on startup` submission to deliver.
+  // Lets the module's real-time loop shorten its wait only while priming is
+  // actually outstanding.
+  bool has_pending_startup() const {
+    for (const container_type &item : items) {
+      if (!item->broken && item->startup_pending) return true;
+    }
+    return false;
+  }
+
+  // Prime the destination for every filter which opted in via `run on
+  // startup` (#584): submit the ok/empty message right away instead of
+  // leaving the destination (e.g. the cache behind check_cache) without an
+  // entry until the first data change or `maximum age` expiry. At boot no
+  // data has been seen yet, which is exactly the state the `maximum age`
+  // timeout reports, so the same message is submitted.
+  //
+  // Returns true once nothing is pending any more. A submission can fail
+  // because the destination module has not registered its channel yet - the
+  // real-time thread starts while later plugins are still loading (the same
+  // ordering problem the Scheduler solves with startModule) - so a failed
+  // attempt stays pending, to be retried by the caller's loop, and is only
+  // logged as an error once the attempts are exhausted (a destination which
+  // is still missing then is a real misconfiguration, which the `maximum
+  // age` path would keep reporting too).
+  bool process_startup() {
+    const boost::posix_time::ptime current_time = boost::posix_time::second_clock::local_time();
+    bool pending = false;
+    for (const container_type &item : items) {
+      if (item->broken || !item->startup_pending) continue;
+      std::string response;
+      nscapi::core_helper ch(core, plugin_id);
+      if (ch.submit_simple_message(item->get_target(), item->get_source_id(), item->get_target_id(), item->command, NSCAPI::query_return_codes::returnOK,
+                                   item->timeout_msg, "", response)) {
+        item->startup_pending = false;
+        item->touch(current_time, false);
+      } else if (startup_attempts + 1 >= max_startup_attempts) {
+        item->error_count.fetch_add(1, std::memory_order_relaxed);
+        item->startup_pending = false;
+        NSC_LOG_ERROR("Failed to submit startup message for '" + item->get_alias() + "', giving up: " + response);
+      } else {
+        pending = true;
+        NSC_DEBUG_MSG("Startup message for '" + item->get_alias() + "' could not be delivered yet, will retry: " + response);
+      }
+    }
+    if (pending) startup_attempts++;
+    return !pending;
   }
 
   void process_items(transient_data_type data) {

--- a/modules/CheckEventLog/realtime_thread.cpp
+++ b/modules/CheckEventLog/realtime_thread.cpp
@@ -65,9 +65,17 @@ void real_time_thread::thread_proc() {
   }
   helper.touch_all();
 
+  // `run on startup` submissions are delivered from inside the loop rather
+  // than as a one-shot here: this thread starts while later plugins (the
+  // destination of the filter) may still be loading, so failed attempts are
+  // retried across the loop's waits - which are shortened while priming is
+  // outstanding - until the destination's channel exists.
+  bool startup_done = !helper.has_pending_startup();
+
   unsigned int errors = 0;
   while (true) {
     bool has_errors = false;
+    if (!startup_done) startup_done = helper.process_startup();
     filter_helper::op_duration dur = helper.find_minimum_timeout();
 
     DWORD dwWaitTime = INFINITE;
@@ -75,6 +83,7 @@ void real_time_thread::thread_proc() {
       dwWaitTime = 0;
     else if (dur)
       dwWaitTime = static_cast<DWORD>(dur->total_milliseconds());
+    if (!startup_done && dwWaitTime > 500) dwWaitTime = 500;
 
     NSC_DEBUG_MSG("Sleeping for: " + str::xtos(dwWaitTime) + "ms");
     DWORD dwWaitReason = WaitForMultipleObjects(static_cast<DWORD>(evlog_list.size() + 1), handles, FALSE, dwWaitTime);

--- a/modules/CheckLogFile/realtime_thread.cpp
+++ b/modules/CheckLogFile/realtime_thread.cpp
@@ -116,8 +116,18 @@ void real_time_thread::thread_proc() {
 
   helper.touch_all();
 
+  // `run on startup` submissions are delivered from inside the loop rather
+  // than as a one-shot here: this thread starts while later plugins (for
+  // instance the SimpleCache behind a `destination = cache`) may still be
+  // loading, so failed attempts are retried across the loop's waits - which
+  // are shortened while priming is outstanding - until the destination's
+  // channel exists.
+  bool startup_done = !helper.has_pending_startup();
+
   while (true) {
+    if (!startup_done) startup_done = helper.process_startup();
     filter_helper::op_duration dur = helper.find_minimum_timeout();
+    if (!startup_done && (!dur || *dur > boost::posix_time::milliseconds(500))) dur = boost::posix_time::milliseconds(500);
     std::string trigger_folder;
 #ifdef WIN32
     DWORD dwWaitTime = INFINITE;

--- a/modules/CheckSystem/check_memory.cpp
+++ b/modules/CheckSystem/check_memory.cpp
@@ -172,6 +172,8 @@ void helper::add_obj(std::shared_ptr<filters::mem::filter_config_object> object)
 
 void helper::boot() { memory_helper->helper.touch_all(); }
 
+bool helper::process_startup() { return memory_helper->helper.process_startup(); }
+
 void helper::check() { memory_helper->helper.process_items(&memchecker); }
 
 std::map<std::string, long long> helper::get_counts() const { return memory_helper->helper.get_counts(); }

--- a/modules/CheckSystem/check_memory.hpp
+++ b/modules/CheckSystem/check_memory.hpp
@@ -20,6 +20,8 @@ struct helper {
   helper(nscapi::core_wrapper *core, int plugin_id);
   void add_obj(std::shared_ptr<filters::mem::filter_config_object> object);
   void boot();
+  // Deliver pending `run on startup` submissions; true once none are left.
+  bool process_startup();
   void check();
   std::map<std::string, long long> get_counts() const;
 };

--- a/modules/CheckSystem/check_process.cpp
+++ b/modules/CheckSystem/check_process.cpp
@@ -176,6 +176,8 @@ void helper::add_obj(std::shared_ptr<filters::proc::filter_config_object> object
 
 void helper::boot() { proc_helper->helper.touch_all(); }
 
+bool helper::process_startup() { return proc_helper->helper.process_startup(); }
+
 void helper::check() {
   NSC_error err;
 

--- a/modules/CheckSystem/check_process.hpp
+++ b/modules/CheckSystem/check_process.hpp
@@ -51,6 +51,8 @@ struct helper {
   helper(nscapi::core_wrapper *core, int plugin_id);
   void add_obj(std::shared_ptr<filters::proc::filter_config_object> object);
   void boot();
+  // Deliver pending `run on startup` submissions; true once none are left.
+  bool process_startup();
   void check();
   std::set<std::string> check_shared();
   std::map<std::string, long long> get_counts() const;

--- a/modules/CheckSystem/pdh_thread.cpp
+++ b/modules/CheckSystem/pdh_thread.cpp
@@ -328,6 +328,13 @@ void pdh_thread::thread_proc() {
   memory_helper.boot();
   process_helper.boot();
 
+  // `run on startup` submissions are delivered from inside the 1 Hz loop
+  // below rather than here: this thread starts while later plugins (the
+  // destinations of the filters) may still be loading, so the first attempt
+  // waits a tick and failed submissions are retried until the destination's
+  // channel exists.
+  bool realtime_startup_done = false;
+
   DWORD waitStatus = 0;
   int i = 0;
 
@@ -475,6 +482,12 @@ void pdh_thread::thread_proc() {
       } catch (...) {
         errors.emplace_back("Failed to sample process CPU");
       }
+    }
+    if (!realtime_startup_done) {
+      const bool cpu_done = cpu_helper.process_startup();
+      const bool mem_done = memory_helper.process_startup();
+      const bool proc_done = process_helper.process_startup();
+      realtime_startup_done = cpu_done && mem_done && proc_done;
     }
     if (has_realtime && i == (min_threshold_ - 1)) {
       if (has_cpu_realtime) cpu_helper.process_items(this);

--- a/modules/CheckSystemUnix/realtime_thread.cpp
+++ b/modules/CheckSystemUnix/realtime_thread.cpp
@@ -82,6 +82,13 @@ void pdh_thread::thread_proc() {
   mem_helper.touch_all();
   proc_helper.touch_all();
 
+  // `run on startup` submissions are delivered from inside the 1 Hz loop
+  // below rather than here: this thread starts while later plugins (the
+  // destinations of the filters) may still be loading, so the first attempt
+  // waits a tick and failed submissions are retried until the destination's
+  // channel exists.
+  bool startup_done = false;
+
   const bool has_cpu_realtime = !cpu_filters_.empty();
   const bool has_mem_realtime = !mem_filters_.empty();
   const bool has_proc_realtime = !proc_filters_.empty();
@@ -135,6 +142,12 @@ void pdh_thread::thread_proc() {
 
     // Evaluate real-time filters once we have collected data
     try {
+      if (!startup_done) {
+        const bool cpu_done = cpu_helper.process_startup();
+        const bool mem_done = mem_helper.process_startup();
+        const bool proc_done = proc_helper.process_startup();
+        startup_done = cpu_done && mem_done && proc_done;
+      }
       if (has_cpu_realtime) cpu_helper.process_items(this);
       if (has_mem_realtime) mem_helper.process_items(this);
       if (has_proc_realtime) proc_helper.process_items(this);

--- a/tests/checklogfile-realtime.test.ts
+++ b/tests/checklogfile-realtime.test.ts
@@ -94,7 +94,9 @@ describe("CheckLogFile real-time run on startup", () => {
 
   afterAll(async () => {
     await nscp?.stop();
-    fs.rmSync(scratch, { recursive: true, force: true });
+    // beforeAll can fail before `scratch` is assigned; don't let teardown
+    // throw a secondary error that masks the original failure.
+    if (scratch) fs.rmSync(scratch, { recursive: true, force: true });
   });
 
   it("primes the cache at startup when run on startup is set", async () => {

--- a/tests/checklogfile-realtime.test.ts
+++ b/tests/checklogfile-realtime.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Covers `run on startup` for real-time filters (issue #584): a real-time
+ * check normally submits nothing until its file changes or `maximum age`
+ * expires, so a destination like SimpleCache stays empty right after the
+ * agent starts and `check_cache` fails with "Entry not found" until the
+ * first trigger. With `run on startup` the filter submits its "empty
+ * message" (OK) as soon as the module is up, priming the destination.
+ *
+ * The suite boots one agent with CheckLogFile real-time filters routed to
+ * SimpleCache and observes the cache over REST via check_cache:
+ *
+ *   - rt_explicit — run on startup = true       → primed within seconds
+ *   - rt_inherit  — inherits true from default  → primed within seconds
+ *   - rt_optout   — run on startup = false      → must stay absent
+ *
+ * `maximum age` is disabled everywhere so the only way an entry can appear
+ * during the test is the startup submission (or a real file change, which
+ * the last test triggers deliberately to prove the primed filter still
+ * reacts to live data).
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  NscpInstance,
+  OK,
+  UNKNOWN,
+  executeQuery,
+  messageOf,
+  pollQuery,
+  setupQueryNscp,
+} from "@fixtures/index";
+
+jest.setTimeout(300_000);
+
+describe("CheckLogFile real-time run on startup", () => {
+  let nscp: NscpInstance;
+  let key: string;
+  let scratch: string;
+  let explicitLog: string;
+  let inheritLog: string;
+  let optoutLog: string;
+
+  function checkCache(cacheKey: string) {
+    return executeQuery(key, "check_cache", { key: cacheKey });
+  }
+
+  beforeAll(async () => {
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), "checklogfile-rt-"));
+    explicitLog = path.join(scratch, "explicit.log");
+    inheritLog = path.join(scratch, "inherit.log");
+    optoutLog = path.join(scratch, "optout.log");
+    for (const f of [explicitLog, inheritLog, optoutLog]) fs.writeFileSync(f, "");
+
+    nscp = new NscpInstance();
+    key = await setupQueryNscp(nscp, "CheckLogFile", {
+      "/modules": {
+        CheckLogFile: "enabled",
+        SimpleCache: "enabled",
+        WEBServer: "enabled",
+      },
+      "/settings/logfile/real-time": { enabled: "true" },
+      // The template: everything below inherits the destination, the filter
+      // and — unless overridden — `run on startup`. `maximum age` is off so
+      // no periodic-ok submission can prime an entry behind the test's back.
+      "/settings/logfile/real-time/checks/default": {
+        destination: "cache",
+        filter: "column1 like 'ERROR'",
+        "maximum age": "false",
+        "run on startup": "true",
+      },
+      "/settings/logfile/real-time/checks/rt_explicit": {
+        file: explicitLog,
+        "maximum age": "false",
+        "empty message": "primed explicit",
+        "run on startup": "true",
+      },
+      "/settings/logfile/real-time/checks/rt_inherit": {
+        file: inheritLog,
+        "maximum age": "false",
+        "empty message": "primed inherit",
+      },
+      // The control: an explicit override wins over the inherited true, so
+      // this filter keeps the old behaviour and submits nothing at boot.
+      "/settings/logfile/real-time/checks/rt_optout": {
+        file: optoutLog,
+        "maximum age": "false",
+        "empty message": "primed optout",
+        "run on startup": "false",
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await nscp?.stop();
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("primes the cache at startup when run on startup is set", async () => {
+    const res = await pollQuery(key, "check_cache", { key: "rt_explicit" }, (q) => q.result === OK);
+    expect(res.result).toBe(OK);
+    expect(messageOf(res)).toBe("primed explicit");
+  });
+
+  it("inherits run on startup from the default filter", async () => {
+    const res = await pollQuery(key, "check_cache", { key: "rt_inherit" }, (q) => q.result === OK);
+    expect(res.result).toBe(OK);
+    expect(messageOf(res)).toBe("primed inherit");
+  });
+
+  it("honours an explicit run on startup = false override", async () => {
+    // The primed entries above prove the startup pass has run and completed,
+    // so an entry for the opted-out filter would have to exist by now too.
+    const res = await checkCache("rt_optout");
+    expect(res.result).toBe(UNKNOWN);
+    expect(messageOf(res)).toMatch(/Entry not found/i);
+  });
+
+  it("still reacts to live file changes after the startup priming", async () => {
+    // The primed entry must be replaced by a real result once data arrives,
+    // proving the startup submission did not consume or break the trigger
+    // path of the filter.
+    fs.appendFileSync(explicitLog, "ERROR live\n");
+    const res = await pollQuery(key, "check_cache", { key: "rt_explicit" }, (q) =>
+      messageOf(q).includes("ERROR live"),
+    );
+    expect(messageOf(res)).toContain("ERROR live");
+  });
+});

--- a/web/src/components/SettingsCollection.tsx
+++ b/web/src/components/SettingsCollection.tsx
@@ -159,6 +159,7 @@ const FILTER_FIELD_GROUPS: FieldGroup[] = [
       "silent period",
       "empty message",
       "maximum age",
+      "run on startup",
       "escape html",
       "debug",
     ],


### PR DESCRIPTION
Fixes #584.

## Problem

Real-time filters submit nothing until their data changes or `maximum age` expires. A destination like SimpleCache therefore stays empty right after the agent starts, and `check_cache` fails with `UNKNOWN: Entry not found` until the first trigger — up to `maximum age` later, or forever when that is disabled.

## Solution

A new opt-in `run on startup` option on the shared real-time filter object: the filter submits its `empty message` (with an OK status) once as soon as NSClient++ has started, priming the destination. Semantically it is the `maximum age` timeout firing at t=0 — at boot no data has been seen yet, which is exactly the state that timeout reports.

- **All real-time consumers get it**: CheckLogFile, CheckEventLog, and the CheckSystem / CheckSystemUnix cpu/memory/process filters, since both the option (`nscapi::settings_filters::filter_object`) and the mechanism (`realtime_filter_helper`) live in shared code.
- **Inheritable**: set it on the `default` filter to enable it for every filter; an explicit `false` on a child still overrides an inherited `true` (same semantics as the Scheduler's same-named option from #392).
- **Boot-ordering safe**: the real-time threads start while later plugins (e.g. the SimpleCache behind `destination = cache`) are still loading, so a one-shot submission at boot could hit an unregistered channel. Delivery is therefore driven from inside each module's real-time loop: failed submissions are retried across shortened waits until the destination's channel exists, quiet (debug-level) until the bounded retries (20) are exhausted, at which point one error per filter is logged — the same signal a misconfigured destination produces via the `maximum age` path.

Example (the reporter's scenario from #584):

```ini
[/settings/logfile/real-time/checks/chktest]
destination = cache
file = D:\chktest.log
filter = line regexp '.*OK$'
maximum age = 1m
run on startup = true
```

`check_cache key=chktest` now returns OK immediately after service start instead of `Entry not found`.

## Tests

- Unit: `filter_test.cpp` covers the new field's default, copy and `apply_parent` semantics (all 71 ctest suites pass).
- Integration: new `tests/checklogfile-realtime.test.ts` boots CheckLogFile real-time filters routed to SimpleCache and asserts over REST that an opted-in filter and a default-inheriting filter are primed, an explicitly opted-out filter stays absent, and a primed filter still reacts to live file changes. `checklogfile-commands` and `metrics-realtime` suites still pass.

Docs: the setting description feeds the generated reference; the real-time monitoring scenario page's tuning table and the web UI's filter field grouping were updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XEmyEaZoAcTS1Hf3UK6k95

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEmyEaZoAcTS1Hf3UK6k95)_