### PR TITLE
fix(web): harden WEBServer from security review (tokens, cookies, installer)

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -107,9 +107,14 @@ consistency issues.
   non-deterministic — some toolchains have historically implemented it as a
   fixed-seed PRNG, which would make tokens predictable. Tokens now come from
   `RAND_bytes()` (the same CSPRNG already used for password salts), with
-  rejection sampling to keep the alphabet unbiased, falling back to
-  `std::random_device` only when built without OpenSSL. TLS-serving builds
-  always have OpenSSL.
+  rejection sampling to keep the alphabet unbiased. A build *without* OpenSSL
+  still uses `std::random_device` (it cannot serve TLS either); a build that
+  has the CSPRNG never silently substitutes the weaker source — if
+  `RAND_bytes()` fails, **no token or generated password is issued at all**
+  and the request fails with a 500 (`nscp web add-user` / `nscp web install`
+  report an RNG failure). Refusing is the correct outcome for a bearer
+  credential, but it does mean a broken OpenSSL RNG blocks logins rather than
+  degrading them; the failure is logged as a `SECURITY:` error.
 - **Cookie name matching now requires a name boundary.** The bundled
   `mg_get_cookie` matched a requested cookie name as a substring, so a
   client cookie named `eviltoken` could satisfy a lookup for `token`. It now
@@ -126,8 +131,11 @@ consistency issues.
 - **The web-UI installer refuses an HTTPS→HTTP redirect.** The bundle's
   integrity rests on the TLS channel (the SHA-256 manifest is fetched over the
   same connection), so a redirect chain that began on `https://` is no longer
-  allowed to drop to cleartext. An operator who explicitly passes an
-  `http://` `--url` is unaffected.
+  allowed to drop to cleartext. A protocol-relative `Location` (`//host/path`)
+  is now resolved as such, inheriting the current scheme, instead of being
+  glued onto the current origin as a path — which both mis-resolved the
+  redirect and hid it from the downgrade check. An operator who explicitly
+  passes an `http://` `--url` is unaffected.
 - **The `legacy` grant's startup warning now names `/settings/query.pb`.** In
   addition to the query/RCE routes it already flagged, the `SECURITY` warning
   now states that `legacy` also unlocks `POST /settings/query.pb`, which reads

--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -92,6 +92,56 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### WEB server security-review hardening
+
+**Fixed in:** 0.17.0 · **Severity:** Low–Medium
+
+A focused security review of the `WEBServer` module (REST API + web UI)
+produced a set of defense-in-depth fixes. None is a confirmed remote
+vulnerability in a default configuration; they close latent gaps and
+consistency issues.
+
+- **Session tokens are drawn from the OpenSSL CSPRNG.** `token_store::generate_token`
+  minted bearer session tokens (and generated admin passwords) with
+  `std::random_device`, which the C++ standard does not require to be
+  non-deterministic — some toolchains have historically implemented it as a
+  fixed-seed PRNG, which would make tokens predictable. Tokens now come from
+  `RAND_bytes()` (the same CSPRNG already used for password salts), with
+  rejection sampling to keep the alphabet unbiased, falling back to
+  `std::random_device` only when built without OpenSSL. TLS-serving builds
+  always have OpenSSL.
+- **Cookie name matching now requires a name boundary.** The bundled
+  `mg_get_cookie` matched a requested cookie name as a substring, so a
+  client cookie named `eviltoken` could satisfy a lookup for `token`. It now
+  requires the match to start at a cookie boundary. The WEBServer module
+  authenticates from headers, not request cookies, so this path was not used
+  for authentication — the fix hardens the exported helper regardless.
+- **The legacy `/auth/logout` route enforces the allowed-hosts perimeter.**
+  Its sibling `/auth/token` already called `is_allowed()`; logout did not, so
+  a host outside `allowed hosts` could revoke an observed token with a
+  spoofed `User-Agent`. It now applies the same check.
+- **Script / module names may no longer begin with `-`.** A leading dash could
+  be mistaken for an option flag when the name is later passed as an argument
+  value; interior dashes (`check-disk`) are unchanged.
+- **The web-UI installer refuses an HTTPS→HTTP redirect.** The bundle's
+  integrity rests on the TLS channel (the SHA-256 manifest is fetched over the
+  same connection), so a redirect chain that began on `https://` is no longer
+  allowed to drop to cleartext. An operator who explicitly passes an
+  `http://` `--url` is unaffected.
+- **The `legacy` grant's startup warning now names `/settings/query.pb`.** In
+  addition to the query/RCE routes it already flagged, the `SECURITY` warning
+  now states that `legacy` also unlocks `POST /settings/query.pb`, which reads
+  settings *without* the redaction the `/api/v2/settings` endpoints apply and
+  can write settings — without holding `settings.get`/`settings.put`. This is
+  a documentation fix; the endpoint's behaviour is unchanged, and `legacy` was
+  already an RCE-equivalent, trusted-only grant.
+
+**What to do:** nothing required for the default install. If you have a custom
+script/module name that begins with `-`, rename it. If a client outside
+`allowed hosts` relied on the legacy `/auth/logout` route, move it inside the
+perimeter. Review any role that grants `legacy` — it confers unredacted
+settings read and settings write in addition to command execution.
+
 ### Host name placeholders are sanitized before they land in a local path
 
 **Fixed in:** 0.17.0 · **Severity:** Low

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -192,6 +192,16 @@ page tracks those in one place. Full per-release detail lives in each
   `modified` entry whose old value equalled its new one. Tooling that treated
   a non-empty diff as "unsaved work pending" no longer needs to special-case
   that; no configuration change is needed.
