### PR TITLE
fix: NSCA-NG cert mode never applied its TLS config (peer verification silently off)

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -140,6 +140,47 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### NSCA-NG client: cert-mode TLS settings (peer verification included) were never applied
+
+**Fixed in:** unreleased (first release after 0.18.0) · **Affected:** 0.18.0, `NSCANgClient` in cert mode only · **Severity:** High for cert-mode targets; the default PSK mode is unaffected
+
+A security review of the NSCA-NG client found that in certificate mode
+(`use psk = false`) the TLS configuration was applied to the OpenSSL
+context *after* the TLS stream had been created from it. `SSL_new()` copies
+the verify mode, certificate, cipher list and protocol-version bounds out of
+the `SSL_CTX` at creation time (only the CA store stays shared), so none of
+that configuration reached the live connection:
+
+- **`verify mode = peer-cert` had no effect** — the connection ran with
+  verification off and accepted any certificate the server presented,
+  including a man-in-the-middle's. The host-name check was installed but is
+  advisory when the underlying verify mode is off, and the client's own
+  "refusing to connect unverified" guard read the *configured* mode rather
+  than the live one, so it passed too.
+- **The configured client certificate and key were never presented**, so
+  mutual-TLS setups authenticated in one direction only (and fail against
+  servers that require a client certificate).
+- The `tls version` floor and `allowed ciphers` list were likewise ignored
+  in cert mode.
+
+The context is now fully configured before the connection object is created
+(the same ordering the other TLS client modules use), unit tests assert the
+settings actually arrive on connections created from it, and integration
+tests drive cert mode against a live TLS endpoint both ways: a wrong CA must
+fail the handshake, and a mutual-TLS round-trip must succeed. The same fix
+removes a rare undefined-behaviour window in the connection's I/O-timeout
+handling (a stale deadline handler could fire into a later operation).
+
+Not affected: the default PSK mode (`use psk = true`) configures the SSL
+object directly and always authenticated both ends via the pre-shared key;
+targets that never set `use psk = false` need no action.
+
+**What to do:** upgrade if any NSCA-NG target uses `use psk = false`. After
+the upgrade, a cert-mode target whose server certificate does not chain to
+the configured `ca` (or does not match the host name) will fail to connect —
+that is the verification taking effect; fix the server certificate or, if
+you accept the MITM exposure, opt out explicitly with `insecure = true`.
+
 ### SMTP client security-review hardening
 
 **Fixed in:** 0.18.0 · **Severity:** Low–Medium

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -14,6 +14,25 @@ per-release detail lives in each
 
 ---
 
+## Unreleased
+
+- 🔒 **NSCA-NG cert mode now actually verifies the server (and presents the
+  client certificate).** In 0.18.0 the `NSCANgClient` cert mode
+  (`use psk = false`) applied its TLS configuration to the OpenSSL context
+  *after* the connection object had been created from it, and OpenSSL copies
+  the verify mode, client certificate, cipher list and TLS-version bounds out
+  of the context at creation time — so `verify mode = peer-cert` was silently
+  ignored, any certificate the server presented was accepted, and the
+  configured client certificate was never sent. The configuration is applied
+  before the connection is created now. Two operator-visible consequences:
+  a cert-mode target that "worked" against a server whose certificate does
+  not chain to the configured `ca` (or does not match the host name) will now
+  fail to connect — that is the verification working; fix the server
+  certificate, or opt out explicitly with `insecure = true` if you accept the
+  MITM risk. And servers that require a client certificate will start seeing
+  it. The default PSK mode (`use psk = true`) is unaffected. See
+  [Security notices](../security/notices.md).
+
 ## 0.18.0
 
 - 💥 **`check_nscp` is now a filter check, and it can see crash reports again.**

--- a/modules/NSCANgClient/nsca_ng_client.cpp
+++ b/modules/NSCANgClient/nsca_ng_client.cpp
@@ -11,6 +11,8 @@
 #include <chrono>
 #include <cstring>
 #include <ctime>
+#include <list>
+#include <memory>
 #include <nscapi/macros.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <nscapi/protobuf/functions_convert.hpp>
@@ -138,6 +140,49 @@ std::string generate_session_id() {
 }
 
 // =====================================================================
