### PR TITLE
security(nrpe): harden NRPEServer/NRPEClient and document secure configuration

### DIFF
--- a/docs/docs/scenarios/nrpe.md
+++ b/docs/docs/scenarios/nrpe.md
@@ -207,6 +207,94 @@ In general certificates can be a bit tricky to get right.
 
 ---
 
+## Securing the NRPE endpoint
+
+The walkthrough above builds up from insecure to client-certificate auth. This
+section is the condensed checklist — the settings that actually decide how
+secure the endpoint is, and the two defaults that most often surprise
+operators.
+
+### Server: authenticate callers, don't just encrypt
+
+With the default `verify mode = none` the server encrypts the channel but does
+**not** ask the caller for a certificate — the only thing separating a
+legitimate monitoring server from anyone else on the network is the
+`allowed hosts` IP list. IP filtering is worth keeping (and it now **fails
+closed**: an empty `allowed hosts` rejects every connection rather than
+allowing all), but it is not authentication. For a genuinely authenticated
+endpoint, require a client certificate signed by a CA you control:
+
+```ini
+[/settings/NRPE/server]
+use ssl                = true
+verify mode            = peer-cert          ; require a client cert, fail if absent
+ca                     = ${certificate-path}/ca.pem
+certificate            = ${certificate-path}/server.pem
+certificate key        = ${certificate-path}/server.key
+allowed hosts          = 192.168.0.0/24     ; still keep this tight
+insecure               = false
+```
+
+`verify mode = peer-cert` is the alias for `peer` + `fail-if-no-cert`: the
+handshake is rejected unless the client presents a certificate that chains to
+`ca`. `nscp nrpe install --verify=peer-cert --ca ...` writes the same config.
+
+Optionally, stamp the verified client's identity onto each request so the core
+permission system can authorize per-caller:
+
+```ini
+[/settings/NRPE/server]
+client identity source = cn                 ; use the client cert Common Name
+```
+
+`client identity source = cn` is only honoured when TLS is actually verifying
+the peer (`verify mode` contains `peer` and `fail-if-no-cert`, plus a `ca`) —
+the module refuses to start otherwise, because an unverified CN would be
+attacker-supplied.
+
+### Server: don't advertise the build
+
+The `_NRPE_CHECK` ping reply (`check_nrpe -H host` with no command) is answered
+before any authentication and, by default, returns the exact NSClient++ version.
+To stop disclosing the build to anything that can open the port:
+
+```ini
+[/settings/NRPE/server]
+expose version = false
+```
+
+`check_nrpe` still receives an OK reply, just without the version string.
+
+### Client: verify the server (NSClient++ as an NRPE client)
+
+When NSClient++ itself calls out over NRPE (the `NRPEClient` module / a
+`[/settings/NRPE/client/targets/...]` target), the client default is likewise
+`verify mode = none` — it encrypts but accepts **any** server certificate,
+which leaves it open to a man-in-the-middle. Point the target at your CA and
+turn verification on:
+
+```ini
+[/settings/NRPE/client/targets/monitored-host]
+address     = monitored-host
+use ssl     = true
+verify mode = peer-cert
+ca          = ${certificate-path}/ca.pem
+```
+
+With `verify mode` set to peer, the client validates the server certificate
+chain **and** checks that its name matches the host it dialled, so a valid
+certificate from the wrong host is rejected.
+
+### Keep the argument guards conservative
+
+Leave `allow nasty characters = false` (the default) — it blocks shell
+metacharacters at the NRPE ingress. If you must accept arguments, enable
+`allow arguments` only, and only behind a tight `allowed hosts` list. See
+[Security Tunables](#security-tunables-allow-arguments-and-allow-nasty-characters)
+below.
+
+---
+
 ## Running Checks with Arguments
 
 Once the connection works, the next step is running real checks. The

--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -140,6 +140,46 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### NRPE: decoded-argument metachar guard, optional version banner, and consistency fixes
+
+**Fixed in:** 0.17.2 · **Severity:** Low
+
+A review of the `NRPEServer` / `NRPEClient` modules produced a set of
+defense-in-depth fixes. None is remotely exploitable on a default install
+(the listener still fails closed on `allowed hosts` and the argument guard
+is off by default), but each tightens a rough edge:
+
+- **Metachars are now re-checked on the *decoded* command and arguments.**
+  The `allow nasty characters = false` guard previously ran only on the raw
+  wire bytes, before the configured `encoding` was applied. With a non-UTF-8
+  `encoding` set, a multi-byte sequence could decode into an ASCII shell
+  metacharacter (`|`, `` ` ``, `&`, `>`, …) that was not literally present on
+  the wire and so slipped past the ingress filter. The guard now also runs on
+  the decoded strings that are actually dispatched. Downstream
+  `CheckExternalScripts` argv isolation already prevented shell execution, so
+  this closes a filter-bypass, not an RCE.
+- **The unauthenticated `_NRPE_CHECK` ping reply can stop disclosing the
+  build.** A new `expose version` server setting (default `true`, preserving
+  the legacy banner `check_nrpe` expects) lets operators return a generic
+  "doing fine" message instead of the exact NSClient++ version to any host
+  permitted to open the port.
+- **`nscp nrpe install` now reads the stored `verify mode`.** It previously
+  queried the value but matched it under the wrong key name, so a re-run
+  silently reset peer verification to its built-in default (`peer-cert` — a
+  fail-secure direction, but it discarded the operator's setting).
+- A cosmetic `std::wstring::npos` vs `std::string::npos` comparison in the
+  metachar guard was corrected (both equal `SIZE_MAX`, so behaviour was
+  unchanged).
+
+**What to do:** nothing required. To harden further, set
+`expose version = false` and prefer client-certificate authentication over
+IP-only filtering — see
+[Active Monitoring with NRPE](../scenarios/nrpe.md#securing-the-nrpe-endpoint).
+The decoded-metachar re-check can reject a request that a non-UTF-8
+`encoding` previously let through while `allow nasty characters = false`;
+such a request was meant to be blocked, so this only affects inputs the
+guard was always intended to catch.
+
 ### Host name placeholders are sanitized before they land in a local path
 
 **Fixed in:** 0.17.0 · **Severity:** Low

--- a/modules/NRPEClient/NRPEClient.cpp
+++ b/modules/NRPEClient/NRPEClient.cpp
@@ -179,7 +179,7 @@ bool NRPEClient::install_server(const PB::Commands::ExecuteRequestMessage::Reque
       insecure = val.get_string();
     else if (val.matches(path, "allow arguments") && val.get_bool())
       arguments = "safe";
-    else if (val.matches(path, "verify"))
+    else if (val.matches(path, "verify mode"))
       verify = val.get_string();
     else if (val.matches(path, "ssl options"))
       sslops = val.get_string();

--- a/modules/NRPEServer/NRPEServer.cpp
+++ b/modules/NRPEServer/NRPEServer.cpp
@@ -270,7 +270,7 @@ std::list<nrpe::packet> NRPEServer::handle(nrpe::packet p, const std::string &pe
     }
     if (cmd.second.find_first_of(NASTY_METACHARS) != std::string::npos) {
       NSC_LOG_ERROR("Request arguments contained illegal metachars!");
-      throw nrpe::nrpe_exception("Request command contained illegal metachars!");
+      throw nrpe::nrpe_exception("Request arguments contained illegal metachars!");
     }
   }
   std::string wmsg, wperf;

--- a/modules/NRPEServer/NRPEServer.cpp
+++ b/modules/NRPEServer/NRPEServer.cpp
@@ -276,6 +276,17 @@ std::list<nrpe::packet> NRPEServer::handle(nrpe::packet p, const std::string &pe
       wcmd = utf8::cvt<std::string>(utf8::from_encoding(cmd.first, encoding_));
       wargs = utf8::cvt<std::string>(utf8::from_encoding(cmd.second, encoding_));
     }
+    // Re-apply the metachar guard to the DECODED command/arguments. The check
+    // above runs on the raw wire bytes; when a non-UTF-8 `encoding` is
+    // configured a multi-byte sequence can decode into an ASCII metacharacter
+    // that was not literally present on the wire (e.g. the historic Shift-JIS
+    // trailing-byte class). wcmd/wargs are what actually gets dispatched, so
+    // this is the authoritative gate; the raw check stays as an early, clearer
+    // rejection for the common UTF-8 case.
+    if (!allowNasty_ && (wcmd.find_first_of(NASTY_METACHARS) != std::string::npos || wargs.find_first_of(NASTY_METACHARS) != std::string::npos)) {
+      NSC_LOG_ERROR("Request contained illegal metachars after decoding!");
+      throw nrpe::nrpe_exception("Request contained illegal metachars after decoding!");
+    }
     // When the transport has resolved a peer identity (e.g. the client
     // cert CN under `client identity source = cn`), stamp it as the
     // principal so the policy sees `NRPEServer:<cn>` rather than a

--- a/modules/NRPEServer/NRPEServer.cpp
+++ b/modules/NRPEServer/NRPEServer.cpp
@@ -254,11 +254,11 @@ std::list<nrpe::packet> NRPEServer::handle(nrpe::packet p, const std::string &pe
     }
   }
   if (!allowNasty_) {
-    if (cmd.first.find_first_of(NASTY_METACHARS) != std::wstring::npos) {
+    if (cmd.first.find_first_of(NASTY_METACHARS) != std::string::npos) {
       NSC_LOG_ERROR("Request command contained illegal metachars!");
       throw nrpe::nrpe_exception("Request command contained illegal metachars!");
     }
-    if (cmd.second.find_first_of(NASTY_METACHARS) != std::wstring::npos) {
+    if (cmd.second.find_first_of(NASTY_METACHARS) != std::string::npos) {
       NSC_LOG_ERROR("Request arguments contained illegal metachars!");
       throw nrpe::nrpe_exception("Request command contained illegal metachars!");
     }

--- a/modules/NRPEServer/NRPEServer.cpp
+++ b/modules/NRPEServer/NRPEServer.cpp
@@ -80,6 +80,12 @@ bool NRPEServer::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
       "extended response", sh::bool_key(&multiple_packets_, !insecure), "EXTENDED RESPONSE",
       "Send more then 1 return packet to allow response to go beyond payload size (requires modified client if legacy is true this defaults to false).");
 
+  settings.alias().add_key_to_settings().add_bool(
+      "expose version", sh::bool_key(&expose_version_, true), "EXPOSE VERSION IN PING REPLY",
+      "Include the full NSClient++ version string in the unauthenticated _NRPE_CHECK ping reply. "
+      "Defaults to true for compatibility with check_nrpe and monitoring tooling; set to false to "
+      "avoid disclosing the exact build to any host permitted to open the NRPE port.");
+
   settings.alias()
       .add_parent("/settings/default")
       .add_key_to_settings()
@@ -238,10 +244,14 @@ std::list<nrpe::packet> NRPEServer::handle(nrpe::packet p, const std::string &pe
                   ", peer_identity='" + peer_identity + "')");
   }
   if (cmd.first == "_NRPE_CHECK") {
-    packets.push_back(nrpe::packet::create_response(
-        p.getVersion(), NSCAPI::query_return_codes::returnOK,
-        "I (" + utf8::cvt<std::string>(nscapi::plugin_singleton->get_core()->getApplicationVersionString()) + ") seem to be doing fine...",
-        p.get_payload_length()));
+    // The ping reply is unauthenticated (it precedes the argument and
+    // permission checks). Only disclose the exact build when `expose version`
+    // is on; otherwise answer OK with a generic banner so version-fingerprint
+    // scanning of a permitted host learns nothing.
+    const std::string ping_message =
+        expose_version_ ? "I (" + utf8::cvt<std::string>(nscapi::plugin_singleton->get_core()->getApplicationVersionString()) + ") seem to be doing fine..."
+                        : "I seem to be doing fine...";
+    packets.push_back(nrpe::packet::create_response(p.getVersion(), NSCAPI::query_return_codes::returnOK, ping_message, p.get_payload_length()));
     // Literal payload — NSC_TRACE_MSG already gates internally so no outer
     // NSC_TRACE_ENABLED block is required here.
     NSC_TRACE_MSG("NRPE response: _NRPE_CHECK ping reply");

--- a/modules/NRPEServer/NRPEServer.h
+++ b/modules/NRPEServer/NRPEServer.h
@@ -14,6 +14,11 @@ class NRPEServer : public nscapi::impl::simple_plugin, nrpe::server::handler {
   bool allowNasty_;
   bool allowArgs_;
   bool multiple_packets_;
+  // Whether the unauthenticated `_NRPE_CHECK` ping reply includes the full
+  // NSClient++ application version string. Default true preserves the legacy
+  // banner that check_nrpe and monitoring tooling expect; set false to avoid
+  // disclosing the exact build to anyone permitted to open the port.
+  bool expose_version_;
   std::string encoding_;
   // "none" -> empty principal (legacy behaviour).
   // "cn"   -> Common Name value of the verified client cert (e.g.


### PR DESCRIPTION
## Summary

Follow-up to a security review of the `NRPEServer` and `NRPEClient` modules. The core packet parser, protocol state machine and TLS layer were already well hardened (bounded buffers, negative-length rejection, fail-closed `allowed hosts`, CRC validation, exception isolation) — no memory-safety or injection vulnerability was found. This PR addresses the residual defense-in-depth and consistency items surfaced by the review, each as its own commit, and documents how to configure NRPE securely.

None of these is remotely exploitable on a default install.

## Changes

Each fix is a separate commit:

| Commit | Type | What |
|---|---|---|
| `std::string::npos` fix | cosmetic | The illegal-metachar guard compared `std::string::find_first_of` against `std::wstring::npos`. Both equal `SIZE_MAX` so behaviour was unchanged; corrected to the matching type. |
| `verify mode` key fix | fail-secure bug | `nscp nrpe install` queried the server's peer-verification setting under key `verify mode` but matched the response under `verify`, so a re-run silently reset it to the built-in default (`peer-cert`). Now reads the key it queried. |
| Decoded-argument metachar guard | filter-bypass | The `allow nasty characters = false` guard ran only on the raw wire bytes, before the configured `encoding` was applied. A non-UTF-8 encoding could decode a multi-byte sequence into an ASCII shell metacharacter absent from the wire. The guard now also runs on the decoded strings that are actually dispatched. (`CheckExternalScripts` argv isolation already prevented shell execution — this closes a filter bypass, not an RCE.) |
| Optional version banner | info-disclosure | The unauthenticated `_NRPE_CHECK` ping reply always returned the exact NSClient++ build. New `expose version` server setting (default `true`, preserving the banner `check_nrpe` expects) lets operators return a generic reply instead. |

## Docs

- **`docs/docs/scenarios/nrpe.md`** — new "Securing the NRPE endpoint" checklist: the two defaults that surprise operators (server authenticates callers by IP only; NSClient++-as-client does not verify the server certificate), how to require client certificates, `client identity source = cn`, the `expose version` knob, and keeping the argument guards conservative.
- **`docs/docs/security/notices.md`** — records the set under "Hardening changes (no CVE)".

## Compatibility / upgrade notes

- Defaults are unchanged; no operator action required.
- The decoded-metachar re-check can reject a request that a non-UTF-8 `encoding` previously let through while `allow nasty characters = false` — such a request was always meant to be blocked.

## Testing

Changes are small and self-contained; reviewed by hand. No configured build tree was available in the review environment to run the module compile/unit suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0126xfwksB7MZfo5YdvW1s5G)_