### PR TITLE
Fix iterator safety in NSClientServer::list_instance

### DIFF
--- a/modules/NSClientServer/NSClientServer.cpp
+++ b/modules/NSClientServer/NSClientServer.cpp
@@ -189,18 +189,16 @@ std::string NSClientServer::list_instance(std::string counter) {
     std::istringstream iss(s);
     std::string line;
     while (std::getline(iss, line, '\n')) {
-      // The porcelain enumeration format is `instance,<object>,<instance>`;
-      // we want the third field. Advance to it, but stop if the line has
-      // fewer fields (e.g. an "ERROR: ..." line from a failed PDH
+      // Each porcelain enumeration line has three comma-separated fields:
+      // the literal "instance", the object name and the instance name. We
+      // want the third (the instance name). Advance to it, but stop if the
+      // line has fewer fields (e.g. an "ERROR: ..." line from a failed PDH
       // enumeration - list_instance does not gate on the command's return
       // code) so we never dereference the end iterator.
       Tokenizer tok(line);
       Tokenizer::const_iterator cit = tok.begin();
       int advanced = 0;
-      while (advanced < 2 && cit != tok.end()) {
-        ++cit;
-        ++advanced;
-      }
+      for (; advanced < 2 && cit != tok.end(); ++advanced) ++cit;
       if (advanced == 2 && cit != tok.end()) {
         if (!result.empty()) result += ",";
         result += *cit;

--- a/modules/NSClientServer/NSClientServer.cpp
+++ b/modules/NSClientServer/NSClientServer.cpp
@@ -189,11 +189,19 @@ std::string NSClientServer::list_instance(std::string counter) {
     std::istringstream iss(s);
     std::string line;
     while (std::getline(iss, line, '\n')) {
+      // The porcelain enumeration format is `instance,<object>,<instance>`;
+      // we want the third field. Advance to it, but stop if the line has
+      // fewer fields (e.g. an "ERROR: ..." line from a failed PDH
+      // enumeration - list_instance does not gate on the command's return
+      // code) so we never dereference the end iterator.
       Tokenizer tok(line);
       Tokenizer::const_iterator cit = tok.begin();
-      int i = 2;
-      while ((i-- > 0) && (cit != tok.end())) ++cit;
-      if (i <= 1) {
+      int advanced = 0;
+      while (advanced < 2 && cit != tok.end()) {
+        ++cit;
+        ++advanced;
+      }
+      if (advanced == 2 && cit != tok.end()) {
         if (!result.empty()) result += ",";
         result += *cit;
       } else {


### PR DESCRIPTION
## Summary
Fixes a potential iterator dereference bug in the `list_instance` method where the code could attempt to dereference an end iterator when processing malformed PDH enumeration output.

## Changes
- **Improved loop logic**: Replaced a decrementing counter approach with an incrementing counter that explicitly tracks how many fields have been advanced through, making the intent clearer and the bounds checking more robust.
- **Safer iterator validation**: Changed the post-loop condition from `if (i <= 1)` to `if (advanced == 2 && cit != tok.end())`, ensuring we only dereference the iterator when we've successfully advanced exactly 2 positions AND the iterator is still valid.
- **Enhanced comments**: Added detailed explanation of the porcelain format and why the code must handle error lines gracefully (since `list_instance` does not check the PDH command's return code).

## Implementation Details
The original code used a countdown loop (`while ((i-- > 0) && (cit != tok.end())) ++cit;`) that could leave `i` in an ambiguous state when the loop exited early due to reaching the end iterator. The new approach:
1. Explicitly counts successful advances (0, 1, or 2)
2. Validates both that we advanced exactly 2 times AND that the iterator is still valid before dereferencing
3. Safely handles error output lines from PDH that have fewer than 3 comma-separated fields

This prevents undefined behavior when processing malformed enumeration results.

https://claude.ai/code/session_019LDQYoWAUYfLeY4CTtoYG4