+// TLS context construction
+// =====================================================================
+
+boost::asio::ssl::context make_ssl_context(const connection_data &con) {
+  boost::asio::ssl::context ctx(boost::asio::ssl::context::tls_client);
+  if (con.use_psk) {
+    // With PSK the key itself authenticates both ends — no X.509 material.
+    // The PSK cipher list / callback / TLS-1.2 pin are applied to the SSL
+    // object by nsca_ng_connection; the context stays at defaults.
+    return ctx;
+  }
+
+  // Cert mode: apply the full TLS configuration (certificate + key, CA,
+  // verify mode, TLS min/max version, allowed ciphers, DH params) to the
+  // context HERE, before any stream/SSL is created from it. SSL_new() copies
+  // the verify mode, certificate, cipher list and protocol-version bounds out
+  // of the SSL_CTX at creation time — only the CA store remains shared — so
+  // configuring the context after the stream exists would leave the live SSL
+  // at its defaults, silently skipping peer verification.
+  std::list<std::string> errors;
+  con.ssl.configure_ssl_context(ctx, errors);
+  if (!errors.empty()) {
+    std::string joined;
+    for (const auto &e : errors) joined += (joined.empty() ? "" : "; ") + e;
+    throw socket_helpers::socket_exception("TLS configuration error: " + joined);
+  }
+
+  const auto vmode = con.ssl.get_verify_mode();
+  const bool verifying = (vmode & boost::asio::ssl::verify_peer) != 0;
+
+  // Refuse to fall through to an unauthenticated TLS session unless the
+  // operator has explicitly opted in. Without this the connection would
+  // tunnel data through an unverified peer — vulnerable to MITM.
+  if (!verifying && !con.insecure) {
+    throw socket_helpers::socket_exception(
+        "Refusing to connect: TLS peer verification is disabled and PSK is not in use. "
+        "Either configure 'verify mode = peer-cert' with a 'ca = <path>', re-enable 'use psk = true', "
+        "or set 'insecure = true' to override (disables MITM protection).");
+  }
+  return ctx;
+}
+
+// =====================================================================
 // nsca_ng_connection — TLS connection with deadline-driven I/O.
 // =====================================================================
 //
