### PR TITLE
test: add unit and browser rendering tests for the web UI

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -12,6 +12,10 @@ dist
 dist-ssr
 *.local
 
+# Playwright artifacts
+test-results
+playwright-report
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/web/README.md
+++ b/web/README.md
@@ -1,3 +1,31 @@
+# NSClient++ web UI
+
+## Testing
+
+Two test suites validate that the UI renders correctly:
+
+- **Unit tests** (`src/**/*.test.ts[x]`, [Vitest](https://vitest.dev/) +
+  [React Testing Library](https://testing-library.com/) in jsdom) cover pure
+  logic (metric parsing, Redux slices, API response transforms) and component
+  rendering (widgets, pages, the login flow, auth gating in the router). The
+  REST API is stubbed at the `fetch` level via `src/test/test-utils.tsx`, so no
+  backend is needed.
+- **Integration tests** (`e2e/*.spec.ts`, [Playwright](https://playwright.dev/))
+  build the production bundle, serve it with `vite preview` and drive a real
+  Chromium against it with the `/api` routes mocked in the browser
+  (`e2e/mock-api.ts`). They validate the rendered UX end to end: the sign-in
+  screen and login flow, dashboard widgets and SVG charts, sidebar navigation,
+  filtering and deep links.
+
+```sh
+npm test           # unit tests (vitest run)
+npm run test:watch # unit tests in watch mode
+npm run test:e2e   # Playwright integration tests (builds the app first)
+```
+
+`npm run test:e2e` needs a Playwright Chromium; run `npx playwright install chromium`
+once, or point `PLAYWRIGHT_CHROMIUM_EXECUTABLE` at an existing Chromium binary.
+
 # React + TypeScript + Vite
 
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.

--- a/web/e2e/dashboard.spec.ts
+++ b/web/e2e/dashboard.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+import { loginViaLocalStorage, mockApi } from "./mock-api";
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+  await loginViaLocalStorage(page);
+});
+
+test("renders every widget the metrics contain data for", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByText("CPU Load")).toBeVisible();
+  await expect(page.getByText("Memory Usage")).toBeVisible();
+  await expect(page.getByText("Disk Space")).toBeVisible();
+  await expect(page.getByText("System Info")).toBeVisible();
+  await expect(page.getByText("Tags", { exact: true })).toBeVisible();
+});
+
+test("draws real SVG charts for CPU and memory", async ({ page }) => {
+  await page.goto("/");
+
+  const cpuCard = page.locator(".MuiCard-root", { hasText: "CPU Load" });
+  await expect(cpuCard.locator("svg").first()).toBeVisible();
+  // The chart legend proves the series were wired up, not just an empty svg.
+  await expect(cpuCard.getByText("Kernel time (%)")).toBeVisible();
+  await expect(cpuCard.getByText("User time (%)")).toBeVisible();
+
+  const memCard = page.locator(".MuiCard-root", { hasText: "Memory Usage" });
+  await expect(memCard.locator("svg").first()).toBeVisible();
+  await expect(memCard.getByText("Memory (%)")).toBeVisible();
+});
+
+test("shows system info values from the metrics API", async ({ page }) => {
+  await page.goto("/");
+
+  const infoCard = page.locator(".MuiCard-root", { hasText: "System Info" });
+  await expect(infoCard.getByRole("row", { name: /Uptime 3d 2:07/ })).toBeVisible();
+  await expect(infoCard.getByRole("row", { name: /Processes 214/ })).toBeVisible();
+  await expect(infoCard.getByRole("row", { name: /Worker jobs 7/ })).toBeVisible();
+});
+
+test("shows the disk usage bar with formatted sizes", async ({ page }) => {
+  await page.goto("/");
+
+  const diskCard = page.locator(".MuiCard-root", { hasText: "Disk Space" });
+  await expect(diskCard.getByText("C:", { exact: true })).toBeVisible();
+  await expect(diskCard.getByText("60%")).toBeVisible();
+  await expect(diskCard.getByText("60.0 GB used · 40.0 GB free · 100.0 GB total")).toBeVisible();
+  await expect(diskCard.getByRole("progressbar")).toBeVisible();
+});
+
+test("shows host tags as chips", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByText("drives: C:,D:")).toBeVisible();
+  await expect(page.getByText("os: windows")).toBeVisible();
+});
+
+test("offers the refresh rate selector with server-aware options", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByLabel("Refresh rate").click();
+  const listbox = page.getByRole("listbox");
+  await expect(listbox.getByRole("option", { name: "Off" })).toBeVisible();
+  await expect(listbox.getByRole("option", { name: "10 seconds" })).toBeVisible();
+  // The server reports a 10s collection interval, so faster rates are disabled
+  // (their accessible name becomes the explanatory tooltip, so match by text).
+  await expect(listbox.getByRole("option").filter({ hasText: "1 second" })).toBeDisabled();
+  await expect(listbox.getByRole("option").filter({ hasText: "5 seconds" })).toBeDisabled();
+  await expect(listbox.getByRole("option", { name: "1 minute" })).toBeEnabled();
+});

--- a/web/e2e/login.spec.ts
+++ b/web/e2e/login.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "@playwright/test";
+import { E2E_PASSWORD, E2E_USER, mockApi } from "./mock-api";
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test("renders the sign-in screen", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("banner").getByText("NSClient++")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
+  await expect(page.getByLabel("Username")).toBeVisible();
+  await expect(page.getByLabel("Password")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  // No stray error alert on a fresh load.
+  await expect(page.getByRole("alert")).toHaveCount(0);
+});
+
+test("shows an error when the credentials are rejected", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByLabel("Username").fill(E2E_USER);
+  await page.getByLabel("Password").fill("wrong-password");
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  await expect(page.getByRole("alert")).toContainText(
+    "Login failed. Please check your credentials and try again.",
+  );
+  // Still on the login screen.
+  await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
+});
+
+test("signs in and lands on the dashboard", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByLabel("Username").fill(E2E_USER);
+  await page.getByLabel("Password").fill(E2E_PASSWORD);
+  await page.getByRole("button", { name: "Sign in" }).click();
+
+  // The authenticated shell replaces the login card.
+  await expect(page.getByRole("heading", { name: "Sign in" })).toHaveCount(0);
+  await expect(page.getByText("Dashboard").first()).toBeVisible();
+  await expect(page.getByText("CPU Load")).toBeVisible();
+  // The app bar now shows the server version delivered by the API.
+  await expect(page.getByText("0.17.0")).toBeVisible();
+});
+
+test("submits the login form with the Enter key", async ({ page }) => {
+  await page.goto("/");
+
+  await page.getByLabel("Username").fill(E2E_USER);
+  await page.getByLabel("Password").fill(E2E_PASSWORD);
+  await page.getByLabel("Password").press("Enter");
+
+  await expect(page.getByText("CPU Load")).toBeVisible();
+});

