### PR TITLE
feature: let the MSI install your own TLS certificates (#568)

### DIFF
--- a/docs/docs/setup/installing.md
+++ b/docs/docs/setup/installing.md
@@ -252,6 +252,9 @@ A list of all the MSI options can be found below.
 | TLS_VERSION         | The TLS version to use (1.0, 1.1, 1.2, *1.3*)                                                                           |
 | TLS_VERIFY_MODE     | The TLS verify mode to use (none, *peer*, fail_if_no_peer_cert)                                                         |
 | TLS_CA              | The CA file to use for TLS connections (defaults to the Windows ROOT store)                                             |
+| CERTIFICATE         | PEM file to install as the agent's TLS server certificate - see [Installing your own TLS certificates](#installing-your-own-tls-certificates) |
+| CERTIFICATE_KEY     | PEM file with the private key for CERTIFICATE, when the key is not embedded in the certificate file                     |
+| CERTIFICATE_CA      | PEM file (bundle) to install as the CA the servers use to verify client certificates                                    |
 | CONF_SET            | Set a configuration value in the form of section1;key1;value1;section2;key2;value2...                                   |
 | IMPORT_CONFIG       | URL or file path to a configuration file to copy during install and use as the configuration for NSClient++             |
 | FLEET_SERVER        | Fleet server url (`https://fleet.example.com`) to enroll this host with during install                                  |
@@ -426,6 +429,50 @@ The same enrollment can be done after installation with the command line:
 ```
 nscp enroll --server https://fleet.example.com --token <bootstrap-token>
 ```
+
+## Installing your own TLS certificates
+
+The MSI itself ships no certificates: when a TLS-enabled server (NRPE, WEB, ...) starts and finds nothing at its default
+certificate path, the service generates a per-host self-signed certificate there. That gets you encryption out of the
+box, but a self-signed certificate is exactly what a monitoring server cannot verify - so a silent install can hand the
+installer CA-signed material instead:
+
+```
+msiexec /qn /i NSCP-<version>-x64.msi CERTIFICATE=c:\certs\myhost.pem CERTIFICATE_KEY=c:\certs\myhost.key CERTIFICATE_CA=c:\certs\my-ca.pem
+```
+
+The files are copied into the `security` folder under the default names every server module reads
+(`certificate.pem`, `certificate_key.pem` and `ca.pem`), wherever the host's [layout](#on-disk-layout-layout) puts that
+folder. Because the files exist, the service never generates its self-signed fallback, and no per-module certificate
+configuration is needed.
+
+- `CERTIFICATE` is the server certificate (chain) in PEM format. If the private key is embedded in the same file - the
+  NSClient++ convention, and what the generated certificate looks like - it is all you need to pass.
+- `CERTIFICATE_KEY` is the private key when you keep it in a separate file. The modules default to reading the key from
+  the certificate file, so the installer also points the NRPE and WEB servers at it
+  (`certificate key = ${certificate-path}/certificate_key.pem`); for other servers (NSCA, check_mk, check_nt) add the
+  same `certificate key` setting to their section by hand. Passing `CERTIFICATE_KEY` therefore requires the installer to
+  be allowed to write the configuration (do not combine it with `ALLOW_CONFIGURATION=0`).
+- `CERTIFICATE_CA` is the CA (bundle) the servers verify *client* certificates against - what
+  `NRPEMODE=SECURE`'s `verify mode = peer-cert` checks the connecting monitoring server against. It is independent of
+  the other two: passing only `CERTIFICATE_CA` keeps the generated server certificate but pins who may connect.
+
+A few things worth knowing:
+
+- **A wrong command line fails the install.** A missing file, a certificate and key swapped, or a certificate with no
+  key anywhere (neither embedded nor via `CERTIFICATE_KEY`) fails before anything is copied, rather than installing an
+  agent that silently serves the self-signed fallback - or nothing at all.
+- **The properties are one-shot.** They name files on the installing machine at install time; the installer copies
+  them and does not remember where they came from. Re-run the installer with the properties (or replace the files in
+  the `security` folder) to rotate the material - passing them again on an upgrade replaces the installed copies.
+- **Uninstalling removes the copies.** The installed `certificate.pem`, `certificate_key.pem` and `ca.pem` are cleaned
+  up with the rest of the key material; the files you pointed the properties at are yours and are left alone.
+- **They configure the servers, not the installer.** These certificates are what the agent *serves*. They are unrelated
+  to `TLS_CA`/`FLEET_CA`, which tell the installer what to trust when *it* connects out (to a settings or fleet
+  server).
+
+To do the same after installation, use `nscp nrpe install --certificate ... --certificate-key ...` and
+`nscp web install --certificate ... --certificate-key ...` - see [Securing NSClient++](securing.md).
 
 ## Copy configuration from a HTTP server
 

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -21,7 +21,13 @@ To set up NRPE with two-way TLS you need to:
 5. Configure the monitoring server to use the client certificate and trust the CA.
 
 Step 1-3 will depend on your environment and is covered in the [Active Monitoring with NRPE](../scenarios/nrpe.md).
-Step 4 can easily be setup with from the command line like so:
+
+On Windows step 4 can also be done at install time: the MSI's `CERTIFICATE`, `CERTIFICATE_KEY` and `CERTIFICATE_CA`
+properties install your files into the `security` folder under the default names, so the agent serves your CA-signed
+certificate from the first start instead of generating a self-signed one - see
+[Installing your own TLS certificates](installing.md#installing-your-own-tls-certificates).
+
+On an installed agent, step 4 can easily be setup from the command line like so:
 
 ```commandline
 $ nscp nrpe install ^

--- a/installer_lib/installer_lib.cpp
+++ b/installer_lib/installer_lib.cpp
@@ -18,6 +18,7 @@
 #include <error/error.hpp>
 #include <file_helpers.hpp>
 #include <fstream>
+#include <iterator>
 #include <memory>
 #include <nsclient/logger/log_message_factory.hpp>
 #include <nsclient/logger/logger.hpp>
@@ -953,6 +954,20 @@ extern "C" UINT __stdcall ScheduleWriteConfig(MSIHANDLE hInstall) {
     write_changed_key(h, data, ALLOWED_HOSTS, defpath, L"allowed hosts");
     write_changed_key(h, data, NSCLIENT_PWD, defpath, L"password");
 
+    // Operator-supplied TLS material: ExecInstallCerts puts the files at the
+    // default names under ${certificate-path}, so certificate.pem and ca.pem
+    // are picked up with no configuration at all - but a *separate* private
+    // key is only read where a `certificate key` setting points at it (the
+    // modules default to reading the key from the certificate file). Wire it
+    // up for the two servers the installer manages TLS for; other servers are
+    // configured by hand, as documented. Written unexpanded, like the fleet
+    // include, so the configuration stays relocatable.
+    if (!boost::algorithm::trim_copy(h.getMsiPropery(CERTIFICATE_KEY)).empty()) {
+      const std::wstring key_file = L"${certificate-path}/certificate_key.pem";
+      write_key(h, data, 1, L"/settings/NRPE/server", L"certificate key", key_file);
+      write_key(h, data, 1, L"/settings/WEB/server", L"certificate key", key_file);
+    }
+
     std::wstring confSet = h.getMsiPropery(L"CONF_SET");
     h.logMessage(L"Adding conf: " + confSet);
     if (!confSet.empty()) {
@@ -1492,6 +1507,206 @@ extern "C" UINT __stdcall ExecPrepareLayout(MSIHANDLE hInstall) {
     return ERROR_INSTALL_FAILURE;
   } catch (...) {
     h.setError(L"ExecPrepareLayout", L"Unknown exception");
+    return ERROR_INSTALL_FAILURE;
+  }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Operator-supplied TLS material (GitHub #568)
+//
+// CERTIFICATE, CERTIFICATE_KEY and CERTIFICATE_CA name PEM files on the
+// installing machine to install as ${certificate-path}/certificate.pem,
+// certificate_key.pem and ca.pem - the default names every server module
+// reads. With the files in place the service never generates its self-signed
+// fallback (that only happens when the file at the default path is missing),
+// so this is how a silent install ships CA-signed material instead of
+// self-signed certificates.
+//
+// Split over two custom actions for the usual reason: the immediate half
+// validates the properties - failing before a single file has been copied
+// when the operator got the command line wrong - and the deferred half runs
+// elevated, after ExecPrepareLayout has created (and on the modern layout
+// secured) the folder the files go into.
+
+namespace {
+
+// What lands where. certificate_key.pem is also the file ScheduleWriteConfig
+// points the `certificate key` settings at, and all three names are already
+// in the uninstall cleanup lists (the RemoveFile rows in Product.wxs and
+// removable_security_files below) - the operator keeps the originals, so the
+// copies do not outlive the installation.
+struct cert_property {
+  const wchar_t *property;
+  const char *file_name;
+  // A cheap sanity marker so CERTIFICATE=<key file> (and friends) fails here,
+  // naming the property, instead of as a TLS handshake error weeks later.
+  // "PRIVATE KEY-----" matches the PKCS#8, RSA/EC and encrypted PEM headers
+  // alike.
+  const char *pem_marker;
+  // What the file was expected to contain, for the error message.
+  const wchar_t *expected;
+};
+const cert_property cert_properties[] = {
+    {CERTIFICATE, "certificate.pem", "-----BEGIN CERTIFICATE-----", L"a PEM certificate"},
+    {CERTIFICATE_KEY, "certificate_key.pem", "PRIVATE KEY-----", L"a PEM private key"},
+    {CERTIFICATE_CA, "ca.pem", "-----BEGIN CERTIFICATE-----", L"a PEM certificate (bundle)"},
+};
+
+bool file_contains_marker(const std::string &file, const char *marker) {
+  std::ifstream in(file.c_str(), std::ios::binary);
+  if (!in) return false;
+  const std::string content((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  return content.find(marker) != std::string::npos;
+}
+
+}  // namespace
+
+extern "C" UINT __stdcall ScheduleInstallCerts(MSIHANDLE hInstall) {
+  msi_helper h(hInstall, L"ScheduleInstallCerts");
+  try {
+    const std::wstring certificate = boost::algorithm::trim_copy(h.getMsiPropery(CERTIFICATE));
+    const std::wstring certificate_key = boost::algorithm::trim_copy(h.getMsiPropery(CERTIFICATE_KEY));
+    const std::wstring ca = boost::algorithm::trim_copy(h.getMsiPropery(CERTIFICATE_CA));
+    if (certificate.empty() && certificate_key.empty() && ca.empty()) {
+      h.logMessage(L"No CERTIFICATE/CERTIFICATE_KEY/CERTIFICATE_CA given: not installing any TLS material");
+      return ERROR_SUCCESS;
+    }
+
+    // Everything below fails the install rather than installing an agent whose
+    // TLS material is not what the operator asked for: the service would fall
+    // back to a generated self-signed certificate (or refuse to serve), and on
+    // an unattended install nobody reads the log that says why.
+    if (!certificate_key.empty() && certificate.empty()) {
+      h.errorMessage(
+          L"CERTIFICATE_KEY was given without CERTIFICATE. A private key on its own is never read - pass CERTIFICATE=<file> with the certificate it "
+          L"belongs to (or put both in one file and pass only CERTIFICATE).");
+      return ERROR_INSTALL_FAILURE;
+    }
+    // A separate key file is only used where a `certificate key` setting
+    // points at it (the modules default to reading the key from the
+    // certificate file itself), and those settings are written by
+    // ScheduleWriteConfig - the exact test repeated here so we fail precisely
+    // when they would not be written, which would leave every server trying
+    // to read a private key from certificate.pem and failing to start TLS.
+    if (!certificate_key.empty() && h.getMsiPropery(INT_CONF_CAN_CHANGE) != L"1") {
+      std::wstring reason = boost::algorithm::trim_copy(h.getMsiPropery(INT_CONF_CAN_CHANGE_REASON));
+      if (reason.empty()) reason = L"the installer is not allowed to change the configuration";
+      h.errorMessage(L"Refusing to install a separate certificate key: the configuration cannot be changed (" + reason +
+                     L"), so the `certificate key` settings pointing the servers at it cannot be written. Let the installer write the configuration (do "
+                     L"not pass ALLOW_CONFIGURATION=0), or concatenate the key into the certificate file and pass only CERTIFICATE.");
+      return ERROR_INSTALL_FAILURE;
+    }
+
+    for (const cert_property &p : cert_properties) {
+      const std::wstring value = boost::algorithm::trim_copy(h.getMsiPropery(p.property));
+      if (value.empty()) continue;
+      const std::string file = utf8::cvt<std::string>(value);
+      boost::system::error_code ec;
+      if (!boost::filesystem::is_regular_file(file, ec)) {
+        h.errorMessage(std::wstring(p.property) + L"=" + value + L" does not name a file on this machine.");
+        return ERROR_INSTALL_FAILURE;
+      }
+      if (!file_contains_marker(file, p.pem_marker)) {
+        h.errorMessage(std::wstring(p.property) + L"=" + value + L" could not be read or does not look like " + p.expected +
+                       L" (expected the file to contain \"" + utf8::cvt<std::wstring>(p.pem_marker) + L"\").");
+        return ERROR_INSTALL_FAILURE;
+      }
+    }
+
+    // The servers read the private key from the certificate file when no
+    // `certificate key` is configured, so a certificate without an embedded
+    // key needs the separate key file - catch the combination that would pass
+    // every per-file check above and still serve nothing.
+    if (!certificate.empty() && certificate_key.empty() && !file_contains_marker(utf8::cvt<std::string>(certificate), "PRIVATE KEY-----")) {
+      h.errorMessage(L"CERTIFICATE=" + certificate +
+                     L" contains no private key and no CERTIFICATE_KEY was given, so the servers would have no key to serve TLS with. Pass the key as "
+                     L"CERTIFICATE_KEY=<file>, or concatenate certificate and key into one file.");
+      return ERROR_INSTALL_FAILURE;
+    }
+
+    msi_helper::custom_action_data_w data;
+    data.write_string(h.getTargetPath(L"INSTALLLOCATION"));
+    data.write_string(certificate);
+    data.write_string(certificate_key);
+    data.write_string(ca);
+    h.logMessage(L"Scheduling (ExecInstallCerts): " + data.to_string());
+    const HRESULT hr = h.do_deferred_action(L"ExecInstallCerts", data, 1000);
+    if (FAILED(hr)) {
+      h.errorMessage(L"failed to schedule the certificate installation");
+      return hr;
+    }
+    return ERROR_SUCCESS;
+  } catch (const installer_exception &e) {
+    h.errorMessage(L"Failed to schedule the certificate installation: " + e.what());
+    return ERROR_INSTALL_FAILURE;
+  } catch (const std::exception &e) {
+    h.errorMessage(L"Failed to schedule the certificate installation: " + utf8::to_unicode(e.what()));
+    return ERROR_INSTALL_FAILURE;
+  } catch (...) {
+    h.errorMessage(L"Failed to schedule the certificate installation: <UNKNOWN EXCEPTION>");
+    return ERROR_INSTALL_FAILURE;
+  }
+}
+
+extern "C" UINT __stdcall ExecInstallCerts(MSIHANDLE hInstall) {
+  msi_helper h(hInstall, L"ExecInstallCerts");
+  try {
+    msi_helper::custom_action_data_r data(h.getMsiPropery(L"CustomActionData"));
+    const std::string install_folder = as_install_folder(data.get_next_string());
+    // Same order the immediate half wrote them, which is the order of
+    // cert_properties.
+    const std::string sources[] = {utf8::cvt<std::string>(data.get_next_string()), utf8::cvt<std::string>(data.get_next_string()),
+                                   utf8::cvt<std::string>(data.get_next_string())};
+
+    // Where the service will look for the files, which depends on the layout -
+    // ExecPrepareLayout has already created (and on the modern layout secured)
+    // the shared folder and recorded the choice in boot.ini, so reading it
+    // back here is how the two agree.
+    const resolved_shared_folder shared = shared_folder_for(resolve_layout(install_folder, L""), install_folder, &h);
+    if (!shared.resolved) {
+      h.errorMessage(
+          L"Cannot install the TLS material: this host uses the modern layout but %ProgramData% could not be determined, so the files cannot be placed "
+          L"where the service will look for them.");
+      return ERROR_INSTALL_FAILURE;
+    }
+    const std::string security_folder = expand_install_path(CERT_FOLDER, install_folder, shared.folder);
+
+    boost::system::error_code ec;
+    boost::filesystem::create_directories(security_folder, ec);
+    if (ec) {
+      h.errorMessage(L"Cannot install the TLS material: could not create " + utf8::cvt<std::wstring>(security_folder) + L": " +
+                     utf8::cvt<std::wstring>(ec.message()));
+      return ERROR_INSTALL_FAILURE;
+    }
+
+    std::size_t index = 0;
+    for (const cert_property &p : cert_properties) {
+      const std::string source = sources[index++];
+      if (source.empty()) continue;
+      const boost::filesystem::path target = boost::filesystem::path(security_folder) / p.file_name;
+      // Overwriting is deliberate, and different from the fleet identity: the
+      // property is an explicit ask, and the operator still has the source
+      // file - unlike a generated key, nothing is lost by replacing it.
+      if (boost::filesystem::exists(target, ec)) {
+        h.logMessage("Replacing the existing " + target.string());
+      }
+      boost::filesystem::copy_file(source, target, boost::filesystem::copy_options::overwrite_existing, ec);
+      if (ec) {
+        h.errorMessage(L"Failed to install " + utf8::cvt<std::wstring>(source) + L" as " + utf8::cvt<std::wstring>(target.string()) + L": " +
+                       utf8::cvt<std::wstring>(ec.message()));
+        return ERROR_INSTALL_FAILURE;
+      }
+      h.logMessage("Installed " + source + " as " + target.string());
+    }
+    return ERROR_SUCCESS;
+  } catch (const installer_exception &e) {
+    h.errorMessage(L"Failed to install the TLS material: " + e.what());
+    return ERROR_INSTALL_FAILURE;
+  } catch (const std::exception &e) {
+    h.errorMessage(L"Failed to install the TLS material: " + utf8::to_unicode(e.what()));
+    return ERROR_INSTALL_FAILURE;
+  } catch (...) {
+    h.errorMessage(L"Failed to install the TLS material: <UNKNOWN EXCEPTION>");
     return ERROR_INSTALL_FAILURE;
   }
 }

--- a/installer_lib/installer_lib.def
+++ b/installer_lib/installer_lib.def
@@ -11,6 +11,8 @@ EXPORTS
 	ExecPrepareLayout
 	ScheduleRemoveSecrets
 	ExecRemoveSecrets
+	ScheduleInstallCerts
+	ExecInstallCerts
 	ScheduleEnrollFleet
 	ExecEnrollFleet
 	NeedUninstall

--- a/installer_lib/keys.hpp
+++ b/installer_lib/keys.hpp
@@ -54,6 +54,15 @@
 #define FLEET_VERIFY_MODE L"FLEET_VERIFY_MODE"
 #define FLEET_INSECURE L"FLEET_INSECURE"
 
+// Operator-supplied TLS material (GitHub #568): install your own certificate,
+// private key and CA into ${certificate-path} instead of letting the service
+// generate a self-signed certificate on first use. Like the fleet properties
+// these are one-shot install-time instructions (paths to files on the
+// installing machine), not configuration we read back and diff.
+#define CERTIFICATE L"CERTIFICATE"
+#define CERTIFICATE_KEY L"CERTIFICATE_KEY"
+#define CERTIFICATE_CA L"CERTIFICATE_CA"
+
 // On-disk layout (experimental): LAYOUT=modern moves the writable state to
 // %ProgramData%\NSClient++ and restricts it to SYSTEM and administrators, while
 // the program stays in Program Files. A plain property for now, with no UI.

--- a/installers/installer-NSCP/Product.wxs
+++ b/installers/installer-NSCP/Product.wxs
@@ -400,6 +400,18 @@
     <CustomAction Id="ScheduleRemoveSecrets" BinaryKey="InstallerHelper" DllEntry="ScheduleRemoveSecrets" Impersonate="yes" Execute="immediate" Return="check" />
     <CustomAction Id="ExecRemoveSecrets"     BinaryKey="InstallerHelper" DllEntry="ExecRemoveSecrets"     Impersonate="no"  Execute="deferred"  Return="check" />
 
+    <!-- Operator-supplied TLS material (CERTIFICATE/CERTIFICATE_KEY/
+         CERTIFICATE_CA, GitHub #568). The immediate action validates the
+         files (so a bad install command fails before anything has been
+         copied) and hands the paths to the deferred one, which runs elevated
+         after ExecPrepareLayout so the security folder it copies into exists,
+         is secured on the modern layout, and is where the service will look.
+         Return="check" on both: an install that was told to use specific TLS
+         material and could not is a failed install, not an agent silently
+         serving a generated self-signed certificate. -->
+    <CustomAction Id="ScheduleInstallCerts" BinaryKey="InstallerHelper" DllEntry="ScheduleInstallCerts" Impersonate="yes" Execute="immediate" Return="check" />
+    <CustomAction Id="ExecInstallCerts"     BinaryKey="InstallerHelper" DllEntry="ExecInstallCerts"     Impersonate="no"  Execute="deferred"  Return="check" />
+
     <!-- Fleet onboarding (FLEET_SERVER/FLEET_TOKEN). The immediate action
          validates the properties (so a bad install command fails before
          anything has been copied) and hands them to the deferred one, which is
@@ -473,7 +485,13 @@
       <!-- First of the three, on install and upgrade alike: the other two write
            into the folder this one creates, secures and migrates into. -->
       <Custom Action="SchedulePrepareLayout" After="InstallFiles">NOT (REMOVE ="ALL")</Custom>
-      <Custom Action="ScheduleEnrollFleet" After="SchedulePrepareLayout">NOT (REMOVE ="ALL") AND FLEET_SERVER</Custom>
+      <!-- After the layout preparation (the deferred halves run in the same
+           order, and this one writes into the folder that one creates) and
+           before the configuration write, so certificate_key.pem exists by
+           the time the configuration gains a `certificate key` pointing at
+           it. -->
+      <Custom Action="ScheduleInstallCerts" After="SchedulePrepareLayout">NOT (REMOVE ="ALL") AND (CERTIFICATE OR CERTIFICATE_KEY OR CERTIFICATE_CA)</Custom>
+      <Custom Action="ScheduleEnrollFleet" After="ScheduleInstallCerts">NOT (REMOVE ="ALL") AND FLEET_SERVER</Custom>
       <Custom Action="ScheduleWriteConfig" After="ScheduleEnrollFleet">NOT (REMOVE ="ALL")</Custom>
       <Custom Action="GenConfig.Command" After="ScheduleWriteConfig">NOT (REMOVE ="ALL") AND GENERATE_SAMPLE_CONFIG = 1</Custom>
       <Custom Action="GenConfig" After="GenConfig.Command">NOT (REMOVE ="ALL") AND GENERATE_SAMPLE_CONFIG = 1</Custom>

--- a/installers/installer-NSCP/properties.wxs
+++ b/installers/installer-NSCP/properties.wxs
@@ -37,6 +37,17 @@
 	<Property Id="FLEET_INSECURE" Secure="yes" />
 	<Property Id="ExecEnrollFleet" Hidden="yes" />
 
+	<!-- OPERATOR-SUPPLIED TLS MATERIAL (GitHub #568)
+	     Paths to PEM files on the installing machine, installed into
+	     ${certificate-path} as certificate.pem / certificate_key.pem / ca.pem
+	     so the servers pick them up under their default settings and the
+	     service never generates its self-signed fallback. Declared to mark
+	     them Secure so they survive a managed/elevated install; they are
+	     paths, not secrets, so they are not hidden. -->
+	<Property Id="CERTIFICATE" Secure="yes" />
+	<Property Id="CERTIFICATE_KEY" Secure="yes" />
+	<Property Id="CERTIFICATE_CA" Secure="yes" />
+
 	<!-- On-disk layout (experimental, no UI yet): LAYOUT=modern keeps the
 	     writable state in %ProgramData%\NSClient++, restricted to SYSTEM and
 	     administrators, while the program stays in Program Files. LAYOUT=legacy

--- a/tests/msi/helpers.py
+++ b/tests/msi/helpers.py
@@ -114,6 +114,88 @@ def ensure_uninstalled(msi_file, target_folder):
             print(f"! Could not remove {shared_folder}; the next test may fail against its leftovers.", flush=True)
 
 
+def generate_certificates(folder):
+    """Generate a throwaway CA + server certificate pair into `folder`.
+
+    Used by the own-certificates case (GitHub #568): the point of the
+    CERTIFICATE/CERTIFICATE_KEY/CERTIFICATE_CA properties is that the agent
+    serves the operator's CA-signed material instead of its generated
+    self-signed fallback, so the test needs real, loadable PEM files whose
+    bytes it can later find - unmodified - inside the install. Generated
+    fresh on every run (never committed) for the same reason the other test
+    suites generate theirs.
+    """
+    from datetime import datetime, timedelta, timezone
+    from cryptography import x509
+    from cryptography.x509.oid import NameOID
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    makedirs(folder, exist_ok=True)
+
+    def name(cn):
+        return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, cn)])
+
+    def builder(subject, issuer, public_key):
+        now = datetime.now(timezone.utc)
+        return (x509.CertificateBuilder()
+                .subject_name(name(subject))
+                .issuer_name(name(issuer))
+                .public_key(public_key)
+                .serial_number(x509.random_serial_number())
+                .not_valid_before(now - timedelta(days=1))
+                .not_valid_after(now + timedelta(days=365)))
+
+    def write(file_name, data):
+        with open(path.join(folder, file_name), 'wb') as f:
+            f.write(data)
+
+    ca_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    ca_cert = (builder("nscp-msi-test CA", "nscp-msi-test CA", ca_key.public_key())
+               .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+               .sign(ca_key, hashes.SHA256()))
+
+    server_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    server_cert = (builder("localhost", "nscp-msi-test CA", server_key.public_key())
+                   .add_extension(x509.SubjectAlternativeName([x509.DNSName("localhost")]), critical=False)
+                   .sign(ca_key, hashes.SHA256()))
+
+    write("ca.pem", ca_cert.public_bytes(serialization.Encoding.PEM))
+    write("server.pem", server_cert.public_bytes(serialization.Encoding.PEM))
+    write("server.key", server_key.private_bytes(serialization.Encoding.PEM,
+                                                 serialization.PrivateFormat.PKCS8,
+                                                 serialization.NoEncryption()))
+    print(f"- Generated test certificates in: {folder}", flush=True)
+
+
+def validate_copied_files(target_folder, source_folder, copied_files):
+    """Assert files the installer copied from `source_folder` byte for byte.
+
+    `copied_files` maps install-folder-relative paths to source file names.
+    Presence alone (validate_files) cannot tell an installed operator
+    certificate from the self-signed one the service generates at the same
+    path when it is missing - identical bytes can.
+    """
+    ok = True
+    for installed, source in copied_files.items():
+        installed_path = path.join(target_folder, installed.replace('/', path.sep))
+        source_path = path.join(source_folder, source)
+        if not path.exists(installed_path):
+            print(f"! Installed file does not exist: {installed_path}", flush=True)
+            ok = False
+            continue
+        with open(installed_path, 'rb') as f:
+            installed_content = f.read()
+        with open(source_path, 'rb') as f:
+            source_content = f.read()
+        if installed_content != source_content:
+            print(f"! {installed_path} does not match {source_path} (the installer should copy it verbatim)", flush=True)
+            ok = False
+        else:
+            print(f"- {installed_path} matches {source_path}", flush=True)
+    return ok
+
+
 def read_config(config_file):
     if not path.exists(config_file):
         print(f"! Configuration file does not exist: {config_file}", flush=True)
@@ -138,8 +220,10 @@ def print_install_log():
         print(f"! Log file {log_file} does not exist.", flush=True)
 
 
-def install(msi_file, target_folder, command_line):
+def install(msi_file, target_folder, command_line, test_data_folder=None):
     command_line = list(map(lambda x: x.replace("$MSI-FILE", msi_file), command_line))
+    if test_data_folder:
+        command_line = list(map(lambda x: x.replace("$TEST-DATA", test_data_folder), command_line))
     print(f"- Installing NSClient++: {' '.join(command_line)}", flush=True)
     try:
         return_code = run_with_timeout(command_line)

--- a/tests/msi/requirements.txt
+++ b/tests/msi/requirements.txt
@@ -1,1 +1,4 @@
 pyyaml==6.0.3
+# For the own-certificates case: generates the throwaway CA + server pair the
+# CERTIFICATE/CERTIFICATE_KEY/CERTIFICATE_CA properties are tested with.
+cryptography>=44.0.0

--- a/tests/msi/test-install.py
+++ b/tests/msi/test-install.py
@@ -1,8 +1,8 @@
-from os import path, listdir
+from os import path, listdir, environ
 from glob import glob
 from argparse import ArgumentParser
 
-from helpers import ensure_uninstalled, read_config, install, compare_file, create_upgrade_config, validate_files, validate_files_absent, resolve_folder, validate_secured
+from helpers import ensure_uninstalled, read_config, install, compare_file, create_upgrade_config, validate_files, validate_files_absent, resolve_folder, validate_secured, generate_certificates, validate_copied_files
 
 # Argument parsing for test selection
 parser = ArgumentParser(description="Run NSCP MSI installer tests.")
@@ -23,6 +23,13 @@ target_folder = path.join('c:\\', 'Program Files (x86)' if 'Win32' in msi_file e
 print(f"* Using Target folder: {target_folder}", flush=True)
 
 TEST_FOLDER = path.join(path.dirname(__file__), 'tests')
+
+# Where generated per-run test data (e.g. the own-certificates case's
+# throwaway CA and server pair) lives, referenced from a test case's
+# command_line as $TEST-DATA. %ProgramData% rather than %TEMP% so the path has
+# no spaces and is readable by both the installing user and SYSTEM (the
+# deferred custom actions).
+TEST_DATA_FOLDER = path.join(environ.get("ProgramData", r"c:\ProgramData"), "nscp-msi-test")
 
 all_test_cases = [
     f for f in listdir(TEST_FOLDER)
@@ -50,7 +57,10 @@ for test_case_file in test_cases:
     if 'upgrade' in test_case:
         create_upgrade_config(test_case['upgrade'], target_folder)
 
-    install(msi_file, target_folder, test_case["command_line"])
+    if test_case.get('certificates'):
+        generate_certificates(TEST_DATA_FOLDER)
+
+    install(msi_file, target_folder, test_case["command_line"], TEST_DATA_FOLDER)
 
     # boot.ini always stays beside the executable - it is what tells the agent
     # where everything else lives. The configuration follows the layout, so a
@@ -77,6 +87,12 @@ for test_case_file in test_cases:
             failure = True
     if 'forbidden_files' in test_case:
         if not validate_files_absent(target_folder, test_case['forbidden_files']):
+            print("! Test failed.", flush=True)
+            failure = True
+    if 'installed_files' in test_case:
+        # Files the installer must have copied verbatim from the test data
+        # folder - presence alone cannot tell them from generated ones.
+        if not validate_copied_files(target_folder, TEST_DATA_FOLDER, test_case['installed_files']):
             print("! Test failed.", flush=True)
             failure = True
 

--- a/tests/msi/tests/own-certificates.yaml
+++ b/tests/msi/tests/own-certificates.yaml
@@ -1,0 +1,56 @@
+# Operator-supplied TLS material (GitHub #568).
+#
+# CERTIFICATE, CERTIFICATE_KEY and CERTIFICATE_CA install the given PEM files
+# into security\ under the default names every server module reads
+# (certificate.pem, certificate_key.pem, ca.pem). The test asserts the
+# installed files match the sources byte for byte: the service generates a
+# self-signed certificate at the same path when it is missing (and it boots
+# during the install), so mere presence would pass even if the properties did
+# nothing.
+#
+# The separate private key is only read where a `certificate key` setting
+# points at it - the modules default to reading the key from the certificate
+# file itself - so the installer also wires it up for the NRPE and WEB
+# servers, which is the other half of what this case pins down.
+#
+# The cert/key/CA sources are generated fresh into $TEST-DATA by the harness
+# (see generate_certificates in helpers.py), triggered by `certificates` below.
+command_line: ["msiexec.exe", "/i", "$MSI-FILE", "/qn", "/l*", "log.txt", "ADDLOCAL=ALL",
+  "CERTIFICATE=$TEST-DATA\\server.pem",
+  "CERTIFICATE_KEY=$TEST-DATA\\server.key",
+  "CERTIFICATE_CA=$TEST-DATA\\ca.pem"]
+replace_password: true
+certificates: true
+
+boot.ini: |
+  [settings]
+  1 = ini://${shared-path}/nsclient.ini
+
+nsclient.ini: |
+  [/modules]
+  checkdisk = enabled
+  checkeventlog = enabled
+  checkexternalscripts = enabled
+  checkhelpers = enabled
+  checknscp = enabled
+  checksystem = enabled
+  nrpeserver = enabled
+  webserver = enabled
+
+  [/settings/NRPE/server]
+  certificate key = ${certificate-path}/certificate_key.pem
+  insecure = false
+  tls version = tlsv1.2+
+  verify mode = peer-cert
+
+  [/settings/WEB/server]
+  certificate key = ${certificate-path}/certificate_key.pem
+
+  [/settings/default]
+  allowed hosts = 127.0.0.1
+  password = $$PASSWORD$$
+
+installed_files:
+  security/certificate.pem: server.pem
+  security/certificate_key.pem: server.key
+  security/ca.pem: ca.pem


### PR DESCRIPTION
The Windows installer had no way to hand the agent CA-signed TLS
material: the service generates a per-host self-signed certificate at
${certificate-path}/certificate.pem when a TLS server starts and finds
nothing there, which is exactly what a monitoring server cannot verify.

New silent-install properties fix that:

- CERTIFICATE=<file>      installed as certificate.pem
- CERTIFICATE_KEY=<file>  installed as certificate_key.pem
- CERTIFICATE_CA=<file>   installed as ca.pem

The files land in the security folder (wherever the host's layout puts
it) under the default names every server module reads, so nothing needs
per-module configuration and the self-signed fallback is never
generated. A separate private key is only read where a `certificate key`
setting points at it, so the installer also wires that up for the NRPE
and WEB servers.

The immediate custom action validates the files (existence plus a PEM
marker check, and a certificate with no key anywhere is refused) so a
bad command line fails before anything is copied; the deferred half runs
elevated after the layout preparation and copies the files. The names
are already covered by the uninstall cleanup (RemoveFile rows and
ExecRemoveSecrets), so the copies do not outlive the installation.

The new own-certificates MSI test case generates a throwaway CA + server
pair and asserts the installed files match the sources byte for byte -
presence alone cannot tell an operator certificate from the generated
one - plus the `certificate key` rows in the written configuration.

Closes #568

Claude-Session: https://claude.ai/code/session_014RKFGUx3s1RwL2JcFTvNyi
Assisted-by: Claude Code
Signed-off-by: Michael Medin <michael@medin.name>