### PR TITLE
feature: add ${address_ipv4} / ${address_ipv6*} hostname placeholders (#349)

### DIFF
--- a/docs/docs/scenarios/passive-monitoring-graphite.md
+++ b/docs/docs/scenarios/passive-monitoring-graphite.md
@@ -295,6 +295,10 @@ hostname = auto                       ; computer name (default)
 | `${domain}`    | domain name                        |
 | `${domain_lc}` | domain lowercase                   |
 | `${domain_uc}` | domain uppercase                   |
+| `${address_ipv4}` | IPv4 address of the machine     |
+| `${address_ipv6}` | IPv6 address (lowercase, compressed) |
+
+The IPv6 address is also available in case and padding variants: `${address_ipv6_lc}` / `${address_ipv6_uc}` pick the case, and appending `_comp` / `_uncomp` (e.g. `${address_ipv6_uc_uncomp}`) picks between the compressed (`2001:db8::7`) and the fully zero-padded (`2001:0db8:0000:0000:0000:0000:0000:0007`) form.
 
 Dots in the hostname become Graphite hierarchy separators, so
 `${host_lc}.${domain_lc}` nests each host under its domain in the tree.

--- a/docs/docs/scenarios/passive-monitoring-icinga.md
+++ b/docs/docs/scenarios/passive-monitoring-icinga.md
@@ -225,6 +225,10 @@ Supported variables:
 | `${domain}`    | Windows domain name                |
 | `${domain_lc}` | Domain lowercase                   |
 | `${domain_uc}` | Domain uppercase                   |
+| `${address_ipv4}` | IPv4 address of the machine     |
+| `${address_ipv6}` | IPv6 address (lowercase, compressed) |
+
+The IPv6 address is also available in case and padding variants: `${address_ipv6_lc}` / `${address_ipv6_uc}` pick the case, and appending `_comp` / `_uncomp` (e.g. `${address_ipv6_uc_uncomp}`) picks between the compressed (`2001:db8::7`) and the fully zero-padded (`2001:0db8:0000:0000:0000:0000:0000:0007`) form.
 
 This name is used both as the Icinga 2 host name in the URL (`?host=…` / `?service=host!service`) and as the
 `check_source` field on the resulting check result, unless you override `check source` on the target explicitly.

--- a/docs/docs/scenarios/passive-monitoring-nsca.md
+++ b/docs/docs/scenarios/passive-monitoring-nsca.md
@@ -308,6 +308,10 @@ Supported variables:
 | `${domain}`    | Windows domain name                |
 | `${domain_lc}` | Domain lowercase                   |
 | `${domain_uc}` | Domain uppercase                   |
+| `${address_ipv4}` | IPv4 address of the machine     |
+| `${address_ipv6}` | IPv6 address (lowercase, compressed) |
+
+The IPv6 address is also available in case and padding variants: `${address_ipv6_lc}` / `${address_ipv6_uc}` pick the case, and appending `_comp` / `_uncomp` (e.g. `${address_ipv6_uc_uncomp}`) picks between the compressed (`2001:db8::7`) and the fully zero-padded (`2001:0db8:0000:0000:0000:0000:0000:0007`) form.
 
 ---
 

--- a/include/net/socket/socket_helpers.cpp
+++ b/include/net/socket/socket_helpers.cpp
@@ -4,7 +4,9 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/asio.hpp>
 #include <boost/filesystem.hpp>
+#include <iomanip>
 #include <net/socket/socket_helpers.hpp>
+#include <sstream>
 #include <str/format.hpp>
 #include <str/utf8.hpp>
 #include <str/utils.hpp>
@@ -32,42 +34,131 @@ std::list<std::string> socket_helpers::connection_info::validate() const { retur
 namespace {
 std::string keep_verbatim(std::string value) { return value; }
 
+// Find the address this machine is best known by in the given family, for the
+// ${address_ipv4} / ${address_ipv6*} placeholders (#349). Loopback, link-local
+// and unspecified addresses never identify a host to a remote monitoring
+// server, so they are rejected everywhere; none() means "this machine has no
+// usable address in this family" and the caller leaves the token unresolved.
+boost::optional<ip::address> discover_local_address(const bool ipv6) {
+  // Routing-table probe: connecting a UDP socket sends no packet, it only asks
+  // the kernel which source address it would use for that destination - which
+  // is exactly the address a remote server would see this machine as. The
+  // probe destinations are from the documentation ranges (TEST-NET-3 and
+  // 2001:db8::/32) so nothing real is ever addressed.
+  try {
+    boost::asio::io_context io;
+    ip::udp::socket probe(io);
+    const ip::udp::endpoint target =
+        ipv6 ? ip::udp::endpoint(ip::make_address_v6("2001:db8::1"), 53) : ip::udp::endpoint(ip::make_address_v4("203.0.113.1"), 53);
+    probe.connect(target);
+    const ip::address addr = probe.local_endpoint().address();
+    if (!addr.is_loopback() && !addr.is_unspecified() && !(addr.is_v6() && addr.to_v6().is_link_local())) return addr;
+  } catch (const std::exception &) {
+    // No route in this family (common for IPv6) - try the resolver below.
+  }
+  // Fall back to what the host name resolves to. This can disagree with the
+  // routing answer (a 127.0.1.1 hosts-file entry, a multi-homed machine), so
+  // it is only consulted when the routing probe has nothing to offer.
+  try {
+    boost::asio::io_context io;
+    ip::udp::resolver resolver(io);
+    for (const auto &entry : resolver.resolve(ipv6 ? ip::udp::v6() : ip::udp::v4(), ip::host_name(), "")) {
+      const ip::address addr = entry.endpoint().address();
+      if (addr.is_loopback() || addr.is_unspecified()) continue;
+      if (addr.is_v6() && addr.to_v6().is_link_local()) continue;
+      return addr;
+    }
+  } catch (const std::exception &) {
+  }
+  return boost::none;
+}
+
 // One host name placeholder substitution pass; `prep` is applied to every
 // value before it is spliced in (identity for a host name spec, the path
 // sanitizer for a string that ends up on the file system).
 std::string expand_placeholders_with(std::string spec, std::string (*prep)(std::string)) {
-  // Nothing to resolve, and asking the OS for its host name is not free (and
-  // can even throw): a settings context or an attachment path usually has no
-  // host name placeholder at all. Every token starts with ${host or ${domain,
-  // so this also skips a spec that only carries path tokens (${shared-path}).
-  if (spec.find("${host") == std::string::npos && spec.find("${domain") == std::string::npos) return spec;
-  std::string host_name;
-  try {
-    host_name = ip::host_name();
-  } catch (const std::exception &) {
-    // No host name to substitute with. Leave the placeholders alone rather
-    // than let a failing gethostname() abort settings boot - the callers all
-    // have a defined answer for an unresolved token.
-    return spec;
+  // Nothing to resolve, and asking the OS for its host name or addresses is
+  // not free (and can even throw): a settings context or an attachment path
+  // usually has no placeholder at all. Every token starts with ${host,
+  // ${domain or ${address_ip, so this also skips a spec that only carries path
+  // tokens (${shared-path}).
+  const bool has_name_token = spec.find("${host") != std::string::npos || spec.find("${domain") != std::string::npos;
+  const bool has_address_token = spec.find("${address_ip") != std::string::npos;
+  if (!has_name_token && !has_address_token) return spec;
+
+  if (has_name_token) {
+    std::string host_name;
+    try {
+      host_name = ip::host_name();
+    } catch (const std::exception &) {
+      // No host name to substitute with. Leave the placeholders alone rather
+      // than let a failing gethostname() abort settings boot - the callers all
+      // have a defined answer for an unresolved token.
+      host_name.clear();
+    }
+    if (!host_name.empty()) {
+      // The full name exactly as the system reports it. ${host} stops at the
+      // first '.', so without this there is no way to get the fqdn from inside
+      // a template - only by setting the whole spec to "auto", which a
+      // template cannot do.
+      str::utils::replace(spec, "${hostname_uc}", prep(boost::algorithm::to_upper_copy(host_name)));
+      str::utils::replace(spec, "${hostname_lc}", prep(boost::algorithm::to_lower_copy(host_name)));
+      str::utils::replace(spec, "${hostname}", prep(host_name));
+
+      const str::utils::token dn = str::utils::getToken(host_name, '.');
+      str::utils::replace(spec, "${host}", prep(dn.first));
+      str::utils::replace(spec, "${domain}", prep(dn.second));
+      str::utils::replace(spec, "${host_uc}", prep(boost::algorithm::to_upper_copy(dn.first)));
+      str::utils::replace(spec, "${domain_uc}", prep(boost::algorithm::to_upper_copy(dn.second)));
+      str::utils::replace(spec, "${host_lc}", prep(boost::algorithm::to_lower_copy(dn.first)));
+      str::utils::replace(spec, "${domain_lc}", prep(boost::algorithm::to_lower_copy(dn.second)));
+    }
   }
 
-  // The full name exactly as the system reports it. ${host} stops at the first
-  // '.', so without this there is no way to get the fqdn from inside a template
-  // - only by setting the whole spec to "auto", which a template cannot do.
-  str::utils::replace(spec, "${hostname_uc}", prep(boost::algorithm::to_upper_copy(host_name)));
-  str::utils::replace(spec, "${hostname_lc}", prep(boost::algorithm::to_lower_copy(host_name)));
-  str::utils::replace(spec, "${hostname}", prep(host_name));
-
-  const str::utils::token dn = str::utils::getToken(host_name, '.');
-  str::utils::replace(spec, "${host}", prep(dn.first));
-  str::utils::replace(spec, "${domain}", prep(dn.second));
-  str::utils::replace(spec, "${host_uc}", prep(boost::algorithm::to_upper_copy(dn.first)));
-  str::utils::replace(spec, "${domain_uc}", prep(boost::algorithm::to_upper_copy(dn.second)));
-  str::utils::replace(spec, "${host_lc}", prep(boost::algorithm::to_lower_copy(dn.first)));
-  str::utils::replace(spec, "${domain_lc}", prep(boost::algorithm::to_lower_copy(dn.second)));
+  if (has_address_token) {
+    // A machine with no usable address in a family keeps that family's tokens
+    // unresolved, same as the host name tokens above when gethostname() fails.
+    if (spec.find("${address_ipv4}") != std::string::npos) {
+      if (const boost::optional<ip::address> v4 = discover_local_address(false)) str::utils::replace(spec, "${address_ipv4}", prep(v4->to_string()));
+    }
+    if (spec.find("${address_ipv6") != std::string::npos) {
+      if (const boost::optional<ip::address> v6 = discover_local_address(true)) {
+        const ip::address_v6 addr = v6->to_v6();
+        str::utils::replace(spec, "${address_ipv6_lc_comp}", prep(socket_helpers::format_ipv6(addr, false, true)));
+        str::utils::replace(spec, "${address_ipv6_lc_uncomp}", prep(socket_helpers::format_ipv6(addr, false, false)));
+        str::utils::replace(spec, "${address_ipv6_uc_comp}", prep(socket_helpers::format_ipv6(addr, true, true)));
+        str::utils::replace(spec, "${address_ipv6_uc_uncomp}", prep(socket_helpers::format_ipv6(addr, true, false)));
+        str::utils::replace(spec, "${address_ipv6_lc}", prep(socket_helpers::format_ipv6(addr, false, true)));
+        str::utils::replace(spec, "${address_ipv6_uc}", prep(socket_helpers::format_ipv6(addr, true, true)));
+        str::utils::replace(spec, "${address_ipv6}", prep(socket_helpers::format_ipv6(addr, false, true)));
+      }
+    }
+  }
   return spec;
 }
 }  // namespace
+
+std::string socket_helpers::format_ipv6(const boost::asio::ip::address_v6 &address, const bool uppercase, const bool compressed) {
+  std::string formatted;
+  if (compressed) {
+    // to_string() is the RFC 5952 canonical form: lowercase hex digits with
+    // the longest zero run elided.
+    formatted = address.to_string();
+  } else {
+    // All eight groups, zero-padded to four digits: the fixed-width form some
+    // inventory/monitoring systems key their host records on.
+    const boost::asio::ip::address_v6::bytes_type bytes = address.to_bytes();
+    std::ostringstream oss;
+    oss << std::hex << std::setfill('0');
+    for (std::size_t i = 0; i < bytes.size(); i += 2) {
+      if (i > 0) oss << ':';
+      oss << std::setw(2) << static_cast<unsigned int>(bytes[i]) << std::setw(2) << static_cast<unsigned int>(bytes[i + 1]);
+    }
+    formatted = oss.str();
+  }
+  if (uppercase) boost::algorithm::to_upper(formatted);
+  return formatted;
+}
 
 std::string socket_helpers::sanitize_path_component(std::string value) {
   // gethostname() is not fully under the operator's control - DHCP can set it

--- a/include/net/socket/socket_helpers.hpp
+++ b/include/net/socket/socket_helpers.hpp
@@ -72,6 +72,17 @@ void validate_certificate(const std::string& certificate, std::list<std::string>
 // after splitting on the first '.' into host and domain. Other text is
 // preserved.
 //
+// The machine's addresses are available too (#349): ${address_ipv4} is the
+// IPv4 address, and ${address_ipv6} the IPv6 address in its RFC 5952 canonical
+// form (lowercase, compressed). The IPv6 variants ${address_ipv6_lc} /
+// ${address_ipv6_uc} pick the case, and appending _comp / _uncomp
+// (${address_ipv6_lc_uncomp}, ...) picks between the compressed
+// (2001:db8::7) and the fully zero-padded eight-group form
+// (2001:0db8:0000:0000:0000:0000:0000:0007). The address is the source
+// address of the default route when there is one, otherwise the first
+// non-loopback, non-link-local address the host name resolves to; a machine
+// with no usable address in a family keeps that family's tokens unresolved.
+//
 // This is the half of expand_hostname which is safe to apply to a string that
 // is not a host name spec - a settings context or an attachment path, say -
 // since it only ever replaces a placeholder and never reinterprets the string
@@ -86,6 +97,13 @@ std::string expand_hostname_placeholders(std::string spec);
 // dots-only component must not be able to redirect a path the agent reads or
 // writes with its (typically root/SYSTEM) privileges.
 std::string expand_hostname_placeholders_in_path(std::string spec);
+
+// Format an IPv6 address for the ${address_ipv6*} placeholders: `compressed`
+// picks between the RFC 5952 elided form (2001:db8::7) and the fully
+// zero-padded eight-group form (2001:0db8:0000:0000:0000:0000:0000:0007),
+// `uppercase` the case of the hex digits. Exposed for unit testing - the
+// placeholder machinery resolves the address itself.
+std::string format_ipv6(const boost::asio::ip::address_v6& address, bool uppercase, bool compressed);
 
 // Reduce `value` to characters safe inside a single path component: letters,
 // digits, '.', '_' and '-' pass, anything else becomes '_', and a value that

--- a/include/net/socket/socket_helpers_test.cpp
+++ b/include/net/socket/socket_helpers_test.cpp
@@ -4,11 +4,13 @@
 #include <gtest/gtest.h>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/asio.hpp>
 #include <boost/asio/ip/host_name.hpp>
 #include <net/socket/server.hpp>
 #include <net/socket/socket_helpers.hpp>
 #include <str/utils.hpp>
 #include <string>
+#include <vector>
 
 // =============================================================================
 // socket_exception tests
@@ -321,6 +323,109 @@ TEST(ExpandHostname, CasePlaceholdersAreExpanded) {
   // placeholders are substituted away.
   std::string out = socket_helpers::expand_hostname("${host_lc}|${host_uc}|${domain_lc}|${domain_uc}|${domain}");
   EXPECT_EQ(out.find("${"), std::string::npos);
+}
+
+// =============================================================================
+// format_ipv6
+//
+// The pure formatting half of the ${address_ipv6*} placeholders (#349). The
+// address discovery half is machine-dependent and covered below only as far as
+// determinism allows.
+// =============================================================================
+
+TEST(FormatIpv6, CompressedLowercaseIsRfc5952) {
+  const auto addr = boost::asio::ip::make_address_v6("2001:0db8:0000:2000:0000:0000:0000:0007");
+  EXPECT_EQ(socket_helpers::format_ipv6(addr, false, true), "2001:db8:0:2000::7");
+}
+
+TEST(FormatIpv6, CompressedUppercase) {
+  const auto addr = boost::asio::ip::make_address_v6("2001:0db8:0000:2000:0000:0000:0000:0007");
+  EXPECT_EQ(socket_helpers::format_ipv6(addr, true, true), "2001:DB8:0:2000::7");
+}
+
+TEST(FormatIpv6, UncompressedLowercaseIsFullyPadded) {
+  const auto addr = boost::asio::ip::make_address_v6("2001:db8:0:2000::7");
+  EXPECT_EQ(socket_helpers::format_ipv6(addr, false, false), "2001:0db8:0000:2000:0000:0000:0000:0007");
+}
+
+TEST(FormatIpv6, UncompressedUppercase) {
+  const auto addr = boost::asio::ip::make_address_v6("2001:db8:0:2000::7");
+  EXPECT_EQ(socket_helpers::format_ipv6(addr, true, false), "2001:0DB8:0000:2000:0000:0000:0000:0007");
+}
+
+TEST(FormatIpv6, LoopbackBothForms) {
+  const auto addr = boost::asio::ip::make_address_v6("::1");
+  EXPECT_EQ(socket_helpers::format_ipv6(addr, false, true), "::1");
+  EXPECT_EQ(socket_helpers::format_ipv6(addr, false, false), "0000:0000:0000:0000:0000:0000:0000:0001");
+}
+
+// =============================================================================
+// ${address_*} placeholder expansion
+//
+// The resolved value is machine-dependent (and a machine may have no address
+// in a family at all, in which case the token is deliberately left alone), so
+// these assert the shape of the substitution, not a specific address.
+// =============================================================================
+
+namespace {
+bool looks_like_ipv4(const std::string& value) {
+  boost::system::error_code ec;
+  boost::asio::ip::make_address_v4(value, ec);
+  return !ec;
+}
+bool looks_like_ipv6(const std::string& value) {
+  boost::system::error_code ec;
+  boost::asio::ip::make_address_v6(value, ec);
+  return !ec;
+}
+}  // namespace
+
+TEST(ExpandHostname, AddressIpv4IsAnAddressOrLeftAlone) {
+  const std::string out = socket_helpers::expand_hostname("ip-${address_ipv4}-end");
+  if (out == "ip-${address_ipv4}-end") return;  // no usable IPv4 on this machine
+  ASSERT_EQ(out.substr(0, 3), "ip-");
+  ASSERT_EQ(out.substr(out.size() - 4), "-end");
+  const std::string value = out.substr(3, out.size() - 7);
+  EXPECT_TRUE(looks_like_ipv4(value)) << value;
+}
+
+TEST(ExpandHostname, AddressIpv6VariantsAgree) {
+  const std::string out = socket_helpers::expand_hostname("${address_ipv6}|${address_ipv6_lc}|${address_ipv6_lc_comp}");
+  if (out == "${address_ipv6}|${address_ipv6_lc}|${address_ipv6_lc_comp}") return;  // no usable IPv6 on this machine
+  // All three spell the same canonical (lowercase, compressed) form.
+  std::vector<std::string> parts;
+  boost::algorithm::split(parts, out, boost::algorithm::is_any_of("|"));
+  ASSERT_EQ(parts.size(), 3u);
+  EXPECT_EQ(parts[0], parts[1]);
+  EXPECT_EQ(parts[0], parts[2]);
+  EXPECT_TRUE(looks_like_ipv6(parts[0])) << parts[0];
+  EXPECT_EQ(parts[0], boost::algorithm::to_lower_copy(parts[0]));
+}
+
+TEST(ExpandHostname, AddressIpv6CaseAndPaddingVariants) {
+  const std::string out = socket_helpers::expand_hostname("${address_ipv6_lc}|${address_ipv6_uc}|${address_ipv6_lc_uncomp}|${address_ipv6_uc_uncomp}");
+  if (out.find("${") != std::string::npos) {
+    // No usable IPv6: every token must have been left alone, not just some.
+    EXPECT_EQ(out, "${address_ipv6_lc}|${address_ipv6_uc}|${address_ipv6_lc_uncomp}|${address_ipv6_uc_uncomp}");
+    return;
+  }
+  std::vector<std::string> parts;
+  boost::algorithm::split(parts, out, boost::algorithm::is_any_of("|"));
+  ASSERT_EQ(parts.size(), 4u);
+  EXPECT_EQ(parts[1], boost::algorithm::to_upper_copy(parts[0]));
+  EXPECT_EQ(parts[3], boost::algorithm::to_upper_copy(parts[2]));
+  // The uncompressed form is always eight fully padded groups.
+  EXPECT_EQ(parts[2].size(), 39u) << parts[2];
+  EXPECT_TRUE(looks_like_ipv6(parts[2])) << parts[2];
+  // ...and both forms name the same address.
+  EXPECT_EQ(boost::asio::ip::make_address_v6(parts[0]), boost::asio::ip::make_address_v6(parts[2]));
+}
+
+TEST(ExpandHostnamePlaceholders, AddressTokensAreExpandedWithoutHostTokens) {
+  // The cheap "does the spec have any placeholder at all" gate must not skip a
+  // spec that only carries address tokens.
+  const std::string out = socket_helpers::expand_hostname_placeholders("${address_ipv4}");
+  if (out != "${address_ipv4}") EXPECT_TRUE(looks_like_ipv4(out)) << out;
 }
 
 // =============================================================================

--- a/modules/CollectdClient/CollectdClient.cpp
+++ b/modules/CollectdClient/CollectdClient.cpp
@@ -67,7 +67,15 @@ bool CollectdClient::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
         "${host_uc}\tHostname in uppercase\n"
         "${domain}\tDomainname\n"
         "${domain_lc}\tDomainname in lowercase\n"
-        "${domain_uc}\tDomainname in uppercase\n")
+        "${domain_uc}\tDomainname in uppercase\n"
+        "${address_ipv4}\tIPv4 address of the computer\n"
+        "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+        "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+        "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+        "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+        "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+        "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+        "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
       .add_int("interval", sh::uint_key(&interval, 10), "METRICS INTERVAL",
         "The interval (in seconds) reported to collectd. Should match the core 'metrics interval' so collectd computes rates correctly.")

--- a/modules/ElasticClient/ElasticClient.cpp
+++ b/modules/ElasticClient/ElasticClient.cpp
@@ -52,11 +52,19 @@ bool ElasticClient::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode)
                     "The host name of the monitored computer.\nSet this to auto (default) to use the windows name of the computer.\n\n"
                     "auto\tHostname\n"
                     "${host}\tHostname\n"
-                    "${host_lc}\nHostname in lowercase\n"
+                    "${host_lc}\tHostname in lowercase\n"
                     "${host_uc}\tHostname in uppercase\n"
                     "${domain}\tDomainname\n"
                     "${domain_lc}\tDomainname in lowercase\n"
-                    "${domain_uc}\tDomainname in uppercase\n")
+                    "${domain_uc}\tDomainname in uppercase\n"
+                    "${address_ipv4}\tIPv4 address of the computer\n"
+                    "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+                    "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+                    "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+                    "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+                    "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+                    "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+                    "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
         .add_string("events", sh::string_key(&events, "eventlog:*,logfile:*"), "Event", "The events to subscribe to such as eventlog:* or logfile:mylog.")
 

--- a/modules/GraphiteClient/GraphiteClient.cpp
+++ b/modules/GraphiteClient/GraphiteClient.cpp
@@ -53,11 +53,19 @@ bool GraphiteClient::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
                     "The host name of the monitored computer.\nSet this to auto (default) to use the windows name of the computer.\n\n"
                     "auto\tHostname\n"
                     "${host}\tHostname\n"
-                    "${host_lc}\nHostname in lowercase\n"
+                    "${host_lc}\tHostname in lowercase\n"
                     "${host_uc}\tHostname in uppercase\n"
                     "${domain}\tDomainname\n"
                     "${domain_lc}\tDomainname in lowercase\n"
-                    "${domain_uc}\tDomainname in uppercase\n")
+                    "${domain_uc}\tDomainname in uppercase\n"
+                    "${address_ipv4}\tIPv4 address of the computer\n"
+                    "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+                    "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+                    "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+                    "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+                    "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+                    "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+                    "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
         .add_string("channel", sh::string_key(&channel_, "GRAPHITE"), "CHANNEL", "The channel to listen to.");
 

--- a/modules/IcingaClient/IcingaClient.cpp
+++ b/modules/IcingaClient/IcingaClient.cpp
@@ -41,11 +41,19 @@ bool IcingaClient::loadModuleEx(const std::string &alias, NSCAPI::moduleLoadMode
                     "The host name of the monitored computer.\nSet this to auto (default) to use the windows name of the computer.\n\n"
                     "auto\tHostname\n"
                     "${host}\tHostname\n"
-                    "${host_lc}\nHostname in lowercase\n"
+                    "${host_lc}\tHostname in lowercase\n"
                     "${host_uc}\tHostname in uppercase\n"
                     "${domain}\tDomainname\n"
                     "${domain_lc}\tDomainname in lowercase\n"
-                    "${domain_uc}\tDomainname in uppercase\n")
+                    "${domain_uc}\tDomainname in uppercase\n"
+                    "${address_ipv4}\tIPv4 address of the computer\n"
+                    "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+                    "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+                    "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+                    "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+                    "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+                    "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+                    "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
         .add_string("channel", sh::string_key(&channel_, "ICINGA"), "CHANNEL", "The channel to listen to.")
 

--- a/modules/NRDPClient/NRDPClient.cpp
+++ b/modules/NRDPClient/NRDPClient.cpp
@@ -45,11 +45,19 @@ bool NRDPClient::loadModuleEx(const std::string &alias, NSCAPI::moduleLoadMode) 
                     "The host name of the monitored computer.\nSet this to auto (default) to use the windows name of the computer.\n\n"
                     "auto\tHostname\n"
                     "${host}\tHostname\n"
-                    "${host_lc}\nHostname in lowercase\n"
+                    "${host_lc}\tHostname in lowercase\n"
                     "${host_uc}\tHostname in uppercase\n"
                     "${domain}\tDomainname\n"
                     "${domain_lc}\tDomainname in lowercase\n"
-                    "${domain_uc}\tDomainname in uppercase\n")
+                    "${domain_uc}\tDomainname in uppercase\n"
+                    "${address_ipv4}\tIPv4 address of the computer\n"
+                    "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+                    "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+                    "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+                    "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+                    "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+                    "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+                    "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
         .add_string("channel", sh::string_key(&channel_, "NRDP"), "CHANNEL", "The channel to listen to.")
 

