### PR TITLE
IcingaClient: security-review hardening (trace redaction, timeouts, verify-mode warning)

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -140,6 +140,37 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### Icinga client security-review hardening
+
+**Fixed in:** unreleased · **Severity:** Low
+
+A security review of the `IcingaClient` module (and of the WEB server path
+Icinga's `check_nscp_api` plugin authenticates through) confirmed the
+defaults are sound — TLS verification on by default for configured and ad-hoc
+targets alike, Icinga filter-expression escaping, and the User-Agent-gated
+legacy auth — and produced three hardening fixes on the client side:
+
+- **Credentials are redacted from the trace log.** With log level `trace`, the
+  client logged the whole target configuration through
+  `destination_container::to_string()`, which printed the raw data map —
+  including the Icinga API `password`. The value of any `password` or `token`
+  key is now masked in that output. The fix sits in the shared client
+  machinery, so the other outbound client modules built on the same type
+  (NRPE, NSCA, NRDP, …) are covered by it as well.
+- **The configured `timeout` is enforced on Icinga API calls.** The HTTP
+  client was built without a deadline (wait forever), so the target's
+  `timeout` setting (default 30 s) was read but never applied — an Icinga
+  endpoint that accepted the connection and then stalled could wedge the
+  submitting thread indefinitely, silently stopping scheduler-driven passive
+  results. This is an availability fix; set `timeout = 0` on the target if you
+  really want the old unbounded wait.
+- **Disabled certificate verification is called out.** An `https` submission
+  whose `verify mode` resolves to no peer verification (empty, `none`, or
+  `fail-if-no-cert` alone) now logs a message naming the endpoint, since the
+  API credentials are then sent to whichever server answers. The option help
+  also no longer suggests `none` for self-signed certificates — the right
+  configuration is `peer-cert` with `ca` pointing at the certificate.
+
 ### Graphite client — status path scrubbed against metric-line injection
 
 **Fixed in:** unreleased (first release after 0.18.0) · **Severity:** Low

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -16,6 +16,18 @@ per-release detail lives in each
 
 ## Unreleased
 
+- 🔒 **Icinga API submissions now honour the configured `timeout`, and
+  credentials no longer reach the trace log.** The `IcingaClient` module's
+  HTTP calls previously waited forever — the target's `timeout` setting
+  (default 30 s) was read but never applied — so a stalled Icinga endpoint
+  could silently wedge passive-result submission; set `timeout = 0` on the
+  target if you depend on the old unbounded wait. The same review masked
+  `password`/`token` values in the trace-level target dump (this also covers
+  the other client modules sharing that machinery) and added a log message
+  when an `https` submission runs with certificate verification disabled
+  (`verify mode` empty or `none`). See
+  [Security notices](../security/notices.md#icinga-client-security-review-hardening).
+
 - 🔒 **CheckExternalScripts hardening.** A security review of the external
   scripts module tightened several rough edges: the `ext-scr install` argument
   lockdown now writes to the setting the module actually reads (previously it

--- a/docs/reference/IcingaClient.yaml
+++ b/docs/reference/IcingaClient.yaml
@@ -133,7 +133,8 @@ common:
             advanced: false
             default_value: peer
             description: 'Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert,
-              workarounds, single. In general use peer-cert or none for self signed certificates.'
+              workarounds, single. For a self signed certificate use peer-cert and point `ca` at that certificate;
+              none disables verification entirely and sends the API credentials to an unverified peer.'
             sample: true
             title: TLS PEER VERIFY MODE
   queries:
@@ -348,12 +349,14 @@ common:
         default_value: ''
         is_simple: true
         long_description: 'Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert,
-          workarounds, single. In general use peer-cert or none for self signed certificates.'
+          workarounds, single. For a self signed certificate use peer-cert and point --ca at that certificate;
+          none disables verification entirely and sends the API credentials to an unverified peer.'
         name: verify-mode
         repeatable: false
         required: false
         short_description: 'Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert,
-          workarounds, single. In general use peer-cert or none for self signed certificates.'
+          workarounds, single. For a self signed certificate use peer-cert and point --ca at that certificate;
+          none disables verification entirely and sends the API credentials to an unverified peer.'
       - content_type: 2
         default_value: ''
         is_simple: true

--- a/docs/reference/IcingaClient.yaml
+++ b/docs/reference/IcingaClient.yaml
@@ -132,9 +132,10 @@ common:
           verify mode:
             advanced: false
             default_value: peer
-            description: 'Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert,
-              workarounds, single. For a self signed certificate use peer-cert and point `ca` at that certificate;
-              none disables verification entirely and sends the API credentials to an unverified peer.'
+            description: 'Comma separated list of options: none, peer (or certificate), peer-cert,
+              fail-if-no-cert (or fail-if-no-peer-cert, client-certificate). Any other value is rejected
+              and the connection fails. For a self signed certificate use peer-cert and point `ca` at that
+              certificate; none disables verification entirely and sends the API credentials to an unverified peer.'
             sample: true
             title: TLS PEER VERIFY MODE
   queries:
@@ -348,14 +349,16 @@ common:
       - content_type: 2
         default_value: ''
         is_simple: true
-        long_description: 'Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert,
-          workarounds, single. For a self signed certificate use peer-cert and point --ca at that certificate;
+        long_description: 'Comma separated list of options: none, peer (or certificate), peer-cert,
+          fail-if-no-cert (or fail-if-no-peer-cert, client-certificate). Any other value is rejected and
+          the connection fails. For a self signed certificate use peer-cert and point --ca at that certificate;
           none disables verification entirely and sends the API credentials to an unverified peer.'
         name: verify-mode
         repeatable: false
         required: false
-        short_description: 'Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert,
-          workarounds, single. For a self signed certificate use peer-cert and point --ca at that certificate;
+        short_description: 'Comma separated list of options: none, peer (or certificate), peer-cert,
+          fail-if-no-cert (or fail-if-no-peer-cert, client-certificate). Any other value is rejected and
+          the connection fails. For a self signed certificate use peer-cert and point --ca at that certificate;
           none disables verification entirely and sends the API credentials to an unverified peer.'
       - content_type: 2
         default_value: ''

--- a/include/client/command_line_parser.cpp
+++ b/include/client/command_line_parser.cpp
@@ -96,7 +96,11 @@ bool is_sensitive_key(const std::string &key) { return key.find("password") != s
 
 std::string client::destination_container::to_string() const {
   std::stringstream ss;
-  ss << "address: " << address.to_string() << ", timeout: " << timeout << ", retry: " << retry << ", data: { ";
+  // to_log_safe_string(), not to_string(): a target address is free to carry
+  // credentials in its query parameters (".../submit.php?token=..."), and this
+  // whole string goes to the trace log. The parameters are not what identifies
+  // the destination.
+  ss << "address: " << address.to_log_safe_string() << ", timeout: " << timeout << ", retry: " << retry << ", data: { ";
   for (const data_map::value_type &t : data) {
     ss << t.first << ": " << (is_sensitive_key(t.first) ? "***" : t.second) << ", ";
   }

--- a/include/client/command_line_parser.cpp
+++ b/include/client/command_line_parser.cpp
@@ -86,11 +86,19 @@ struct payload_builder {
   }
 };
 
+namespace {
+// Keys whose values are credentials. to_string() feeds trace/debug logging in
+// every client module (IcingaClient traces the whole target container on
+// submit, for instance), and a password copied into the log outlives every
+// other control protecting it — so mask by key here, not at each call site.
+bool is_sensitive_key(const std::string &key) { return key.find("password") != std::string::npos || key.find("token") != std::string::npos; }
+}  // namespace
+
 std::string client::destination_container::to_string() const {
   std::stringstream ss;
   ss << "address: " << address.to_string() << ", timeout: " << timeout << ", retry: " << retry << ", data: { ";
   for (const data_map::value_type &t : data) {
-    ss << t.first << ": " << t.second << ", ";
+    ss << t.first << ": " << (is_sensitive_key(t.first) ? "***" : t.second) << ", ";
   }
   ss << "}";
   return ss.str();

--- a/include/client/command_line_parser_test.cpp
+++ b/include/client/command_line_parser_test.cpp
@@ -189,6 +189,19 @@ TEST(destination_container, to_string_masks_credentials) {
   EXPECT_NE(s.find("username: root"), std::string::npos) << "non-secret values are still printed: " << s;
 }
 
+TEST(destination_container, to_string_drops_the_address_query_string) {
+  // A target address may carry credentials in its parameters, and the whole
+  // string goes to the trace log. The host still has to identify the target.
+  client::destination_container d;
+  d.set_address("https://icinga.example.com:5665/submit.php?token=s3cret");
+
+  const std::string s = d.to_string();
+
+  EXPECT_EQ(s.find("s3cret"), std::string::npos) << s;
+  EXPECT_EQ(s.find("token"), std::string::npos) << s;
+  EXPECT_NE(s.find("icinga.example.com"), std::string::npos) << "the destination must stay identifiable: " << s;
+}
+
 TEST(destination_container, address_sets_protocol_host_and_port_at_once) {
   client::destination_container d;
   d.set_string_data("address", "nrpe://server.example.com:5667");

--- a/include/client/command_line_parser_test.cpp
+++ b/include/client/command_line_parser_test.cpp
@@ -172,6 +172,23 @@ TEST(destination_container, unknown_keys_are_kept_as_data) {
   EXPECT_EQ(d.get_string_data("missing", "fallback"), "fallback");
 }
 
+TEST(destination_container, to_string_masks_credentials) {
+  // to_string() feeds trace/debug logging in every client module (the Icinga
+  // client traces the whole target container on submit), so credential values
+  // must never appear in it - only their keys.
+  client::destination_container d;
+  d.set_string_data("username", "root");
+  d.set_string_data("password", "s3cret");
+  d.set_string_data("token", "tok-value");
+
+  const std::string s = d.to_string();
+
+  EXPECT_EQ(s.find("s3cret"), std::string::npos) << s;
+  EXPECT_EQ(s.find("tok-value"), std::string::npos) << s;
+  EXPECT_NE(s.find("password: ***"), std::string::npos) << "the key should stay visible for debugging: " << s;
+  EXPECT_NE(s.find("username: root"), std::string::npos) << "non-secret values are still printed: " << s;
+}
+
 TEST(destination_container, address_sets_protocol_host_and_port_at_once) {
   client::destination_container d;
   d.set_string_data("address", "nrpe://server.example.com:5667");

--- a/modules/IcingaClient/icinga.cpp
+++ b/modules/IcingaClient/icinga.cpp
@@ -11,6 +11,7 @@
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
+#include <str/utils.hpp>
 
 namespace json = boost::json;
 
@@ -190,16 +191,26 @@ submit_result parse_check_result_response(const std::string &body) {
 }
 
 bool is_verification_disabled(const std::string &verify_mode) {
-  // Token-for-token mirror of socket_helpers::verify_mode_parser (which does
-  // not trim whitespace either): boost::asio::ssl::verify_peer is only set by
-  // these three tokens, and without verify_peer the other flags do nothing —
-  // the handshake accepts whatever certificate the peer presents.
-  std::vector<std::string> keys;
-  boost::split(keys, verify_mode, boost::is_any_of(","));
-  for (const std::string &key : keys) {
-    if (key == "peer" || key == "certificate" || key == "peer-cert") return false;
+  // Token-for-token mirror of socket_helpers::verify_mode_parser, down to the
+  // splitter it uses (neither trims whitespace, and the split of "" yields no
+  // tokens at all, so an unset verify mode parses to verify_none).
+  //
+  // Only these three tokens set boost::asio::ssl::verify_peer, and without it
+  // the remaining flags do nothing — the handshake accepts whatever
+  // certificate the peer presents. Anything the parser does NOT accept makes
+  // it throw instead of building a mode, so no connection is established at
+  // all: that is a configuration error the connection attempt reports on its
+  // own, not an unverified submission, and claiming "verification disabled"
+  // for it would be misleading.
+  bool verifies_peer = false;
+  for (const std::string &key : str::utils::split_lst(verify_mode, std::string(","))) {
+    if (key == "peer" || key == "certificate" || key == "peer-cert") {
+      verifies_peer = true;
+    } else if (key != "none" && key != "fail-if-no-cert" && key != "fail-if-no-peer-cert" && key != "client-certificate") {
+      return false;
+    }
   }
-  return true;
+  return !verifies_peer;
 }
 
 std::string url_encode(const std::string &value) {

--- a/modules/IcingaClient/icinga.cpp
+++ b/modules/IcingaClient/icinga.cpp
@@ -189,6 +189,19 @@ submit_result parse_check_result_response(const std::string &body) {
   return r;
 }
 
+bool is_verification_disabled(const std::string &verify_mode) {
+  // Token-for-token mirror of socket_helpers::verify_mode_parser (which does
+  // not trim whitespace either): boost::asio::ssl::verify_peer is only set by
+  // these three tokens, and without verify_peer the other flags do nothing —
+  // the handshake accepts whatever certificate the peer presents.
+  std::vector<std::string> keys;
+  boost::split(keys, verify_mode, boost::is_any_of(","));
+  for (const std::string &key : keys) {
+    if (key == "peer" || key == "certificate" || key == "peer-cert") return false;
+  }
+  return true;
+}
+
 std::string url_encode(const std::string &value) {
   std::ostringstream escaped;
   escaped.fill('0');

--- a/modules/IcingaClient/icinga.hpp
+++ b/modules/IcingaClient/icinga.hpp
@@ -45,11 +45,13 @@ submit_result parse_check_result_response(const std::string &body);
 /// for inclusion in a path or a query string.
 std::string url_encode(const std::string &value);
 
-/// True when a `verify mode` string leaves TLS peer verification off — no
-/// token in it enables certificate-chain verification, so the connection
-/// accepts any certificate.  Mirrors socket_helpers::verify_mode_parser: only
-/// `peer`, `certificate` and `peer-cert` turn verification on; everything
-/// else (an empty string included) resolves to verify_none.
+/// True when a `verify mode` string leaves TLS peer verification off — the
+/// mode parses, but no token in it enables certificate-chain verification, so
+/// the connection accepts any certificate.  Mirrors
+/// socket_helpers::verify_mode_parser: only `peer`, `certificate` and
+/// `peer-cert` turn verification on, and an empty string resolves to
+/// verify_none.  A string the parser would reject is not "disabled" — it
+/// throws, so no connection is made.
 bool is_verification_disabled(const std::string &verify_mode);
 
 }  // namespace icinga

--- a/modules/IcingaClient/icinga.hpp
+++ b/modules/IcingaClient/icinga.hpp
@@ -45,4 +45,11 @@ submit_result parse_check_result_response(const std::string &body);
 /// for inclusion in a path or a query string.
 std::string url_encode(const std::string &value);
 
+/// True when a `verify mode` string leaves TLS peer verification off — no
+/// token in it enables certificate-chain verification, so the connection
+/// accepts any certificate.  Mirrors socket_helpers::verify_mode_parser: only
+/// `peer`, `certificate` and `peer-cert` turn verification on; everything
+/// else (an empty string included) resolves to verify_none.
+bool is_verification_disabled(const std::string &verify_mode);
+
 }  // namespace icinga

--- a/modules/IcingaClient/icinga_client.hpp
+++ b/modules/IcingaClient/icinga_client.hpp
@@ -49,10 +49,15 @@ struct connection_data : socket_helpers::connection_info {
       protocol = "https";
       port_ = arguments.address.get_port_string("5665");
     }
-    timeout = arguments.get_int_data("timeout", 30);
+    // destination_container routes the well-known "timeout" and "retry" keys
+    // into its typed fields (see set_string_data), so they must be read from
+    // there: get_int_data("timeout") only consults the free-form data map and
+    // always returned the fallback, which is why the target's timeout setting
+    // never took effect.
+    timeout = arguments.timeout;
+    retry = arguments.retry;
     username = arguments.get_string_data("username");
     password = arguments.get_string_data("password");
-    retry = arguments.get_int_data("retry", 3);
     tls_version = arguments.get_string_data("tls version", "1.3");
     verify_mode = arguments.get_string_data("verify mode");
     ca = arguments.get_string_data("ca");
@@ -96,11 +101,22 @@ struct http_response {
   std::string body;
 };
 
+// Build the HTTP client options for a connection, including the per-target
+// timeout. Kept out of do_http so the mapping is unit-testable: without the
+// timeout the client waits forever, and a stalled Icinga endpoint then wedges
+// the submitting thread (scheduler-driven passive results silently stop).
+inline http::http_client_options make_client_options(const connection_data &con) {
+  http::http_client_options options(con.protocol, con.tls_version, con.verify_mode, con.ca);
+  // connection_info::timeout is the target's "timeout" setting (default 30);
+  // 0 keeps the http client's wait-forever behaviour as an explicit opt-out.
+  options.timeout_seconds_ = con.timeout;
+  return options;
+}
+
 inline http_response do_http(const connection_data &con, const std::string &verb, const std::string &path, const std::string &json_body) {
   http_response result;
   result.status = 0;
-  http::http_client_options options(con.protocol, con.tls_version, con.verify_mode, con.ca);
-  http::simple_client c(options);
+  http::simple_client c(make_client_options(con));
 
   http::request request(verb, con.get_address(), path);
   request.add_header("Authorization", make_basic_auth(con.username, con.password));
@@ -140,6 +156,13 @@ struct icinga_client_handler : client::handler_interface {
 
     NSC_TRACE_ENABLED() { NSC_TRACE_MSG("Sender configuration: " + sender.to_string()); }
     NSC_TRACE_ENABLED() { NSC_TRACE_MSG("Target configuration: " + target.to_string()); }
+
+    if (con.protocol == "https" && icinga::is_verification_disabled(con.verify_mode)) {
+      NSC_LOG_MESSAGE("TLS certificate verification is disabled for " + con.get_endpoint_string() + " (verify mode: " +
+                      (con.verify_mode.empty() ? "<not set>" : con.verify_mode) +
+                      "): the Icinga API credentials are sent to whichever server answers. Set verify mode = peer, or peer-cert with ca pointing at the "
+                      "self-signed certificate, unless this is intentional.");
+    }
 
     for (const ::PB::Commands::QueryResponseMessage_Response &p : request_message.payload()) {
       submit_one(response_message.add_payload(), con, p);

--- a/modules/IcingaClient/icinga_client_test.cpp
+++ b/modules/IcingaClient/icinga_client_test.cpp
@@ -168,6 +168,27 @@ TEST(IcingaConnectionData, TlsVersionDefaultsToOneThree) {
   EXPECT_EQ(con.tls_version, "1.3");
 }
 
+TEST(IcingaConnectionData, TheTimeoutReachesTheHttpClient) {
+  // The http client's timeout_seconds_ defaults to 0 = wait forever, so if the
+  // target's timeout is not copied across, a stalled Icinga endpoint wedges
+  // the submitting thread indefinitely. Note that destination_container routes
+  // "timeout" into its typed field, not the data map - reading it with
+  // get_int_data() silently yields the fallback instead of the setting.
+  const icinga_client::connection_data con(target_with({{"address", "https://h"}, {"timeout", "7"}}), client::destination_container());
+
+  EXPECT_EQ(con.timeout, 7u);
+  EXPECT_EQ(icinga_client::make_client_options(con).timeout_seconds_, 7u);
+}
+
+TEST(IcingaConnectionData, ADefaultConstructedTargetStillGetsAFiniteTimeout) {
+  // Whatever the default ends up being (the configured target object seeds
+  // 30), it must be non-zero: 0 means wait forever on the http client.
+  const icinga_client::connection_data con(target_with({{"address", "https://h"}}), client::destination_container());
+
+  EXPECT_GT(con.timeout, 0u);
+  EXPECT_EQ(icinga_client::make_client_options(con).timeout_seconds_, con.timeout);
+}
+
 TEST(IcingaConnectionData, ObjectTemplatesAndEnsureFlagAreRead) {
   const icinga_client::connection_data con(target_with({{"address", "https://h"},
                                                         {"ensure_objects", "true"},
@@ -309,6 +330,44 @@ TEST(IcingaSubmit, AnUnreachableApiIsReportedAsAnError) {
 
   ASSERT_EQ(response.payload_size(), 1);
   EXPECT_EQ(response.payload(0).result().code(), PB::Common::Result_StatusCodeType_STATUS_ERROR);
+}
+
+TEST(IcingaSubmit, AStalledApiTimesOutInsteadOfHangingForever) {
+  // A server that accepts the connection and then never answers. Before the
+  // timeout was wired through, this hung the submitting thread forever.
+  std::promise<unsigned short> p;
+  std::future<unsigned short> f = p.get_future();
+  std::thread server([prom = std::move(p)]() mutable {
+    try {
+      boost::asio::io_context io;
+      tcp::acceptor acceptor(io, {tcp::v4(), 0});
+      prom.set_value(acceptor.local_endpoint().port());
+      tcp::socket socket(io);
+      acceptor.accept(socket);
+      // Never answer: drain until the client gives up and closes, at which
+      // point the read reports EOF and the thread exits.
+      boost::system::error_code ec;
+      char buf[4096];
+      while (!ec) socket.read_some(boost::asio::buffer(buf), ec);
+    } catch (...) {
+    }
+  });
+  const unsigned short port = f.get();
+
+  PB::Commands::SubmitRequestMessage request;
+  PB::Commands::QueryResponseMessage::Response *payload = request.add_payload();
+  payload->set_command("check_something");
+  payload->set_result(PB::Common::ResultCode::OK);
+  payload->add_lines()->set_message("fine");
+
+  PB::Commands::SubmitResponseMessage response;
+  icinga_client::icinga_client_handler handler;
+  handler.submit(client::destination_container(), target_with({{"address", "http://127.0.0.1:" + std::to_string(port)}, {"timeout", "1"}}), request, response);
+  server.join();
+
+  ASSERT_EQ(response.payload_size(), 1);
+  EXPECT_EQ(response.payload(0).result().code(), PB::Common::Result_StatusCodeType_STATUS_ERROR);
+  EXPECT_NE(response.payload(0).result().message().find("timed out"), std::string::npos) << response.payload(0).result().message();
 }
 
 TEST(IcingaSubmit, QueryAndExecAreNotSupported) {

--- a/modules/IcingaClient/icinga_target_object.hpp
+++ b/modules/IcingaClient/icinga_target_object.hpp
@@ -56,7 +56,8 @@ struct icinga_target_object : nscapi::targets::target_object {
                     "TLS VERSION", "The TLS version to use 1.0, 1.1, 1.2, 1.3")
         .add_string("verify mode", sh::string_fun_key([this](const auto&  value) { this->set_property_string("verify mode", value); }, "peer"),
                     "TLS PEER VERIFY MODE",
-                    "Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert, workarounds, single. "
+                    "Comma separated list of options: none, peer (or certificate), peer-cert, fail-if-no-cert "
+                    "(or fail-if-no-peer-cert, client-certificate). Any other value is rejected and the connection fails. "
                     "For a self signed certificate use peer-cert and point `ca` at that certificate; "
                     "none disables verification entirely and sends the API credentials to an unverified peer.")
         // path_fun_key (not string_fun_key) so the ${ca-path} placeholder
@@ -104,7 +105,8 @@ struct options_reader_impl : client::options_reader_interface {
     ("tls-version", po::value<std::string>()->default_value("1.3")->notifier([&data] (const auto&  value) { data.set_string_data("tls version", value); }),
         "The TLS version to use 1.0, 1.1, 1.2, 1.3 or any")
     ("verify-mode", po::value<std::string>()->notifier([&data] (const auto&  value) { data.set_string_data("verify mode", value); }),
-        "Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert, workarounds, single. "
+        "Comma separated list of options: none, peer (or certificate), peer-cert, fail-if-no-cert "
+        "(or fail-if-no-peer-cert, client-certificate). Any other value is rejected and the connection fails. "
         "For a self signed certificate use peer-cert and point --ca at that certificate; "
         "none disables verification entirely and sends the API credentials to an unverified peer.")
     ("ca", po::value<std::string>()->notifier([&data] (const auto&  value) { data.set_string_data("ca", value); }),

--- a/modules/IcingaClient/icinga_target_object.hpp
+++ b/modules/IcingaClient/icinga_target_object.hpp
@@ -57,7 +57,8 @@ struct icinga_target_object : nscapi::targets::target_object {
         .add_string("verify mode", sh::string_fun_key([this](const auto&  value) { this->set_property_string("verify mode", value); }, "peer"),
                     "TLS PEER VERIFY MODE",
                     "Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert, workarounds, single. "
-                    "In general use peer-cert or none for self signed certificates.")
+                    "For a self signed certificate use peer-cert and point `ca` at that certificate; "
+                    "none disables verification entirely and sends the API credentials to an unverified peer.")
         // path_fun_key (not string_fun_key) so the ${ca-path} placeholder
         // expands via the settings layer to the actual bundle path. On
         // Windows that's the ROOT-store export the service writes at boot;
@@ -104,7 +105,8 @@ struct options_reader_impl : client::options_reader_interface {
         "The TLS version to use 1.0, 1.1, 1.2, 1.3 or any")
     ("verify-mode", po::value<std::string>()->notifier([&data] (const auto&  value) { data.set_string_data("verify mode", value); }),
         "Comma separated list of options: none, peer, peer-cert, client-once, fail-if-no-cert, workarounds, single. "
-        "In general use peer-cert or none for self signed certificates.")
+        "For a self signed certificate use peer-cert and point --ca at that certificate; "
+        "none disables verification entirely and sends the API credentials to an unverified peer.")
     ("ca", po::value<std::string>()->notifier([&data] (const auto&  value) { data.set_string_data("ca", value); }),
         "Certificate authority to use when verifying certificates.")
     ;

--- a/modules/IcingaClient/icinga_test.cpp
+++ b/modules/IcingaClient/icinga_test.cpp
@@ -167,3 +167,25 @@ TEST(IcingaTest, VerificationIsEnabledByAnyPeerToken) {
   EXPECT_FALSE(icinga::is_verification_disabled("none,peer"));
   EXPECT_FALSE(icinga::is_verification_disabled("peer,fail-if-no-cert"));
 }
+
+TEST(IcingaTest, AnUnparsableVerifyModeIsNotReportedAsDisabled) {
+  // verify_mode_parser throws on any token it does not know, so these never
+  // produce a connection at all - let the connection attempt report the
+  // configuration error rather than warning about an unverified submission
+  // that never happens.
+  EXPECT_FALSE(icinga::is_verification_disabled("workarounds"));
+  EXPECT_FALSE(icinga::is_verification_disabled("client-once"));
+  EXPECT_FALSE(icinga::is_verification_disabled("single"));
+  EXPECT_FALSE(icinga::is_verification_disabled("none,typo"));
+}
+
+TEST(IcingaTest, EveryTokenTheParserAcceptsIsClassified) {
+  // Guards the mirror: each of these must parse in
+  // socket_helpers::verify_mode_parser, and only the peer-enabling ones may
+  // read as verified. If a token is added there and not here, the "unknown
+  // token" branch above silently reclassifies it.
+  EXPECT_TRUE(icinga::is_verification_disabled("none"));
+  EXPECT_TRUE(icinga::is_verification_disabled("fail-if-no-cert"));
+  EXPECT_TRUE(icinga::is_verification_disabled("fail-if-no-peer-cert"));
+  EXPECT_TRUE(icinga::is_verification_disabled("client-certificate"));
+}

--- a/modules/IcingaClient/icinga_test.cpp
+++ b/modules/IcingaClient/icinga_test.cpp
@@ -148,3 +148,22 @@ TEST(IcingaTest, UrlEncode) {
   EXPECT_EQ(icinga::url_encode("host!service"), "host%21service");
   EXPECT_EQ(icinga::url_encode("a b/c"), "a%20b%2Fc");
 }
+
+TEST(IcingaTest, VerificationIsDisabledWhenNoTokenEnablesPeerVerification) {
+  // These all resolve to verify_none in socket_helpers::verify_mode_parser:
+  // an empty string parses to no flags at all, "none" is explicit, and
+  // fail-if-no-cert alone does nothing without verify_peer.
+  EXPECT_TRUE(icinga::is_verification_disabled(""));
+  EXPECT_TRUE(icinga::is_verification_disabled("none"));
+  EXPECT_TRUE(icinga::is_verification_disabled("fail-if-no-cert"));
+}
+
+TEST(IcingaTest, VerificationIsEnabledByAnyPeerToken) {
+  EXPECT_FALSE(icinga::is_verification_disabled("peer"));
+  EXPECT_FALSE(icinga::is_verification_disabled("certificate"));
+  EXPECT_FALSE(icinga::is_verification_disabled("peer-cert"));
+  // The parser ORs flags together, so a list that names peer anywhere
+  // verifies even if it also says none.
+  EXPECT_FALSE(icinga::is_verification_disabled("none,peer"));
+  EXPECT_FALSE(icinga::is_verification_disabled("peer,fail-if-no-cert"));
+}


### PR DESCRIPTION
A security review of the Icinga client (and of the WEB server path Icinga's `check_nscp_api` plugin authenticates through) confirmed the defaults are sound — TLS verification on by default for configured and ad-hoc targets, Icinga filter-expression escaping, and the User-Agent-gated legacy auth — and produced three hardening fixes on the client side.

## Changes

### 1. Credentials are redacted from the trace log
With log level `trace`, the Icinga client logged the whole target configuration through `destination_container::to_string()`, which printed the raw data map — including the Icinga API `password`. The value of any `password` or `token` key is now masked (`***`) in that output. The fix sits in the shared client machinery (`include/client/command_line_parser.cpp`), so the other outbound client modules built on the same type (NRPE, NSCA, NRDP, …) are covered as well.

### 2. The target's `timeout` is enforced on Icinga API calls
The HTTP client was built without a deadline (wait forever), so an Icinga endpoint that accepted the connection and then stalled wedged the submitting thread indefinitely — silently stopping scheduler-driven passive results. Two bugs stacked here:

- the timeout was never copied into `http_client_options::timeout_seconds_`, and
- `connection_data` read `"timeout"`/`"retry"` via `get_int_data()`, which only consults the free-form data map, while `destination_container::set_string_data()` routes those keys into typed fields — so the configured value never reached the connection either.

Both are fixed; `timeout = 0` on the target keeps the old unbounded wait as an explicit opt-out. The options mapping is extracted into `make_client_options()` so it is unit-testable.

### 3. Disabled certificate verification is called out
An `https` submission whose `verify mode` resolves to no peer verification (empty, `none`, or `fail-if-no-cert` alone — see `icinga::is_verification_disabled()`, a token-for-token mirror of `socket_helpers::verify_mode_parser`) now logs a message naming the endpoint, since the API credentials are then sent to whichever server answers. The option help (settings, CLI, and the reference YAML) also no longer suggests `none` for self-signed certificates — the right configuration is `peer-cert` with `ca` pointing at the certificate.

## Tests

- `destination_container.to_string_masks_credentials` — values of `password`/`token` never appear in `to_string()`, keys stay visible.
- `IcingaConnectionData.TheTimeoutReachesTheHttpClient` / `ADefaultConstructedTargetStillGetsAFiniteTimeout` — the routed timeout lands in `http_client_options`, and the default is non-zero.
- `IcingaSubmit.AStalledApiTimesOutInsteadOfHangingForever` — a loopback server that accepts and never answers: the submission now fails with a "timed out" error after the configured 1 s (it previously hung; before the routing fix it took the 30 s fallback).
- `IcingaTest.VerificationIs{Disabled,Enabled}…` — verify-mode token parsing, including `none,peer` (the parser ORs flags, so it verifies).

`icinga_client_test` (43/43) and `client_command_line_parser_test` (38/38) pass locally; full Linux build compiles clean. The remaining local ctest failures (zip-fixture and Lua suites) are sandbox-environment issues unrelated to this diff.

## Docs

Per the project convention for security-relevant changes: a "Hardening changes (no CVE)" entry in `docs/docs/security/notices.md` and a 🔒 entry in `docs/docs/setup/upgrading.md` (new *Unreleased* section) linking to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KVjNQQHpqmmrPb9YMmmbhv

---
_Generated by [Claude Code](https://claude.ai/code/session_01KVjNQQHpqmmrPb9YMmmbhv)_