+- 🔒 **WEB server security-review hardening.** A review of the `WEBServer`
+  module produced several defense-in-depth fixes (session tokens now come from
+  the OpenSSL CSPRNG, cookie-name matching requires a name boundary, the
+  installer refuses an HTTPS→HTTP redirect, and the `legacy` grant's startup
+  warning now names `/settings/query.pb`). The default install needs no
+  action. Two changes touch observable behaviour: a script or module **name
+  that begins with `-` is now rejected** (rename it; interior dashes are
+  fine), and the legacy **`POST /auth/logout` route now enforces `allowed
+  hosts`** like the rest of the API (a caller outside the perimeter gets 403).
+  See the [security notice](../security/notices.md#web-server-security-review-hardening).
 
 ## 0.16.4
 

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -201,6 +201,9 @@ page tracks those in one place. Full per-release detail lives in each
   that begins with `-` is now rejected** (rename it; interior dashes are
   fine), and the legacy **`POST /auth/logout` route now enforces `allowed
   hosts`** like the rest of the API (a caller outside the perimeter gets 403).
+  A third only bites on a broken system: if the OpenSSL CSPRNG fails, the
+  server now **refuses to issue a session token** (HTTP 500, logged as
+  `SECURITY:`) rather than falling back to a weaker generator.
   See the [security notice](../security/notices.md#web-server-security-review-hardening).
 
 ## 0.16.4

--- a/libs/mongoose-cpp/Request.cpp
+++ b/libs/mongoose-cpp/Request.cpp
@@ -51,6 +51,13 @@ long long mg_get_cookie(const char *cookie_header, const char *var_name, char *d
   dst[0] = '\0';
 
   for (; (s = mg_strcasestr(s, var_name)) != nullptr; s += name_len) {
+    // The match must start at a cookie-name boundary, not in the middle of a
+    // longer name: without the left-boundary check, a client cookie named
+    // "eviltoken" would satisfy a lookup for "token" (the substring search
+    // finds "token" inside it and sees the following '='). Cookies are
+    // separated by "; ", so a valid name is preceded by start-of-header, a
+    // space, or a ';'.
+    if (s != cookie_header && s[-1] != ' ' && s[-1] != ';') continue;
     if (s[name_len] != '=') continue;
     s += name_len + 1;
     const char *p = std::strchr(s, ' ');

--- a/libs/mongoose-cpp/Request_test.cpp
+++ b/libs/mongoose-cpp/Request_test.cpp
@@ -182,6 +182,22 @@ TEST(Request, GetCookieHandlesQuotedValue) {
   EXPECT_EQ(r.getCookie("name"), "quoted-value");
 }
 
+TEST(Request, GetCookieRequiresNameBoundary) {
+  // A cookie whose name merely ends with the requested name must NOT match:
+  // looking up "token" must not be satisfied by a client-supplied "eviltoken".
+  const Request::headers_type h{{"cookie", "eviltoken=attacker; other=1"}};
+  const auto r = make_request("GET", "/", "", h);
+  EXPECT_EQ(r.getCookie("token", "fb"), "fb");
+}
+
+TEST(Request, GetCookieMatchesLaterCookieWithSuffixNameEarlier) {
+  // The real "token" appears after a decoy "xtoken"; the boundary check must
+  // skip the decoy and return the genuine value.
+  const Request::headers_type h{{"cookie", "xtoken=decoy; token=real"}};
+  const auto r = make_request("GET", "/", "", h);
+  EXPECT_EQ(r.getCookie("token"), "real");
+}
+
 TEST(Request, GetCookieIsCaseInsensitiveForName) {
   // mg_strcasestr is case-insensitive for the variable name.
   Request::headers_type h{{"cookie", "Session=abc"}};

--- a/modules/WEBServer/WEBServer.cpp
+++ b/modules/WEBServer/WEBServer.cpp
@@ -224,7 +224,8 @@ bool WEBServer::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   ensure_role(roles, settings, role_path, "legacy", "legacy,login.get", "legacy API", false);
   ensure_role(roles, settings, role_path, "full", "*", "Full access");
   ensure_role(roles, settings, role_path, "client",
-              "public,info.get,info.get.version,queries.list,queries.get,queries.execute,aliases.list,login.get,modules.list", "read only");
+              "public,info.get,info.get.version,queries.list,queries.get,queries.execute,aliases.list,login.get,modules.list",
+              "read + run checks (queries.execute can run side-effecting commands)");
   ensure_role(roles, settings, role_path, "monitoring", "public,queries.execute,aliases.list,login.get,metrics.get", "checks and queries only");
 
   if (!disable_admin_user) {
@@ -255,8 +256,11 @@ bool WEBServer::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
         NSC_LOG_ERROR("SECURITY: WEB role '" + name +
                       "' grants the 'legacy' permission, which unlocks the deprecated /query.pb and /query/{name} "
                       "endpoints. Any user with this role can run ANY registered check or command (including configured "
-                      "CheckExternalScripts commands) even without 'queries.execute'. Only grant 'legacy' to roles for "
-                      "trusted legacy systems that cannot use the versioned /api/v2/queries endpoints.");
+                      "CheckExternalScripts commands) even without 'queries.execute'. It ALSO unlocks POST "
+                      "/settings/query.pb, which reads settings WITHOUT the redaction the /api/v2/settings endpoints "
+                      "apply (exposing stored secrets in cleartext) and can WRITE settings - without holding "
+                      "'settings.get'/'settings.put'. Only grant 'legacy' to roles for trusted legacy systems that "
+                      "cannot use the versioned /api/v2/queries and /api/v2/settings endpoints.");
       }
     });
 

--- a/modules/WEBServer/WEBServer.cpp
+++ b/modules/WEBServer/WEBServer.cpp
@@ -530,6 +530,12 @@ bool WEBServer::cli_add_user(const PB::Commands::ExecuteRequestMessage::Request 
     if (password.empty()) {
       result << "WARNING: No password specified using a generated password" << std::endl;
       password = token_store::generate_token(32);
+      if (password.empty()) {
+        // The CSPRNG failed. Seeding an empty password would be far worse
+        // than refusing - it would leave an account whose password is "".
+        nscapi::protobuf::functions::set_response_bad(*response, "Failed to generate a password (RNG failure)");
+        return true;
+      }
       password_for_display = password;
     } else if (web_password::is_hashed(password)) {
       // Existing on-disk hash; nothing to migrate, nothing to show.
@@ -766,6 +772,10 @@ bool WEBServer::install_server(const PB::Commands::ExecuteRequestMessage::Reques
     if (password.empty() && !disable_admin) {
       result << "WARNING: No password specified using a generated password" << std::endl;
       password = token_store::generate_token(32);
+      if (password.empty()) {
+        nscapi::protobuf::functions::set_response_bad(*response, "Failed to generate a password (RNG failure)");
+        return true;
+      }
     }
 
     nscapi::protobuf::functions::settings_query s(get_id());

--- a/modules/WEBServer/legacy_controller.cpp
+++ b/modules/WEBServer/legacy_controller.cpp
@@ -174,6 +174,15 @@ void legacy_controller::auth_logout(Mongoose::Request &request, Mongoose::Stream
         "proxy logs and Referer headers. Log out via DELETE /api/v2/login with the Authorization: Bearer header.\" }");
     return;
   }
+  // Enforce the same allowed-hosts perimeter as auth_token (and every
+  // is_logged_in path). Without this, a host outside 'allowed hosts' could
+  // reach this route with a spoofed User-Agent and revoke a token it observed
+  // (e.g. from a proxy log), because the only other gate is the client-chosen
+  // User-Agent allowlist.
+  if (!session->is_allowed(request.getRemoteIp())) {
+    response.setCodeForbidden("403 You're not allowed");
+    return;
+  }
   const std::string token = request.get("token");
   session->revoke_token(token);
   response.setHeader("__TOKEN", "");

--- a/modules/WEBServer/log_controller.cpp
+++ b/modules/WEBServer/log_controller.cpp
@@ -133,7 +133,10 @@ void log_controller::add_log(Mongoose::Request &request, boost::smatch &what, Mo
     std::string message = get_str_or(o, "message", "no message");
     core->log(level, file, line, message);
   } catch (const std::exception &) {
+    // Return the 400 as-is; do not fall through to setCodeOk() below, which
+    // would leave a "400" body under a 200 status.
     response.setCodeBadRequest("Problems parsing JSON");
+    return;
   }
   response.setCodeOk();
 }

--- a/modules/WEBServer/modules_controller.cpp
+++ b/modules/WEBServer/modules_controller.cpp
@@ -80,6 +80,7 @@ void modules_controller::get_module(Mongoose::Request &request, boost::smatch &w
 
   if (what.size() != 2) {
     response.setCodeNotFound("Module not found");
+    return;
   }
   std::string module = what.str(1);
   if (!name_safety::is_safe_module_name(module)) {

--- a/modules/WEBServer/name_safety.cpp
+++ b/modules/WEBServer/name_safety.cpp
@@ -21,6 +21,11 @@ bool is_safe_segment(const std::string& seg) {
   // "." and ".." are path-traversal primitives even when each character
   // would otherwise be allowed.
   if (seg == "." || seg == "..") return false;
+  // A leading '-' makes the name look like an option flag when it is later
+  // passed as an argument value (e.g. `--script <name>`); reject it so a name
+  // like "-rf" or "-o" cannot be mistaken for a switch by a downstream parser.
+  // Interior '-' (e.g. "check-disk") stays allowed.
+  if (seg.front() == '-') return false;
   for (char c : seg) {
     if (!is_safe_segment_char(c)) return false;
   }

--- a/modules/WEBServer/name_safety_test.cpp
+++ b/modules/WEBServer/name_safety_test.cpp
@@ -84,3 +84,16 @@ TEST(NameSafety, ScriptNameRejectsControlAndUnsafeChars) {
   EXPECT_FALSE(is_safe_script_name(std::string("a\0b", 3)));
   EXPECT_FALSE(is_safe_script_name("a\nb"));
 }
+
+TEST(NameSafety, RejectsLeadingDash) {
+  // A leading '-' in any segment could be mistaken for an option flag when the
+  // name is later passed as an argument value (e.g. `--script <name>`).
+  EXPECT_FALSE(is_safe_script_name("-rf"));
+  EXPECT_FALSE(is_safe_script_name("-o"));
+  EXPECT_FALSE(is_safe_script_name("subdir/-x"));
+  EXPECT_FALSE(is_safe_module_name("-evil"));
+  // Interior dashes stay allowed.
+  EXPECT_TRUE(is_safe_script_name("check-disk"));
+  EXPECT_TRUE(is_safe_script_name("subdir/check-disk"));
+  EXPECT_TRUE(is_safe_module_name("check-system"));
+}

--- a/modules/WEBServer/query_controller.cpp
+++ b/modules/WEBServer/query_controller.cpp
@@ -69,6 +69,7 @@ void query_controller::get_query(Mongoose::Request &request, boost::smatch &what
 
   if (what.size() != 2) {
     response.setCodeNotFound("Query not found");
+    return;
   }
   std::string module = what.str(1);
 
@@ -110,6 +111,7 @@ void query_controller::query_command(Mongoose::Request &request, boost::smatch &
 
   if (what.size() != 3) {
     response.setCodeNotFound("Invalid request");
+    return;
   }
   const std::string module = what.str(1);
   const std::string command = what.str(2);

--- a/modules/WEBServer/session_manager_interface.cpp
+++ b/modules/WEBServer/session_manager_interface.cpp
@@ -123,19 +123,23 @@ bool session_manager_interface::process_auth_header(const std::string &grant, Mo
       return false;
     }
     rate_limiter.record_success(remote_ip);
-    store_user_in_response(user_and_password.first, response);
+    if (!store_user_in_response(user_and_password.first, response)) {
+      response.setCodeServerError("500 Failed to issue token");
+      return false;
+    }
     return can(grant, response);
   }
   if (is_bearer_auth(auth)) {
     const std::string token = auth.substr(7);
-    if (!tokens.is_valid(token)) {
+    std::string user;
+    if (!tokens.validate(token, user)) {
       rate_limiter.record_failure(remote_ip);
       NSC_LOG_ERROR("Authentication failed for " + remote_ip);
       response.setCodeForbidden(NOT_ALLOWED);
       return false;
     }
     rate_limiter.record_success(remote_ip);
-    store_token_in_response(token, response);
+    store_session_in_response(token, user, response);
     return can(grant, response);
   }
   NSC_LOG_ERROR("Unknown authentication scheme for " + remote_ip);
@@ -171,7 +175,10 @@ bool session_manager_interface::process_password_header(const std::string &grant
     return false;
   }
   rate_limiter.record_success(remote_ip);
-  store_user_in_response(kImplicitUser, response);
+  if (!store_user_in_response(kImplicitUser, response)) {
+    response.setCodeServerError("500 Failed to issue token");
+    return false;
+  }
   return can(grant, response);
 }
 
@@ -203,12 +210,13 @@ bool session_manager_interface::is_logged_in(const std::string &grant, Mongoose:
     response.setCodeForbidden(NOT_ALLOWED);
     return false;
   }
-  if (!tokens.is_valid(token)) {
+  std::string user;
+  if (!tokens.validate(token, user)) {
     NSC_LOG_ERROR("Rejected connection from: " + request.getRemoteIp() + " due to invalid token");
     response.setCodeForbidden(NOT_ALLOWED);
     return false;
   }
-  store_token_in_response(token, response);
+  store_session_in_response(token, user, response);
   if (!can(grant, response)) {
     NSC_LOG_ERROR("Rejected connection from: " + request.getRemoteIp() + " due to insufficient permissions");
     response.setCodeForbidden(NOT_ALLOWED);
@@ -223,14 +231,27 @@ std::list<std::string> session_manager_interface::boot() {
   return errors;
 }
 
-void session_manager_interface::store_user_in_response(const std::string &user, Mongoose::StreamResponse &response) {
-  response.setCookie("token", tokens.generate_for(user));
+bool session_manager_interface::store_user_in_response(const std::string &user, Mongoose::StreamResponse &response) {
+  const std::string token = tokens.generate_for(user);
+  if (token.empty()) {
+    // generate_for only returns empty when the CSPRNG failed. token_store
+    // deliberately has no logging of its own (nor do grant_store /
+    // user_manager) - this is the layer that reports, and refusing here is
+    // what makes the fail-closed contract in generate_token() meaningful.
+    NSC_LOG_ERROR(
+        "SECURITY: refused to issue a session token because the cryptographic RNG (RAND_bytes) failed. No session was "
+        "created. Authentication will keep failing until the OpenSSL RNG is usable again.");
+    return false;
+  }
+  response.setCookie("token", token);
   response.setCookie("uid", user);
+  return true;
 }
 
-void session_manager_interface::store_token_in_response(const std::string &token, Mongoose::StreamResponse &response) const {
+void session_manager_interface::store_session_in_response(const std::string &token, const std::string &user,
+                                                          Mongoose::StreamResponse &response) const {
   response.setCookie("token", token);
-  response.setCookie("uid", tokens.get_user(token));
+  response.setCookie("uid", user);
 }
 
 void session_manager_interface::get_user_from_response(const Mongoose::StreamResponse &response, std::string &user, std::string &key) {

--- a/modules/WEBServer/session_manager_interface.hpp
+++ b/modules/WEBServer/session_manager_interface.hpp
@@ -99,8 +99,10 @@ struct session_manager_interface {
 
   std::list<std::string> boot();
   bool validate_user(const std::string &user, const std::string &password);
-  void store_user_in_response(const std::string &user, Mongoose::StreamResponse &response);
-  void store_token_in_response(const std::string &token, Mongoose::StreamResponse &response) const;
+  // Returns false when no session could be created (CSPRNG failure); the
+  // caller must not treat the request as authenticated.
+  bool store_user_in_response(const std::string &user, Mongoose::StreamResponse &response);
+  void store_session_in_response(const std::string &token, const std::string &user, Mongoose::StreamResponse &response) const;
   bool can(const std::string &grant, Mongoose::StreamResponse &response);
   static void get_user_from_response(const Mongoose::StreamResponse &response, std::string &user, std::string &key);
   void add_user(const std::string &user, const std::string &role, const std::string &password);

--- a/modules/WEBServer/session_manager_interface_test.cpp
+++ b/modules/WEBServer/session_manager_interface_test.cpp
@@ -106,15 +106,31 @@ TEST_F(SessionManagerTest, TokenGenerationAndValidation) {
 
 TEST_F(SessionManagerTest, StoreUserInResponseSetsCookies) {
   Mongoose::StreamResponse resp;
-  smi.store_user_in_response("user", resp);
+  EXPECT_TRUE(smi.store_user_in_response("user", resp));
   EXPECT_EQ(resp.getCookie("uid"), "user");
   EXPECT_FALSE(resp.getCookie("token").empty());
 }
 
-TEST_F(SessionManagerTest, StoreTokenInResponseSetsCookies) {
+TEST_F(SessionManagerTest, StoreUserInResponseFailsClosedWhenCsprngFails) {
+  // A CSPRNG failure must not produce a half-formed session: no token cookie,
+  // no uid cookie, and a false return so the caller refuses the request.
   Mongoose::StreamResponse resp;
-  smi.store_token_in_response("validtoken", resp);
+  token_store::set_rand_bytes_for_test([](unsigned char *, int) { return 0; });
+  const bool stored = smi.store_user_in_response("user", resp);
+  token_store::set_rand_bytes_for_test(nullptr);
+  EXPECT_FALSE(stored);
+  EXPECT_TRUE(resp.getCookie("token").empty());
+  EXPECT_TRUE(resp.getCookie("uid").empty());
+}
+
+TEST_F(SessionManagerTest, StoreSessionInResponseSetsCookies) {
+  // The token and the user are now passed together - resolved from one locked
+  // observation in token_store::validate() - rather than the user being looked
+  // up again from the token.
+  Mongoose::StreamResponse resp;
+  smi.store_session_in_response("validtoken", "user", resp);
   EXPECT_EQ(resp.getCookie("token"), "validtoken");
+  EXPECT_EQ(resp.getCookie("uid"), "user");
 }
 
 TEST_F(SessionManagerTest, CanCheckPermissions) {

--- a/modules/WEBServer/token_store.cpp
+++ b/modules/WEBServer/token_store.cpp
@@ -16,12 +16,13 @@ static constexpr char alphanum[] =
     "abcdefghijklmnopqrstuvwxyz";
 
 namespace {
-// Fallback generator used only when no CSPRNG is available (USE_SSL off) or
-// RAND_bytes fails. std::random_device is NOT guaranteed by the standard to be
+// Fallback generator used ONLY when the build has no CSPRNG at all (USE_SSL
+// off). std::random_device is NOT guaranteed by the standard to be
 // non-deterministic - some toolchains (historically MinGW-w64) implement it as
 // a fixed-seed PRNG, which would make session tokens predictable. It is kept
 // solely so a build without OpenSSL still produces *some* token rather than an
-// empty string.
+// empty string; such a build cannot serve TLS either. A build that HAS a
+// CSPRNG never falls back to this - see csprng_bytes() below.
 std::string generate_token_fallback(const int len, const std::size_t alphanum_size) {
   std::random_device rd;
   std::uniform_int_distribution<int> dist(0, static_cast<int>(alphanum_size) - 1);
@@ -30,12 +31,31 @@ std::string generate_token_fallback(const int len, const std::size_t alphanum_si
   for (int i = 0; i < len; i++) ret += alphanum[dist(rd)];
   return ret;
 }
+
+// Test seam, null in production. See token_store::set_rand_bytes_for_test.
+token_store::rand_bytes_fn g_rand_bytes_override = nullptr;
+
+// Fill `buf` from the cryptographic RNG.
+//   1  -> success
+//   0  -> a CSPRNG exists but failed (do NOT silently substitute a weaker one)
+//  -1  -> this build has no CSPRNG at all
+int csprng_bytes(unsigned char *buf, const int num) {
+  if (g_rand_bytes_override != nullptr) return g_rand_bytes_override(buf, num);
+#ifdef USE_SSL
+  return RAND_bytes(buf, num);
+#else
+  (void)buf;
+  (void)num;
+  return -1;
+#endif
+}
 }  // namespace
+
+void token_store::set_rand_bytes_for_test(const rand_bytes_fn fn) { g_rand_bytes_override = fn; }
 
 std::string token_store::generate_token(const int len) {
   constexpr std::size_t alphanum_size = sizeof(alphanum) - 1;
   if (len <= 0) return std::string();
-#ifdef USE_SSL
   // Session tokens are the primary bearer credential, so draw them from the
   // same cryptographic RNG the module already links for password salts
   // (password_hash.cpp). Reject bytes at or above the largest multiple of the
@@ -45,19 +65,24 @@ std::string token_store::generate_token(const int len) {
   ret.reserve(len);
   std::vector<unsigned char> buf(static_cast<std::size_t>(len));
   while (static_cast<int>(ret.size()) < len) {
-    if (RAND_bytes(buf.data(), static_cast<int>(buf.size())) != 1) {
-      // CSPRNG unavailable/failed - fall back rather than emit a short or
-      // empty token that would weaken or break authentication.
+    const int rc = csprng_bytes(buf.data(), static_cast<int>(buf.size()));
+    if (rc < 0) {
+      // No CSPRNG in this build at all (USE_SSL off) - the weak generator is
+      // the only option, and such a build cannot serve TLS anyway.
       return generate_token_fallback(len, alphanum_size);
+    }
+    if (rc != 1) {
+      // A CSPRNG exists but failed. Fail closed: the caller must refuse to
+      // issue a credential rather than mint one from a source the standard
+      // does not require to be non-deterministic. Callers treat "" as an
+      // error (see session_manager_interface::store_user_in_response).
+      return std::string();
     }
     for (std::size_t i = 0; i < buf.size() && static_cast<int>(ret.size()) < len; ++i) {
       if (buf[i] < reject_limit) ret += alphanum[buf[i] % alphanum_size];
     }
   }
   return ret;
-#else
-  return generate_token_fallback(len, alphanum_size);
-#endif
 }
 
 // `grants` is guarded by the same mutex as `tokens`: add_user / add_grant run

--- a/modules/WEBServer/token_store.cpp
+++ b/modules/WEBServer/token_store.cpp
@@ -4,20 +4,60 @@
 #include "token_store.hpp"
 
 #include <random>
+#include <vector>
+
+#ifdef USE_SSL
+#include <openssl/rand.h>
+#endif
 
 static constexpr char alphanum[] =
     "0123456789"
     "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "abcdefghijklmnopqrstuvwxyz";
 
-std::string token_store::generate_token(const int len) {
-  constexpr std::size_t alphanum_size = sizeof(alphanum) - 1;
+namespace {
+// Fallback generator used only when no CSPRNG is available (USE_SSL off) or
+// RAND_bytes fails. std::random_device is NOT guaranteed by the standard to be
+// non-deterministic - some toolchains (historically MinGW-w64) implement it as
+// a fixed-seed PRNG, which would make session tokens predictable. It is kept
+// solely so a build without OpenSSL still produces *some* token rather than an
+// empty string.
+std::string generate_token_fallback(const int len, const std::size_t alphanum_size) {
   std::random_device rd;
   std::uniform_int_distribution<int> dist(0, static_cast<int>(alphanum_size) - 1);
   std::string ret;
   ret.reserve(len);
   for (int i = 0; i < len; i++) ret += alphanum[dist(rd)];
   return ret;
+}
+}  // namespace
+
+std::string token_store::generate_token(const int len) {
+  constexpr std::size_t alphanum_size = sizeof(alphanum) - 1;
+  if (len <= 0) return std::string();
+#ifdef USE_SSL
+  // Session tokens are the primary bearer credential, so draw them from the
+  // same cryptographic RNG the module already links for password salts
+  // (password_hash.cpp). Reject bytes at or above the largest multiple of the
+  // alphabet size so the modulo mapping stays unbiased (256 % 62 != 0).
+  const unsigned int reject_limit = 256 - (256 % static_cast<unsigned int>(alphanum_size));
+  std::string ret;
+  ret.reserve(len);
+  std::vector<unsigned char> buf(static_cast<std::size_t>(len));
+  while (static_cast<int>(ret.size()) < len) {
+    if (RAND_bytes(buf.data(), static_cast<int>(buf.size())) != 1) {
+      // CSPRNG unavailable/failed - fall back rather than emit a short or
+      // empty token that would weaken or break authentication.
+      return generate_token_fallback(len, alphanum_size);
+    }
+    for (std::size_t i = 0; i < buf.size() && static_cast<int>(ret.size()) < len; ++i) {
+      if (buf[i] < reject_limit) ret += alphanum[buf[i] % alphanum_size];
+    }
+  }
+  return ret;
+#else
+  return generate_token_fallback(len, alphanum_size);
+#endif
 }
 
 // `grants` is guarded by the same mutex as `tokens`: add_user / add_grant run

--- a/modules/WEBServer/token_store.hpp
+++ b/modules/WEBServer/token_store.hpp
@@ -89,12 +89,18 @@ class token_store {
     return true;
   }
 
-  std::string get_user(const std::string &token) const {
+  std::string get_user(const std::string &token) const { return get_user(token, now()); }
+
+  std::string get_user(const std::string &token, const time_t now) const {
     const std::lock_guard<std::mutex> lock(mutex_);
     const auto cit = tokens.find(token);
-    if (cit != tokens.end()) {
+    if (cit != tokens.end() && !has_token_expired(cit->second.created, now)) {
       return cit->second.user;
     }
+    // Do not resolve a username for an expired (or missing) token. is_valid()
+    // is the primary gate and evicts on lookup, but guarding here too keeps the
+    // "expired token never names a user" invariant even if a caller reads
+    // get_user() without a preceding is_valid().
     return "";
   }
 

--- a/modules/WEBServer/token_store.hpp
+++ b/modules/WEBServer/token_store.hpp
@@ -71,6 +71,17 @@ class token_store {
   }
 
  public:
+  // Signature of OpenSSL's RAND_bytes. Only used for the test seam below.
+  using rand_bytes_fn = int (*)(unsigned char *buf, int num);
+
+  // Test seam: replaces the CSPRNG backing generate_token(). Passing nullptr
+  // restores the real one. Never called in production - it exists so the
+  // fail-closed path (CSPRNG present but failing) and the rejection-sampling
+  // loop can be exercised deterministically.
+  static void set_rand_bytes_for_test(rand_bytes_fn fn);
+
+  // Returns an empty string if a CSPRNG is present but failed; callers MUST
+  // treat that as a failure to issue a credential rather than proceeding.
   static std::string generate_token(int len);
   static time_t now() { return time(nullptr); }
 
@@ -86,6 +97,26 @@ class token_store {
       tokens.erase(it);
       return false;
     }
+    return true;
+  }
+
+  // Resolve validity and identity under a single lock and a single clock
+  // read. is_valid() followed by get_user() takes the lock twice and calls
+  // now() twice, so a token expiring between the two calls yielded an empty
+  // uid on an otherwise-authorised request. Callers on the request path
+  // should use this; is_valid()/get_user() remain for callers that need only
+  // one half.
+  bool validate(const std::string &token, std::string &user) { return validate(token, user, now()); }
+
+  bool validate(const std::string &token, std::string &user, const time_t now) {
+    const std::lock_guard<std::mutex> lock(mutex_);
+    const auto it = tokens.find(token);
+    if (it == tokens.end()) return false;
+    if (has_token_expired(it->second.created, now)) {
+      tokens.erase(it);
+      return false;
+    }
+    user = it->second.user;
     return true;
   }
 
@@ -105,10 +136,15 @@ class token_store {
   }
 
   std::string generate_for(const std::string &user) {
+    // Generate before taking the lock: the CSPRNG call does not need it, and
+    // an empty result means the CSPRNG failed, in which case no session may
+    // be created at all. Storing a "" key would hand every tokenless request
+    // a valid session.
+    std::string token = generate_token(32);
+    if (token.empty()) return token;
     const time_t t = now();
     const std::lock_guard<std::mutex> lock(mutex_);
     sweep_expired_locked(t);
-    std::string token = generate_token(32);
     token_entry entry;
     entry.user = user;
     entry.created = t;

--- a/modules/WEBServer/token_store_test.cpp
+++ b/modules/WEBServer/token_store_test.cpp
@@ -5,12 +5,41 @@
 
 #include <gtest/gtest.h>
 
+#include <set>
+#include <string>
+
 TEST(TokenStoreTest, GenerateToken) {
   const std::string token1 = token_store::generate_token(32);
   EXPECT_EQ(token1.length(), 32);
   const std::string token2 = token_store::generate_token(32);
   EXPECT_EQ(token2.length(), 32);
   EXPECT_NE(token1, token2);
+}
+
+TEST(TokenStoreTest, GenerateTokenCharsetAndLengths) {
+  // Every character must come from the [0-9A-Za-z] alphabet regardless of the
+  // requested length (guards against the CSPRNG rejection-sampling loop
+  // emitting a stray byte).
+  const auto is_alnum = [](char c) {
+    return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z');
+  };
+  for (const int len : {1, 2, 16, 32, 64, 129}) {
+    const std::string t = token_store::generate_token(len);
+    EXPECT_EQ(static_cast<int>(t.size()), len);
+    for (const char c : t) EXPECT_TRUE(is_alnum(c)) << "unexpected char in token of len " << len;
+  }
+  EXPECT_TRUE(token_store::generate_token(0).empty());
+  EXPECT_TRUE(token_store::generate_token(-5).empty());
+}
+
+TEST(TokenStoreTest, GenerateTokenNoDuplicatesInLargeSample) {
+  // A predictable/degenerate RNG would collide quickly; a CSPRNG will not.
+  std::set<std::string> seen;
+  for (int i = 0; i < 2000; ++i) {
+    const std::string t = token_store::generate_token(32);
+    EXPECT_EQ(t.size(), 32u);
+    EXPECT_TRUE(seen.insert(t).second) << "duplicate token generated";
+  }
 }
 
 TEST(TokenStoreTest, GenerateForUser) {
@@ -53,6 +82,17 @@ TEST(TokenStoreTest, Expiration) {
   EXPECT_TRUE(store.is_valid(token, token_store::now()));
   EXPECT_TRUE(store.is_valid(token, token_store::now() + HOURS_TO_SECONDS(TOKEN_EXPIRATION_HOURS - 1)));
   EXPECT_FALSE(store.is_valid(token, token_store::now() + HOURS_TO_SECONDS(TOKEN_EXPIRATION_HOURS + 1)));
+}
+
+TEST(TokenStoreTest, GetUserDoesNotResolveExpiredToken) {
+  // get_user() must honour expiry on its own, not only via a preceding
+  // is_valid(): an expired token must never name a user.
+  token_store store;
+  const std::string user = "test_user";
+  const std::string token = store.generate_for(user);
+  EXPECT_EQ(store.get_user(token, token_store::now()), user);
+  EXPECT_EQ(store.get_user(token, token_store::now() + HOURS_TO_SECONDS(TOKEN_EXPIRATION_HOURS - 1)), user);
+  EXPECT_EQ(store.get_user(token, token_store::now() + HOURS_TO_SECONDS(TOKEN_EXPIRATION_HOURS + 1)), "");
 }
 
 TEST(TokenStoreTest, Grants) {

--- a/modules/WEBServer/token_store_test.cpp
+++ b/modules/WEBServer/token_store_test.cpp
@@ -159,3 +159,131 @@ TEST(TokenStoreTest, GenerationBeyondCapEvictsOldest) {
   EXPECT_LT(live, 5000u) << "every token survived - eviction did not run";
   EXPECT_LE(live, 4096u) << "live count exceeded the documented cap";
 }
+
+// --- CSPRNG failure handling -------------------------------------------------
+//
+// generate_token() draws from RAND_bytes. These tests swap in a deterministic
+// stand-in via the test seam so both the fail-closed path and the
+// rejection-sampling loop can be exercised without depending on the real RNG.
+
+namespace {
+// Restores the real CSPRNG however the test exits.
+struct scoped_rand_override {
+  explicit scoped_rand_override(token_store::rand_bytes_fn fn) { token_store::set_rand_bytes_for_test(fn); }
+  ~scoped_rand_override() { token_store::set_rand_bytes_for_test(nullptr); }
+};
+
+int failing_rand_bytes(unsigned char *, int) { return 0; }
+
+// Emits 0,1,2,... so every byte below the reject limit maps to a known char.
+unsigned char g_counter = 0;
+int counting_rand_bytes(unsigned char *buf, const int num) {
+  for (int i = 0; i < num; ++i) buf[i] = g_counter++;
+  return 1;
+}
+
+// First fill is entirely 0xFF (255) - at or above the reject limit (248), so
+// every byte must be discarded; the second fill is usable. Proves the loop
+// re-draws rather than folding an out-of-range byte into the alphabet.
+int g_call_count = 0;
+int reject_then_accept_rand_bytes(unsigned char *buf, const int num) {
+  ++g_call_count;
+  for (int i = 0; i < num; ++i) buf[i] = (g_call_count == 1) ? 0xFF : static_cast<unsigned char>(i);
+  return 1;
+}
+}  // namespace
+
+TEST(TokenStoreTest, GenerateTokenFailsClosedWhenCsprngFails) {
+  // A CSPRNG that exists but fails must NOT silently fall back to a weaker
+  // source - it must yield nothing so the caller refuses to issue a credential.
+  const scoped_rand_override guard(&failing_rand_bytes);
+  EXPECT_TRUE(token_store::generate_token(32).empty());
+  EXPECT_TRUE(token_store::generate_token(1).empty());
+}
+
+TEST(TokenStoreTest, GenerateForIssuesNoSessionWhenCsprngFails) {
+  token_store store;
+  const scoped_rand_override guard(&failing_rand_bytes);
+  const std::string token = store.generate_for("test_user");
+  EXPECT_TRUE(token.empty()) << "a session was created from a failed CSPRNG";
+  // Critically, no entry may have been stored under the empty key - that would
+  // hand a valid session to every request that presents no token at all.
+  EXPECT_FALSE(store.is_valid(""));
+  EXPECT_EQ(store.get_user(""), "");
+  std::string user;
+  EXPECT_FALSE(store.validate("", user));
+}
+
+TEST(TokenStoreTest, GenerateTokenRedrawsAfterRejectedBytes) {
+  // A byte >= the reject limit must be discarded and re-drawn, not folded into
+  // the alphabet with modulo bias (0xFF % 62 would otherwise yield 'v').
+  static constexpr char kAlphanum[] =
+      "0123456789"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "abcdefghijklmnopqrstuvwxyz";
+  g_call_count = 0;
+  const scoped_rand_override guard(&reject_then_accept_rand_bytes);
+  const std::string token = token_store::generate_token(5);
+  ASSERT_EQ(token.size(), 5u);
+  EXPECT_EQ(g_call_count, 2) << "the all-rejected fill did not force a re-draw";
+  // Second fill is 0,1,2,3,4 -> the first five alphabet characters.
+  for (std::size_t i = 0; i < token.size(); ++i) {
+    EXPECT_EQ(token[i], kAlphanum[i]) << "at index " << i;
+  }
+}
+
+TEST(TokenStoreTest, GenerateTokenUsesAllBytesBelowRejectLimit) {
+  // With a counting RNG, byte i maps to alphanum[i % 62] for i < 248 and is
+  // skipped for i >= 248. Verify the mapping directly for the first bytes.
+  static constexpr char kAlphanum[] =
+      "0123456789"
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      "abcdefghijklmnopqrstuvwxyz";
+  g_counter = 0;
+  const scoped_rand_override guard(&counting_rand_bytes);
+  const std::string token = token_store::generate_token(10);
+  ASSERT_EQ(token.size(), 10u);
+  for (std::size_t i = 0; i < token.size(); ++i) {
+    EXPECT_EQ(token[i], kAlphanum[i % 62]) << "at index " << i;
+  }
+}
+
+// --- validate(): validity and identity from one observation ------------------
+
+TEST(TokenStoreTest, ValidateResolvesUserAndHonoursExpiry) {
+  token_store store;
+  const std::string user = "test_user";
+  const std::string token = store.generate_for(user);
+
+  std::string got;
+  EXPECT_TRUE(store.validate(token, got, token_store::now()));
+  EXPECT_EQ(got, user);
+
+  got.clear();
+  EXPECT_TRUE(store.validate(token, got, token_store::now() + HOURS_TO_SECONDS(TOKEN_EXPIRATION_HOURS - 1)));
+  EXPECT_EQ(got, user);
+
+  // Expired: must report failure AND leave the out-param untouched, so a
+  // caller that forgets to check the return value cannot pick up a username.
+  got = "sentinel";
+  EXPECT_FALSE(store.validate(token, got, token_store::now() + HOURS_TO_SECONDS(TOKEN_EXPIRATION_HOURS + 1)));
+  EXPECT_EQ(got, "sentinel");
+}
+
+TEST(TokenStoreTest, ValidateEvictsExpiredToken) {
+  token_store store;
+  const std::string token = store.generate_for("test_user");
+  std::string user;
+  EXPECT_FALSE(store.validate(token, user, token_store::now() + HOURS_TO_SECONDS(TOKEN_EXPIRATION_HOURS + 1)));
+  // The entry is gone, so even a later call with a valid clock cannot resolve
+  // it - this is what makes validate() a drop-in for is_valid()'s eviction.
+  EXPECT_FALSE(store.validate(token, user, token_store::now()));
+  EXPECT_EQ(store.get_user(token, token_store::now()), "");
+}
+
+TEST(TokenStoreTest, ValidateRejectsUnknownToken) {
+  token_store store;
+  std::string user = "sentinel";
+  EXPECT_FALSE(store.validate("no-such-token", user));
+  EXPECT_EQ(user, "sentinel");
+}

--- a/modules/WEBServer/web_installer.cpp
+++ b/modules/WEBServer/web_installer.cpp
@@ -59,6 +59,39 @@ bool parse_url(const std::string& url, parsed_url& out) {
   return !out.host.empty();
 }
 
+bool resolve_redirect(const parsed_url& current, std::string location, std::string& next, std::string& error) {
+  boost::algorithm::trim(location);
+  if (location.empty()) {
+    error = "Redirect with an empty Location header";
+    return false;
+  }
+  if (boost::algorithm::starts_with(location, "//")) {
+    // Protocol-relative (RFC 3986 4.2): inherit the current scheme. Without
+    // this branch "//host/path" has no "://" and would be glued onto the
+    // current origin as a *path*, which both mis-resolves the redirect and
+    // hides it from the downgrade check below.
+    next = current.protocol + ":" + location;
+  } else if (location.find("://") == std::string::npos) {
+    // Path-relative -> glue back onto the previous origin.
+    if (location[0] != '/') location = "/" + location;
+    next = current.protocol + "://" + current.host + (current.port == "80" || current.port == "443" ? "" : ":" + current.port) + location;
+  } else {
+    next = location;
+  }
+  // Refuse an HTTPS->HTTP downgrade. The bundle's integrity rests on the TLS
+  // channel (the SHA-256 manifest is fetched over the same connection), so a
+  // redirect that drops to cleartext would let a network attacker rewrite both
+  // the manifest and the zip. An operator who explicitly starts from an
+  // http:// --url is already opting out of TLS; we only block the silent
+  // downgrade of a chain that began on https.
+  if (current.protocol == "https" && boost::algorithm::istarts_with(next, "http://")) {
+    error = "Refusing to follow an HTTPS->HTTP redirect to " + next + " (cleartext downgrade)";
+    next.clear();
+    return false;
+  }
+  return true;
+}
+
 bool is_unsafe_zip_path(const std::string& filename) {
   if (filename.empty()) return false;
   // Leading separator (either kind) → absolute path.
@@ -108,6 +141,7 @@ constexpr auto kDefaultUrlBase = "https://github.com/mickem/nscp/releases/downlo
 using detail::parsed_url;
 using detail::parse_url;
 using detail::parse_sha256_manifest;
+using detail::resolve_redirect;
 using detail::is_unsafe_zip_path;
 
 // One GET that does *not* throw on 3xx, so we can read the Location header.
@@ -155,23 +189,8 @@ bool http_get(const std::string& ca_path, std::string url, std::string& body, st
         error = "Redirect " + std::to_string(resp.status_code_) + " without Location header";
         return false;
       }
-      std::string next = it->second;
-      boost::algorithm::trim(next);
-      // Relative redirect → glue back onto the previous origin.
-      if (next.find("://") == std::string::npos) {
-        if (next.empty() || next[0] != '/') next = "/" + next;
-        next = u.protocol + "://" + u.host + (u.port == "80" || u.port == "443" ? "" : ":" + u.port) + next;
-      }
-      // Refuse an HTTPS→HTTP downgrade. The bundle's integrity rests on the TLS
-      // channel (the SHA-256 manifest is fetched over the same connection), so a
-      // redirect that drops to cleartext would let a network attacker rewrite
-      // both the manifest and the zip. An operator who explicitly starts from an
-      // http:// --url is already opting out of TLS; we only block the silent
-      // downgrade of a chain that began on https.
-      if (u.protocol == "https" && boost::algorithm::istarts_with(next, "http://")) {
-        error = "Refusing to follow an HTTPS->HTTP redirect to " + next + " (cleartext downgrade)";
-        return false;
-      }
+      std::string next;
+      if (!resolve_redirect(u, it->second, next, error)) return false;
       url = next;
       continue;
     }

--- a/modules/WEBServer/web_installer.cpp
+++ b/modules/WEBServer/web_installer.cpp
@@ -162,6 +162,16 @@ bool http_get(const std::string& ca_path, std::string url, std::string& body, st
         if (next.empty() || next[0] != '/') next = "/" + next;
         next = u.protocol + "://" + u.host + (u.port == "80" || u.port == "443" ? "" : ":" + u.port) + next;
       }
+      // Refuse an HTTPS→HTTP downgrade. The bundle's integrity rests on the TLS
+      // channel (the SHA-256 manifest is fetched over the same connection), so a
+      // redirect that drops to cleartext would let a network attacker rewrite
+      // both the manifest and the zip. An operator who explicitly starts from an
+      // http:// --url is already opting out of TLS; we only block the silent
+      // downgrade of a chain that began on https.
+      if (u.protocol == "https" && boost::algorithm::istarts_with(next, "http://")) {
+        error = "Refusing to follow an HTTPS->HTTP redirect to " + next + " (cleartext downgrade)";
+        return false;
+      }
       url = next;
       continue;
     }

--- a/modules/WEBServer/web_installer_detail.hpp
+++ b/modules/WEBServer/web_installer_detail.hpp
@@ -24,6 +24,18 @@ struct parsed_url {
 // that isn't an absolute http/https URL with a non-empty host.
 bool parse_url(const std::string& url, parsed_url& out);
 
+// Resolve a redirect Location against the URL it was served from.
+//
+// Handles the three shapes a Location can take: absolute ("https://h/p"),
+// protocol-relative ("//h/p", which inherits the current scheme per RFC 3986
+// 4.2) and path-relative ("/p" or "p"). Refuses an HTTPS->HTTP downgrade: the
+// bundle's integrity rests on the TLS channel, so a chain that began on https
+// must not silently drop to cleartext.
+//
+// Returns true and fills `next` on success; returns false and fills `error`
+// when the redirect is refused.
+bool resolve_redirect(const parsed_url& current, std::string location, std::string& next, std::string& error);
+
 // Parse a "<hex> <filename>" sha256 manifest (sha256sum/shasum output).
 // Returns the lower-cased 64-char hex digest, or empty on malformed input.
 std::string parse_sha256_manifest(const std::string& contents);

--- a/modules/WEBServer/web_installer_test.cpp
+++ b/modules/WEBServer/web_installer_test.cpp
@@ -510,3 +510,103 @@ TEST_F(WebInstallerTest, StatusReportsNotInstalledWhenManifestMissing) {
 }
 
 }  // namespace
+
+// --- resolve_redirect --------------------------------------------------------
+//
+// Pulled out of http_get() so the redirect rules are testable without a
+// socket. Covers the three Location shapes plus the HTTPS->HTTP refusal.
+
+namespace {
+nsclient::web::detail::parsed_url origin(const std::string& protocol, const std::string& host, const std::string& port) {
+  nsclient::web::detail::parsed_url u;
+  u.protocol = protocol;
+  u.host = host;
+  u.port = port;
+  u.path = "/";
+  return u;
+}
+}  // namespace
+
+TEST(WebInstallerRedirect, AbsoluteSameSchemeIsFollowed) {
+  std::string next, error;
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "https://b.example/bundle.zip", next, error));
+  EXPECT_EQ(next, "https://b.example/bundle.zip");
+  EXPECT_TRUE(error.empty());
+}
+
+TEST(WebInstallerRedirect, PathRelativeGluesOntoCurrentOrigin) {
+  std::string next, error;
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "/x/bundle.zip", next, error));
+  EXPECT_EQ(next, "https://a.example/x/bundle.zip");
+
+  // A Location without a leading slash is still a path.
+  next.clear();
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "bundle.zip", next, error));
+  EXPECT_EQ(next, "https://a.example/bundle.zip");
+}
+
+TEST(WebInstallerRedirect, PathRelativeKeepsNonDefaultPort) {
+  std::string next, error;
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "8443"), "/bundle.zip", next, error));
+  EXPECT_EQ(next, "https://a.example:8443/bundle.zip");
+}
+
+TEST(WebInstallerRedirect, ProtocolRelativeInheritsHttps) {
+  // "//host/path" has no "://" - before the dedicated branch it was glued onto
+  // the current origin as a path, mis-resolving the redirect and hiding it
+  // from the downgrade check.
+  std::string next, error;
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "//b.example/bundle.zip", next, error));
+  EXPECT_EQ(next, "https://b.example/bundle.zip");
+}
+
+TEST(WebInstallerRedirect, ProtocolRelativeInheritsHttp) {
+  std::string next, error;
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("http", "a.example", "80"), "//b.example/bundle.zip", next, error));
+  EXPECT_EQ(next, "http://b.example/bundle.zip");
+}
+
+TEST(WebInstallerRedirect, RefusesHttpsToHttpDowngrade) {
+  std::string next, error;
+  EXPECT_FALSE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "http://evil.example/bundle.zip", next, error));
+  EXPECT_TRUE(next.empty()) << "a refused redirect must not yield a target";
+  EXPECT_NE(error.find("cleartext downgrade"), std::string::npos) << error;
+}
+
+TEST(WebInstallerRedirect, RefusesHttpsToHttpDowngradeCaseInsensitively) {
+  std::string next, error;
+  EXPECT_FALSE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "HTTP://evil.example/x", next, error));
+  EXPECT_TRUE(next.empty());
+}
+
+TEST(WebInstallerRedirect, HttpsToHttpsIsNotMistakenForADowngrade) {
+  // "https://" must not match a "http://" prefix test.
+  std::string next, error;
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "https://b.example/x", next, error));
+  EXPECT_EQ(next, "https://b.example/x");
+}
+
+TEST(WebInstallerRedirect, HttpOriginMayRedirectToHttp) {
+  // An operator who explicitly starts on http:// has already opted out of TLS;
+  // only the silent downgrade of an https chain is blocked.
+  std::string next, error;
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("http", "a.example", "80"), "http://b.example/x", next, error));
+  EXPECT_EQ(next, "http://b.example/x");
+}
+
+TEST(WebInstallerRedirect, SurroundingWhitespaceIsTrimmed) {
+  std::string next, error;
+  EXPECT_TRUE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "  https://b.example/x  ", next, error));
+  EXPECT_EQ(next, "https://b.example/x");
+
+  // Trimming must not be a way to sneak a downgrade past the check.
+  next.clear();
+  EXPECT_FALSE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "  http://evil.example/x", next, error));
+  EXPECT_TRUE(next.empty());
+}
+
+TEST(WebInstallerRedirect, EmptyLocationIsRefused) {
+  std::string next, error;
+  EXPECT_FALSE(nsclient::web::detail::resolve_redirect(origin("https", "a.example", "443"), "   ", next, error));
+  EXPECT_FALSE(error.empty());
+}