@@ -163,13 +208,15 @@ class nsca_ng_connection {
   psk_credentials psk_creds_;
   bool tls_active_ = false;
 
-  nsca_ng_connection(bool use_psk, const std::string &psk_cipher_list, const int timeout_seconds)
-      : ctx_(boost::asio::ssl::context::tls_client),
-        ssl_socket_(io_service_, ctx_),
-        resolver_(io_service_),
-        timer_(io_service_),
-        timeout_seconds_(timeout_seconds) {
-    if (use_psk) {
+  // The context must be fully configured before `ssl_socket_` is constructed
+  // from it (member order guarantees this): the stream constructor calls
+  // SSL_new(ctx), which copies verify mode / certificate / cipher list /
+  // proto-version bounds out of the CTX at that moment. make_ssl_context()
+  // does the cert-mode configuration; PSK settings target the SSL object and
+  // are applied below.
+  explicit nsca_ng_connection(const connection_data &con)
+      : ctx_(make_ssl_context(con)), ssl_socket_(io_service_, ctx_), resolver_(io_service_), timer_(io_service_), timeout_seconds_(con.timeout) {
+    if (con.use_psk) {
       // IMPORTANT: configure on the SSL object (`ssl_socket_.native_handle()`),
       // NOT the SSL_CTX. The boost::asio::ssl::stream constructor above already
       // called SSL_new(ctx) and copied the cipher list / seclevel / etc. out of
@@ -191,7 +238,8 @@ class nsca_ng_connection {
       // would leave the agent with an empty cipher list at handshake.
       SSL_set_security_level(ssl, 0);
 
-      const std::string cipher_list = psk_cipher_list.empty() ? kDefaultPskCiphers : psk_cipher_list;
+      // allowed_ciphers (when set) overrides the default PSK cipher list.
+      const std::string cipher_list = con.ssl.allowed_ciphers.empty() ? kDefaultPskCiphers : con.ssl.allowed_ciphers;
       // Throw on cipher-list parse failure rather than letting OpenSSL fall
       // back to its cert-based default. With a silent fallback the resulting
       // PSK handshakes alert with confusing messages like "no suitable
@@ -236,25 +284,42 @@ class nsca_ng_connection {
     }
   }
 
+  // Per-operation state shared between the deadline-timer handler and the
+  // I/O completion handler. Heap-allocated (shared_ptr) rather than stack
+  // locals captured by reference: when the deadline fires in the same event
+  // batch in which the operation completes, run_one() can consume the
+  // completion handler first — timer_.cancel() is then too late (the wait
+  // already finished; its handler sits queued with a success code) and the
+  // loop below exits with that timer handler still pending. It runs during
+  // the NEXT run_with_deadline call's loop, and with by-reference captures it
+  // would write through dangling references into a dead stack frame and
+  // cancel the new operation. With shared state it keeps its own block alive,
+  // and the would_block guard turns the stale firing into a no-op.
+  struct deadline_op_state {
+    boost::system::error_code ec{boost::asio::error::would_block};
+    bool timed_out = false;
+  };
+
   // Run an async op against the io_service with the configured deadline.
   // The passed-in initiator should call `start_async(handler)` with a handler
   // signature of `void(boost::system::error_code)`.
   template <class Initiator>
   void run_with_deadline(Initiator initiator, const std::string &what) {
-    boost::system::error_code op_ec = boost::asio::error::would_block;
-    bool timed_out = false;
+    auto state = std::make_shared<deadline_op_state>();
 
     timer_.expires_after(std::chrono::seconds(timeout_seconds_));
-    timer_.async_wait([this, &timed_out](const boost::system::error_code &ec) {
-      if (ec != boost::asio::error::operation_aborted) {
-        timed_out = true;
-        boost::system::error_code ignored;
-        ssl_socket_.lowest_layer().cancel(ignored);
-      }
+    timer_.async_wait([this, state](const boost::system::error_code &ec) {
+      if (ec == boost::asio::error::operation_aborted) return;
+      // Stale firing: the operation this deadline guarded already completed
+      // (see deadline_op_state above) — don't cancel whatever runs now.
+      if (state->ec != boost::asio::error::would_block) return;
+      state->timed_out = true;
+      boost::system::error_code ignored;
+      ssl_socket_.lowest_layer().cancel(ignored);
     });
 
-    initiator([&op_ec, this](const boost::system::error_code &ec) {
-      op_ec = ec;
+    initiator([state, this](const boost::system::error_code &ec) {
+      state->ec = ec;
       // cancel() can throw (the non-throwing cancel(error_code&) overload is
       // removed under BOOST_ASIO_NO_DEPRECATED). Swallow it here so a completed
       // operation isn't turned into an exception escaping run_one() below.
@@ -265,18 +330,18 @@ class nsca_ng_connection {
     });
 
     io_service_.restart();
-    while (op_ec == boost::asio::error::would_block) {
+    while (state->ec == boost::asio::error::would_block) {
       io_service_.run_one();
     }
 
-    if (timed_out) {
+    if (state->timed_out) {
       throw socket_helpers::socket_exception(what + " timed out after " + std::to_string(timeout_seconds_) + "s");
     }
-    if (op_ec) {
+    if (state->ec) {
       // boost::system::error_code::message() returns the OS-localized native
       // encoding (e.g. CP1252 on Swedish Windows). Convert to UTF-8 so the
       // string can flow through protobuf log fields without being rejected.
-      throw socket_helpers::socket_exception(what + " failed: " + utf8::utf8_from_native(op_ec.message()));
+      throw socket_helpers::socket_exception(what + " failed: " + utf8::utf8_from_native(state->ec.message()));
     }
   }
 
@@ -302,28 +367,10 @@ class nsca_ng_connection {
       // PSK mode intentionally ignores cert/key/ca/verify-mode/tls-version.
       ssl_socket_.set_verify_mode(boost::asio::ssl::verify_none);
     } else {
-      // Apply the full cert-mode TLS configuration: certificate + key,
-      // CA, verify mode, TLS min/max version, allowed ciphers, DH params.
-      std::list<std::string> errors;
-      con.ssl.configure_ssl_context(ctx_, errors);
-      if (!errors.empty()) {
-        std::string joined;
-        for (const auto &e : errors) joined += (joined.empty() ? "" : "; ") + e;
-        throw socket_helpers::socket_exception("TLS configuration error: " + joined);
-      }
-
-      const auto vmode = con.ssl.get_verify_mode();
-      const bool verifying = (vmode & boost::asio::ssl::verify_peer) != 0;
-
-      // Refuse to fall through to an unauthenticated TLS session unless the
-      // operator has explicitly opted in. Without this the connection would
-      // tunnel data through an unverified peer — vulnerable to MITM.
-      if (!verifying && !con.insecure) {
-        throw socket_helpers::socket_exception(
-            "Refusing to connect: TLS peer verification is disabled and PSK is not in use. "
-            "Either configure 'verify mode = peer-cert' with a 'ca = <path>', re-enable 'use psk = true', "
-            "or set 'insecure = true' to override (disables MITM protection).");
-      }
+      // The cert-mode TLS configuration (certificate, CA, verify mode, TLS
+      // version bounds, ciphers) was applied by make_ssl_context() before the
+      // stream was constructed — SSL_new() copied it into the live SSL at
+      // that point. Only the per-connection, host-dependent pieces remain.
 
       // SNI: a server hosting several certs needs the server name to return the
       // right one; without it it may answer with its default cert and fail the
@@ -331,7 +378,9 @@ class nsca_ng_connection {
       if (!host.empty()) {
         SSL_set_tlsext_host_name(ssl_socket_.native_handle(), host.c_str());
       }
-      // Hostname pinning still required even when CA verifies.
+      // Hostname pinning still required even when CA verifies. (Boost keeps
+      // the SSL's current verify mode when installing the callback.)
+      const bool verifying = (con.ssl.get_verify_mode() & boost::asio::ssl::verify_peer) != 0;
       if (verifying) {
         ssl_socket_.set_verify_callback(boost::asio::ssl::host_name_verification(host));
       }
@@ -434,9 +483,11 @@ struct submit_outcome {
 submit_outcome do_send_once(const connection_data &con, const PB::Commands::SubmitRequestMessage &request_message) {
   submit_outcome r;
   try {
-    // For PSK, allowed_ciphers (when set) overrides the default PSK cipher list.
-    // For cert mode, the cipher list is applied later via configure_ssl_context.
-    nsca_ng_connection conn(con.use_psk, con.use_psk ? con.ssl.allowed_ciphers : std::string(), con.timeout);
+    // The constructor builds and applies the full TLS configuration (PSK on
+    // the SSL object, cert mode on the context before the stream exists) and
+    // throws on configuration errors — including the cert-mode refusal to run
+    // unverified without an explicit `insecure = true`.
+    nsca_ng_connection conn(con);
     NSC_TRACE_ENABLED() { NSC_TRACE_MSG("Connecting to: " + con.to_string()); }
     psk_credentials creds{con.identity, con.password};
     conn.connect(con.get_address(), con.get_port(), con, creds);

--- a/modules/NSCANgClient/nsca_ng_client.hpp
+++ b/modules/NSCANgClient/nsca_ng_client.hpp
@@ -5,6 +5,7 @@
 
 #include <openssl/ssl.h>
 
+#include <boost/asio/ssl/context.hpp>
 #include <client/command_line_parser.hpp>
 #include <net/socket/socket_helpers.hpp>
 #include <sstream>
@@ -59,6 +60,21 @@ struct nsca_ng_client_handler final : public client::handler_interface {
 };
 
 // --- visible for unit tests ---
+
+// Build the TLS context for one connection. For PSK targets this returns a
+// plain TLS-client context: all PSK configuration happens on the SSL object
+// after the stream is created (see nsca_ng_connection). For cert mode the
+// full TLS configuration — certificate + key, CA, verify mode, TLS version
+// bounds, allowed ciphers — is applied here, and it MUST run before any SSL
+// object is created from the context: SSL_new() copies the verify mode,
+// certificate, cipher list and protocol-version bounds out of the SSL_CTX at
+// creation time (only the CA store stays shared), so configuring the context
+// after the stream exists silently leaves the live SSL unconfigured — most
+// critically with peer verification off.
+// Also enforces the cert-mode safety gate: throws unless the configuration
+// verifies the peer or the operator explicitly opted out via `insecure`.
+// Throws socket_helpers::socket_exception on any configuration error.
+boost::asio::ssl::context make_ssl_context(const connection_data &con);
 
 // Generate a base64-encoded session ID (6 random bytes, 8 base64 chars).
 // Throws std::runtime_error if OpenSSL's RNG fails (B3 fix).

--- a/modules/NSCANgClient/nsca_ng_test.cpp
+++ b/modules/NSCANgClient/nsca_ng_test.cpp
@@ -356,3 +356,96 @@ TEST(NscaNgConnectionData, DisablePsk) {
   nsca_ng_client::connection_data c(target, sender);
   EXPECT_FALSE(c.use_psk);
 }
+
+// ============================================================================
+// make_ssl_context
+// ============================================================================
+//
+// Regression guard for the cert-mode configuration-ordering fix: SSL_new()
+// copies the verify mode, certificate, cipher list and protocol-version
+// bounds out of the SSL_CTX at creation time, so the context must be fully
+// configured BEFORE the ssl::stream is constructed from it. These tests
+// create an SSL object from the context exactly the way the stream
+// constructor does and assert the configuration actually arrived on it —
+// which is what the previous implementation (configuring the context after
+// the stream existed) silently failed to do.
+
+namespace {
+
+nsca_ng_client::connection_data make_cert_mode_data(const std::string &verify_mode, const bool insecure, const std::string &tls_version = "") {
+  client::destination_container target;
+  target.address.host = "server.example";
+  target.set_bool_data("use psk", false);
+  if (!verify_mode.empty()) target.set_string_data("verify mode", verify_mode);
+  if (insecure) target.set_bool_data("insecure", true);
+  if (!tls_version.empty()) target.set_string_data("tls version", tls_version);
+  client::destination_container sender;
+  sender.address.host = "agent";
+  return nsca_ng_client::connection_data(target, sender);
+}
+
+// Minimal RAII for an SSL created off the context under test.
+struct ssl_from_ctx {
+  SSL *ssl = nullptr;
+  explicit ssl_from_ctx(boost::asio::ssl::context &ctx) : ssl(SSL_new(ctx.native_handle())) {}
+  ~ssl_from_ctx() {
+    if (ssl) SSL_free(ssl);
+  }
+};
+
+}  // namespace
+
+TEST(NscaNgSslContext, CertModeVerifyModeReachesSslObjects) {
+  const auto con = make_cert_mode_data("peer-cert", false);
+  auto ctx = nsca_ng_client::make_ssl_context(con);
+  ssl_from_ctx s(ctx);
+  ASSERT_NE(s.ssl, nullptr);
+  EXPECT_EQ(SSL_get_verify_mode(s.ssl), SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT)
+      << "verify mode configured on the context must be copied into SSL objects created from it";
+}
+
+TEST(NscaNgSslContext, CertModeTlsVersionBoundsReachSslObjects) {
+  // Default floor is tlsv1.2+ (set by connection_data when unspecified).
+  const auto con = make_cert_mode_data("peer-cert", false);
+  auto ctx = nsca_ng_client::make_ssl_context(con);
+  ssl_from_ctx s(ctx);
+  ASSERT_NE(s.ssl, nullptr);
+  EXPECT_EQ(SSL_get_min_proto_version(s.ssl), TLS1_2_VERSION);
+  EXPECT_EQ(SSL_get_max_proto_version(s.ssl), TLS1_3_VERSION);
+
+  const auto con13 = make_cert_mode_data("peer-cert", false, "tlsv1.3");
+  auto ctx13 = nsca_ng_client::make_ssl_context(con13);
+  ssl_from_ctx s13(ctx13);
+  ASSERT_NE(s13.ssl, nullptr);
+  EXPECT_EQ(SSL_get_min_proto_version(s13.ssl), TLS1_3_VERSION);
+}
+
+TEST(NscaNgSslContext, CertModeUnverifiedRequiresInsecureOptIn) {
+  // No verify mode and no insecure flag: the connection would be wide open to
+  // MITM, so context construction must refuse.
+  EXPECT_THROW(nsca_ng_client::make_ssl_context(make_cert_mode_data("", false)), socket_helpers::socket_exception);
+}
+
+TEST(NscaNgSslContext, CertModeInsecureOptInAllowsUnverified) {
+  const auto con = make_cert_mode_data("", true);
+  auto ctx = nsca_ng_client::make_ssl_context(con);
+  ssl_from_ctx s(ctx);
+  ASSERT_NE(s.ssl, nullptr);
+  EXPECT_EQ(SSL_get_verify_mode(s.ssl), SSL_VERIFY_NONE);
+}
+
+TEST(NscaNgSslContext, PskModeContextStaysAtDefaults) {
+  // PSK authenticates both ends via the key — no cert verification and no
+  // insecure opt-in required; the context must build without throwing.
+  client::destination_container target;
+  target.address.host = "h";
+  client::destination_container sender;
+  sender.address.host = "a";
+  const nsca_ng_client::connection_data con(target, sender);
+  ASSERT_TRUE(con.use_psk);
+
+  auto ctx = nsca_ng_client::make_ssl_context(con);
+  ssl_from_ctx s(ctx);
+  ASSERT_NE(s.ssl, nullptr);
+  EXPECT_EQ(SSL_get_verify_mode(s.ssl), SSL_VERIFY_NONE);
+}

--- a/tests/nsca-ng-certmode.test.ts
+++ b/tests/nsca-ng-certmode.test.ts
@@ -1,0 +1,227 @@
+/**
+ * NSCA-NG certificate-mode (`use psk = false`) TLS tests.
+ *
+ * The PSK path is covered end-to-end by nsca-ng-submit.test.ts against a real
+ * nsca-ng daemon. Cert mode has no docker dependency here: an in-process Node
+ * `tls` server speaks the four-line NSCA-NG dialogue (MOIN / PUSH / data /
+ * QUIT), which is enough to verify the TLS layer the mode exists for:
+ *
+ *   1. with `verify mode = peer-cert` + the CA that signed the server cert,
+ *      the submission round-trips — and the server REQUIRES a client
+ *      certificate, so this also proves the agent presents the configured
+ *      certificate/key (mutual TLS);
+ *   2. with a CA that did NOT sign the server cert, the handshake fails and
+ *      nothing is submitted (peer verification fails closed).
+ *
+ * Regression context: the module used to configure the SSL context after the
+ * TLS stream had been created from it, and SSL_new() copies verify mode,
+ * certificate and version bounds out of the context at creation time — so
+ * cert mode silently skipped peer verification and never sent the client
+ * certificate. Both directions below would have failed before that fix:
+ * (1) because the server rejects a client that offers no certificate, and
+ * (2) because an unverified client would happily complete the handshake.
+ */
+import * as net from "net";
+import * as tls from "tls";
+import { NscpInstance, generateCertChain, type CertBundle } from "@fixtures/index";
+
+jest.setTimeout(120_000);
+
+interface StubServer {
+  port: number;
+  /** Raw PUSH payloads (external command lines) accepted so far. */
+  commands: string[];
+  /** TLS-level errors seen (handshake failures land here). */
+  tlsErrors: string[];
+  close(): Promise<void>;
+}
+
+/**
+ * Minimal NSCA-NG server on 127.0.0.1: answers MOIN with `MOIN 1`, PUSH with
+ * OKAY, records each pushed command block, and OKAYs QUIT. Requires and
+ * verifies a client certificate against `clientCa`.
+ */
+function startStubServer(
+  serverCert: { certPem: string; keyPem: string },
+  clientCa: string,
+): Promise<StubServer> {
+  const commands: string[] = [];
+  const tlsErrors: string[] = [];
+  const server = tls.createServer(
+    {
+      key: serverCert.keyPem,
+      cert: serverCert.certPem,
+      ca: [clientCa],
+      requestCert: true,
+      rejectUnauthorized: true,
+    },
+    (socket) => {
+      let buf = Buffer.alloc(0);
+      let pendingData = 0; // bytes of PUSH payload still expected
+      socket.on("data", (chunk: Buffer) => {
+        buf = Buffer.concat([buf, chunk]);
+        for (;;) {
+          if (pendingData > 0) {
+            if (buf.length < pendingData) return;
+            commands.push(buf.subarray(0, pendingData).toString("utf8").trimEnd());
+            buf = buf.subarray(pendingData);
+            pendingData = 0;
+            socket.write("OKAY\n");
+            continue;
+          }
+          const nl = buf.indexOf(0x0a);
+          if (nl < 0) return;
+          const line = buf.subarray(0, nl).toString("utf8").trimEnd();
+          buf = buf.subarray(nl + 1);
+          if (line.startsWith("MOIN")) {
+            socket.write("MOIN 1\n");
+          } else if (line.startsWith("PUSH ")) {
+            pendingData = parseInt(line.slice(5), 10);
+            socket.write("OKAY\n");
+          } else if (line === "QUIT") {
+            socket.write("OKAY\n");
+            socket.end();
+          } else {
+            socket.write("BAIL unexpected line\n");
+            socket.end();
+          }
+        }
+      });
+    },
+  );
+  server.on("tlsClientError", (err) => {
+    tlsErrors.push(String(err?.message ?? err));
+  });
+  return new Promise((resolve, reject) => {
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as net.AddressInfo).port;
+      resolve({
+        port,
+        commands,
+        tlsErrors,
+        close: () => new Promise<void>((res) => server.close(() => res())),
+      });
+    });
+  });
+}
+
+describe("NSCA-NG cert mode (TLS peer verification)", () => {
+  let nscp: NscpInstance;
+  let chain: CertBundle;
+  let wrongCaPath: string;
+  let server: StubServer;
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+
+    // Server cert carries DNS:localhost + IP:127.0.0.1 SANs so hostname
+    // verification passes against 127.0.0.1; the client cert is signed by the
+    // same CA, which the stub server also uses to verify the client.
+    chain = generateCertChain({
+      outDir: nscp.scratch("nsca_ng_certmode"),
+      signed: {
+        server: { commonName: "localhost", isServer: true },
+        client: { commonName: "nscp-agent" },
+      },
+    });
+    // A second, unrelated CA for the negative test (did not sign the server cert).
+    wrongCaPath = generateCertChain({
+      outDir: nscp.scratch("nsca_ng_certmode_wrong"),
+      caCommonName: "wrong-ca",
+      signed: { unused: { commonName: "localhost", isServer: true } },
+    }).ca.certPath;
+
+    server = await startStubServer(chain.signed.server, chain.ca.certPem);
+  });
+
+  afterAll(async () => {
+    await server?.close();
+    await nscp?.stop();
+  });
+
+  function baseArgs(caPath: string): string[] {
+    return [
+      "nsca-ng",
+      "--host=127.0.0.1",
+      `--port=${server.port}`,
+      "--no-psk",
+      "--verify",
+      "peer-cert",
+      "--ca",
+      caPath,
+      "--certificate",
+      chain.signed.client.certPath,
+      "--certificate-key",
+      chain.signed.client.keyPath,
+      "--hostname",
+      "test-host",
+    ];
+  }
+
+  it("round-trips a submission over mutually-authenticated TLS", async () => {
+    const r = await nscp.run([
+      ...baseArgs(chain.ca.certPath),
+      "--command",
+      "certmode-ok",
+      "--result",
+      "0",
+      "--message",
+      "over cert tls",
+    ]);
+    expect(r.exitCode).toBe(0);
+    // The server required and verified a client certificate, so a successful
+    // round-trip proves the agent both verified the server and presented the
+    // configured client certificate.
+    expect(server.commands.join("\n")).toContain(
+      "PROCESS_SERVICE_CHECK_RESULT;test-host;certmode-ok;0;over cert tls",
+    );
+  });
+
+  it("fails closed when the server cert is not signed by the trusted CA", async () => {
+    const before = server.commands.length;
+    const r = await nscp.run(
+      [
+        ...baseArgs(wrongCaPath),
+        "--command",
+        "certmode-bad",
+        "--result",
+        "0",
+        "--message",
+        "should not arrive",
+      ],
+      // Verification failure retries as a network error (attempts with
+      // 1s/2s backoff) before giving up, so allow a little extra time.
+      { allowFailure: true, timeout: 60_000 },
+    );
+    expect(r.exitCode).not.toBe(0);
+    // The failure must be the TLS handshake itself...
+    expect(String(r.all)).toMatch(/handshake/i);
+    // ...and nothing may have reached the application protocol.
+    expect(server.commands.length).toBe(before);
+    expect(server.commands.join("\n")).not.toContain("certmode-bad");
+  });
+
+  it("refuses to run unverified without the explicit insecure opt-in", async () => {
+    const r = await nscp.run(
+      [
+        "nsca-ng",
+        "--host=127.0.0.1",
+        `--port=${server.port}`,
+        "--no-psk",
+        "--hostname",
+        "test-host",
+        "--command",
+        "certmode-unverified",
+        "--result",
+        "0",
+        "--message",
+        "should not arrive",
+      ],
+      { allowFailure: true, timeout: 60_000 },
+    );
+    expect(r.exitCode).not.toBe(0);
+    expect(String(r.all)).toMatch(/Refusing to connect/i);
+    expect(server.commands.join("\n")).not.toContain("certmode-unverified");
+  });
+});


### PR DESCRIPTION
Fixes the two code findings from the NSCA-ng security review.

## Cert-mode TLS configuration ordering (high severity)

In cert mode (`use psk = false`) the module configured the SSL *context* after the `boost::asio::ssl::stream` had already been constructed from it. `SSL_new()` copies the verify mode, certificate, cipher list and protocol-version bounds out of the `SSL_CTX` at creation time — only the CA store stays shared — so none of that configuration ever reached the live connection:

- `verify mode = peer-cert` was silently ignored: the connection ran with `SSL_VERIFY_NONE` and accepted **any** server certificate, including a MITM's. The host-name callback didn't rescue it (Boost installs it with the SSL's current — unconfigured — mode, under which its result is advisory), and the "refusing to connect unverified" guard read the *configured* mode rather than the live one, so it passed too.
- The configured client certificate/key was never presented (mutual TLS broken).
- The `tls version` floor and `allowed ciphers` were likewise ignored.

The context is now built and fully configured in a new `make_ssl_context()` that runs **before** the stream is constructed (the same ordering `include/net/socket/client.hpp` uses). The default PSK mode is unaffected — it always configured the SSL object directly.

## `run_with_deadline` stale-handler race (UB)

The deadline helper captured its completion flags by reference on the stack. If the deadline expired in the same event batch in which the I/O op completed and `run_one()` consumed the completion handler first, the timer's handler stayed queued past the function's return and fired during the *next* operation's loop — writing through dangling references into a dead stack frame and cancelling the new operation. Per-operation state is now `shared_ptr`-owned with a `would_block` guard that turns a stale firing into a no-op.

## Tests

- **Unit** (`nsca_ng_test.cpp`): creates `SSL` objects from the built context exactly the way the stream constructor does and asserts the configuration actually arrived — verify mode, TLS version bounds, the `insecure` opt-in gate (throws without it, `SSL_VERIFY_NONE` with it), and the PSK context staying at defaults.
- **Integration** (`tests/nsca-ng-certmode.test.ts`, no docker needed): an in-process Node TLS server speaks the minimal NSCA-NG dialogue and **requires a client certificate**. A mutual-TLS round-trip must succeed (proves server verification passes *and* the client cert is presented — both broken before), a server cert from an untrusted CA must fail the handshake with nothing submitted, and cert mode without verification must refuse to run without `insecure`.

## Docs (same PR per the embargo convention)

- `docs/docs/security/notices.md`: hardening entry (no CVE) describing the issue, affected scope (0.18.0, cert mode only) and operator action.
- `docs/docs/setup/upgrading.md`: 🔒 entry under **Unreleased** — cert-mode targets that only connected because verification was broken will now fail until the server cert is fixed or `insecure = true` is set explicitly.

Remaining review findings (PSK guidance, least-privilege `authorize` examples, the broken scenario-doc snippet) are documentation-only and ship separately for independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BbQmbhgWEhsC86yeQpVfg6

---
_Generated by [Claude Code](https://claude.ai/code/session_01BbQmbhgWEhsC86yeQpVfg6)_