--- a/modules/NSCAClient/NSCAClient.cpp
+++ b/modules/NSCAClient/NSCAClient.cpp
@@ -54,11 +54,19 @@ bool NSCAClient::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
                     "The host name of the monitored computer.\nSet this to auto (default) to use the windows name of the computer.\n\n"
                     "auto\tHostname\n"
                     "${host}\tHostname\n"
-                    "${host_lc}\nHostname in lowercase\n"
+                    "${host_lc}\tHostname in lowercase\n"
                     "${host_uc}\tHostname in uppercase\n"
                     "${domain}\tDomainname\n"
                     "${domain_lc}\tDomainname in lowercase\n"
-                    "${domain_uc}\tDomainname in uppercase\n")
+                    "${domain_uc}\tDomainname in uppercase\n"
+                    "${address_ipv4}\tIPv4 address of the computer\n"
+                    "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+                    "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+                    "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+                    "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+                    "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+                    "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+                    "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
         .add_string("encoding", sh::string_key(&encoding_, ""), "NSCA DATA ENCODING", "", true)
 

--- a/modules/NSCANgClient/NSCANgClient.cpp
+++ b/modules/NSCANgClient/NSCANgClient.cpp
@@ -45,11 +45,19 @@ bool NSCANgClient::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
                     "The host name of the monitored computer.\nSet this to auto (default) to use the windows name of the computer.\n\n"
                     "auto\tHostname\n"
                     "${host}\tHostname\n"