--- a/web/e2e/mock-api.ts
+++ b/web/e2e/mock-api.ts
@@ -1,0 +1,172 @@
+import type { Page, Route } from "@playwright/test";
+
+/** Credentials accepted by the mocked login endpoint. */
+export const E2E_USER = "admin";
+export const E2E_PASSWORD = "s3cret";
+export const E2E_TOKEN = "e2e-session-token";
+
+export const METRICS_FIXTURE: Record<string, string | number> = {
+  "system.cpu.total.kernel": 12.5,
+  "system.cpu.total.user": 30.1,
+  "system.mem.physical.used": 4 * 1024 ** 3,
+  "system.mem.physical.total": 16 * 1024 ** 3,
+  "system.uptime.uptime": "3d 2:07",
+  "system.uptime.boot": "2026-08-24 09:00",
+  "system.metrics.procs.procs": 214,
+  "system.metrics.procs.threads": 1890,
+  "workers.jobs": 7,
+  "workers.submitted": 421,
+  "workers.errors": 0,
+  "workers.refresh_interval": 10,
+  "system.refresh_interval": 10,
+  "disk.free.C:.total": 100 * 1024 ** 3,
+  "disk.free.C:.free": 40 * 1024 ** 3,
+  "disk.free.C:.used": 60 * 1024 ** 3,
+  "disk.free.C:.used_pct": 60,
+};
+
+export const TAGS_FIXTURE = { drives: "C:,D:", os: "windows" };
+
+const moduleFixture = (id: string, loaded: boolean, enabled: boolean, description: string) => ({
+  id,
+  name: id,
+  title: id,
+  description,
+  enabled,
+  loaded,
+  metadata: { alias: "", plugin_id: "0" },
+  load_url: "",
+  unload_url: "",
+  module_url: "",
+});
+
+export const MODULES_FIXTURE = [
+  moduleFixture("CheckDisk", true, true, "Monitors disk usage"),
+  moduleFixture("CheckSystem", true, true, "Monitors cpu, memory and processes"),
+  moduleFixture("WEBServer", false, false, "Serves this web interface"),
+];
+
+export const QUERIES_FIXTURE = [
+  {
+    name: "check_cpu",
+    title: "check_cpu",
+    plugin: "CheckSystem",
+    description: "Check the CPU load",
+    query_url: "",
+  },
+  {
+    name: "check_drivesize",
+    title: "check_drivesize",
+    plugin: "CheckDisk",
+    description: "Check free disk space",
+    query_url: "",
+  },
+];
+
+export const ALIASES_FIXTURE = [
+  {
+    name: "alias_cpu",
+    title: "alias_cpu",
+    plugin: "CheckSystem",
+    description: "Alias for check_cpu",
+    alias_url: "",
+  },
+];
+
+export const LOGS_FIXTURE = [
+  {
+    date: "2026-08-27 10:00:00",
+    file: "core.cpp",
+    level: "info",
+    line: 1,
+    message: "Service started",
+  },
+  {
+    date: "2026-08-27 10:00:05",
+    file: "web.cpp",
+    level: "error",
+    line: 42,
+    message: "Sample error entry",
+  },
+];
+
+type JsonBody = unknown;
+type Overrides = Record<string, JsonBody | ((route: Route) => Promise<void> | void)>;
+
+function json(route: Route, body: JsonBody, headers: Record<string, string> = {}) {
+  return route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Intercept every /api call the UI makes and answer with deterministic
+ * fixtures, so the rendering tests never need a live NSClient++ backend.
+ * `overrides` maps a pathname (e.g. "/api/v2/metrics") to a replacement JSON
+ * body or a custom route handler.
+ */
+export async function mockApi(page: Page, overrides: Overrides = {}) {
+  await page.route("**/api/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+
+    const override = overrides[path];
+    if (override !== undefined) {
+      if (typeof override === "function") {
+        await override(route);
+      } else {
+        await json(route, override);
+      }
+      return;
+    }
+
+    switch (path) {
+      case "/api/v2/login": {
+        const auth = route.request().headers()["authorization"] || "";
+        const expected = `Basic ${Buffer.from(`${E2E_USER}:${E2E_PASSWORD}`).toString("base64")}`;
+        if (auth === expected) {
+          return json(route, { key: E2E_TOKEN, user: E2E_USER });
+        }
+        return route.fulfill({ status: 403, body: "Forbidden" });
+      }
+      case "/api/v2/info":
+        return json(route, { name: "NSClient++", version: "0.17.0", version_url: "" });
+      case "/api/v2/info/version":
+        return json(route, { version: "0.17.0" });
+      case "/api/v2/metrics":
+        return json(route, METRICS_FIXTURE);
+      case "/api/v2/tags":
+        return json(route, TAGS_FIXTURE);
+      case "/api/v2/logs/status":
+        return json(route, { errors: 0, last_error: "" });
+      case "/api/v2/logs":
+        return json(route, LOGS_FIXTURE, {
+          "X-Pagination-Count": String(LOGS_FIXTURE.length),
+          "X-Pagination-Page": "1",
+          "X-Pagination-Limit": "10",
+        });
+      case "/api/v2/settings/status":
+        return json(route, { context: "ini://", type: "ini", has_changed: false });
+      case "/api/v2/modules":
+        return json(route, MODULES_FIXTURE);
+      case "/api/v2/queries":
+        return json(route, QUERIES_FIXTURE);
+      case "/api/v2/aliases":
+        return json(route, ALIASES_FIXTURE);
+      case "/api/v2/events":
+        return json(route, []);
+      default:
+        // Fail loudly: an unmocked endpoint means the fixture set is stale.
+        return route.fulfill({ status: 404, body: `No e2e mock for ${path}` });
+    }
+  });
+}
+
+/** Seed the persisted token so the app boots straight into the shell. */
+export async function loginViaLocalStorage(page: Page) {
+  await page.addInitScript((token: string) => {
+    window.localStorage.setItem("token", token);
+  }, E2E_TOKEN);
+}

