### PR TITLE
GraphiteClient: scrub status path against metric-line injection

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -140,6 +140,28 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### Graphite client — status path scrubbed against metric-line injection
+
+**Fixed in:** unreleased (first release after 0.18.0) · **Severity:** Low
+
+`GraphiteClient` speaks the carbon plaintext protocol, where every metric is
+one `<path> <value> <timestamp>` line and `;` separates tags. The perf-data
+path and every metric value were already scrubbed so text from a check (a
+check alias, a perfdata label) cannot embed a newline or `;` — but the
+**status path** was only scrubbed for spaces. The `${check_alias}` substituted
+into it can originate from a remote submitter (an NSCA passive result, a
+forwarded submission), so an alias carrying a newline injected an extra,
+attacker-chosen metric line into Graphite, and a `;` injected carbon tags.
+Corrupting a metric another system alerts on, or planting a fake one, is a
+way to hide a real problem or fabricate one.
+
+The status path now goes through the same scrub as the perf path (`\n`, `\r`,
+tab, `;`, NUL, spaces and the other reserved characters all become `_`), and
+the scrub itself additionally replaces tabs, which split a carbon field the
+same way a space does. No operator action is needed; a status path built from
+an alias containing these characters (which previously produced corrupt lines)
+now renders them as `_`.
+
 ### CheckExternalScripts security-review hardening
 
 **Fixed in:** unreleased (first release after 0.18.0) · **Severity:** Low–Medium
@@ -383,6 +405,7 @@ was genuinely intended. If you see the new empty-password error in the log,
 set the same `password` on both ends. If you counted on
 `performance data = false` while it was broken, note that perfdata now
 really is dropped.
+
 ### SMTP client security-review hardening
 
 **Fixed in:** 0.18.0 · **Severity:** Low–Medium

--- a/modules/GraphiteClient/graphite_client.hpp
+++ b/modules/GraphiteClient/graphite_client.hpp
@@ -10,11 +10,15 @@
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <client/command_line_parser.hpp>
 #include <net/socket/socket_helpers.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <nscapi/protobuf/functions_convert.hpp>
 #include <nscapi/protobuf/functions_perfdata.hpp>
 #include <nscapi/protobuf/nagios.hpp>