-                    "${host_lc}\nHostname in lowercase\n"
+                    "${host_lc}\tHostname in lowercase\n"
                     "${host_uc}\tHostname in uppercase\n"
                     "${domain}\tDomainname\n"
                     "${domain_lc}\tDomainname in lowercase\n"
-                    "${domain_uc}\tDomainname in uppercase\n")
+                    "${domain_uc}\tDomainname in uppercase\n"
+                    "${address_ipv4}\tIPv4 address of the computer\n"
+                    "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+                    "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+                    "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+                    "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+                    "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+                    "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+                    "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
         .add_string("channel", sh::string_key(&channel_, "NSCA-NG"), "CHANNEL", "The channel to listen to.");
 

--- a/modules/Op5Client/Op5Client.cpp
+++ b/modules/Op5Client/Op5Client.cpp
@@ -70,11 +70,19 @@ bool Op5Client::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
                     "The host name of this monitored computer.\nSet this to auto (default) to use the windows name of the computer.\n\n"
                     "auto\tHostname\n"
                     "${host}\tHostname\n"
-                    "${host_lc}\nHostname in lowercase\n"
+                    "${host_lc}\tHostname in lowercase\n"
                     "${host_uc}\tHostname in uppercase\n"
                     "${domain}\tDomainname\n"
                     "${domain_lc}\tDomainname in lowercase\n"