--- a/web/e2e/navigation.spec.ts
+++ b/web/e2e/navigation.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+import { loginViaLocalStorage, mockApi } from "./mock-api";
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+  await loginViaLocalStorage(page);
+});
+
+// The permanent sidebar drawer (desktop layout) holds the navigation items.
+// (The temporary mobile drawer portals to <body>, so scope to the <nav> element.)
+const nav = (page: import("@playwright/test").Page) => page.locator("nav");
+
+test("shows all navigation entries in the sidebar", async ({ page }) => {
+  await page.goto("/");
+
+  for (const item of [
+    "Dashboard",
+    "Modules",
+    "Settings",
+    "Queries",
+    "Metrics",
+    "Events",
+    "Logs",
+    "About",
+  ]) {
+    await expect(nav(page).getByText(item, { exact: true })).toBeVisible();
+  }
+});
+
+test("navigates to the modules list", async ({ page }) => {
+  await page.goto("/");
+
+  await nav(page).getByText("Modules", { exact: true }).click();
+  await expect(page).toHaveURL(/\/modules$/);
+  await expect(page.getByText("CheckDisk")).toBeVisible();
+  await expect(page.getByText("Monitors disk usage")).toBeVisible();
+  await expect(page.getByText("WEBServer")).toBeVisible();
+});
+
+test("filters the modules list", async ({ page }) => {
+  await page.goto("/modules");
+
+  await expect(page.getByText("CheckDisk")).toBeVisible();
+  await page.getByPlaceholder("Filter modules").fill("disk");
+
+  await expect(page.getByText("CheckDisk")).toBeVisible();
+  await expect(page.getByText("CheckSystem")).toHaveCount(0);
+  await expect(page.getByText("1/3")).toBeVisible();
+});
+
+test("navigates to the queries page with queries and aliases", async ({ page }) => {
+  await page.goto("/");
+
+  await nav(page).getByText("Queries", { exact: true }).click();
+  await expect(page).toHaveURL(/\/queries$/);
+  await expect(page.getByText("check_cpu", { exact: true })).toBeVisible();
+  await expect(page.getByText("check_drivesize", { exact: true })).toBeVisible();
+  await expect(page.getByText("alias_cpu", { exact: true })).toBeVisible();
+  await expect(page.getByText("Queries (2)")).toBeVisible();
+  await expect(page.getByText("Aliases (1)")).toBeVisible();
+});
+
+test("navigates to the logs page and renders log entries", async ({ page }) => {
+  await page.goto("/");
+
+  await nav(page).getByText("Logs", { exact: true }).click();
+  await expect(page).toHaveURL(/\/logs$/);
+  await expect(page.getByText("Service started")).toBeVisible();
+  await expect(page.getByText("Sample error entry")).toBeVisible();
+});
+
+test("navigates to the about page", async ({ page }) => {
+  await page.goto("/");
+
+  await nav(page).getByText("About", { exact: true }).click();
+  await expect(page).toHaveURL(/\/about$/);
+  await expect(page.getByText("Third-party components")).toBeVisible();
+  await expect(page.getByText("Licensed under Apache-2.0 OR GPL-2.0-only.")).toBeVisible();
+});
+
+test("supports deep links straight into a sub-page", async ({ page }) => {
+  // The SPA fallback must serve index.html for nested routes on a cold load.
+  await page.goto("/queries");
+  await expect(page.getByText("check_cpu", { exact: true })).toBeVisible();
+});
+
+test("logs out from the account menu and returns to the login screen", async ({ page }) => {
+  await page.goto("/");
+  await expect(page.getByText("CPU Load")).toBeVisible();
+
+  await page.getByRole("button", { name: "account of current user" }).click();
+  await page.getByRole("menuitem", { name: "Logout" }).click();
+
+  await expect(page.getByRole("heading", { name: "Sign in" })).toBeVisible();
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "nsclient-ui",
       "version": "0.0.0",
+      "license": "Apache-2.0 OR GPL-2.0-only",
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -23,6 +24,10 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.62.1",
+        "@testing-library/jest-dom": "^7.0.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.6",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
@@ -30,10 +35,72 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.6.0",
+        "jsdom": "^30.0.1",
         "prettier": "^3.8.3",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.59.3",
-        "vite": "^8.0.13"
+        "vite": "^8.0.13",
+        "vitest": "^4.1.11"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -280,6 +347,159 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.1.tgz",
+      "integrity": "sha512-YpAJZhaHplYQkG8ib+/Fx5Y0eF2lVWi3tIvMJA6i39TLyUNp2439cifzW8VMjhlqrBjHzK5hVGugRRm2zTKI/A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.9.tgz",
+      "integrity": "sha512-iGGw4OsAYsS6pD29MdJ2bX/nJx65a04ZZiw6x+VwWlP2DdXf6f++Zmuv/OzALpdyfVhjbduIIF2cXM7HWBIe9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -617,6 +837,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@fontsource/roboto": {
@@ -1087,6 +1325,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -1216,9 +1470,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1236,9 +1487,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1256,9 +1504,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1276,9 +1521,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1296,9 +1538,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1316,9 +1555,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1417,6 +1653,105 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.1.tgz",
+      "integrity": "sha512-oMDTC3oA+6CXSO2JZnvOI7CA6oVub6kij5ggk9ohwye5slmkwxYDXcPOVxgMw/RQlticjtO0C1RZkR97HgrWMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=22",
+        "npm": ">=6",
+        "yarn": ">=1"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=10 <11",
+        "vitest": ">= 0.32"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -1426,6 +1761,25 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3-array": {
@@ -1495,6 +1849,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -1878,6 +2239,126 @@
         }
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1918,6 +2399,17 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1940,6 +2432,26 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/babel-plugin-macros": {
       "version": "3.1.0",
@@ -1978,6 +2490,16 @@
       "resolved": "https://registry.npmjs.org/bezier-easing/-/bezier-easing-2.1.0.tgz",
       "integrity": "sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==",
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
@@ -2053,6 +2575,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2165,6 +2697,27 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2284,6 +2837,35 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2301,12 +2883,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2317,6 +2916,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -2335,6 +2942,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/error-ex": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
@@ -2343,6 +2963,13 @@
       "dependencies": {
         "is-arrayish": "^0.2.1"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -2540,6 +3167,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2548,6 +3185,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -2766,6 +3413,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2810,6 +3470,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/internmap": {
@@ -2865,6 +3535,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2889,6 +3566,57 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -3110,9 +3838,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3134,9 +3859,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3158,9 +3880,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3182,9 +3901,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3291,6 +4007,44 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -3350,6 +4104,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/optionator": {
@@ -3432,6 +4200,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3467,6 +4248,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3484,6 +4272,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {
@@ -3540,6 +4375,44 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -3656,6 +4529,20 @@
         "react-dom": ">=16.6.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -3669,6 +4556,16 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -3747,6 +4644,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3792,6 +4702,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -3809,6 +4726,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3855,6 +4799,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -3870,6 +4838,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -3942,6 +4966,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.0.tgz",
+      "integrity": "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -4072,6 +5106,144 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4088,6 +5260,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4097,6 +5286,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,10 @@
     "build": "npm run licenses && tsc -b && vite build",
     "licenses": "node scripts/generate-licenses.mjs",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",
@@ -27,6 +30,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.62.1",
+    "@testing-library/jest-dom": "^7.0.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.6",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
@@ -34,9 +41,11 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.6.0",
+    "jsdom": "^30.0.1",
     "prettier": "^3.8.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.59.3",
-    "vite": "^8.0.13"
+    "vite": "^8.0.13",
+    "vitest": "^4.1.11"
   }
 }

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "@playwright/test";
+import fs from "node:fs";
+
+// Some sandboxes ship a pre-installed Chromium instead of the exact build this
+// Playwright version would download. Prefer an explicit override, fall back to
+// the well-known shared location, and otherwise let Playwright resolve its own
+// managed browser.
+const chromiumOverride =
+  process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE ||
+  (fs.existsSync("/opt/pw-browsers/chromium") ? "/opt/pw-browsers/chromium" : undefined);
+
+export default defineConfig({
+  testDir: "./e2e",
+  timeout: 30_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    ...(chromiumOverride ? { launchOptions: { executablePath: chromiumOverride } } : {}),
+  },
+  webServer: {
+    // Serve the production bundle the way it ships; /api never resolves here —
+    // every spec installs its own route mocks before loading a page.
+    command: "npm run build && npm run preview -- --port 4173 --strictPort",
+    url: "http://127.0.0.1:4173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 240_000,
+  },
+});

--- a/web/src/Routes.test.tsx
+++ b/web/src/Routes.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import Router from "./Routes";
+import {
+  authenticatedState,
+  installFetchMock,
+  jsonResponse,
+  renderWithProviders,
+} from "./test/test-utils";
+
+// Everything the authenticated shell (navbar, sidebar, dashboard) requests.
+function mockShellApi() {
+  return installFetchMock({
+    "/api/v2/info": jsonResponse({ name: "NSClient++", version: "0.17.0", version_url: "" }),
+    "/api/v2/logs/status": jsonResponse({ errors: 0, last_error: "" }),
+    "/api/v2/settings/status": jsonResponse({ context: "ini", type: "ini", has_changed: false }),
+    "/api/v2/metrics": jsonResponse({}),
+    "/api/v2/tags": jsonResponse({}),
+  });
+}
+
+describe("Router authentication gating", () => {
+  it("shows the login page while unauthenticated", () => {
+    mockShellApi();
+    // Router brings its own BrowserRouter, so skip the MemoryRouter wrapper.
+    renderWithProviders(<Router />, { withRouter: false });
+
+    expect(screen.getByRole("heading", { name: "Sign in" })).toBeInTheDocument();
+    expect(screen.queryByText("Dashboard")).not.toBeInTheDocument();
+  });
+
+  it("shows the dashboard shell once a token is present", async () => {
+    mockShellApi();
+    renderWithProviders(<Router />, {
+      withRouter: false,
+      preloadedState: authenticatedState,
+    });
+
+    // The refresh-rate selector is unique to the dashboard page; the nav
+    // entries prove the sidebar rendered too.
+    expect(await screen.findByLabelText("Refresh rate")).toBeInTheDocument();
+    for (const item of ["Modules", "Settings", "Queries", "Metrics", "Events", "Logs", "About"]) {
+      expect(screen.getAllByText(item).length).toBeGreaterThan(0);
+    }
+    expect(screen.queryByRole("heading", { name: "Sign in" })).not.toBeInTheDocument();
+  });
+
+  it("falls back to the login page when the API rejects the token", async () => {
+    installFetchMock({
+      "/api/v2/info": new Response("Forbidden", { status: 403 }),
+      "/api/v2/logs/status": new Response("Forbidden", { status: 403 }),
+      "/api/v2/settings/status": new Response("Forbidden", { status: 403 }),
+      "/api/v2/metrics": new Response("Forbidden", { status: 403 }),
+      "/api/v2/tags": new Response("Forbidden", { status: 403 }),
+    });
+    const { store } = renderWithProviders(<Router />, {
+      withRouter: false,
+      preloadedState: authenticatedState,
+    });
+
+    // A 403 dispatches removeToken which swaps the router back to the login page.
+    await waitFor(() => {
+      expect(store.getState().auth.token).toBeUndefined();
+    });
+    expect(await screen.findByRole("heading", { name: "Sign in" })).toBeInTheDocument();
+  });
+});

--- a/web/src/api/api.test.ts
+++ b/web/src/api/api.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { FetchBaseQueryMeta } from "@reduxjs/toolkit/query";
+import { responseHandler, transformPaginatedResponse } from "./api";
+
+function metaWithHeaders(headers: Record<string, string>): FetchBaseQueryMeta {
+  return {
+    response: new Response(null, { headers }),
+  } as FetchBaseQueryMeta;
+}
+
+describe("transformPaginatedResponse", () => {
+  it("reads pagination info from the response headers", () => {
+    const meta = metaWithHeaders({
+      "X-Pagination-Count": "42",
+      "X-Pagination-Page": "2",
+      "X-Pagination-Limit": "10",
+    });
+    const page = transformPaginatedResponse(["a", "b"], meta);
+    expect(page.content).toEqual(["a", "b"]);
+    expect(page.count).toBe(42);
+    expect(page.page).toBe(2);
+    expect(page.limit).toBe(10);
+    expect(page.pages).toBe(5);
+  });
+
+  it("defaults missing headers to zero", () => {
+    const page = transformPaginatedResponse([], metaWithHeaders({}));
+    expect(page.count).toBe(0);
+    expect(page.page).toBe(0);
+    expect(page.limit).toBe(0);
+  });
+});
+
+describe("responseHandler", () => {
+  it("parses JSON bodies on success", async () => {
+    const response = new Response(JSON.stringify({ hello: "world" }), { status: 200 });
+    await expect(responseHandler(response)).resolves.toEqual({ hello: "world" });
+  });
+
+  it.each([400, 401, 403, 404, 500])("wraps a %i response as an error object", async (status) => {
+    const response = new Response("boom", { status });
+    await expect(responseHandler(response)).resolves.toEqual({ error: "boom", status });
+  });
+});

--- a/web/src/common/authSlice.test.ts
+++ b/web/src/common/authSlice.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { authSlice } from "./authSlice";
+
+const { reducer, actions } = authSlice;
+
+describe("authSlice", () => {
+  it("starts without a token", () => {
+    const state = reducer(undefined, { type: "@@INIT" });
+    expect(state.token).toBeUndefined();
+    expect(state.tokenInvalid).toBe(false);
+  });
+
+  it("stores the token on setToken and clears the invalid flag", () => {
+    const invalid = reducer(undefined, actions.removeToken());
+    const state = reducer(invalid, actions.setToken("abc123"));
+    expect(state.token).toBe("abc123");
+    expect(state.tokenInvalid).toBe(false);
+  });
+
+  it("drops the token and flags it invalid on removeToken", () => {
+    const loggedIn = reducer(undefined, actions.setToken("abc123"));
+    const state = reducer(loggedIn, actions.removeToken());
+    expect(state.token).toBeUndefined();
+    expect(state.tokenInvalid).toBe(true);
+  });
+});

--- a/web/src/common/dashboardSlice.test.ts
+++ b/web/src/common/dashboardSlice.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { HISTORY_SIZE, dashboardSlice } from "./dashboardSlice";
+
+const { reducer, actions } = dashboardSlice;
+const initial = reducer(undefined, { type: "@@INIT" });
+
+describe("dashboardSlice", () => {
+  it("defaults to a 10s refresh rate and zero-filled histories", () => {
+    expect(initial.refreshRate).toBe(10000);
+    expect(initial.cpuHistory.kernel).toHaveLength(HISTORY_SIZE);
+    expect(initial.cpuHistory.kernel.every((v) => v === 0)).toBe(true);
+    expect(initial.memHistory).toHaveLength(HISTORY_SIZE);
+    expect(initial.hideDefaults).toBe(false);
+  });
+
+  it("appends samples while keeping the history size fixed", () => {
+    let state = initial;
+    state = reducer(state, actions.pushCpu({ kernel: 12, user: 34 }));
+    expect(state.cpuHistory.kernel).toHaveLength(HISTORY_SIZE);
+    expect(state.cpuHistory.kernel[HISTORY_SIZE - 1]).toBe(12);
+    expect(state.cpuHistory.user[HISTORY_SIZE - 1]).toBe(34);
+  });
+
+  it("trims the oldest samples once the history is full", () => {
+    let state = initial;
+    for (let i = 0; i < HISTORY_SIZE + 5; i++) {
+      state = reducer(state, actions.pushMem(i));
+    }
+    expect(state.memHistory).toHaveLength(HISTORY_SIZE);
+    expect(state.memHistory[HISTORY_SIZE - 1]).toBe(HISTORY_SIZE + 4);
+    expect(state.memHistory[0]).toBe(5);
+  });
+
+  it("resets all histories when the refresh rate changes", () => {
+    let state = reducer(initial, actions.pushCpu({ kernel: 99, user: 99 }));
+    state = reducer(state, actions.pushMem(55));
+    state = reducer(state, actions.setRefreshRate(5000));
+    expect(state.refreshRate).toBe(5000);
+    expect(state.cpuHistory.kernel.every((v) => v === 0)).toBe(true);
+    expect(state.memHistory.every((v) => v === 0)).toBe(true);
+  });
+
+  it("resets the network history when another NIC is selected", () => {
+    let state = reducer(initial, actions.pushNetwork({ received: 100, sent: 200 }));
+    expect(state.networkHistory.bytesReceived[HISTORY_SIZE - 1]).toBe(100);
+    state = reducer(state, actions.setSelectedNic("eth1"));
+    expect(state.selectedNic).toBe("eth1");
+    expect(state.networkHistory.bytesReceived.every((v) => v === 0)).toBe(true);
+    expect(state.networkHistory.bytesSent.every((v) => v === 0)).toBe(true);
+  });
+
+  it("toggles hideDefaults", () => {
+    let state = reducer(initial, actions.toggleHideDefaults());
+    expect(state.hideDefaults).toBe(true);
+    state = reducer(state, actions.toggleHideDefaults());
+    expect(state.hideDefaults).toBe(false);
+    state = reducer(state, actions.setHideDefaults(true));
+    expect(state.hideDefaults).toBe(true);
+  });
+});

--- a/web/src/components/AppNavbar.test.tsx
+++ b/web/src/components/AppNavbar.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AppNavbar from "./AppNavbar";
+import {
+  authenticatedState,
+  installFetchMock,
+  jsonResponse,
+  renderWithProviders,
+} from "../test/test-utils";
+
+function setup(logStatus: { errors: number; last_error: string }) {
+  installFetchMock({
+    "/api/v2/info": jsonResponse({ name: "NSClient++", version: "0.17.0", version_url: "" }),
+    "/api/v2/logs/status": jsonResponse(logStatus),
+  });
+  return renderWithProviders(<AppNavbar handleDrawerToggle={() => {}} />, {
+    preloadedState: authenticatedState,
+  });
+}
+
+describe("AppNavbar", () => {
+  it("shows the product name and the server version", async () => {
+    setup({ errors: 0, last_error: "" });
+
+    expect(screen.getByText("NSClient++")).toBeInTheDocument();
+    expect(await screen.findByText("0.17.0")).toBeInTheDocument();
+  });
+
+  it("hides the error badge while the log is clean", async () => {
+    setup({ errors: 0, last_error: "" });
+    await screen.findByText("0.17.0");
+    expect(screen.queryByText("3")).not.toBeInTheDocument();
+  });
+
+  it("shows an error badge with the error count when the log has errors", async () => {
+    setup({ errors: 3, last_error: "something failed" });
+    expect(await screen.findByText("3")).toBeInTheDocument();
+  });
+
+  it("opens the account menu with a logout entry", async () => {
+    setup({ errors: 0, last_error: "" });
+
+    await userEvent.click(screen.getByRole("button", { name: "account of current user" }));
+    expect(await screen.findByRole("menuitem", { name: "Logout" })).toBeInTheDocument();
+  });
+
+  it("clears the session when logging out", async () => {
+    const { store } = setup({ errors: 0, last_error: "" });
+    expect(store.getState().auth.token).toBe("test-token");
+
+    await userEvent.click(screen.getByRole("button", { name: "account of current user" }));
+    await userEvent.click(await screen.findByRole("menuitem", { name: "Logout" }));
+
+    expect(store.getState().auth.token).toBeUndefined();
+  });
+});

--- a/web/src/components/DiskFreeWidget.test.tsx
+++ b/web/src/components/DiskFreeWidget.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DiskFreeWidget from "./DiskFreeWidget";
+import { parseMetrics } from "../metric_parser";
+
+const GB = 1024 ** 3;
+
+describe("DiskFreeWidget", () => {
+  it("renders nothing without disk metrics", () => {
+    const { container } = render(<DiskFreeWidget metrics={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a usage bar per disk with formatted sizes", () => {
+    const { metrics } = parseMetrics({
+      "disk.free.C:.total": 100 * GB,
+      "disk.free.C:.free": 40 * GB,
+      "disk.free.C:.used": 60 * GB,
+      "disk.free.C:.used_pct": 60,
+      "disk.free.D:.total": 2 * 1024 ** 4,
+      "disk.free.D:.free": 1024 ** 4,
+      "disk.free.D:.used": 1024 ** 4,
+      "disk.free.D:.used_pct": 50,
+    });
+    render(<DiskFreeWidget metrics={metrics} />);
+
+    expect(screen.getByText("Disk Space")).toBeInTheDocument();
+    expect(screen.getByText("C:")).toBeInTheDocument();
+    expect(screen.getByText("D:")).toBeInTheDocument();
+    expect(screen.getByText("60%")).toBeInTheDocument();
+    expect(screen.getByText("60.0 GB used · 40.0 GB free · 100.0 GB total")).toBeInTheDocument();
+    expect(screen.getByText("1.0 TB used · 1.0 TB free · 2.0 TB total")).toBeInTheDocument();
+    expect(screen.getAllByRole("progressbar")).toHaveLength(2);
+  });
+
+  it("skips disks reporting a zero total", () => {
+    const { metrics } = parseMetrics({
+      "disk.free.E:.total": 0,
+      "disk.free.E:.used_pct": 0,
+    });
+    const { container } = render(<DiskFreeWidget metrics={metrics} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/web/src/components/SystemInfoWidget.test.tsx
+++ b/web/src/components/SystemInfoWidget.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SystemInfoWidget from "./SystemInfoWidget";
+import { parseMetrics } from "../metric_parser";
+
+describe("SystemInfoWidget", () => {
+  it("renders nothing when no known metric is present", () => {
+    const { container } = render(<SystemInfoWidget metrics={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders one row per available metric", () => {
+    const { metrics } = parseMetrics({
+      "system.uptime.uptime": "3d 2:01",
+      "system.metrics.procs.procs": 123,
+      "workers.jobs": 4,
+    });
+    render(<SystemInfoWidget metrics={metrics} />);
+
+    expect(screen.getByText("System Info")).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /Uptime 3d 2:01/ })).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /Processes 123/ })).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /Worker jobs 4/ })).toBeInTheDocument();
+    // Rows whose metric is missing must not render at all.
+    expect(screen.queryByText("Threads")).not.toBeInTheDocument();
+    expect(screen.queryByText("Handles")).not.toBeInTheDocument();
+  });
+
+  it("formats large numbers with locale separators and rounds floats", () => {
+    const { metrics } = parseMetrics({
+      "system.metrics.procs.threads": 1234567,
+      "system.metrics.procs.handles": 98.7,
+    });
+    render(<SystemInfoWidget metrics={metrics} />);
+    expect(screen.getByText((1234567).toLocaleString())).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /Handles 99/ })).toBeInTheDocument();
+  });
+});