+#include <str/utf8.hpp>
+#include <str/utils.hpp>
+#include <str/xtos.hpp>
 
 namespace graphite_client {
 struct connection_data : public socket_helpers::connection_info {
@@ -75,13 +79,15 @@ std::string fix_graphite_string(const std::string &s) {
   str::utils::replace(sc, ")", "_");
   str::utils::replace(sc, "%", "percent");
   // Graphite uses the plaintext line protocol "<path> <value> <ts>\n" - one
-  // metric per line, fields separated by spaces. A metric path or value
-  // containing a newline would split into multiple Graphite records. `;`
-  // is the tag separator in the Graphite carbon tag-aware protocol; an
-  // unintended `;` injects fake tags. Replace all four with `_` so a check
-  // name or perfdata label with these characters cannot inject metrics.
+  // metric per line, fields separated by whitespace. A metric path or value
+  // containing a newline would split into multiple Graphite records, and a
+  // tab splits a field the same way a space does. `;` is the tag separator
+  // in the Graphite carbon tag-aware protocol; an unintended `;` injects
+  // fake tags. Replace them all with `_` so a check name or perfdata label
+  // with these characters cannot inject metrics.
   str::utils::replace(sc, "\r", "_");
   str::utils::replace(sc, "\n", "_");
+  str::utils::replace(sc, "\t", "_");
   str::utils::replace(sc, ";", "_");
   str::utils::replace(sc, std::string("\0", 1), "_");
   return sc;
@@ -125,8 +131,12 @@ struct graphite_client_handler : public client::handler_interface {
         g_data d;
         d.path = spath;
         str::utils::replace(d.path, "${check_alias}", p.alias());
-        str::utils::replace(d.path, " ", "_");
         d.value = str::xtos(nscapi::protobuf::functions::gbp_to_nagios_status(p.result()));
+        // Scrub the whole status path like the perf path above: the alias (and
+        // the ${hostname} substituted earlier) may come from a remote submitter
+        // (NSCA, forwarded results), so an embedded newline or ';' must not be
+        // able to inject extra metric lines or carbon tags.
+        d.path = fix_graphite_string(d.path);
         list.push_back(d);
       }
     }
@@ -186,9 +196,7 @@ struct graphite_client_handler : public client::handler_interface {
   // the Graphite line protocol is "<path> <value> <ts>\n", so a value with a
   // space, newline or ';' could otherwise inject an extra metric/tag line.
   // fix_graphite_string leaves a normal numeric value untouched.
-  static std::string make_line(const g_data &d, const std::string &ts) {
-    return d.path + " " + fix_graphite_string(d.value) + " " + ts + "\n";
-  }
+  static std::string make_line(const g_data &d, const std::string &ts) { return d.path + " " + fix_graphite_string(d.value) + " " + ts + "\n"; }
 
   boost::tuple<bool, std::string> send(connection_data con, const std::list<g_data> &data) {
     try {

--- a/modules/GraphiteClient/graphite_client_test.cpp
+++ b/modules/GraphiteClient/graphite_client_test.cpp
@@ -17,8 +17,8 @@
 
 #include <algorithm>
 #include <boost/asio.hpp>
+#include <chrono>
 #include <client/command_line_parser.hpp>
-#include <future>
 #include <map>
 #include <str/xtos.hpp>
 #include <string>
@@ -39,30 +39,28 @@ client::destination_container container_with(const std::map<std::string, std::st
 
 // Accepts one connection and keeps every byte received until the peer closes,
 // which matches how GraphiteClient submits: connect, write all lines, close.
+//
+// Everything runs async on one io_context with a hard deadline, so a
+// submission that fails before connecting (or stalls mid-stream) cannot leave
+// the server thread blocked in accept()/read() and wedge the join() in
+// received() / the destructor - the deadline cancels the pending operation,
+// run() returns, and the assertions fail loudly on whatever was captured.
 class loopback_carbon_receiver {
  public:
-  loopback_carbon_receiver() {
-    std::promise<unsigned short> p;
-    std::future<unsigned short> f = p.get_future();
-    thread_ = std::thread([this, prom = std::move(p)]() mutable {
-      try {
-        boost::asio::io_context io;
-        tcp::acceptor acceptor(io, {tcp::v4(), 0});
-        prom.set_value(acceptor.local_endpoint().port());
-        tcp::socket socket(io);
-        acceptor.accept(socket);
-        boost::system::error_code ec;
-        char buf[4096];
-        for (;;) {
-          const std::size_t n = socket.read_some(boost::asio::buffer(buf), ec);
-          if (n > 0) received_.append(buf, n);
-          if (ec) break;
-        }
-      } catch (...) {
-        // Leave received_ as-is; the assertions on it will fail loudly.
-      }
+  explicit loopback_carbon_receiver(const std::chrono::seconds deadline = std::chrono::seconds(30))
+      : acceptor_(io_, {tcp::v4(), 0}), socket_(io_), deadline_(io_) {
+    port_ = acceptor_.local_endpoint().port();
+    deadline_.expires_after(deadline);
+    deadline_.async_wait([this](const boost::system::error_code &ec) {
+      if (!ec) stop();
     });
-    port_ = f.get();
+    acceptor_.async_accept(socket_, [this](const boost::system::error_code &ec) {
+      if (ec)
+        stop();
+      else
+        start_read();
+    });
+    thread_ = std::thread([this] { io_.run(); });
   }
   ~loopback_carbon_receiver() {
     if (thread_.joinable()) thread_.join();
@@ -74,8 +72,32 @@ class loopback_carbon_receiver {
   }
 
  private:
+  void start_read() {
+    socket_.async_read_some(boost::asio::buffer(buf_), [this](const boost::system::error_code &ec, const std::size_t n) {
+      if (n > 0) received_.append(buf_, n);
+      if (ec)
+        stop();  // EOF: the client wrote its lines and closed.
+      else
+        start_read();
+    });
+  }
+  void stop() {
+    boost::system::error_code ignored;
+    acceptor_.close(ignored);
+    socket_.close(ignored);
+    try {
+      deadline_.cancel();
+    } catch (...) {
+    }
+  }
+
+  boost::asio::io_context io_;
+  tcp::acceptor acceptor_;
+  tcp::socket socket_;
+  boost::asio::steady_timer deadline_;
   std::thread thread_;
   unsigned short port_ = 0;
+  char buf_[4096] = {};
   std::string received_;
 };
 
@@ -94,6 +116,17 @@ std::vector<std::string> split_lines(const std::string &s) {
 }
 
 }  // namespace
+
+// Regression test for the review finding that the receiver could wedge the
+// test process: when no client ever connects (a submission failing before the
+// connect), received() must return once the deadline fires instead of
+// blocking forever in join().
+TEST(GraphiteLoopbackReceiverTest, does_not_hang_when_no_client_connects) {
+  const auto start = std::chrono::steady_clock::now();
+  loopback_carbon_receiver server{std::chrono::seconds(1)};
+  EXPECT_EQ("", server.received());
+  EXPECT_LT(std::chrono::steady_clock::now() - start, std::chrono::seconds(10));
+}
 
 TEST(GraphiteFixStringTest, replaces_line_and_field_separators) {
   EXPECT_EQ("a_b", graphite_client::fix_graphite_string("a b"));

--- a/modules/GraphiteClient/graphite_client_test.cpp
+++ b/modules/GraphiteClient/graphite_client_test.cpp
@@ -1,0 +1,199 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Tests for the Graphite client's carbon line rendering, in particular the
+// sanitization that keeps attacker-influenced text (check aliases arrive from
+// remote submitters via NSCA/forwarded results, perfdata labels from checks)
+// from injecting extra metric lines or carbon tags into the plaintext
+// "<path> <value> <ts>\n" protocol.
+//
+// The submission itself is captured by a loopback TCP server standing in for
+// carbon, so what is asserted is the exact byte stream a carbon receiver
+// would parse.
+
+#include "graphite_client.hpp"
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <boost/asio.hpp>
+#include <client/command_line_parser.hpp>
+#include <future>
+#include <map>
+#include <str/xtos.hpp>
+#include <string>
+#include <thread>
+#include <vector>
+
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+using boost::asio::ip::tcp;
+
+client::destination_container container_with(const std::map<std::string, std::string> &options) {
+  client::destination_container d;
+  for (const auto &o : options) d.set_string_data(o.first, o.second);
+  return d;
+}
+
+// Accepts one connection and keeps every byte received until the peer closes,
+// which matches how GraphiteClient submits: connect, write all lines, close.
+class loopback_carbon_receiver {
+ public:
+  loopback_carbon_receiver() {
+    std::promise<unsigned short> p;
+    std::future<unsigned short> f = p.get_future();
+    thread_ = std::thread([this, prom = std::move(p)]() mutable {
+      try {
+        boost::asio::io_context io;
+        tcp::acceptor acceptor(io, {tcp::v4(), 0});
+        prom.set_value(acceptor.local_endpoint().port());
+        tcp::socket socket(io);
+        acceptor.accept(socket);
+        boost::system::error_code ec;
+        char buf[4096];
+        for (;;) {
+          const std::size_t n = socket.read_some(boost::asio::buffer(buf), ec);
+          if (n > 0) received_.append(buf, n);
+          if (ec) break;
+        }
+      } catch (...) {
+        // Leave received_ as-is; the assertions on it will fail loudly.
+      }
+    });
+    port_ = f.get();
+  }
+  ~loopback_carbon_receiver() {
+    if (thread_.joinable()) thread_.join();
+  }
+  unsigned short port() const { return port_; }
+  std::string received() {
+    if (thread_.joinable()) thread_.join();
+    return received_;
+  }
+
+ private:
+  std::thread thread_;
+  unsigned short port_ = 0;
+  std::string received_;
+};
+
+std::vector<std::string> split_lines(const std::string &s) {
+  std::vector<std::string> lines;
+  std::string::size_type start = 0;
+  for (;;) {
+    const std::string::size_type pos = s.find('\n', start);
+    if (pos == std::string::npos) {
+      if (start < s.size()) lines.push_back(s.substr(start));
+      return lines;
+    }
+    lines.push_back(s.substr(start, pos - start));
+    start = pos + 1;
+  }
+}
+
+}  // namespace
+
+TEST(GraphiteFixStringTest, replaces_line_and_field_separators) {
+  EXPECT_EQ("a_b", graphite_client::fix_graphite_string("a b"));
+  EXPECT_EQ("a_b", graphite_client::fix_graphite_string("a\nb"));
+  EXPECT_EQ("a_b", graphite_client::fix_graphite_string("a\rb"));
+  EXPECT_EQ("a_b", graphite_client::fix_graphite_string("a\tb"));
+  EXPECT_EQ("a_b", graphite_client::fix_graphite_string("a;b"));
+  EXPECT_EQ("a_b", graphite_client::fix_graphite_string(std::string("a\0b", 3)));
+  EXPECT_EQ("a_b", graphite_client::fix_graphite_string("a\\b"));
+  EXPECT_EQ("_a__b_", graphite_client::fix_graphite_string("[a](b)"));
+  EXPECT_EQ("apercent", graphite_client::fix_graphite_string("a%"));
+}
+
+TEST(GraphiteFixStringTest, leaves_normal_metric_text_alone) {
+  EXPECT_EQ("nsclient.host-1.cpu.total", graphite_client::fix_graphite_string("nsclient.host-1.cpu.total"));
+  EXPECT_EQ("42.5", graphite_client::fix_graphite_string("42.5"));
+}
+
+TEST(GraphiteMakeLineTest, scrubs_value_so_it_cannot_split_the_line) {
+  graphite_client::g_data d;
+  d.path = "nsclient.host.check.metric";
+  d.value = "1 2;3\n4";
+  EXPECT_EQ("nsclient.host.check.metric 1_2_3_4 1234\n", graphite_client::graphite_client_handler::make_line(d, "1234"));
+}
+
+// A hostile alias must not be able to inject extra carbon lines through the
+// status path (which historically was only scrubbed for spaces, unlike the
+// perf path) nor through the perf path.
+TEST(GraphiteSubmitTest, hostile_alias_and_perf_label_cannot_inject_metric_lines) {
+  loopback_carbon_receiver server;
+
+  client::destination_container sender = container_with({{"host", "sender-host"}});
+  client::destination_container target = container_with({
+      {"address", "127.0.0.1:" + str::xtos(server.port())},
+      {"perf path", "nsclient.${hostname}.${check_alias}.${perf_alias}"},
+      {"status path", "nsclient.${hostname}.${check_alias}.status"},
+      {"send perfdata", "true"},
+      {"send status", "true"},
+  });
+
+  PB::Commands::SubmitRequestMessage request;
+  auto *payload = request.add_payload();
+  payload->set_command("check_evil");
+  payload->set_alias("evil\ninjected.metric 666");
+  payload->set_result(PB::Common::ResultCode::OK);
+  auto *line = payload->add_lines();
+  line->set_message("all good");
+  auto *perf = line->add_perf();
+  perf->set_alias("rate;tag=x");
+  perf->mutable_float_value()->set_value(42.5);
+
+  PB::Commands::SubmitResponseMessage response;
+  graphite_client::graphite_client_handler handler;
+  ASSERT_TRUE(handler.submit(sender, target, request, response));
+  ASSERT_EQ(1, response.payload_size());
+  EXPECT_EQ(PB::Common::Result_StatusCodeType_STATUS_OK, response.payload(0).result().code()) << response.payload(0).result().message();
+
+  const std::string data = server.received();
+  const std::vector<std::string> lines = split_lines(data);
+  // One perf line + one status line. If the newline in the alias survived,
+  // there would be a third, attacker-chosen line starting "injected.metric".
+  ASSERT_EQ(2u, lines.size()) << "raw capture: " << data;
+  EXPECT_EQ("nsclient.sender-host.evil_injected.metric_666.rate_tag=x 42.5", lines[0].substr(0, lines[0].rfind(' ')));
+  EXPECT_EQ("nsclient.sender-host.evil_injected.metric_666.status 0", lines[1].substr(0, lines[1].rfind(' ')));
+  for (const std::string &l : lines) {
+    EXPECT_EQ(std::string::npos, l.find(';')) << l;
+    // Exactly "<path> <value> <ts>": two spaces, no more.
+    EXPECT_EQ(2, std::count(l.begin(), l.end(), ' ')) << l;
+  }
+}
+
+TEST(GraphiteSubmitTest, benign_submission_renders_expected_lines) {
+  loopback_carbon_receiver server;
+
+  client::destination_container sender = container_with({{"host", "myhost"}});
+  client::destination_container target = container_with({
+      {"address", "127.0.0.1:" + str::xtos(server.port())},
+      {"perf path", "nsclient.${hostname}.${check_alias}.${perf_alias}"},
+      {"status path", "nsclient.${hostname}.${check_alias}.status"},
+      {"send perfdata", "true"},
+      {"send status", "true"},
+  });
+
+  PB::Commands::SubmitRequestMessage request;
+  auto *payload = request.add_payload();
+  payload->set_command("check_cpu");
+  payload->set_alias("cpu load");
+  payload->set_result(PB::Common::ResultCode::WARNING);
+  auto *line = payload->add_lines();
+  line->set_message("warning");
+  auto *perf = line->add_perf();
+  perf->set_alias("total 5m");
+  perf->mutable_float_value()->set_value(87);
+
+  PB::Commands::SubmitResponseMessage response;
+  graphite_client::graphite_client_handler handler;
+  ASSERT_TRUE(handler.submit(sender, target, request, response));
+
+  const std::vector<std::string> lines = split_lines(server.received());
+  ASSERT_EQ(2u, lines.size());
+  EXPECT_EQ(0u, lines[0].find("nsclient.myhost.cpu_load.total_5m 87 ")) << lines[0];
+  EXPECT_EQ(0u, lines[1].find("nsclient.myhost.cpu_load.status 1 ")) << lines[1];
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -577,6 +577,12 @@ NSCP_CREATE_TEST(
         ${Boost_THREAD_LIBRARY}
         ${Boost_DATE_TIME_LIBRARY}
         ${EXTRA_LIBS}
+        # The Windows builds link OpenSSL statically, and libcrypto's CAPI
+        # engine / winstore STORE loader call into the Windows certificate
+        # store, so Crypt32 has to be on the link line. Module targets get it
+        # from their own EXTRA_LIBS; a test target has to spell it out (same
+        # as net_test / settings_http_test above).
+        $<$<PLATFORM_ID:Windows>:CRYPT32>
     INCLUDES
         ${NSCP_INCLUDEDIR}
         ${CMAKE_SOURCE_DIR}/modules/GraphiteClient

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -561,6 +561,27 @@ NSCP_CREATE_TEST(
 )
 
 
+# graphite_client.hpp renders the carbon plaintext lines; the test drives a
+# whole submission against a loopback TCP server so the sanitization that
+# stops metric-line injection is asserted on the actual byte stream.
+NSCP_CREATE_TEST(
+    graphite_client_test
+    SOURCES
+        ${CMAKE_SOURCE_DIR}/modules/GraphiteClient/graphite_client_test.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_SOURCE_DIR}/modules/GraphiteClient
+)
+
 set(SETTINGS_INI_TEST_SOURCES
     ${NSCP_INCLUDEDIR}/settings/impl/settings_ini_test.cpp
     ${NSCP_INCLUDEDIR}/str/utf8.cpp


### PR DESCRIPTION
## Summary

Fix a security vulnerability in `GraphiteClient` where the status path was insufficiently sanitized, allowing check aliases from remote submitters to inject extra metric lines or carbon tags into the Graphite plaintext protocol.

## Changes

- **Added comprehensive test suite** (`graphite_client_test.cpp`): 
  - Unit tests for `fix_graphite_string()` sanitization function
  - Integration tests using a loopback TCP server to verify the exact byte stream sent to Graphite
  - Tests confirming that hostile aliases and perfdata labels cannot inject metric lines or tags
  - Tests verifying benign submissions render correctly

- **Enhanced sanitization in `graphite_client.hpp`**:
  - Extended `fix_graphite_string()` to also replace tab characters (`\t`), which split carbon fields the same way spaces do
  - Updated the status path rendering to apply full `fix_graphite_string()` scrubbing (previously only spaces were replaced)
  - Added clarifying comments about the carbon plaintext protocol and injection vectors
  - The perf path was already properly scrubbed; status path now receives the same treatment

- **Updated security documentation** (`docs/docs/security/notices.md`):
  - Added notice documenting the vulnerability and fix
  - Explains the attack vector (remote submitters via NSCA/forwarded results)
  - Notes that no operator action is needed; corrupt lines now render safely

## Implementation Details

The vulnerability existed because `${check_alias}` in the status path can originate from remote submitters (NSCA passive results, forwarded submissions). An alias containing a newline would split into multiple Graphite records, and a semicolon would inject fake carbon tags. The fix applies the same comprehensive character replacement used for the perf path to the status path, ensuring all dangerous characters (`\n`, `\r`, `\t`, `;`, NUL, spaces, and reserved characters) become underscores.

The test suite validates this by submitting a request with a hostile alias (`"evil\ninjected.metric 666"`) and verifying that only the expected two metric lines (perf + status) are received, with no injected lines and no unescaped special characters.

https://claude.ai/code/session_011ibCLoMoXBqD5CC2HR8RzF