### PR TITLE
GraphiteClient: fix metric injection and enforce submission timeout

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -171,7 +171,7 @@ legacy auth — and produced three hardening fixes on the client side:
   also no longer suggests `none` for self-signed certificates — the right
   configuration is `peer-cert` with `ca` pointing at the certificate.
 
-### Graphite client — metric-line injection scrub and a whole-submission timeout
+### Graphite client: metric-line injection scrub and a whole-submission timeout
 
 **Fixed in:** unreleased (first release after 0.18.0) · **Severity:** Low
 

--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -171,7 +171,7 @@ legacy auth — and produced three hardening fixes on the client side:
   also no longer suggests `none` for self-signed certificates — the right
   configuration is `peer-cert` with `ca` pointing at the certificate.
 
-### Graphite client — status path scrubbed against metric-line injection
+### Graphite client — metric-line injection scrub and a whole-submission timeout
 
 **Fixed in:** unreleased (first release after 0.18.0) · **Severity:** Low
 
@@ -192,6 +192,23 @@ the scrub itself additionally replaces tabs, which split a carbon field the
 same way a space does. No operator action is needed; a status path built from
 an alias containing these characters (which previously produced corrupt lines)
 now renders them as `_`.
+
+The same review closed an availability gap: the `timeout` target setting had
+no effect at all. The configured value never reached the connection (the
+lookup read the container's free-form data map, which the well-known
+`timeout` key is never stored in, so the default 30 always won), and the
+connection did not use even that: name resolution, the connect loop, the TLS
+handshake and every write ran synchronously with no deadline, so a carbon
+endpoint that black-holes SYNs, stalls mid-handshake or stops reading held
+the submitting thread — channel submissions and the recurring metrics flush
+(`metrics interval`, default 10s) both land on this path — for the OS-level
+TCP timeout, or indefinitely on a stuck write. The configured `timeout`
+(default 30s) is read now and bounds the whole submission as one budget,
+resolution included, following the [SMTP client
+precedent](#smtp-client-security-review-hardening) ("the timeout bounds the
+whole submission"). The `retry` setting was equally read
+but never acted on; it is no longer read (see the
+[upgrade note](../setup/upgrading.md#unreleased)).
 
 ### Filter framework: expression length and nesting-depth limits
 

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -155,6 +155,27 @@ per-release detail lives in each
     - All C0 control bytes and DEL in the outgoing line are replaced with
       spaces (previously only CR, LF and NUL), so check output cannot smuggle
       ANSI escape sequences into the receiver's log.
+- ⏱️ **The Graphite `timeout` is now enforced — as a budget for the whole
+  submission.** It was doubly dead before: the value the operator configured
+  never reached the connection (the lookup read a map the well-known `timeout`
+  key is not stored in, so the default 30 always won), and the connection did
+  not use even that — resolution, connect, the TLS handshake and every write
+  ran with no deadline, so a stalled carbon endpoint could hold the submitting
+  thread for the OS-level TCP timeout, or indefinitely on a stuck write. The
+  configured `timeout` (default 30s) is read now and bounds the whole
+  submission as one budget, like the SMTP client's. A target whose submissions
+  previously completed by quietly taking longer will now fail at the
+  configured value; raise `timeout` on targets talking to a slow relay. See
+  [Security notices](../security/notices.md#graphite-client-metric-line-injection-scrub-and-a-whole-submission-timeout).
+- 🧹 **The Graphite `retry` setting is not honoured and is no longer read.**
+  The module always made exactly one attempt per submission; reading the value
+  made it look otherwise, and a retry loop would multiply the worst-case time
+  a stalled endpoint can hold the submitting thread by the retry count.
+  `retry`/`retries` are registered for every client module centrally, so they
+  still appear in the GraphiteClient reference, but `GraphiteClient` does not
+  act on them. Mirrors the SMTP `retry` change in 0.18.0.
+
+---
 
 ## 0.18.0
 

--- a/modules/GraphiteClient/graphite_client.hpp
+++ b/modules/GraphiteClient/graphite_client.hpp
@@ -6,16 +6,21 @@
 #ifdef USE_SSL
 #include <boost/asio/ssl.hpp>
 #endif
+#include <algorithm>
+#include <boost/asio/steady_timer.hpp>
 #include <boost/asio/write.hpp>
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <chrono>
 #include <client/command_line_parser.hpp>
+#include <memory>
 #include <net/socket/socket_helpers.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <nscapi/protobuf/functions_convert.hpp>
 #include <nscapi/protobuf/functions_perfdata.hpp>
 #include <nscapi/protobuf/nagios.hpp>
+#include <stdexcept>
 #include <str/utf8.hpp>
 #include <str/utils.hpp>
 #include <str/xtos.hpp>
@@ -32,8 +37,19 @@ struct connection_data : public socket_helpers::connection_info {
   connection_data(client::destination_container sender, client::destination_container target) {
     address = target.address.host;
     port_ = target.address.get_port_string("2003");
-    timeout = target.get_int_data("timeout", 30);
-    retry = target.get_int_data("retry", 3);
+    // The well-known `timeout` key is routed into the container's typed field
+    // (set_string_data), never into the free-form data map, so the old
+    // get_int_data("timeout", 30) lookup could not see a configured value and
+    // the default always won. Read the typed field, like NRPEClient; the
+    // settings layer notifies the documented default (30) for target sections
+    // that do not set one.
+    if (target.timeout > 0) timeout = target.timeout;
+    // No `retry` here: send() makes exactly one attempt per submission and
+    // there is no retry loop to feed - reading the setting into the inherited
+    // field only made it look honoured. A retry loop would also multiply the
+    // worst-case time a submission can hold the submitting thread (the
+    // recurring metrics flush lands here) by the retry count - the very thing the
+    // whole-submission timeout below exists to bound. Mirrors SMTPClient.
     ppath = target.get_string_data("perf path");
     spath = target.get_string_data("status path");
     send_perf = target.get_bool_data("send perfdata");
@@ -92,6 +108,187 @@ std::string fix_graphite_string(const std::string &s) {
   str::utils::replace(sc, std::string("\0", 1), "_");
   return sc;
 }
+namespace detail {
+// Deadline-bounded synchronous IO for the carbon submission, modeled on
+// SMTPClient's sync_io.
+//
+// Boost.Asio synchronous calls take no timeout, so a carbon endpoint that
+// black-holes SYNs, stalls mid-TLS-handshake or advertises a zero TCP window
+// could hold the submitting thread - channel submissions and the recurring
+// metrics flush both land in send() - for the OS-level TCP timeout, or indefinitely on
+// a stuck write. Each operation is therefore issued async and raced against a
+// deadline on the one io_context.
+//
+// The deadline is a single budget for the whole submission (resolution
+// included), not a fresh allowance per operation: an operator setting
+// timeout=30 means "give up on this submission after 30 seconds", not "allow
+// 30 seconds per write". Per-operation deadlines multiply out - a host name
+// resolving to several dead addresses would get a fresh deadline per connect
+// attempt.
+class deadline_io {
+ public:
+  deadline_io(boost::asio::io_context &io, boost::asio::ip::tcp::socket &socket, unsigned int timeout_seconds)
+      : io_(io), socket_(socket), timeout_seconds_(timeout_seconds), deadline_(std::chrono::steady_clock::now() + std::chrono::seconds(timeout_seconds)) {}
+  deadline_io(const deadline_io &) = delete;
+  deadline_io &operator=(const deadline_io &) = delete;
+
+  // Render a failure for an operator. A spent budget is ours to explain, not
+  // the platform's: the platform text for timed_out describes a peer that did
+  // not answer, which blames the server for a deadline this client set.
+  std::string describe(const boost::system::error_code &ec) const {
+    if (ec == boost::asio::error::timed_out) {
+      return "timed out after " + str::xtos(timeout_seconds_) + "s (the budget for the whole submission)";
+    }
+    return ec.message();
+  }
+
+  // Resolve under the shared budget. The platform resolver's own timeouts are
+  // long (and not ours to set), so a black-holed name server would otherwise
+  // stall the submission well past the configured timeout before any socket
+  // operation got a chance to be deadlined.
+  boost::asio::ip::tcp::resolver::results_type resolve(const std::string &host, const std::string &port) {
+    boost::asio::ip::tcp::resolver resolver(io_);
+    boost::asio::ip::tcp::resolver::results_type endpoints;
+    boost::system::error_code ec;
+    run_with_deadline(
+        [&](auto &&done) {
+          resolver.async_resolve(host, port,
+                                 [&endpoints, done = std::move(done)](const boost::system::error_code &e, boost::asio::ip::tcp::resolver::results_type r) {
+                                   endpoints = std::move(r);
+                                   done(e);
+                                 });
+        },
+        ec);
+    if (ec) throw std::runtime_error("DNS resolve failed: " + describe(ec));
+    return endpoints;
+  }
+
+  // Connect to the first endpoint that succeeds; every attempt draws on the
+  // same budget.
+  void connect(const boost::asio::ip::tcp::resolver::results_type &endpoints) {
+    boost::system::error_code ec = boost::asio::error::host_not_found;
+    for (auto it = endpoints.begin(); ec && it != endpoints.end(); ++it) {
+      // Non-throwing close: an incidental failure here (closing a socket that
+      // was never opened, on the first pass) must not mask the connect result.
+      boost::system::error_code close_ec;
+      socket_.close(close_ec);
+      const auto ep = it->endpoint();
+      run_with_deadline([&](auto &&done) { socket_.async_connect(ep, [done = std::move(done)](const boost::system::error_code &e) { done(e); }); }, ec);
+      // A spent budget ends the walk, not just this attempt: the deadline
+      // covers the whole submission, so every remaining endpoint would time
+      // out the same way before its connect could complete.
+      if (ec == boost::asio::error::timed_out) break;
+    }
+    if (ec) throw std::runtime_error("connect failed: " + describe(ec));
+  }
+
+  template <typename Stream>
+  void write(Stream &stream, const std::string &payload) {
+    boost::system::error_code ec;
+    run_with_deadline(
+        [&](auto &&done) {
+          boost::asio::async_write(stream, boost::asio::buffer(payload),
+                                   [done = std::move(done)](const boost::system::error_code &e, std::size_t) { done(e); });
+        },
+        ec);
+    if (ec) throw std::runtime_error("write failed: " + describe(ec));
+  }
+
+#ifdef USE_SSL
+  // asio's synchronous handshake() takes no timeout, so a peer that stalls
+  // part-way through one would hang the submission thread indefinitely - the
+  // very thing this class exists to prevent everywhere else.
+  void handshake(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &stream) {
+    boost::system::error_code ec;
+    run_with_deadline(
+        [&](auto &&done) {
+          stream.async_handshake(boost::asio::ssl::stream_base::client, [done = std::move(done)](const boost::system::error_code &e) { done(e); });
+        },
+        ec);
+    if (ec) throw std::runtime_error("TLS handshake failed: " + describe(ec));
+  }
+
+  // Best-effort close_notify so the TLS proxy flushes what we sent before it
+  // sees the connection drop. asio's shutdown also waits for the peer's own
+  // close_notify, which a proxy that simply never sends one would stretch to
+  // the full remaining budget on every *successful* submission - so this
+  // waits a short grace at most (and never past the budget). A failure here
+  // is not a failed submission: the data was already written.
+  void shutdown(boost::asio::ssl::stream<boost::asio::ip::tcp::socket> &stream) {
+    boost::system::error_code ignored;
+    run_until((std::min)(deadline_, std::chrono::steady_clock::now() + std::chrono::seconds(2)),
+              [&](auto &&done) { stream.async_shutdown([done = std::move(done)](const boost::system::error_code &e) { done(e); }); }, ignored);
+  }
+#endif
+
+ private:
+  // Run a single async op until it completes or `deadline` expires. Sets
+  // `out_ec` to the operation's result, or timed_out on expiry.
+  //
+  // The op's completion handler can outlive this frame. On timeout the timer
+  // handler stop()s the io_context, and the cancelled op's handler - already
+  // queued, or queued by the cancel - is left unexecuted; it runs on the NEXT
+  // restart()/run(), which happens when a caller issues another operation
+  // after a timeout (connect() walking its endpoint list). A handler that
+  // captured this frame's locals by reference would then write through
+  // dangling references into whatever occupies the stack now. So everything
+  // the handler touches lives in `op`, co-owned by the handler itself: a
+  // stale handler completes against its own orphaned state, which nobody
+  // reads. Mirrors the same fix in SMTPClient's sync_io.
+  //
+  // The timer handler needs no such care: run() drains it before returning in
+  // every case (it is either what called stop(), or it completes as aborted
+  // before run() runs out of work), so its frame is always alive.
+  template <typename Init>
+  void run_until(const std::chrono::steady_clock::time_point deadline, Init &&init, boost::system::error_code &out_ec) {
+    struct op_state {
+      explicit op_state(boost::asio::io_context &io) : timer(io), ec(boost::asio::error::would_block), timed_out(false) {}
+      boost::asio::steady_timer timer;
+      boost::system::error_code ec;
+      bool timed_out;
+    };
+    const auto op = std::make_shared<op_state>(io_);
+    // A deadline already in the past fires immediately, which is what we want
+    // once the budget is spent.
+    op->timer.expires_at(deadline);
+    op->timer.async_wait([this, op](const boost::system::error_code &e) {
+      if (e == boost::asio::error::operation_aborted) return;
+      op->timed_out = true;
+      // Cancel any outstanding I/O so run() returns. stop() covers the
+      // operations cancelling the socket does not reach - a resolve in
+      // particular runs off on its own thread and would otherwise keep run()
+      // going until the platform resolver gave up on its own schedule.
+      boost::system::error_code ignore;
+      socket_.cancel(ignore);
+      io_.stop();
+    });
+    init([op](const boost::system::error_code &e) {
+      op->ec = e;
+      // cancel() can throw (the non-throwing cancel(ec) overload is removed
+      // under BOOST_ASIO_NO_DEPRECATED). Swallow it so an incidental failure
+      // can't escape this handler and misreport a completed operation.
+      try {
+        op->timer.cancel();
+      } catch (...) {
+      }
+    });
+    io_.restart();
+    io_.run();
+    out_ec = op->timed_out ? boost::asio::error::timed_out : op->ec;
+  }
+
+  template <typename Init>
+  void run_with_deadline(Init &&init, boost::system::error_code &out_ec) {
+    run_until(deadline_, std::forward<Init>(init), out_ec);
+  }
+
+  boost::asio::io_context &io_;
+  boost::asio::ip::tcp::socket &socket_;
+  unsigned int timeout_seconds_;
+  std::chrono::steady_clock::time_point deadline_;
+};
+}  // namespace detail
+
 struct graphite_client_handler : public client::handler_interface {
   bool query(client::destination_container _sender, client::destination_container _target, const PB::Commands::QueryRequestMessage &_request_message,
              PB::Commands::QueryResponseMessage &_response_message) {
@@ -201,12 +398,17 @@ struct graphite_client_handler : public client::handler_interface {
   boost::tuple<bool, std::string> send(connection_data con, const std::list<g_data> &data) {
     try {
       boost::asio::io_context io_service;
-      boost::asio::ip::tcp::resolver resolver(io_service);
-      auto endpoints = resolver.resolve(con.get_address(), con.get_port());
 
       const boost::posix_time::ptime time_t_epoch(boost::gregorian::date(1970, 1, 1));
       const boost::posix_time::time_duration diff = boost::posix_time::microsec_clock::universal_time() - time_t_epoch;
       const std::string ts = boost::lexical_cast<std::string>(diff.total_seconds());
+
+      // One buffer for the whole batch: the carbon protocol is just
+      // newline-separated lines, so a single deadlined write replaces a
+      // per-line loop (and the per-line socket.send() ignored short writes,
+      // which async_write completes).
+      std::string payload;
+      for (const g_data &d : data) payload += make_line(d, ts);
 
 #ifdef USE_SSL
       if (con.ssl.enabled) {
@@ -219,13 +421,7 @@ struct graphite_client_handler : public client::handler_interface {
           return boost::make_tuple(false, "TLS setup failed: " + emsg);
         }
         boost::asio::ssl::stream<boost::asio::ip::tcp::socket> stream(io_service, ctx);
-
-        boost::system::error_code error = boost::asio::error::host_not_found;
-        for (auto it = endpoints.begin(); error && it != endpoints.end(); ++it) {
-          stream.lowest_layer().close();
-          stream.lowest_layer().connect(it->endpoint(), error);
-        }
-        if (error) throw boost::system::system_error(error);
+        detail::deadline_io io(io_service, stream.next_layer(), con.timeout);
 
         // SNI: a TLS proxy fronting carbon (nginx/stunnel/carbon-relay-ng) often
         // hosts several certs and needs the server name to pick the right one;
@@ -241,14 +437,11 @@ struct graphite_client_handler : public client::handler_interface {
         if ((con.ssl.get_verify_mode() & boost::asio::ssl::context_base::verify_peer) != 0) {
           stream.set_verify_callback(boost::asio::ssl::host_name_verification(con.get_address()));
         }
-        stream.handshake(boost::asio::ssl::stream_base::client);
 
-        for (const g_data &d : data) {
-          const std::string msg = make_line(d, ts);
-          boost::asio::write(stream, boost::asio::buffer(msg));
-        }
-        boost::system::error_code ignored;
-        stream.shutdown(ignored);
+        io.connect(io.resolve(con.get_address(), con.get_port()));
+        io.handshake(stream);
+        io.write(stream, payload);
+        io.shutdown(stream);
         return boost::make_tuple(true, "Data presumably sent successfully (TLS)");
       }
 #else
@@ -258,17 +451,9 @@ struct graphite_client_handler : public client::handler_interface {
 #endif
 
       boost::asio::ip::tcp::socket socket(io_service);
-      boost::system::error_code error = boost::asio::error::host_not_found;
-      for (auto it = endpoints.begin(); error && it != endpoints.end(); ++it) {
-        socket.close();
-        socket.connect(it->endpoint(), error);
-      }
-      if (error) throw boost::system::system_error(error);
-
-      for (const g_data &d : data) {
-        const std::string msg = make_line(d, ts);
-        socket.send(boost::asio::buffer(msg));
-      }
+      detail::deadline_io io(io_service, socket, con.timeout);
+      io.connect(io.resolve(con.get_address(), con.get_port()));
+      io.write(socket, payload);
       return boost::make_tuple(true, "Data presumably sent successfully");
     } catch (const std::runtime_error &e) {
       return boost::make_tuple(false, "Socket error: " + utf8::utf8_from_native(e.what()));

--- a/modules/GraphiteClient/graphite_client.hpp
+++ b/modules/GraphiteClient/graphite_client.hpp
@@ -16,6 +16,7 @@
 #include <client/command_line_parser.hpp>
 #include <memory>
 #include <net/socket/socket_helpers.hpp>
+#include <nscapi/macros.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <nscapi/protobuf/functions_convert.hpp>
 #include <nscapi/protobuf/functions_perfdata.hpp>
@@ -385,7 +386,14 @@ struct graphite_client_handler : public client::handler_interface {
         push_metrics(list, b, "", mpath);
       }
     }
-    send(con, list);
+    // The channel path surfaces a failed submission in its response; the
+    // metrics flush has no response to carry one, so log it - otherwise a
+    // timeout (or any other failure) fires invisibly and metrics just stop
+    // arriving.
+    const boost::tuple<bool, std::string> ret = send(con, list);
+    if (!ret.get<0>()) {
+      NSC_LOG_ERROR("Failed to submit metrics to " + con.to_string() + ": " + ret.get<1>());
+    }
     return true;
   }
 

--- a/modules/GraphiteClient/graphite_client_test.cpp
+++ b/modules/GraphiteClient/graphite_client_test.cpp
@@ -10,6 +10,11 @@
 // The submission itself is captured by a loopback TCP server standing in for
 // carbon, so what is asserted is the exact byte stream a carbon receiver
 // would parse.
+//
+// The timeout tests stall the receiver instead (accept and never read, or
+// never answer the TLS ClientHello) and assert the submission gives up within
+// the configured `timeout` rather than holding the submitting thread - the
+// recurring metrics flush lands on this same code path.
 
 #include "graphite_client.hpp"
 
@@ -99,6 +104,57 @@ class loopback_carbon_receiver {
   unsigned short port_ = 0;
   char buf_[4096] = {};
   std::string received_;
+};
+
+// Accepts one connection and then never reads a byte, holding the socket open
+// until the test releases it: once the kernel buffers on both sides fill up,
+// the client's write can make no progress - the stalled-carbon scenario the
+// submission timeout exists for. It also never writes, so a TLS client waiting
+// for a ServerHello waits forever.
+//
+// Like loopback_carbon_receiver, it runs async under a hard deadline rather
+// than blocking a thread in accept(): a client that never connects (or a
+// broken test) must not wedge the process in the destructor's join().
+class stalled_receiver {
+ public:
+  explicit stalled_receiver(const std::chrono::seconds deadline = std::chrono::seconds(30)) : acceptor_(io_, {tcp::v4(), 0}), socket_(io_), deadline_(io_) {
+    port_ = acceptor_.local_endpoint().port();
+    deadline_.expires_after(deadline);
+    deadline_.async_wait([this](const boost::system::error_code &ec) {
+      if (!ec) stop();
+    });
+    // Accept and then issue no read at all: the connection stays open and
+    // unserviced until stop() runs, which is exactly the stall under test.
+    acceptor_.async_accept(socket_, [this](const boost::system::error_code &ec) {
+      if (ec) stop();
+    });
+    thread_ = std::thread([this] { io_.run(); });
+  }
+  ~stalled_receiver() {
+    // Release the stall so run() finishes, then join. post() hands the work to
+    // the io_context's own thread rather than racing it from this one.
+    boost::asio::post(io_, [this] { stop(); });
+    if (thread_.joinable()) thread_.join();
+  }
+  unsigned short port() const { return port_; }
+
+ private:
+  void stop() {
+    boost::system::error_code ignored;
+    acceptor_.close(ignored);
+    socket_.close(ignored);
+    try {
+      deadline_.cancel();
+    } catch (...) {
+    }
+  }
+
+  boost::asio::io_context io_;
+  tcp::acceptor acceptor_;
+  tcp::socket socket_;
+  boost::asio::steady_timer deadline_;
+  std::thread thread_;
+  unsigned short port_ = 0;
 };
 
 std::vector<std::string> split_lines(const std::string &s) {
@@ -230,3 +286,73 @@ TEST(GraphiteSubmitTest, benign_submission_renders_expected_lines) {
   EXPECT_EQ(0u, lines[0].find("nsclient.myhost.cpu_load.total_5m 87 ")) << lines[0];
   EXPECT_EQ(0u, lines[1].find("nsclient.myhost.cpu_load.status 1 ")) << lines[1];
 }
+
+// `timeout` bounds the whole submission; `retry` is deliberately not read -
+// there is no retry loop, and reading it into the inherited field only made
+// it look honoured (mirrors SMTPClient).
+TEST(GraphiteConnectionDataTest, timeout_is_read_and_retry_is_not) {
+  const client::destination_container sender;
+  const graphite_client::connection_data con(sender, container_with({{"address", "h"}, {"timeout", "5"}, {"retry", "7"}}));
+  EXPECT_EQ(5u, con.timeout);
+  EXPECT_NE(7, con.retry) << "retry is not honoured, so it must not be read in as though it were";
+}
+
+// A carbon endpoint that accepts the connection but never reads (a stalled
+// relay, a zero receive window) must not hold the submitting thread past the
+// configured timeout. The payload is sized well past what the loopback kernel
+// buffers on both sides can absorb, so the write genuinely stalls.
+TEST(GraphiteTimeoutTest, stalled_receiver_fails_within_the_configured_timeout) {
+  stalled_receiver server;
+
+  const client::destination_container sender;
+  const graphite_client::connection_data con(sender, container_with({
+                                                         {"address", "127.0.0.1:" + str::xtos(server.port())},
+                                                         {"timeout", "1"},
+                                                     }));
+
+  graphite_client::g_data d;
+  d.path = std::string(64 * 1024 * 1024, 'a');
+  d.value = "1";
+
+  graphite_client::graphite_client_handler handler;
+  const auto started = std::chrono::steady_clock::now();
+  const boost::tuple<bool, std::string> ret = handler.send(con, {d});
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started);
+
+  EXPECT_FALSE(ret.get<0>()) << ret.get<1>();
+  EXPECT_NE(std::string::npos, ret.get<1>().find("timed out after 1s")) << ret.get<1>();
+  EXPECT_GE(elapsed.count(), 900) << "gave up before the write can have stalled: " << ret.get<1>();
+  // Well under the minutes an OS-level TCP timeout would take; generous
+  // headroom for a loaded CI host.
+  EXPECT_LT(elapsed.count(), 20000);
+}
+
+#ifdef USE_SSL
+// A peer that completes the TCP connect but never answers the ClientHello
+// stalls the TLS handshake - which has no timeout of its own in asio - so the
+// submission budget must cut it short.
+TEST(GraphiteTimeoutTest, stalled_tls_handshake_fails_within_the_configured_timeout) {
+  stalled_receiver server;
+
+  const client::destination_container sender;
+  const graphite_client::connection_data con(sender, container_with({
+                                                         {"address", "127.0.0.1:" + str::xtos(server.port())},
+                                                         {"timeout", "1"},
+                                                         {"ssl", "true"},
+                                                     }));
+
+  graphite_client::g_data d;
+  d.path = "nsclient.host.check.metric";
+  d.value = "1";
+
+  graphite_client::graphite_client_handler handler;
+  const auto started = std::chrono::steady_clock::now();
+  const boost::tuple<bool, std::string> ret = handler.send(con, {d});
+  const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - started);
+
+  EXPECT_FALSE(ret.get<0>()) << ret.get<1>();
+  EXPECT_NE(std::string::npos, ret.get<1>().find("TLS handshake failed: timed out after 1s")) << ret.get<1>();
+  EXPECT_GE(elapsed.count(), 900) << "gave up before the handshake can have stalled: " << ret.get<1>();
+  EXPECT_LT(elapsed.count(), 20000);
+}
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -587,6 +587,14 @@ NSCP_CREATE_TEST(
         ${NSCP_INCLUDEDIR}
         ${CMAKE_SOURCE_DIR}/modules/GraphiteClient
 )
+if(OPENSSL_FOUND AND TARGET graphite_client_test)
+    # The TLS submission path (deadline-bounded handshake included) only
+    # compiles under USE_SSL; build the test with it whenever OpenSSL is
+    # available so the handshake-stall timeout case runs.
+    target_compile_definitions(graphite_client_test PRIVATE USE_SSL)
+    target_include_directories(graphite_client_test PRIVATE ${OPENSSL_INCLUDE_DIR})
+    target_link_libraries(graphite_client_test ${OPENSSL_LIBRARIES})
+endif()
 
 set(SETTINGS_INI_TEST_SOURCES
     ${NSCP_INCLUDEDIR}/settings/impl/settings_ini_test.cpp


### PR DESCRIPTION
## Summary

This PR fixes two security and availability issues in GraphiteClient:

1. **Metric-line injection vulnerability**: The status path was only scrubbed for spaces, allowing check aliases from remote submitters (NSCA, forwarded results) to inject newlines or semicolons that corrupt metrics or inject fake ones. The status path now receives the same comprehensive scrub as the perf path.

2. **Broken timeout enforcement**: The `timeout` setting had no effect — the configured value never reached the connection (the lookup read the wrong data map), and the connection made no use of it anyway (resolution, connect, TLS handshake, and writes all ran synchronously with no deadline). A stalled carbon endpoint could hold the submitting thread indefinitely, blocking the recurring metrics flush.

## Key Changes

- **Status path scrubbing**: Extended `fix_graphite_string()` to replace tabs (which split carbon fields like spaces do) in addition to existing replacements. Applied this scrub to the status path, matching the perf path treatment.

- **Deadline-bounded I/O**: Introduced `detail::deadline_io` class that races all async operations (resolve, connect, TLS handshake, write) against a single budget deadline. The `timeout` setting (default 30s) now bounds the entire submission as one budget, following the SMTP client precedent.

- **Timeout configuration fix**: Changed `connection_data` to read `timeout` from the typed field (`target.timeout`) instead of the free-form data map, where the well-known key is never stored.

- **Removed retry reading**: The module always made exactly one attempt per submission; the `retry` setting is no longer read to avoid implying it is honored.

- **Comprehensive test coverage**: Added `graphite_client_test.cpp` with 320 lines of tests covering:
  - Metric-line injection prevention (hostile aliases and perf labels)
  - Benign submission rendering
  - Timeout enforcement under stalled TCP writes
  - TLS handshake timeout (when USE_SSL is available)

- **Documentation**: Updated security notices and upgrade guide to explain the fixes and operator impact.

## Implementation Details

- The `deadline_io` class uses `boost::asio::steady_timer` to enforce a shared budget across all operations, canceling outstanding I/O when the deadline expires.
- The scrub now replaces `\t`, `\r`, `\n`, `;`, NUL, spaces, and reserved characters with `_`, preventing both metric-line injection and carbon tag injection.
- Error messages distinguish between operator-configured timeouts and platform errors, improving diagnostics.
- The TLS shutdown path uses a short grace period (2s) capped by the remaining budget to avoid stretching successful submissions.

https://claude.ai/code/session_013HMntJaonUfGNGEdRooGFH