### PR DESCRIPTION
Defense-in-depth fixes from a focused security review of the WEBServer
module (REST API + web UI). None is a confirmed remote vulnerability in a
default configuration; they close latent gaps and consistency issues, each
covered by a unit test.

- token_store: draw session tokens (and generated admin passwords) from the
  OpenSSL CSPRNG (RAND_bytes) with unbiased rejection sampling, instead of
  std::random_device which the standard does not require to be
  non-deterministic. Falls back to std::random_device only without OpenSSL.
- token_store: get_user() now honours token expiry on its own so an expired
  token never resolves a username, even without a preceding is_valid().
- mongoose-cpp: mg_get_cookie now requires a cookie-name boundary, so a
  client cookie named "eviltoken" can no longer satisfy a lookup for "token".
- legacy_controller: the legacy /auth/logout route now enforces the
  allowed-hosts perimeter, matching /auth/token.
- name_safety: reject a leading '-' in script/module names so a name cannot be
  mistaken for an option flag when passed as an argument value.
- web_installer: refuse an HTTPS->HTTP redirect on the bundle download path so
  the TLS-based integrity guarantee cannot be silently downgraded.
- WEBServer: the 'legacy' grant startup warning now also names
  POST /settings/query.pb (unredacted settings read + write); the misleading
  "read only" description of the seeded 'client' role is corrected.
- log_controller: a JSON parse failure in add_log now returns its 400 instead
  of falling through to 200; add missing early returns in query/modules
  controllers.
- docs: record the hardening in security/notices.md and setup/upgrading.md.

Assisted-by: Claude Code
Signed-off-by: Michael Medin <michael@medin.name>