### PR TITLE
NRDP client security hardening: token redaction and cert verification

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -140,6 +140,43 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### NRDP client security-review hardening
+
+**Fixed in:** 0.17.1 · **Severity:** Low–Medium
+
+A focused security review of the passive submission protocols (`NRDPClient`,
+`NSCAClient`/`NSCAServer`) produced a small set of defense-in-depth fixes on
+the NRDP side. None is a confirmed remote vulnerability in a default
+configuration; they close latent gaps and bring NRDP in line with the
+redaction already applied to NSCA.
+
+- **A malformed NRDP server response can no longer crash the submitting
+  agent.** `nrdp::data::parse_response` dereferenced the text node of the
+  `<status>`/`<message>` elements without a null check, so a response
+  containing an empty element (`<status></status>`) — which anyone able to
+  answer or tamper with the connection can send, including a man-in-the-middle
+  on a plaintext or unverified link — dereferenced a null pointer and crashed
+  the process rather than throwing. It is now reported as an invalid response.
+- **The NRDP token is no longer written to the trace log.** The per-target
+  configuration is emitted at trace level on every submission and included the
+  `token` — a shared secret equivalent to the NSCA password, which was already
+  redacted. It now logs `<set>`/`<unset>`, and any credentials embedded in a
+  configured `proxy` URL (`http://user:pass@host`) are redacted to
+  `<redacted>@host`.
+- **HTTPS submissions no longer silently skip certificate verification when no
+  verify mode is set.** An unset `verify mode` resolves to `verify_none` in the
+  TLS layer. Configured targets already defaulted to `peer`, but the bare
+  `nscp client`/REST submission path did not, so an `https://` submission made
+  that way validated neither the certificate chain nor the host name and
+  exposed the token to a man-in-the-middle. That path now defaults to `peer`
+  as well; plain `http://` is unaffected.
+
+**What to do:** nothing required for the default install or for targets
+configured through settings. If you submit to an `https://` NRDP endpoint via
+`nscp client`/REST against a self-signed certificate *without* a configured
+verify mode, add `--verify none` (or a CA) explicitly — the previous
+behaviour was to trust any certificate silently.
+
 ### WEB server security-review hardening
 
 **Fixed in:** 0.17.0 · **Severity:** Low–Medium

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -24,6 +24,16 @@ page tracks those in one place. Full per-release detail lives in each
   fixes. No configuration change is needed. The Linux packages link the
   distribution's OpenSSL and are unaffected. See
   [Security notices](../security/notices.md).
+- 🔒 **NRDP HTTPS submissions now verify the server certificate by default on
+  the `nscp client`/REST path.** Previously an `https://` submission made that
+  way with no `verify mode` set trusted any certificate silently (configured
+  targets already defaulted to `peer`). If you submit to a self-signed NRDP
+  endpoint that way and want to keep skipping verification, pass `--verify
+  none` (or point `--ca` at the certificate) explicitly. Plain `http://` is
+  unaffected. Two further NRDP hardening fixes ship in the same release — a
+  malformed server response can no longer crash the agent, and the NRDP token
+  and any proxy-URL credentials are redacted from the trace log. See
+  [Security notices](../security/notices.md).
 
 ## 0.17.0
 

--- a/modules/NRDPClient/nrdp.cpp
+++ b/modules/NRDPClient/nrdp.cpp
@@ -79,9 +79,19 @@ boost::tuple<int, std::string> data::parse_response(const std::string& str) {
   }
   tinyxml2::XMLNode* tnStatus = nStatus->FirstChild();
   tinyxml2::XMLNode* tnError = nError->FirstChild();
+  // An element with no text child (e.g. "<status></status>") yields a null
+  // FirstChild(); dereferencing it would crash the submission thread. A remote
+  // NRDP server — or anyone able to inject a response on a plaintext or
+  // unverified connection — could send exactly that, so treat a missing text
+  // node as an invalid response rather than a segfault.
+  if (tnStatus == nullptr || tnError == nullptr) {
+    return boost::make_tuple(-1, "Invalid response from server");
+  }
 
-  std::string status = tnStatus->Value();
-  std::string error = tnError->Value();
+  const char* status_value = tnStatus->Value();
+  const char* error_value = tnError->Value();
+  const std::string status = status_value != nullptr ? status_value : "";
+  const std::string error = error_value != nullptr ? error_value : "";
   return boost::make_tuple(str::stox<int>(status, -1), error);
 }
 }  // namespace nrdp