-                    "${domain_uc}\tDomainname in uppercase\n")
+                    "${domain_uc}\tDomainname in uppercase\n"
+                    "${address_ipv4}\tIPv4 address of the computer\n"
+                    "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+                    "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+                    "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+                    "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+                    "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+                    "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+                    "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
         .add_string("channel", sh::string_key(&channel_, "op5"), "CHANNEL", "The channel to listen to.")
 

--- a/modules/SyslogClient/SyslogClient.cpp
+++ b/modules/SyslogClient/SyslogClient.cpp
@@ -52,11 +52,19 @@ bool SyslogClient::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
                     "The host name of the monitored computer.\nSet this to auto (default) to use the windows name of the computer.\n\n"
                     "auto\tHostname\n"
                     "${host}\tHostname\n"
-                    "${host_lc}\nHostname in lowercase\n"
+                    "${host_lc}\tHostname in lowercase\n"
                     "${host_uc}\tHostname in uppercase\n"
                     "${domain}\tDomainname\n"
                     "${domain_lc}\tDomainname in lowercase\n"
-                    "${domain_uc}\tDomainname in uppercase\n")
+                    "${domain_uc}\tDomainname in uppercase\n"
+                    "${address_ipv4}\tIPv4 address of the computer\n"
+                    "${address_ipv6}\tIPv6 address of the computer (lowercase, compressed)\n"
+                    "${address_ipv6_lc}\tIPv6 address in lowercase (compressed)\n"
+                    "${address_ipv6_uc}\tIPv6 address in uppercase (compressed)\n"
+                    "${address_ipv6_lc_comp}\tIPv6 address in lowercase, compressed (2001:db8::7)\n"
+                    "${address_ipv6_lc_uncomp}\tIPv6 address in lowercase, uncompressed (2001:0db8:0000:0000:0000:0000:0000:0007)\n"
+                    "${address_ipv6_uc_comp}\tIPv6 address in uppercase, compressed\n"
+                    "${address_ipv6_uc_uncomp}\tIPv6 address in uppercase, uncompressed\n")
 
         .add_string("channel", sh::string_key(&channel_, "syslog"), "CHANNEL", "The channel to listen to.");
 