--- a/web/src/components/TagsWidget.test.tsx
+++ b/web/src/components/TagsWidget.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import TagsWidget from "./TagsWidget";
+import { installFetchMock, jsonResponse, renderWithProviders } from "../test/test-utils";
+
+describe("TagsWidget", () => {
+  it("renders one chip per tag, sorted by key", async () => {
+    installFetchMock({
+      "/api/v2/tags": jsonResponse({ os: "windows", drives: "C:,D:" }),
+    });
+    renderWithProviders(<TagsWidget />, { withRouter: false });
+
+    await waitFor(() => {
+      expect(screen.getByText("Tags")).toBeInTheDocument();
+    });
+    const chips = [screen.getByText("drives: C:,D:"), screen.getByText("os: windows")];
+    chips.forEach((chip) => expect(chip).toBeInTheDocument());
+    // Sorted alphabetically: drives before os.
+    expect(
+      chips[0].compareDocumentPosition(chips[1]) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("renders nothing while there are no tags", async () => {
+    const fetchMock = installFetchMock({
+      "/api/v2/tags": jsonResponse({}),
+    });
+    const { container } = renderWithProviders(<TagsWidget />, { withRouter: false });
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    await waitFor(() => expect(container).toBeEmptyDOMElement());
+  });
+});

--- a/web/src/components/atoms/NscpAlert.test.tsx
+++ b/web/src/components/atoms/NscpAlert.test.tsx
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NscpAlert from "./NscpAlert";
+
+describe("NscpAlert", () => {
+  it("renders the message text", () => {
+    render(<NscpAlert severity="error" text="Something broke" />);
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Something broke");
+  });
+
+  it.each(["success", "info", "warning", "error"] as const)(
+    "renders the %s severity styling",
+    (severity) => {
+      render(<NscpAlert severity={severity} text="msg" />);
+      const capitalized = severity.charAt(0).toUpperCase() + severity.slice(1);
+      expect(screen.getByRole("alert").className).toContain(capitalized);
+    },
+  );
+
+  it("renders no action button without an actionTitle", () => {
+    render(<NscpAlert severity="info" text="msg" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("fires onClick when the action button is pressed", async () => {
+    const onClick = vi.fn();
+    render(<NscpAlert severity="warning" text="msg" actionTitle="Retry" onClick={onClick} />);
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/atoms/QueryResultChip.test.tsx
+++ b/web/src/components/atoms/QueryResultChip.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryResultChip } from "./QueryResultChip";
+
+describe("QueryResultChip", () => {
+  it.each([
+    [0, "Ok", "colorSuccess"],
+    [1, "Warning", "colorWarning"],
+    [2, "Critical", "colorError"],
+    [3, "Unknown", "colorSecondary"],
+  ] as const)("renders result %i as %s", (result, label, colorClass) => {
+    render(<QueryResultChip result={result} />);
+    const chip = screen.getByText(label);
+    expect(chip).toBeInTheDocument();
+    // The MUI color class lives on the chip root, one level up from the label.
+    expect(chip.parentElement?.className).toContain(colorClass);
+  });
+});

--- a/web/src/generated/licenses.json
+++ b/web/src/generated/licenses.json
@@ -87,61 +87,61 @@
     },
     {
       "name": "@mui/core-downloads-tracker",
-      "version": "7.3.7",
+      "version": "7.3.11",
       "license": "MIT",
       "url": "https://mui.com/"
     },
     {
       "name": "@mui/icons-material",
-      "version": "7.3.7",
+      "version": "7.3.11",
       "license": "MIT",
       "url": "https://mui.com/material-ui/material-icons/"
     },
     {
       "name": "@mui/material",
-      "version": "7.3.7",
+      "version": "7.3.11",
       "license": "MIT",
       "url": "https://mui.com/material-ui/"
     },
     {
       "name": "@mui/private-theming",
-      "version": "7.3.7",
+      "version": "7.3.11",
       "license": "MIT",
       "url": "https://github.com/mui/material-ui/tree/master/packages/mui-private-theming"
     },
     {
       "name": "@mui/styled-engine",
-      "version": "7.3.7",
+      "version": "7.3.10",
       "license": "MIT",
       "url": "https://mui.com/system/styled/"
     },
     {
       "name": "@mui/system",
-      "version": "7.3.7",
+      "version": "7.3.11",
       "license": "MIT",
       "url": "https://mui.com/system/getting-started/"
     },
     {
       "name": "@mui/types",
-      "version": "7.4.10",
+      "version": "7.4.12",
       "license": "MIT",
       "url": "https://github.com/mui/material-ui/tree/master/packages/mui-types"
     },
     {
       "name": "@mui/utils",
-      "version": "7.3.7",
+      "version": "7.3.11",
       "license": "MIT",
       "url": "https://github.com/mui/material-ui/tree/master/packages/mui-utils"
     },
     {
       "name": "@mui/x-charts",
-      "version": "8.25.0",
+      "version": "8.28.2",
       "license": "MIT",
       "url": "https://mui.com/x/react-charts/"
     },
     {
       "name": "@mui/x-charts-vendor",
-      "version": "8.25.0",
+      "version": "8.26.0",
       "license": "MIT AND ISC",
       "url": "https://github.com/mui/mui-x"
     },
@@ -153,7 +153,7 @@
     },
     {
       "name": "@mui/x-internals",
-      "version": "8.25.0",
+      "version": "8.26.0",
       "license": "MIT",
       "url": "https://mui.com/x/"
     },
@@ -321,13 +321,13 @@
     },
     {
       "name": "react",
-      "version": "19.2.3",
+      "version": "19.2.6",
       "license": "MIT",
       "url": "https://react.dev/"
     },
     {
       "name": "react-dom",
-      "version": "19.2.3",
+      "version": "19.2.6",
       "license": "MIT",
       "url": "https://react.dev/"
     },
@@ -345,7 +345,7 @@
     },
     {
       "name": "react-router",
-      "version": "7.12.0",
+      "version": "7.15.1",
       "license": "MIT",
       "url": "https://github.com/remix-run/react-router"
     },
@@ -399,7 +399,7 @@
     },
     {
       "name": "zod",
-      "version": "4.3.5",
+      "version": "4.4.3",
       "license": "MIT",
       "url": "https://zod.dev"
     }

--- a/web/src/metric_parser.test.ts
+++ b/web/src/metric_parser.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { parseMetrics } from "./metric_parser";
+
+describe("parseMetrics", () => {
+  it("returns an empty result for undefined input", () => {
+    const result = parseMetrics(undefined);
+    expect(result.metrics).toEqual([]);
+    expect(result.modules).toEqual([]);
+  });
+
+  it("parses a two-part key as module + metric", () => {
+    const result = parseMetrics({ "workers.jobs": 5 });
+    expect(result.metrics).toEqual([
+      { module: "workers", key: "workers.jobs", metric: "jobs", value: 5 },
+    ]);
+    expect(result.modules).toEqual(["workers"]);
+  });
+
+  it("parses a three-part key as module + type + metric", () => {
+    const result = parseMetrics({ "system.uptime.uptime": "3d 4h" });
+    expect(result.metrics).toEqual([
+      {
+        module: "system",
+        type: "uptime",
+        key: "system.uptime.uptime",
+        metric: "uptime",
+        value: "3d 4h",
+      },
+    ]);
+  });
+
+  it("parses a four-part key with an instance", () => {
+    const result = parseMetrics({ "disk.free.C:.total": 1024 });
+    expect(result.metrics).toEqual([
+      {
+        module: "disk",
+        type: "free",
+        instance: "C:",
+        key: "disk.free.C:.total",
+        metric: "total",
+        value: 1024,
+      },
+    ]);
+  });
+
+  it("joins multi-part instances with dots", () => {
+    const result = parseMetrics({ "system.network.my.fancy.nic.NetConnectionID": "eth0" });
+    expect(result.metrics[0].instance).toBe("my.fancy.nic");
+    expect(result.metrics[0].metric).toBe("NetConnectionID");
+  });
+
+  it("collects unique modules across metrics", () => {
+    const result = parseMetrics({
+      "system.cpu.total.kernel": 10,
+      "system.cpu.total.user": 20,
+      "disk.free.C:.total": 100,
+      "workers.jobs": 1,
+    });
+    expect(result.modules).toEqual(["system", "disk", "workers"]);
+    expect(result.metrics).toHaveLength(4);
+  });
+});

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import Dashboard from "./Dashboard";
+import { installFetchMock, jsonResponse, renderWithProviders } from "../test/test-utils";
+
+describe("Dashboard page", () => {
+  it("renders the heading and refresh selector without any metrics", async () => {
+    const fetchMock = installFetchMock({
+      "/api/v2/metrics": jsonResponse({}),
+      "/api/v2/tags": jsonResponse({}),
+    });
+    renderWithProviders(<Dashboard />);
+
+    expect(screen.getByText("Dashboard")).toBeInTheDocument();
+    expect(screen.getByLabelText("Refresh rate")).toBeInTheDocument();
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    // No data: none of the widgets may render.
+    expect(screen.queryByText("CPU Load")).not.toBeInTheDocument();
+    expect(screen.queryByText("Memory Usage")).not.toBeInTheDocument();
+    expect(screen.queryByText("System Info")).not.toBeInTheDocument();
+  });
+
+  it("renders the widgets matching the metrics the server reports", async () => {
+    installFetchMock({
+      "/api/v2/metrics": jsonResponse({
+        "system.cpu.total.kernel": 12.5,
+        "system.cpu.total.user": 30.1,
+        "system.mem.physical.used": 4 * 1024 ** 3,
+        "system.mem.physical.total": 16 * 1024 ** 3,
+        "system.uptime.uptime": "3d 2:07",
+        "workers.jobs": 7,
+        "workers.refresh_interval": 10,
+        "system.refresh_interval": 10,
+        "disk.free.C:.total": 100 * 1024 ** 3,
+        "disk.free.C:.free": 40 * 1024 ** 3,
+        "disk.free.C:.used": 60 * 1024 ** 3,
+        "disk.free.C:.used_pct": 60,
+      }),
+      "/api/v2/tags": jsonResponse({ drives: "C:" }),
+    });
+    renderWithProviders(<Dashboard />);
+
+    expect(await screen.findByText("CPU Load")).toBeInTheDocument();
+    expect(screen.getByText("Memory Usage")).toBeInTheDocument();
+    expect(screen.getByText("Disk Space")).toBeInTheDocument();
+    expect(screen.getByText("System Info")).toBeInTheDocument();
+    expect(screen.getByRole("row", { name: /Uptime 3d 2:07/ })).toBeInTheDocument();
+    expect(await screen.findByText("Tags")).toBeInTheDocument();
+    expect(screen.getByText("drives: C:")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Login.test.tsx
+++ b/web/src/pages/Login.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Login from "./Login";
+import { installFetchMock, jsonResponse, renderWithProviders } from "../test/test-utils";
+
+const loginRoute = (validPassword: string) => ({
+  "/api/v2/login": (req: Request) => {
+    const auth = req.headers.get("authorization") || "";
+    const expected = `Basic ${btoa(`admin:${validPassword}`)}`;
+    if (auth === expected) {
+      return jsonResponse({ key: "session-key-123" });
+    }
+    return new Response("Forbidden", { status: 403 });
+  },
+});
+
+describe("Login page", () => {
+  it("renders branding, credential fields and the sign-in button", () => {
+    installFetchMock({});
+    renderWithProviders(<Login />, { withRouter: false });
+
+    expect(screen.getByText("NSClient++")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Sign in" })).toBeInTheDocument();
+    expect(screen.getByLabelText(/username/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Sign in" })).toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("masks the password input", () => {
+    installFetchMock({});
+    renderWithProviders(<Login />, { withRouter: false });
+    expect(screen.getByLabelText(/password/i)).toHaveAttribute("type", "password");
+  });
+
+  it("shows an error alert when the credentials are rejected", async () => {
+    installFetchMock(loginRoute("right"));
+    renderWithProviders(<Login />, { withRouter: false });
+
+    await userEvent.type(screen.getByLabelText(/username/i), "admin");
+    await userEvent.type(screen.getByLabelText(/password/i), "wrong");
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Login failed. Please check your credentials and try again.");
+  });
+
+  it("stores the token on a successful login", async () => {
+    installFetchMock(loginRoute("s3cret"));
+    const { store } = renderWithProviders(<Login />, { withRouter: false });
+
+    await userEvent.type(screen.getByLabelText(/username/i), "admin");
+    await userEvent.type(screen.getByLabelText(/password/i), "s3cret");
+    await userEvent.click(screen.getByRole("button", { name: "Sign in" }));
+
+    await waitFor(() => {
+      expect(store.getState().auth.token).toBe("session-key-123");
+    });
+    expect(localStorage.getItem("token")).toBe("session-key-123");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("submits the form when pressing Enter in a field", async () => {
+    installFetchMock(loginRoute("s3cret"));
+    const { store } = renderWithProviders(<Login />, { withRouter: false });
+
+    await userEvent.type(screen.getByLabelText(/username/i), "admin");
+    await userEvent.type(screen.getByLabelText(/password/i), "s3cret{Enter}");
+
+    await waitFor(() => {
+      expect(store.getState().auth.token).toBe("session-key-123");
+    });
+  });
+
+  it("restores a previously stored token from localStorage", async () => {
+    installFetchMock({});
+    localStorage.setItem("token", "stored-token");
+    const { store } = renderWithProviders(<Login />, { withRouter: false });
+
+    await waitFor(() => {
+      expect(store.getState().auth.token).toBe("stored-token");
+    });
+  });
+});

--- a/web/src/pages/Modules.test.tsx
+++ b/web/src/pages/Modules.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Modules from "./Modules";
+import { installFetchMock, jsonResponse, renderWithProviders } from "../test/test-utils";
+
+const moduleFixture = (id: string, loaded: boolean, enabled: boolean, description: string) => ({
+  id,
+  name: id,
+  title: id,
+  description,
+  enabled,
+  loaded,
+  metadata: { alias: "", plugin_id: "0" },
+  load_url: "",
+  unload_url: "",
+  module_url: "",
+});
+
+const MODULES = [
+  moduleFixture("CheckDisk", true, true, "Monitors disk usage"),
+  moduleFixture("CheckSystem", true, false, "Monitors cpu and memory"),
+  moduleFixture("WEBServer", false, false, "Serves the web interface"),
+];
+
+function setup() {
+  installFetchMock({
+    "/api/v2/modules": jsonResponse(MODULES),
+  });
+  return renderWithProviders(<Modules />);
+}
+
+describe("Modules page", () => {
+  it("renders the module list with names and descriptions", async () => {
+    setup();
+
+    expect(screen.getByText("Modules")).toBeInTheDocument();
+    expect(await screen.findByText("CheckDisk")).toBeInTheDocument();
+    expect(screen.getByText("CheckSystem")).toBeInTheDocument();
+    expect(screen.getByText("WEBServer")).toBeInTheDocument();
+    expect(screen.getByText("Monitors disk usage")).toBeInTheDocument();
+  });
+
+  it("filters modules by name and description and shows the hit count", async () => {
+    setup();
+    await screen.findByText("CheckDisk");
+
+    await userEvent.type(screen.getByPlaceholderText("Filter modules"), "disk");
+
+    expect(screen.getByText("CheckDisk")).toBeInTheDocument();
+    expect(screen.queryByText("CheckSystem")).not.toBeInTheDocument();
+    expect(screen.queryByText("WEBServer")).not.toBeInTheDocument();
+    expect(screen.getByText("1/3")).toBeInTheDocument();
+  });
+
+  it("shows an empty state when the filter matches nothing", async () => {
+    setup();
+    await screen.findByText("CheckDisk");
+
+    await userEvent.type(screen.getByPlaceholderText("Filter modules"), "nonexistent");
+
+    expect(screen.getByText(/No modules match/)).toBeInTheDocument();
+    expect(screen.getByText("0/3")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/Queries.test.tsx
+++ b/web/src/pages/Queries.test.tsx
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Queries from "./Queries";
+import { installFetchMock, jsonResponse, renderWithProviders } from "../test/test-utils";
+
+const query = (name: string, plugin: string, description: string) => ({
+  name,
+  title: name,
+  plugin,
+  description,
+  query_url: "",
+});
+
+const alias = (name: string, plugin: string, description: string) => ({
+  name,
+  title: name,
+  plugin,
+  description,
+  alias_url: "",
+});
+
+function setup() {
+  installFetchMock({
+    "/api/v2/queries": jsonResponse([
+      query("check_cpu", "CheckSystem", "Check the CPU load"),
+      query("check_drivesize", "CheckDisk", "Check disk space"),
+      // Legacy alias form (checkXXX without underscore) must be hidden.
+      query("checkcpu", "CheckSystem", "Legacy alias"),
+    ]),
+    "/api/v2/aliases": jsonResponse([
+      alias("alias_cpu", "CheckSystem", "Alias for check_cpu"),
+    ]),
+  });
+  return renderWithProviders(<Queries />);
+}
+
+describe("Queries page", () => {
+  it("renders queries and aliases in separate tables", async () => {
+    setup();
+
+    expect(await screen.findByText("check_cpu")).toBeInTheDocument();
+    expect(screen.getByText("check_drivesize")).toBeInTheDocument();
+    expect(screen.getByText("alias_cpu")).toBeInTheDocument();
+    expect(screen.getByText("Queries (2)")).toBeInTheDocument();
+    expect(screen.getByText("Aliases (1)")).toBeInTheDocument();
+  });
+
+  it("hides legacy checkXXX aliases from the query list", async () => {
+    setup();
+    await screen.findByText("check_cpu");
+    expect(screen.queryByText("checkcpu")).not.toBeInTheDocument();
+  });
+
+  it("filters both tables from the filter field", async () => {
+    setup();
+    await screen.findByText("check_cpu");
+
+    await userEvent.type(screen.getByPlaceholderText("Filter checks..."), "drivesize");
+
+    expect(screen.getByText("check_drivesize")).toBeInTheDocument();
+    expect(screen.queryByText("check_cpu")).not.toBeInTheDocument();
+    expect(screen.queryByText("alias_cpu")).not.toBeInTheDocument();
+    expect(screen.getByText(/No aliases match/)).toBeInTheDocument();
+  });
+
+  it("sorts queries when clicking a column header", async () => {
+    setup();
+    await screen.findByText("check_cpu");
+
+    const queriesTable = screen.getAllByRole("table")[0];
+    const nameHeader = within(queriesTable).getByRole("button", { name: "Name" });
+    // The name column starts active/ascending, so one click flips it to descending.
+    await userEvent.click(nameHeader);
+
+    const rows = within(queriesTable).getAllByRole("row").slice(1);
+    const names = rows.map((row) => within(row).getAllByRole("cell")[0].textContent);
+    expect(names).toEqual(["check_drivesize", "check_cpu"]);
+  });
+});

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,49 @@
+import "@testing-library/jest-dom/vitest";
+import { afterEach, vi } from "vitest";
+
+// jsdom does not implement ResizeObserver, which @mui/x-charts and some MUI
+// components rely on for sizing.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+if (!("ResizeObserver" in globalThis)) {
+  (globalThis as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverStub;
+}
+
+// Node's undici Request (used under vitest) rejects the relative URLs that
+// fetchBaseQuery produces ("/api/..."); resolve them against the jsdom origin
+// the way a browser would.
+const NativeRequest = globalThis.Request;
+class RelativeUrlRequest extends NativeRequest {
+  constructor(input: RequestInfo | URL, init?: RequestInit) {
+    if (typeof input === "string" && input.startsWith("/")) {
+      input = new URL(input, window.location.origin).toString();
+    }
+    super(input, init);
+  }
+}
+globalThis.Request = RelativeUrlRequest;
+
+// jsdom does not implement matchMedia, used by MUI's useMediaQuery.
+if (!window.matchMedia) {
+  window.matchMedia = (query: string): MediaQueryList =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as MediaQueryList;
+}
+
+afterEach(() => {
+  // Tests seed tokens through localStorage (the auth hook persists there);
+  // make sure state never leaks from one test into the next.
+  localStorage.clear();
+  vi.unstubAllGlobals();
+});

--- a/web/src/test/test-utils.tsx
+++ b/web/src/test/test-utils.tsx
@@ -1,0 +1,91 @@
+import { ReactElement, ReactNode } from "react";
+import { render } from "@testing-library/react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
+import { vi } from "vitest";
+import { nsclientApi } from "../api/api";
+import { authSlice } from "../common/authSlice";
+import { dashboardSlice } from "../common/dashboardSlice";
+import type { RootState } from "../store/store";
+
+/**
+ * Build a fresh store with the same shape as the production store so tests
+ * never share RTK Query caches or auth state with each other.
+ */
+export function makeStore(preloadedState?: Partial<RootState>) {
+  return configureStore({
+    reducer: {
+      [authSlice.name]: authSlice.reducer,
+      [dashboardSlice.name]: dashboardSlice.reducer,
+      [nsclientApi.reducerPath]: nsclientApi.reducer,
+    },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(nsclientApi.middleware),
+    // Cast: RTK's preloadedState typing wants every slice, tests only seed some.
+    preloadedState: preloadedState as never,
+  });
+}
+
+export type TestStore = ReturnType<typeof makeStore>;
+
+interface RenderOptions {
+  store?: TestStore;
+  preloadedState?: Partial<RootState>;
+  /** Wrap in a MemoryRouter (needed by components using useNavigate & co). */
+  route?: string;
+  withRouter?: boolean;
+}
+
+/** Render a component inside Redux (and optionally router) providers. */
+export function renderWithProviders(ui: ReactElement, options: RenderOptions = {}) {
+  const store = options.store ?? makeStore(options.preloadedState);
+  const withRouter = options.withRouter ?? true;
+
+  const Wrapper = ({ children }: { children: ReactNode }) => {
+    const inner = <Provider store={store}>{children}</Provider>;
+    if (!withRouter) {
+      return inner;
+    }
+    return <MemoryRouter initialEntries={[options.route ?? "/"]}>{inner}</MemoryRouter>;
+  };
+
+  return { store, ...render(ui, { wrapper: Wrapper }) };
+}
+
+export const authenticatedState: Partial<RootState> = {
+  auth: { token: "test-token", tokenInvalid: false },
+};
+
+type RouteHandler = Response | ((req: Request) => Response | Promise<Response>);
+
+export function jsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+/**
+ * Stub the global fetch used by RTK Query's fetchBaseQuery. Routes are keyed
+ * by URL pathname (e.g. "/api/v2/metrics"); query strings are ignored when
+ * matching. Unrouted paths get a 404 so a missing mock is visible in the test
+ * rather than hanging.
+ */
+export function installFetchMock(routes: Record<string, RouteHandler>) {
+  const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    const path = new URL(request.url, "http://localhost").pathname;
+    const handler = routes[path];
+    if (handler === undefined) {
+      return new Response(`No fetch mock for ${path}`, { status: 404 });
+    }
+    if (typeof handler === "function") {
+      return handler(request);
+    }
+    // Response bodies are single-use: clone so a route can serve repeatedly.
+    return handler.clone();
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}

--- a/web/tsconfig.app.json
+++ b/web/tsconfig.app.json
@@ -23,5 +23,7 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  // Tests are type-checked by vitest/eslint tooling, not the production build.
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/test"]
 }

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
+  },
+});


### PR DESCRIPTION
Add two test suites to the web client, which previously had none, both
focused on validating that the UX renders correctly:

- Unit tests (Vitest + React Testing Library, jsdom): 65 tests covering
  the metric parser, API response transforms, the auth and dashboard
  Redux slices, atom components (NscpAlert, QueryResultChip), the
  dashboard widgets (SystemInfo, DiskFree, Tags), the login page
  (rendering, error handling, token persistence), the Modules and
  Queries pages (rendering, filtering, sorting), the AppNavbar (version,
  error badge, logout) and the router's authentication gating including
  the 403-drops-the-session flow. REST calls are stubbed at the fetch
  level (src/test/test-utils.tsx) so no backend is needed.

- Integration tests (Playwright): 18 tests that build the production
  bundle, serve it with vite preview and drive a real Chromium with the
  /api routes mocked in-browser (e2e/mock-api.ts). They verify the
  sign-in screen, failed/successful login, dashboard widgets actually
  drawing SVG charts, system info and disk usage values, tag chips, the
  server-aware refresh-rate selector, sidebar navigation across pages,
  module filtering, deep links via the SPA fallback and logout.

Infrastructure: vitest.config.ts, a jsdom setup file (ResizeObserver /
matchMedia shims and relative-URL Request support for fetchBaseQuery),
playwright.config.ts with a webServer block, npm scripts (test,
test:watch, test:e2e), README instructions, and .gitignore entries for
Playwright artifacts. Test files are excluded from the production
tsc build; licenses.json is regenerated to match the locked versions.

Assisted-by: Claude Code
Signed-off-by: Michael Medin <michael@medin.name>