--- a/modules/NRDPClient/nrdp_client.hpp
+++ b/modules/NRDPClient/nrdp_client.hpp
@@ -17,6 +17,21 @@
 #include "nrdp.hpp"
 
 namespace nrdp_client {
+// Replace any "user:pass@" userinfo in a proxy URL with "<redacted>@" so the
+// URL can be logged without leaking embedded credentials. Anything without
+// userinfo is returned unchanged.
+inline std::string redact_proxy_url(const std::string &url) {
+  const auto scheme_pos = url.find("://");
+  const std::size_t host_start = scheme_pos == std::string::npos ? 0 : scheme_pos + 3;
+  // Userinfo lives only in the authority, i.e. before the first '/', '?' or '#'
+  // that ends it. An '@' after that (in the path or query) is not a credential
+  // separator and must be left alone.
+  const auto authority_end = url.find_first_of("/?#", host_start);
+  const auto at_pos = url.rfind('@', authority_end == std::string::npos ? std::string::npos : authority_end);
+  if (at_pos == std::string::npos || at_pos < host_start) return url;
+  return url.substr(0, host_start) + "<redacted>" + url.substr(at_pos);
+}
+
 struct connection_data : socket_helpers::connection_info {
   std::string token;
   std::string protocol;
@@ -46,6 +61,14 @@ struct connection_data : socket_helpers::connection_info {
     tls_version = arguments.get_string_data("tls version");
     if (tls_version.empty()) tls_version = "1.2+";
     verify_mode = arguments.get_string_data("verify mode");
+    // Fail safe: an empty verify mode resolves to verify_none in the TLS layer,
+    // which would submit over HTTPS without validating the server certificate
+    // (defeating the point of using TLS and exposing the token to a MITM). The
+    // configured-target path already defaults to "peer"; mirror that for the
+    // bare CLI/REST path so a missing verify mode never silently downgrades.
+    // Operators who intentionally want no verification (self-signed without a
+    // pinned CA) must now set it to "none" explicitly.
+    if (verify_mode.empty() && protocol == "https") verify_mode = "peer";
     ca = arguments.get_string_data("ca");
     proxy_url = arguments.get_string_data("proxy");
     no_proxy_str = arguments.get_string_data("no proxy");
@@ -79,11 +102,16 @@ struct connection_data : socket_helpers::connection_info {
     ss << ", port: " << port_;
     ss << ", path: " << path;
     ss << ", timeout: " << timeout;
-    ss << ", token: " << token;
+    // Never log the actual token: this string is emitted at trace level on
+    // every submission and the NRDP token is a shared secret equivalent to the
+    // NSCA password (which is redacted the same way in nsca_client.hpp).
+    ss << ", token: " << (token.empty() ? "<unset>" : "<set>");
     ss << ", sender: " << sender_hostname;
     ss << ", tls version: " << tls_version;
     ss << ", verify mode: " << verify_mode;
-    if (!proxy_url.empty()) ss << ", proxy: " << proxy_url;
+    // A proxy URL may embed credentials (http://user:pass@proxy:3128/); redact
+    // rather than leak them into the trace log.
+    if (!proxy_url.empty()) ss << ", proxy: " << redact_proxy_url(proxy_url);
     if (!no_proxy_str.empty()) ss << ", no proxy: " << no_proxy_str;
     return ss.str();
   }

--- a/modules/NRDPClient/nrdp_client.hpp
+++ b/modules/NRDPClient/nrdp_client.hpp
@@ -129,7 +129,11 @@ struct nrdp_client_handler : client::handler_interface {
     nscapi::protobuf::functions::make_return_header(response_message.mutable_header(), request_header);
     connection_data con(target, sender);
 
-    NSC_TRACE_ENABLED() { NSC_TRACE_MSG("Target configuration: " + target.to_string()); }
+    // Log the redacted connection_data, never target.to_string(): the latter
+    // dumps the raw destination_container data map, which still contains the
+    // `token` and any `proxy` credentials in the clear and would defeat the
+    // redaction in connection_data::to_string().
+    NSC_TRACE_ENABLED() { NSC_TRACE_MSG("Target configuration: " + con.to_string()); }
 
     nrdp::data nrdp_data;
 

--- a/modules/NRDPClient/nrdp_client_test.cpp
+++ b/modules/NRDPClient/nrdp_client_test.cpp
@@ -172,6 +172,69 @@ TEST(NrdpConnectionData, CarriesTheTokenAndTlsSettings) {
   EXPECT_EQ(con.ca, "/etc/ca.pem");
 }
 
+TEST(NrdpConnectionData, HttpsDefaultsVerifyModeToPeer) {
+  // A missing verify mode must not silently disable certificate verification
+  // on HTTPS: the TLS layer maps an empty string to verify_none, so the client
+  // would submit the token to an unauthenticated (possibly MITM) server.
+  const nrdp_client::connection_data con(target_with({{"address", "https://h"}}), client::destination_container());
+
+  EXPECT_EQ(con.verify_mode, "peer");
+}
+
+TEST(NrdpConnectionData, AnExplicitVerifyModeIsNotOverridden) {
+  const nrdp_client::connection_data con(target_with({{"address", "https://h"}, {"verify mode", "none"}}), client::destination_container());
+
+  EXPECT_EQ(con.verify_mode, "none") << "an operator opting out of verification must still be honoured";
+}
+
+TEST(NrdpConnectionData, PlainHttpLeavesVerifyModeEmpty) {
+  // verify mode is meaningless without TLS, so http must not gain a spurious
+  // default.
+  const nrdp_client::connection_data con(target_with({{"address", "http://h"}}), client::destination_container());
+
+  EXPECT_EQ(con.verify_mode, "");
+}
+
+TEST(NrdpConnectionData, ToStringDoesNotLeakTheToken) {
+  // The token is a shared secret; to_string() is emitted at trace level on
+  // every submission and must never carry it in the clear.
+  const nrdp_client::connection_data con(target_with({{"address", "https://h"}, {"token", "s3cret-token"}}), client::destination_container());
+
+  const std::string s = con.to_string();
+  EXPECT_EQ(s.find("s3cret-token"), std::string::npos) << s;
+  EXPECT_NE(s.find("<set>"), std::string::npos) << s;
+}
+
+TEST(NrdpConnectionData, ToStringMarksAnUnsetTokenWithoutLeaking) {
+  const nrdp_client::connection_data con(target_with({{"address", "https://h"}}), client::destination_container());
+
+  EXPECT_NE(con.to_string().find("token: <unset>"), std::string::npos) << con.to_string();
+}
+
+TEST(NrdpConnectionData, ToStringRedactsProxyCredentials) {
+  const nrdp_client::connection_data con(target_with({{"address", "https://h"}, {"proxy", "http://user:p4ss@proxy:3128/"}}),
+                                         client::destination_container());
+
+  const std::string s = con.to_string();
+  EXPECT_EQ(s.find("p4ss"), std::string::npos) << s;
+  EXPECT_EQ(s.find("user:"), std::string::npos) << s;
+  EXPECT_NE(s.find("<redacted>@proxy:3128"), std::string::npos) << s;
+}
+
+TEST(NrdpRedactProxyUrl, LeavesACredentiallessUrlUnchanged) {
+  EXPECT_EQ(nrdp_client::redact_proxy_url("http://proxy:3128/"), "http://proxy:3128/");
+}
+
+TEST(NrdpRedactProxyUrl, RedactsUserinfo) {
+  EXPECT_EQ(nrdp_client::redact_proxy_url("http://user:pass@proxy:3128/"), "http://<redacted>@proxy:3128/");
+}
+
+TEST(NrdpRedactProxyUrl, DoesNotMistakeAPathAtForUserinfo) {
+  // An '@' after the host (in the path) must not be treated as a userinfo
+  // separator.
+  EXPECT_EQ(nrdp_client::redact_proxy_url("http://proxy:3128/path@thing"), "http://proxy:3128/path@thing");
+}
+
 TEST(NrdpConnectionData, TlsVersionDefaultsToTwelveOrLater) {
   // Not a cosmetic default: it is what keeps the client off TLS 1.0/1.1 when
   // the target says nothing.

--- a/modules/NRDPClient/nrdp_test.cpp
+++ b/modules/NRDPClient/nrdp_test.cpp
@@ -177,6 +177,46 @@ TEST(NrdpParse, MissingMessageElementFails) {
   EXPECT_EQ(ret.get<1>(), "Invalid response from server");
 }
 
+TEST(NrdpParse, EmptyStatusElementIsInvalidNotACrash) {
+  // "<status></status>" has no text child, so tinyxml2's FirstChild() returns
+  // null. Dereferencing it used to crash the submission thread; a hostile or
+  // broken server (or a MITM on an unverified/plaintext link) could trigger it
+  // at will. It must now be reported as an invalid response.
+  const std::string body =
+      "<?xml version=\"1.0\"?>"
+      "<result>"
+      "<status></status>"
+      "<message>hello</message>"
+      "</result>";
+  const auto ret = nrdp::data::parse_response(body);
+  EXPECT_EQ(ret.get<0>(), -1);
+  EXPECT_EQ(ret.get<1>(), "Invalid response from server");
+}
+
+TEST(NrdpParse, EmptyMessageElementIsInvalidNotACrash) {
+  const std::string body =
+      "<?xml version=\"1.0\"?>"
+      "<result>"
+      "<status>0</status>"
+      "<message></message>"
+      "</result>";
+  const auto ret = nrdp::data::parse_response(body);
+  EXPECT_EQ(ret.get<0>(), -1);
+  EXPECT_EQ(ret.get<1>(), "Invalid response from server");
+}
+
+TEST(NrdpParse, BothElementsEmptyIsInvalidNotACrash) {
+  const std::string body =
+      "<?xml version=\"1.0\"?>"
+      "<result>"
+      "<status/>"
+      "<message/>"
+      "</result>";
+  const auto ret = nrdp::data::parse_response(body);
+  EXPECT_EQ(ret.get<0>(), -1);
+  EXPECT_EQ(ret.get<1>(), "Invalid response from server");
+}
+
 TEST(NrdpParse, NonNumericStatusFallsBackToMinusOne) {
   const std::string body =
       "<?xml version=\"1.0\"?>"

--- a/modules/NSCAClient/nsca_client.hpp
+++ b/modules/NSCAClient/nsca_client.hpp
@@ -103,7 +103,11 @@ struct nsca_client_handler final : public client::handler_interface {
     nscapi::protobuf::functions::make_return_header(response_message.mutable_header(), request_header);
     connection_data con(target, sender);
 
-    NSC_TRACE_ENABLED() { NSC_TRACE_MSG("Target configuration: " + target.to_string()); }
+    // Log the redacted connection_data, never target.to_string(): the latter
+    // dumps the raw destination_container data map, which still contains the
+    // `password` in the clear and would defeat the redaction in
+    // connection_data::to_string().
+    NSC_TRACE_ENABLED() { NSC_TRACE_MSG("Target configuration: " + con.to_string()); }
     unsigned int len = 512;
     if (target.has_data("buffer length"))
       len = target.get_int_data("buffer length", 512);


### PR DESCRIPTION
## Summary

This PR implements defense-in-depth security hardening for the NRDP client following a focused security review. It addresses three latent security gaps: potential null-pointer dereference on malformed server responses, exposure of the NRDP token in trace logs, and silent skipping of certificate verification on HTTPS submissions via the CLI/REST path.

## Key Changes

- **Crash prevention on malformed responses:** Added null checks in `nrdp::data::parse_response()` to handle empty XML elements (`<status></status>`) that would previously cause a segfault when dereferenced. Malformed responses are now reported as invalid rather than crashing the submission thread.

- **Token and credential redaction:** 
  - The NRDP token is no longer written to trace logs; it now logs `<set>` or `<unset>` instead (matching NSCA's existing redaction pattern)
  - Proxy URLs with embedded credentials (`http://user:pass@proxy:3128/`) are redacted to `http://<redacted>@proxy:3128/` in logs
  - Added `redact_proxy_url()` helper function with proper authority boundary detection to avoid mistaking path `@` characters for credential separators

- **HTTPS certificate verification hardening:** HTTPS submissions now default to `verify_mode = "peer"` when no explicit verify mode is set, preventing silent downgrade to `verify_none` on the CLI/REST path. Configured targets already had this default; this extends it to bare `nscp client` submissions. Plain HTTP is unaffected.

- **Comprehensive test coverage:** Added 10 new unit tests covering the verify mode defaults, token/credential redaction, and malformed response handling.

- **Documentation:** Updated security notices and upgrade guide to explain the changes and migration path for users relying on the previous (insecure) behavior.

## Implementation Details

- The verify mode default is applied only when the protocol is HTTPS and verify_mode is empty, preserving explicit operator choices (including `verify_mode = "none"`)
- The `redact_proxy_url()` function correctly identifies the authority section (before the first `/`, `?`, or `#`) to avoid redacting `@` characters in the path or query
- Null checks in `parse_response()` validate both status and message text nodes before dereferencing

https://claude.ai/code/session_014z3X28B7wA3UJWeF2W8z1D