--- a/tests/nrdp-submit.test.ts
+++ b/tests/nrdp-submit.test.ts
@@ -13,6 +13,7 @@ import {
   anyFileContains,
   containerChmodReadable,
   dockerOrSkip,
+  readAllUnder,
   trackContainerLogs,
   type StartedTestContainer,
 } from "@fixtures/index";
@@ -146,6 +147,35 @@ dockerOrSkip()("NRDP integration", () => {
     // Make sure none of the macro tokens leaked through unexpanded.
     expect(anyFileContains(spoolDir, "${host}")).toBe(false);
     expect(anyFileContains(spoolDir, "${domain}")).toBe(false);
+  });
+
+  it("expands the ${address_ipv4} hostname macro end-to-end", async () => {
+    // ${address_ipv4} (issue #349) resolves to the source address of the
+    // machine's default route. A machine with no usable address in a family
+    // deliberately keeps that family's token unresolved, so only IPv4 is
+    // asserted here: a docker-capable host always has an IPv4 route, while
+    // IPv6 may be absent.
+    const r = await nscp.run([
+      "nrdp",
+      "--define",
+      "/settings/NRDP/client:hostname=addr-${address_ipv4}-end",
+      "--address",
+      `http://127.0.0.1:${httpPort}/nrdp/server/`,
+      "--token",
+      TOKEN,
+      "--command",
+      "addr-macro-check",
+      "--result",
+      "0",
+      "--message",
+      "Address macro check",
+    ]);
+    expect(r.exitCode).toBe(0);
+    await containerChmodReadable(server, "/nrdp/checkresults");
+    expect(anyFileContains(spoolDir, "addr-macro-check")).toBe(true);
+    const spool = readAllUnder(spoolDir);
+    expect(spool).toMatch(/addr-\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}-end/);
+    expect(spool).not.toContain("${address_ipv4}");
   });
 
   it("rejects an invalid token over HTTP", async () => {


### PR DESCRIPTION
Implements #349: the `hostname` setting of the submit clients can now report the machine by IP address instead of (or combined with) its name.

## New placeholders

| Token | Value |
|---|---|
| `${address_ipv4}` | IPv4 address |
| `${address_ipv6}` | IPv6 address, lowercase compressed (RFC 5952 canonical) |
| `${address_ipv6_lc}` / `${address_ipv6_uc}` | case variants (compressed) |
| `${address_ipv6_lc_comp}` / `${address_ipv6_lc_uncomp}` / `${address_ipv6_uc_comp}` / `${address_ipv6_uc_uncomp}` | compressed `2001:db8::7` vs fully zero-padded `2001:0db8:0000:0000:0000:0000:0000:0007` |

Available in all nine submit clients (NSCA, NSCA-NG, NRDP, Graphite, Syslog, Op5, Icinga, Elastic, Collectd) — the expansion lives in the shared `socket_helpers::expand_hostname` machinery, so a single implementation serves them all, and address discovery only runs when a spec actually contains an address token.

## How the address is discovered

1. **Routing-table probe**: a UDP `connect()` toward a documentation-range destination (TEST-NET-3 / `2001:db8::/32`) — this sends no packet, it only asks the kernel which source address it would use, which is the address a remote monitoring server would actually see.
2. **Fallback**: the first non-loopback, non-link-local address the host name resolves to.

A machine with no usable address in a family keeps that family's tokens unresolved — the same contract as the existing host name tokens when `gethostname()` fails.

## Also in this PR

- Fixed a stray `\n`-instead-of-`\t` typo in the `${host_lc}` description of NSCAClient and GraphiteClient.
- Documented the new placeholders in the per-module setting descriptions and the three passive-monitoring scenario pages (the generated `docs/reference` files are left to the doc-build pipeline).

## Testing

- **Unit** (`socket_helpers_test.cpp`): 5 exact-string tests for the new `format_ipv6()` (compressed/uncompressed × case, loopback), plus shape-asserting expansion tests (valid dotted-quad, variants agree, uncompressed is 8 padded groups naming the same address, address tokens expand without host tokens present). Full `net_test` suite: 541 tests, 0 failures locally.
- **Integration** (`tests/nrdp-submit.test.ts`): submits over NRDP with `hostname=addr-${address_ipv4}-end` and asserts a real IPv4 address lands in the server spool with no unexpanded token.
- Verified live behaviour on an IPv4-only host: `${address_ipv4}` resolves to the outbound address, IPv6 tokens correctly stay verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013FDcXvZgYcmERScrq4PWMF

---
_Generated by [Claude Code](https://claude.ai/code/session_013FDcXvZgYcmERScrq4PWMF)_