### PR TITLE
CheckExternalScripts security-review hardening

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -145,7 +145,7 @@ first, alongside the release that contains them.
 **Fixed in:** unreleased (first release after 0.18.0) · **Severity:** Low–Medium
 
 A review of the `CheckExternalScripts` module and the process launcher it uses
-produced a set of hardening fixes. None is a remotely exploitable RExecution on
+produced a set of hardening fixes. None is a remotely exploitable RCE on
 a default install — the argument guard is off by default, arguments allowed only
 when an operator opts in, and the script-management operations require an
 authenticated administrator — but each closes a rough edge.

--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -140,6 +140,57 @@ Security-relevant changes that are handled as defense-in-depth / consistency
 hardening rather than assigned a CVE are listed here as they ship, newest
 first, alongside the release that contains them.
 
+### CheckExternalScripts security-review hardening
+
+**Fixed in:** unreleased (first release after 0.18.0) · **Severity:** Low–Medium
+
+A review of the `CheckExternalScripts` module and the process launcher it uses
+produced a set of hardening fixes. None is a remotely exploitable RExecution on
+a default install — the argument guard is off by default, arguments allowed only
+when an operator opts in, and the script-management operations require an
+authenticated administrator — but each closes a rough edge.
+
+- **`ext-scr install --arguments=...` now writes to the path the module reads.**
+  The argument-lockdown helper read and wrote `allow arguments` /
+  `allow nasty characters` under `/settings/external scripts/server`, a path
+  nothing consults; the module reads them from `/settings/external scripts`. So
+  `install --arguments=false` printed and "applied" a lockdown that had no
+  effect — on a host with an existing `allow arguments = true` it left arguments
+  enabled while reporting they were disabled. It now updates the effective path.
+- **The command timeout is enforced on every path, and output is bounded.** On
+  Unix the single-string shell-fallback ran through `popen()`, which hid the
+  child PID: a hung script blocked forever with `timeout=` silently unenforced,
+  wedging a worker thread per invocation. On Windows the read loop counted
+  iterations rather than elapsed time, so a continuously-chatty script escaped
+  the timeout entirely and leaked an unkillable process each run. Both launchers
+  now bound the wait by wall-clock deadline and cap captured output at 8 MiB,
+  removing a low-effort resource-exhaustion vector for anyone able to trigger a
+  misbehaving check.
+- **The show/delete sandbox resolves symlinks.** `ext-scr show` / `delete`
+  bounded their target with a lexical path check that normalised `..` but did
+  not resolve symlinks, so a symlink placed inside the script root pointing
+  outside it passed — letting an authenticated admin read or remove files
+  anywhere the service account could reach. The target and root are now
+  canonicalised before the containment test.
+- **`%` and `^` are blocked on the shell-fallback path.** The stricter
+  metacharacter set applied to user arguments when a command degrades to the
+  shell fallback omitted cmd.exe's `%VAR%` expansion and `^` escape character,
+  so an argument reaching a `.bat` through cmd could smuggle environment
+  contents or escape sequences into the command line. Both are now refused on
+  that path (opt-out via `allow nasty characters`).
+- **Documentation of two boundaries was corrected.** The `script root` setting
+  claimed scripts cannot be uploaded/downloaded outside the folder, but `add`
+  never enforced that; and `script path` turns every file in a directory into a
+  runnable command. Both descriptions now state the real boundary, and
+  `allow arguments` documents that it governs external scripts, not aliases.
+
+**What to do:** if you rely on `ext-scr install` to lock arguments down, re-run
+it after upgrading to write the effective setting (or set
+`/settings/external scripts` `allow arguments` / `allow nasty characters`
+directly). Treat write access to any `script path` directory, and the ability to
+configure external-script commands, as equivalent to code execution as the
+service account.
+
 ### NRDP client: transport hardening and shared TLS version-floor fix
 
 **Fixed in:** unreleased (first release after 0.18.0) · **Severity:** Low–Medium
@@ -290,7 +341,6 @@ was genuinely intended. If you see the new empty-password error in the log,
 set the same `password` on both ends. If you counted on
 `performance data = false` while it was broken, note that perfdata now
 really is dropped.
-
 ### SMTP client security-review hardening
 
 **Fixed in:** 0.18.0 · **Severity:** Low–Medium

--- a/docs/docs/setup/upgrading.md
+++ b/docs/docs/setup/upgrading.md
@@ -16,6 +16,16 @@ per-release detail lives in each
 
 ## Unreleased
 
+- 🔒 **CheckExternalScripts hardening.** A security review of the external
+  scripts module tightened several rough edges: the `ext-scr install` argument
+  lockdown now writes to the setting the module actually reads (previously it
+  was a no-op, so a lockdown could silently not apply), the command timeout is
+  enforced on every execution path with output capped, the `show`/`delete`
+  sandbox resolves symlinks, and `%`/`^` are blocked on the shell-fallback path.
+  The default install is unaffected (arguments are off by default). If you rely
+  on `ext-scr install` to disable arguments, re-run it after upgrading so the
+  effective setting is written. See the
+  [security notice](../security/notices.md#checkexternalscripts-security-review-hardening).
 - 🔒 **NSCA-NG cert mode now actually verifies the server (and presents the
   client certificate).** In 0.18.0 the `NSCANgClient` cert mode
   (`use psk = false`) applied its TLS configuration to the OpenSSL context

--- a/include/config.h.in
+++ b/include/config.h.in
@@ -82,13 +82,17 @@
 #endif
 
 #define NASTY_METACHARS "|`&><'\"\\[]{}" /* This may need to be modified for windows directory seperator */
-/* Stricter set, enforced ONLY when a command degrades to the /bin/sh -c (popen)
- * fallback in CheckExternalScripts. The shared NASTY_METACHARS above deliberately
- * permits %, (, ), $ so internal check syntax (e.g. "top-syntax=%(status): %(list)"
+/* Stricter set, enforced ONLY when a command degrades to the shell fallback
+ * (/bin/sh -c on Unix, a raw CreateProcess command line on Windows) in
+ * CheckExternalScripts. The shared NASTY_METACHARS above deliberately permits
+ * %, (, ), $ so internal check syntax (e.g. "top-syntax=%(status): %(list)"
  * / "filter=...") keeps working over NRPE/check_nt - those checks never touch a
  * shell. Once a string is handed to a shell, however, those characters are
- * dangerous, so block them on that path only. */
-#define SHELL_METACHARS "|`&><'\"\\[]{}$;()*?~!\n\r"
+ * dangerous, so block them on that path only. `%` and `^` are included for
+ * cmd.exe: `%VAR%` expands environment variables and `^` is cmd's escape
+ * character, so an argument reaching a .bat via cmd could otherwise smuggle
+ * environment contents or escape sequences into the command line. */
+#define SHELL_METACHARS "|`&><'\"\\[]{}$;()*?~!\n\r%^"
 
 #define MAIN_MODULES_SECTION "/modules"
 #define NS_HKEY_ROOT HKEY_LOCAL_MACHINE

--- a/include/process/execute_process_unix.cpp
+++ b/include/process/execute_process_unix.cpp
@@ -14,12 +14,20 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <bytes/buffer.hpp>
 #include <process/execute_process.hpp>
 #include <string>
 #include <vector>
 
 #define BUFFER_SIZE 4096
+
+// Upper bound on captured child output. A check is expected to print one Nagios
+// line; without a cap a script (buggy or hostile) can emit hundreds of MB within
+// its timeout window and balloon the service's memory. 8 MiB is far above any
+// legitimate check output. Once reached we keep reading (so the child never
+// blocks on a full pipe and the timeout stays enforceable) but discard the rest.
+#define MAX_OUTPUT_BYTES (8u * 1024u * 1024u)
 
 bool early_timeout = false;
 typedef hlp::buffer<char> buffer_type;
@@ -67,8 +75,14 @@ std::string drain_with_timeout(int fd, time_t deadline, bool& timed_out, bool& h
       // EOF: child closed its end of the pipe.
       return out;
     }
-    buffer[static_cast<std::size_t>(n)] = 0;
-    out.append(buffer.get(), static_cast<std::size_t>(n));
+    // Append up to the cap; past it keep draining but discard, so the child is
+    // never blocked on a full pipe (which would defeat the timeout) yet memory
+    // stays bounded.
+    if (out.size() < MAX_OUTPUT_BYTES) {
+      const std::size_t room = MAX_OUTPUT_BYTES - out.size();
+      out.append(buffer.get(), std::min(static_cast<std::size_t>(n), room));
+      if (out.size() >= MAX_OUTPUT_BYTES) out.append("\n[output truncated]");
+    }
   }
 }
 
@@ -185,29 +199,6 @@ int execute_argv(const process::exec_arguments& args, std::string& output) {
   return map_exit_status(status);
 }
 
-// Legacy popen path, used when the caller did not supply argv. /bin/sh -c
-// is involved, so any operator-controlled string still has to be carefully
-// quoted by the caller. New callers should populate exec_arguments::argv.
-int execute_popen(const process::exec_arguments& args, std::string& output) {
-  FILE* fp = popen(args.command.c_str(), "r");
-  if (fp == nullptr) {
-    output = "NRPE: Call to popen() failed";
-    return NSCAPI::query_return_codes::returnUNKNOWN;
-  }
-  buffer_type buffer(BUFFER_SIZE);
-  std::size_t bytes_read = 0;
-  while ((bytes_read = fread(buffer.get(), 1, buffer.size() - 1, fp)) > 0) {
-    if (bytes_read < BUFFER_SIZE) {
-      buffer[bytes_read] = 0;
-      output += std::string(buffer.get());
-    }
-  }
-  const int status = pclose(fp);
-  if (status == -1 || !WIFEXITED(status)) {
-    return NSCAPI::query_return_codes::returnUNKNOWN;
-  }
-  return WEXITSTATUS(status);
-}
 }  // namespace
 
 int process::execute_process(const process::exec_arguments& args, std::string& output) {
@@ -215,5 +206,13 @@ int process::execute_process(const process::exec_arguments& args, std::string& o
   if (!args.argv.empty()) {
     return execute_argv(args, output);
   }
-  return execute_popen(args, output);
+  // Legacy single-string command (no argv supplied). Run it through the shell,
+  // but via the same fork/exec machinery as execute_argv rather than popen(),
+  // so the timeout and output cap are enforced. popen() hid the child pid, so a
+  // hung script blocked fread()/pclose() forever with `timeout=` silently
+  // unenforced - a worker thread wedged per invocation. `/bin/sh -c <command>`
+  // reproduces popen's semantics exactly (popen itself execs `/bin/sh -c`).
+  process::exec_arguments shell_args = args;
+  shell_args.argv = {"/bin/sh", "-c", args.command};
+  return execute_argv(shell_args, output);
 }

--- a/include/process/execute_process_unix.cpp
+++ b/include/process/execute_process_unix.cpp
@@ -29,6 +29,13 @@
 // blocks on a full pipe and the timeout stays enforceable) but discard the rest.
 #define MAX_OUTPUT_BYTES (8u * 1024u * 1024u)
 
+namespace {
+// The truncation marker and the content ceiling that leaves room for it, so the
+// captured string is a strict <= MAX_OUTPUT_BYTES bound (marker included).
+const char kOutputTruncMarker[] = "\n[output truncated]";
+const std::size_t kOutputContentCap = MAX_OUTPUT_BYTES - (sizeof(kOutputTruncMarker) - 1);
+}  // namespace
+
 bool early_timeout = false;
 typedef hlp::buffer<char> buffer_type;
 
@@ -75,13 +82,13 @@ std::string drain_with_timeout(int fd, time_t deadline, bool& timed_out, bool& h
       // EOF: child closed its end of the pipe.
       return out;
     }
-    // Append up to the cap; past it keep draining but discard, so the child is
-    // never blocked on a full pipe (which would defeat the timeout) yet memory
-    // stays bounded.
-    if (out.size() < MAX_OUTPUT_BYTES) {
-      const std::size_t room = MAX_OUTPUT_BYTES - out.size();
+    // Append up to the content cap; past it keep draining but discard, so the
+    // child is never blocked on a full pipe (which would defeat the timeout) yet
+    // memory stays bounded. The marker fits within MAX_OUTPUT_BYTES.
+    if (out.size() < kOutputContentCap) {
+      const std::size_t room = kOutputContentCap - out.size();
       out.append(buffer.get(), std::min(static_cast<std::size_t>(n), room));
-      if (out.size() >= MAX_OUTPUT_BYTES) out.append("\n[output truncated]");
+      if (out.size() >= kOutputContentCap) out.append(kOutputTruncMarker);
     }
   }
 }
@@ -151,7 +158,10 @@ int execute_argv(const process::exec_arguments& args, std::string& output) {
   // Parent.
   close(pipefd[1]);
 
-  const time_t deadline = time(nullptr) + (args.timeout > 0 ? args.timeout : 30);
+  // Compute the effective timeout once so the deadline and the messages that
+  // report it agree (a caller-supplied 0 falls back to 30s here).
+  const unsigned int effective_timeout = args.timeout > 0 ? args.timeout : 30;
+  const time_t deadline = time(nullptr) + effective_timeout;
   bool timed_out = false;
   bool had_error = false;
   output = drain_with_timeout(pipefd[0], deadline, timed_out, had_error);
@@ -164,7 +174,7 @@ int execute_argv(const process::exec_arguments& args, std::string& output) {
       int status = 0;
       const pid_t r = waitpid(pid, &status, WNOHANG);
       if (r == pid) {
-        output = "Command " + args.alias + " didn't terminate within " + std::to_string(args.timeout) + "s; killed";
+        output = "Command " + args.alias + " didn't terminate within " + std::to_string(effective_timeout) + "s; killed";
         return NSCAPI::query_return_codes::returnUNKNOWN;
       }
       if (r < 0 && errno != EINTR) break;
@@ -176,7 +186,7 @@ int execute_argv(const process::exec_arguments& args, std::string& output) {
     kill(pid, SIGKILL);
     int status = 0;
     waitpid(pid, &status, 0);
-    output = "Command " + args.alias + " didn't terminate within " + std::to_string(args.timeout) + "s; killed";
+    output = "Command " + args.alias + " didn't terminate within " + std::to_string(effective_timeout) + "s; killed";
     return NSCAPI::query_return_codes::returnUNKNOWN;
   }
 

--- a/include/process/execute_process_w32.cpp
+++ b/include/process/execute_process_w32.cpp
@@ -3,6 +3,11 @@
 
 #define BUFF_SIZE 4096
 
+// Upper bound on captured child output; see the Unix launcher for the rationale.
+// Past the cap we keep reading (so the child never blocks on a full pipe and the
+// timeout stays enforceable) but discard the excess.
+#define MAX_OUTPUT_BYTES (8u * 1024u * 1024u)
+
 #include <NSCAPI.h>
 #include <win/tool-helper.h>
 
@@ -257,7 +262,13 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
         break;
       }
       if (dwAvail > 0) {
-        str += readFromFile(buffer, hChildOutR.get());
+        const std::string chunk = readFromFile(buffer, hChildOutR.get());
+        // Append up to the cap; past it drop the excess but keep draining so the
+        // child never blocks on a full pipe.
+        if (str.size() < MAX_OUTPUT_BYTES) {
+          str.append(chunk, 0, MAX_OUTPUT_BYTES - str.size());
+          if (str.size() >= MAX_OUTPUT_BYTES) str.append("\n[output truncated]");
+        }
         // Drained a chunk; re-check the clock before looping so a chatty child
         // cannot hold us here past the deadline.
         if (GetTickCount64() >= deadline_ms) {
@@ -282,7 +293,11 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
 
     dwAvail = 0;
     if (::PeekNamedPipe(hChildOutR.get(), nullptr, 0, nullptr, &dwAvail, nullptr) && dwAvail > 0) {
-      str += readFromFile(buffer, hChildOutR.get());
+      const std::string chunk = readFromFile(buffer, hChildOutR.get());
+      if (str.size() < MAX_OUTPUT_BYTES) {
+        str.append(chunk, 0, MAX_OUTPUT_BYTES - str.size());
+        if (str.size() >= MAX_OUTPUT_BYTES) str.append("\n[output truncated]");
+      }
     }
     output = utf8::cvt<std::string>(utf8::from_encoding(str, args.encoding));
 

--- a/include/process/execute_process_w32.cpp
+++ b/include/process/execute_process_w32.cpp
@@ -260,9 +260,16 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
     // every iteration in microseconds and returned with `state` still at its
     // initial value - skipping the timeout/kill block entirely and leaking a
     // still-running (now unwaited) process. `while (1) echo x` in a script was
-    // an unkillable per-invocation orphan. Track a deadline instead, and treat
+    // an unkillable per-invocation orphan. Track elapsed time instead, and treat
     // "deadline reached, process still alive" as the timeout path.
-    const ULONGLONG deadline_ms = GetTickCount64() + static_cast<ULONGLONG>(effective_timeout) * 1000ULL;
+    //
+    // GetTickCount (not GetTickCount64) so this keeps compiling on the XP
+    // toolset (v141_xp / NTDDI_VERSION=0x0501); GetTickCount64 needs Vista+.
+    // Its 32-bit millisecond counter wraps every ~49.7 days, but the unsigned
+    // subtraction `GetTickCount() - start_ms` yields the correct elapsed time
+    // across a single wrap, so a bounded timeout is measured correctly.
+    const DWORD start_ms = GetTickCount();
+    const DWORD timeout_ms = static_cast<DWORD>(effective_timeout) * 1000u;
     state = WAIT_TIMEOUT;  // "not yet observed to have exited"
     for (;;) {
       if (!::PeekNamedPipe(hChildOutR.get(), nullptr, 0, nullptr, &dwAvail, nullptr)) {
@@ -281,7 +288,7 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
         }
         // Drained a chunk; re-check the clock before looping so a chatty child
         // cannot hold us here past the deadline.
-        if (GetTickCount64() >= deadline_ms) {
+        if (GetTickCount() - start_ms >= timeout_ms) {
           state = WAIT_TIMEOUT;
           break;
         }
@@ -292,7 +299,7 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
       if (state != WAIT_TIMEOUT) {
         break;  // process exited; final drain happens below
       }
-      if (GetTickCount64() >= deadline_ms) {
+      if (GetTickCount() - start_ms >= timeout_ms) {
         state = WAIT_TIMEOUT;
         break;
       }

--- a/include/process/execute_process_w32.cpp
+++ b/include/process/execute_process_w32.cpp
@@ -239,18 +239,41 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
     DWORD dwAvail = 0;
     std::string str;
     buffer_type buffer(BUFF_SIZE);
-    for (unsigned int i = 0; i < args.timeout * 10; i++) {
+    // Bound the wait by wall-clock time, not iteration count. The previous loop
+    // ran a fixed `timeout * 10` iterations: a child that always had output
+    // pending never entered the `dwAvail == 0` wait branch, so it burned through
+    // every iteration in microseconds and returned with `state` still at its
+    // initial value - skipping the timeout/kill block entirely and leaking a
+    // still-running (now unwaited) process. `while (1) echo x` in a script was
+    // an unkillable per-invocation orphan. Track a deadline instead, and treat
+    // "deadline reached, process still alive" as the timeout path.
+    const ULONGLONG deadline_ms = GetTickCount64() + static_cast<ULONGLONG>(args.timeout > 0 ? args.timeout : 30) * 1000ULL;
+    state = WAIT_TIMEOUT;  // "not yet observed to have exited"
+    for (;;) {
       if (!::PeekNamedPipe(hChildOutR.get(), nullptr, 0, nullptr, &dwAvail, nullptr)) {
+        // Pipe broke (write end closed / child gone). Resolve the real process
+        // state so a genuinely-exited child is reaped rather than killed.
+        state = WaitForSingleObject(pi.hProcess, 0);
         break;
       }
       if (dwAvail > 0) {
         str += readFromFile(buffer, hChildOutR.get());
-      }
-      if (dwAvail == 0) {
-        state = WaitForSingleObject(pi.hProcess, 100);
-        if (state != WAIT_TIMEOUT) {
+        // Drained a chunk; re-check the clock before looping so a chatty child
+        // cannot hold us here past the deadline.
+        if (GetTickCount64() >= deadline_ms) {
+          state = WAIT_TIMEOUT;
           break;
         }
+        continue;
+      }
+      // Nothing pending: wait briefly for either more output or exit.
+      state = WaitForSingleObject(pi.hProcess, 100);
+      if (state != WAIT_TIMEOUT) {
+        break;  // process exited; final drain happens below
+      }
+      if (GetTickCount64() >= deadline_ms) {
+        state = WAIT_TIMEOUT;
+        break;
       }
     }
     hChildInW.close();
@@ -273,11 +296,15 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
       // service. Surface it via the proper log so operators can see when
       // NSClient++'s own timeout fired vs. some upstream cutoff.
       NSC_LOG_ERROR("External script '" + args.alias + "' (pid=" + str::xtos(pi.dwProcessId) + ") exceeded timeout=" + str::xtos(args.timeout) +
-                    "s; sending CTRL+C");
-      if (GenerateConsoleCtrlEvent(CTRL_C_EVENT, pi.dwProcessId)) {
+                    "s; sending CTRL+BREAK");
+      // The child is launched into its own process group (CREATE_NEW_PROCESS_GROUP
+      // when !fork), so a group-targeted CTRL+C is discarded - only CTRL+BREAK can
+      // be delivered to another group. Use it here; if we share no console (the
+      // service case) the call simply fails and we fall through to the hard kill.
+      if (GenerateConsoleCtrlEvent(CTRL_BREAK_EVENT, pi.dwProcessId)) {
         if (WaitForSingleObject(pi.hProcess, 2000) == WAIT_OBJECT_0) {
           state = WAIT_OBJECT_0;
-          NSC_TRACE_ENABLED() { NSC_TRACE_MSG("External script '" + args.alias + "' (pid=" + str::xtos(pi.dwProcessId) + ") exited after CTRL+C"); }
+          NSC_TRACE_ENABLED() { NSC_TRACE_MSG("External script '" + args.alias + "' (pid=" + str::xtos(pi.dwProcessId) + ") exited after CTRL+BREAK"); }
         }
       }
       if (state == WAIT_TIMEOUT) {

--- a/include/process/execute_process_w32.cpp
+++ b/include/process/execute_process_w32.cpp
@@ -54,6 +54,11 @@ void kill_process_tree(const DWORD parent_pid) {
 
 typedef hlp::buffer<char> buffer_type;
 
+// The truncation marker and the content ceiling that leaves room for it, so the
+// captured string is a strict <= MAX_OUTPUT_BYTES bound (marker included).
+static const char kOutputTruncMarker[] = "\n[output truncated]";
+static const std::size_t kOutputContentCap = MAX_OUTPUT_BYTES - (sizeof(kOutputTruncMarker) - 1);
+
 struct generic_closer {
   static void close(HANDLE handle) { ::CloseHandle(handle); }
 };
@@ -232,8 +237,13 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
     // Trace the spawn so an operator can correlate "spawn -> kill -> exit"
     // log entries when triaging a hung or runaway script. The full command
     // line was already traced by the caller (CheckExternalScripts).
+    // Effective timeout: a caller-supplied 0 falls back to 30s. Compute it once
+    // so the deadline and every message that reports it agree (previously the
+    // deadline used the 30s fallback while the log lines still printed
+    // "timeout=0s").
+    const unsigned int effective_timeout = args.timeout > 0 ? args.timeout : 30;
     NSC_TRACE_ENABLED() {
-      NSC_TRACE_MSG("Spawned external script: alias='" + args.alias + "' pid=" + str::xtos(pi.dwProcessId) + " timeout=" + str::xtos(args.timeout) +
+      NSC_TRACE_MSG("Spawned external script: alias='" + args.alias + "' pid=" + str::xtos(pi.dwProcessId) + " timeout=" + str::xtos(effective_timeout) +
                     "s fork=" + (args.fork ? "true" : "false"));
     }
     if (args.fork) {
@@ -252,7 +262,7 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
     // still-running (now unwaited) process. `while (1) echo x` in a script was
     // an unkillable per-invocation orphan. Track a deadline instead, and treat
     // "deadline reached, process still alive" as the timeout path.
-    const ULONGLONG deadline_ms = GetTickCount64() + static_cast<ULONGLONG>(args.timeout > 0 ? args.timeout : 30) * 1000ULL;
+    const ULONGLONG deadline_ms = GetTickCount64() + static_cast<ULONGLONG>(effective_timeout) * 1000ULL;
     state = WAIT_TIMEOUT;  // "not yet observed to have exited"
     for (;;) {
       if (!::PeekNamedPipe(hChildOutR.get(), nullptr, 0, nullptr, &dwAvail, nullptr)) {
@@ -265,9 +275,9 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
         const std::string chunk = readFromFile(buffer, hChildOutR.get());
         // Append up to the cap; past it drop the excess but keep draining so the
         // child never blocks on a full pipe.
-        if (str.size() < MAX_OUTPUT_BYTES) {
-          str.append(chunk, 0, MAX_OUTPUT_BYTES - str.size());
-          if (str.size() >= MAX_OUTPUT_BYTES) str.append("\n[output truncated]");
+        if (str.size() < kOutputContentCap) {
+          str.append(chunk, 0, kOutputContentCap - str.size());
+          if (str.size() >= kOutputContentCap) str.append(kOutputTruncMarker);
         }
         // Drained a chunk; re-check the clock before looping so a chatty child
         // cannot hold us here past the deadline.
@@ -294,9 +304,9 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
     dwAvail = 0;
     if (::PeekNamedPipe(hChildOutR.get(), nullptr, 0, nullptr, &dwAvail, nullptr) && dwAvail > 0) {
       const std::string chunk = readFromFile(buffer, hChildOutR.get());
-      if (str.size() < MAX_OUTPUT_BYTES) {
-        str.append(chunk, 0, MAX_OUTPUT_BYTES - str.size());
-        if (str.size() >= MAX_OUTPUT_BYTES) str.append("\n[output truncated]");
+      if (str.size() < kOutputContentCap) {
+        str.append(chunk, 0, kOutputContentCap - str.size());
+        if (str.size() >= kOutputContentCap) str.append(kOutputTruncMarker);
       }
     }
     output = utf8::cvt<std::string>(utf8::from_encoding(str, args.encoding));
@@ -310,7 +320,7 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
       // tree-kill path used std::cout which is lost when running as a
       // service. Surface it via the proper log so operators can see when
       // NSClient++'s own timeout fired vs. some upstream cutoff.
-      NSC_LOG_ERROR("External script '" + args.alias + "' (pid=" + str::xtos(pi.dwProcessId) + ") exceeded timeout=" + str::xtos(args.timeout) +
+      NSC_LOG_ERROR("External script '" + args.alias + "' (pid=" + str::xtos(pi.dwProcessId) + ") exceeded timeout=" + str::xtos(effective_timeout) +
                     "s; sending CTRL+BREAK");
       // The child is launched into its own process group (CREATE_NEW_PROCESS_GROUP
       // when !fork), so a group-targeted CTRL+C is discarded - only CTRL+BREAK can
@@ -330,7 +340,7 @@ int process::execute_process(const exec_arguments &args, std::string &output) {
           NSC_LOG_ERROR("External script '" + args.alias + "' (pid=" + str::xtos(pi.dwProcessId) + ") did not exit; calling TerminateProcess");
           TerminateProcess(pi.hProcess, 5);
         }
-        output = "Command " + args.alias + " didn't terminate within the timeout period " + str::xtos(args.timeout) + "s";
+        output = "Command " + args.alias + " didn't terminate within the timeout period " + str::xtos(effective_timeout) + "s";
         return NSCAPI::query_return_codes::returnUNKNOWN;
       }
     }

--- a/modules/CheckExternalScripts/CheckExternalScripts.cpp
+++ b/modules/CheckExternalScripts/CheckExternalScripts.cpp
@@ -172,7 +172,10 @@ bool CheckExternalScripts::loadModuleEx(std::string alias, NSCAPI::moduleLoadMod
                   "This option determines whether or not the we will allow clients to specify nasty (as in |`&><'\"\\[]{}) characters in arguments.")
 
         .add_file("script path", sh::string_key(&scriptDirectory), "Load all scripts in a given folder",
-                  "Load all scripts in a given directory and use them as commands.")
+                  "Load all scripts in a given directory and use them as commands. SECURITY: every file in this directory becomes a runnable command (with "
+                  "%ARGS% appended when arguments are allowed), so write/create access to the directory is equivalent to command execution as the service "
+                  "account - restrict it with filesystem ACLs. Prefer listing individual scripts explicitly under the scripts section over pointing this at a "
+                  "shared or writable folder.")
 
         .add_file("script root", sh::path_key(&scriptRoot, "${scripts}"), "Script root folder",
                   "Root path used to sandbox the ext-scr show/delete operations and the destination of ext-scr add --import: those cannot read, remove, or "

--- a/modules/CheckExternalScripts/CheckExternalScripts.cpp
+++ b/modules/CheckExternalScripts/CheckExternalScripts.cpp
@@ -172,7 +172,9 @@ bool CheckExternalScripts::loadModuleEx(std::string alias, NSCAPI::moduleLoadMod
                   "Load all scripts in a given directory and use them as commands.")
 
         .add_file("script root", sh::path_key(&scriptRoot, "${scripts}"), "Script root folder",
-                  "Root path where all scripts are contained (You can not upload/download scripts outside this folder).");
+                  "Root path used to sandbox the ext-scr show/delete operations and the destination of ext-scr add --import: those cannot read, remove, or "
+                  "import a file outside this folder. Note this does NOT bound ext-scr add --script <path>, which can still register an existing file anywhere "
+                  "on disk as a command (an administrator-only action, equivalent to editing the configuration directly).");
 
     settings.register_all();
     settings.notify();

--- a/modules/CheckExternalScripts/CheckExternalScripts.cpp
+++ b/modules/CheckExternalScripts/CheckExternalScripts.cpp
@@ -163,7 +163,10 @@ bool CheckExternalScripts::loadModuleEx(std::string alias, NSCAPI::moduleLoadMod
                   "Kill all child processes (notice this might accidentally kill other processes if PIDs are reused when killing the process).")
 
         .add_bool("allow arguments", sh::bool_key(&allowArgs_, false), "Allow arguments when executing external scripts",
-                  "This option determines whether or not the we will allow clients to specify arguments to commands that are executed.")
+                  "This option determines whether or not the we will allow clients to specify arguments to commands that are executed. NOTICE this governs "
+                  "external script commands only. Command aliases (the alias section) always substitute their client arguments into the internal command they "
+                  "wrap regardless of this setting, because they dispatch to another internal check rather than spawning a process - the wrapped check's own "
+                  "argument handling applies. Restrict which commands an alias may reach through the query permissions, not this flag.")
 
         .add_bool("allow nasty characters", sh::bool_key(&allowNasty_, false), "Allow certain potentially dangerous characters in arguments",
                   "This option determines whether or not the we will allow clients to specify nasty (as in |`&><'\"\\[]{}) characters in arguments.")

--- a/modules/CheckExternalScripts/CheckExternalScripts.cpp
+++ b/modules/CheckExternalScripts/CheckExternalScripts.cpp
@@ -163,7 +163,7 @@ bool CheckExternalScripts::loadModuleEx(std::string alias, NSCAPI::moduleLoadMod
                   "Kill all child processes (notice this might accidentally kill other processes if PIDs are reused when killing the process).")
 
         .add_bool("allow arguments", sh::bool_key(&allowArgs_, false), "Allow arguments when executing external scripts",
-                  "This option determines whether or not the we will allow clients to specify arguments to commands that are executed. NOTICE this governs "
+                  "This option determines whether or not we will allow clients to specify arguments to commands that are executed. NOTICE this governs "
                   "external script commands only. Command aliases (the alias section) always substitute their client arguments into the internal command they "
                   "wrap regardless of this setting, because they dispatch to another internal check rather than spawning a process - the wrapped check's own "
                   "argument handling applies. Restrict which commands an alias may reach through the query permissions, not this flag.")

--- a/modules/CheckExternalScripts/CheckExternalScripts.cpp
+++ b/modules/CheckExternalScripts/CheckExternalScripts.cpp
@@ -268,6 +268,7 @@ bool CheckExternalScripts::commandLineExec(const int target_mode, const PB::Comm
     } else {
       if (!provider_) {
         nscapi::protobuf::functions::set_response_bad(*response, "Failed to create provider");
+        return true;
       }
       extscr_cli client(provider_);
       return client.run(command, request, response);
@@ -536,19 +537,27 @@ void CheckExternalScripts::handle_alias(const alias::command_object &cd, const s
       std::stringstream ss;
       int i = 1;
       // TODO: CHange this top use protobuffer!
+      // Enumerate $ARGn$ / %ARGn% placeholders in ascending order, one index at
+      // a time, stopping at the first index that appears in no argument. The
+      // previous form incremented `i` up to four times inside a single inner
+      // pass (once per str::xtos(i++)), so the index probed by find() differed
+      // from the one printed and whole numbers were skipped.
       bool found = true;
       while (found) {
         found = false;
+        const std::string arg_dollar = "$ARG" + str::xtos(i) + "$";
+        const std::string arg_percent = "%ARG" + str::xtos(i) + "%";
         for (std::string &arg : args) {
-          if (arg.find("$ARG" + str::xtos(i++) + "$") != std::string::npos) {
-            ss << "$ARG" << str::xtos(i++) << "$,false,," << arg << "\n";
+          if (arg.find(arg_dollar) != std::string::npos) {
+            ss << arg_dollar << ",false,," << arg << "\n";
             found = true;
           }
-          if (arg.find("%ARG" + str::xtos(i++) + "%") != std::string::npos) {
-            ss << "%ARG" << str::xtos(i++) << "%,false,," << arg << "\n";
+          if (arg.find(arg_percent) != std::string::npos) {
+            ss << arg_percent << ",false,," << arg << "\n";
             found = true;
           }
         }
+        ++i;
       }
       nscapi::protobuf::functions::set_response_good(*response, ss.str());
       return;

--- a/modules/CheckExternalScripts/extscr_cli.cpp
+++ b/modules/CheckExternalScripts/extscr_cli.cpp
@@ -42,7 +42,18 @@ bool extscr_cli::run(std::string cmd, const PB::Commands::ExecuteRequestMessage_
 
 bool extscr_cli::validate_sandbox(boost::filesystem::path pscript, PB::Commands::ExecuteResponseMessage::Response *response) {
   boost::filesystem::path path = provider_->get_root();
-  if (!file_helpers::checks::path_contains_file(path, pscript)) {
+  // Resolve symlinks before the containment check. path_contains_file compares
+  // lexically only, so a symlink placed inside the script root but pointing
+  // outside it would otherwise pass, letting show/delete read or remove files
+  // anywhere the service account can reach. weakly_canonical resolves the real
+  // targets (the candidate has already been confirmed to be a regular file by
+  // the callers); fall back to the lexical path if resolution fails.
+  boost::system::error_code ec;
+  boost::filesystem::path real_root = boost::filesystem::weakly_canonical(path, ec);
+  if (ec) real_root = path;
+  boost::filesystem::path real_script = boost::filesystem::weakly_canonical(pscript, ec);
+  if (ec) real_script = pscript;
+  if (!file_helpers::checks::path_contains_file(real_root, real_script)) {
     nscapi::protobuf::functions::set_response_bad(*response, "Not allowed outside: " + path.string());
     return false;
   }

--- a/modules/CheckExternalScripts/extscr_cli.cpp
+++ b/modules/CheckExternalScripts/extscr_cli.cpp
@@ -108,8 +108,19 @@ void extscr_cli::list(const PB::Commands::ExecuteRequestMessage::Request &reques
       if (boost::algorithm::starts_with(s, rel.string())) s = s.substr(rel.string().size());
       if (s.size() == 0) continue;
       if (s[0] == '\\' || s[0] == '/') s = s.substr(1);
-      boost::filesystem::path clone = i.parent_path();
-      if (boost::filesystem::is_regular_file(i) && !boost::algorithm::contains(clone.string(), "lib")) {
+      // Skip scripts under a `lib` folder unless --include-lib was given. The
+      // previous test used a substring match on the whole path (so a `libs` or
+      // `calibrate` folder was wrongly excluded) AND never consulted the parsed
+      // `lib` flag, so --include-lib did nothing. Match a path *component* named
+      // exactly `lib`, and honour the flag.
+      bool in_lib = false;
+      for (const boost::filesystem::path &part : i) {
+        if (part.string() == "lib") {
+          in_lib = true;
+          break;
+        }
+      }
+      if (boost::filesystem::is_regular_file(i) && (lib || !in_lib)) {
         if (json) {
           data.push_back(json::value(s));
         } else {
@@ -348,9 +359,14 @@ void extscr_cli::add_script(const PB::Commands::ExecuteRequestMessage::Request &
   if (wrapped)
     actual = "\nActual command is: " + provider_->generate_wrapped_command(script + " " + arguments);
   else {
-    provider_->add_command(alias, script);
+    // Register the same command line that was (or would have been) persisted -
+    // including the arguments. Previously the transient registration used
+    // \`script\` alone, so \`add --no-config\` (and the in-memory copy on a normal
+    // add) silently dropped the \`--arguments\` the operator supplied.
+    const std::string command_line = script + " " + arguments;
+    provider_->add_command(alias, command_line);
     nscapi::core_helper core(provider_->get_core(), provider_->get_id());
-    core.register_command(alias, "Alias for: " + script);
+    core.register_command(alias, "Alias for: " + command_line);
   }
   nscapi::protobuf::functions::set_response_good(*response, "Added " + alias + " as " + script + actual);
 }

--- a/modules/CheckExternalScripts/extscr_cli.cpp
+++ b/modules/CheckExternalScripts/extscr_cli.cpp
@@ -348,7 +348,14 @@ void extscr_cli::configure(const PB::Commands::ExecuteRequestMessage::Request &r
   po::variables_map vm;
   po::options_description desc;
   std::string arguments = "false";
-  const std::string path = "/settings/external scripts/server";
+  // The module reads `allow arguments` / `allow nasty characters` from
+  // `/settings/external scripts` (see CheckExternalScripts::loadModuleEx). The
+  // previous `/settings/external scripts/server` path was never read by anyone,
+  // so this tool reported and "applied" a lockdown that had no effect - a
+  // fail-dangerous mismatch (running `install --arguments=false` left an
+  // existing `allow arguments=true` in force). Write to the path the module
+  // actually consults.
+  const std::string path = "/settings/external scripts";
 
   pf::settings_query q(provider_->get_id());
   q.get(path, "allow arguments", false);

--- a/modules/CheckExternalScripts/extscr_cli.cpp
+++ b/modules/CheckExternalScripts/extscr_cli.cpp
@@ -341,12 +341,20 @@ void extscr_cli::add_script(const PB::Commands::ExecuteRequestMessage::Request &
     alias = file.filename().stem().string();
   }
 
+  // The command line stored/registered for this script. Only add the separator
+  // space when there actually are arguments, so an argument-less add does not
+  // leave a trailing space in the stored value, the alias description, or the
+  // transient command. Previously the transient registration used `script`
+  // alone, so `add --no-config` (and the in-memory copy on a normal add)
+  // silently dropped the `--arguments` the operator supplied.
+  const std::string command_line = arguments.empty() ? script : (script + " " + arguments);
+
   if (!no_config) {
     nscapi::protobuf::functions::settings_query s(provider_->get_id());
     if (!wrapped)
-      s.set("/settings/external scripts/scripts", alias, script + " " + arguments);
+      s.set("/settings/external scripts/scripts", alias, command_line);
     else
-      s.set("/settings/external scripts/wrapped scripts", alias, script + " " + arguments);
+      s.set("/settings/external scripts/wrapped scripts", alias, command_line);
     s.set(MAIN_MODULES_SECTION, "CheckExternalScripts", "enabled");
     s.save();
     provider_->get_core()->settings_query(s.request(), s.response());
@@ -357,13 +365,8 @@ void extscr_cli::add_script(const PB::Commands::ExecuteRequestMessage::Request &
   }
   std::string actual = "";
   if (wrapped)
-    actual = "\nActual command is: " + provider_->generate_wrapped_command(script + " " + arguments);
+    actual = "\nActual command is: " + provider_->generate_wrapped_command(command_line);
   else {
-    // Register the same command line that was (or would have been) persisted -
-    // including the arguments. Previously the transient registration used
-    // \`script\` alone, so \`add --no-config\` (and the in-memory copy on a normal
-    // add) silently dropped the \`--arguments\` the operator supplied.
-    const std::string command_line = script + " " + arguments;
     provider_->add_command(alias, command_line);
     nscapi::core_helper core(provider_->get_core(), provider_->get_id());
     core.register_command(alias, "Alias for: " + command_line);

--- a/tests/checkexternalscripts-commands.test.ts
+++ b/tests/checkexternalscripts-commands.test.ts
@@ -119,3 +119,52 @@ describe("CheckExternalScripts — command timeout enforcement", () => {
     expect(out).toMatch(/hello-from-script/);
   });
 });
+
+describe("CheckExternalScripts — shell-fallback metacharacter guard", () => {
+  // When a command template is not argv-safe (e.g. it contains a backslash the
+  // tokeniser rejects), the command degrades to the shell fallback and the
+  // stricter SHELL_METACHARS set is applied to user arguments. `%` and `^`
+  // (cmd.exe variable expansion / escape) must be blocked there.
+  if (onWindows) {
+    it.skip("shell-fallback guard (Unix launcher only)", () => undefined);
+    return;
+  }
+
+  let nscp: NscpInstance;
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    // A backslash escape (`\x`) makes the template tokeniser throw, forcing the
+    // shell-fallback path where the SHELL_METACHARS guard runs. Arguments are
+    // allowed but nasty characters are not.
+    const ini = [
+      "[/modules]",
+      "CheckExternalScripts = enabled",
+      "",
+      "[/settings/external scripts]",
+      "allow arguments = true",
+      "allow nasty characters = false",
+      "",
+      "[/settings/external scripts/scripts]",
+      "check_fallback = /bin/echo not\\xargv $ARG1$",
+      "",
+    ].join("\n");
+    fs.writeFileSync(nscp.settingsFile, ini);
+  });
+
+  async function query(arg: string) {
+    const r = await nscp.run(["client", "--module", "CheckExternalScripts", "--boot", "--query", "check_fallback", arg], { allowFailure: true });
+    return r.all ?? `${r.stdout}\n${r.stderr}`;
+  }
+
+  it.each(["pct%val", "car^et"])("rejects an argument containing a cmd.exe metacharacter (%s)", async (arg) => {
+    const out = await query(arg);
+    expect(out).toMatch(/illegal characters/i);
+  });
+
+  it("still runs a clean argument through the shell fallback", async () => {
+    const out = await query("plainvalue");
+    expect(out).toMatch(/plainvalue/);
+    expect(out).not.toMatch(/illegal characters/i);
+  });
+});

--- a/tests/checkexternalscripts-commands.test.ts
+++ b/tests/checkexternalscripts-commands.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Exercises the CheckExternalScripts module end-to-end against the real nscp
+ * binary, over the one-shot CLI / client-query path (no server/port/docker).
+ *
+ * These cover the security-relevant behaviour of the module: the `ext-scr
+ * install` argument-lockdown tool, the argument metacharacter guard, and the
+ * timeout enforcement on a runaway script. They are cross-platform except where
+ * a case explicitly guards on the OS.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(120_000);
+
+const onWindows = process.platform === "win32";
+
+describe("CheckExternalScripts — ext-scr install argument lockdown (settings path)", () => {
+  let nscp: NscpInstance;
+
+  beforeAll(() => {
+    nscp = new NscpInstance();
+  });
+
+  /** Read a single settings value back from the store. */
+  async function getSetting(settingsPath: string, key: string): Promise<string> {
+    const r = await nscp.run(["settings", "--show", "--path", settingsPath, "--key", key], { allowFailure: true });
+    return (r.all ?? `${r.stdout}\n${r.stderr}`).trim();
+  }
+
+  it("`ext-scr install --arguments=false` actually disables arguments on the path the module reads", async () => {
+    // Start from a permissive config written where the module actually reads it.
+    await nscp.configure({
+      "/settings/external scripts": { "allow arguments": "true", "allow nasty characters": "true" },
+    });
+
+    // The lockdown tool must clear it on the same path. Before the fix it wrote
+    // to `/settings/external scripts/server`, which nothing reads, so the
+    // permissive value below stayed in force — a fail-dangerous no-op.
+    const r = await nscp.run(["ext-scr", "install", "--arguments=false"], { allowFailure: true });
+    const out = r.all ?? `${r.stdout}\n${r.stderr}`;
+    expect(out).toMatch(/Arguments are NOT allowed/i);
+
+    expect(await getSetting("/settings/external scripts", "allow arguments")).toMatch(/false/i);
+    expect(await getSetting("/settings/external scripts", "allow nasty characters")).toMatch(/false/i);
+  });
+
+  it("`ext-scr install --arguments=safe` enables arguments but not nasty characters", async () => {
+    await nscp.configure({
+      "/settings/external scripts": { "allow arguments": "false", "allow nasty characters": "false" },
+    });
+
+    const r = await nscp.run(["ext-scr", "install", "--arguments=safe"], { allowFailure: true });
+    const out = r.all ?? `${r.stdout}\n${r.stderr}`;
+    expect(out).toMatch(/SAFE Arguments are allowed/i);
+
+    expect(await getSetting("/settings/external scripts", "allow arguments")).toMatch(/true/i);
+    expect(await getSetting("/settings/external scripts", "allow nasty characters")).toMatch(/false/i);
+  });
+});

--- a/tests/checkexternalscripts-commands.test.ts
+++ b/tests/checkexternalscripts-commands.test.ts
@@ -60,3 +60,62 @@ describe("CheckExternalScripts — ext-scr install argument lockdown (settings p
     expect(await getSetting("/settings/external scripts", "allow nasty characters")).toMatch(/false/i);
   });
 });
+
+describe("CheckExternalScripts — command timeout enforcement", () => {
+  // A runaway script must be killed at the configured timeout and reported, not
+  // left running. On Unix the shell-fallback path used to run through popen(),
+  // which hid the child pid and blocked forever with the timeout unenforced;
+  // both paths now go through the same fork/exec + deadline machinery.
+  if (onWindows) {
+    it.skip("timeout enforcement (Unix launcher only)", () => undefined);
+    return;
+  }
+
+  let nscp: NscpInstance;
+  let scriptsDir: string;
+
+  beforeAll(() => {
+    scriptsDir = fs.mkdtempSync(path.join(os.tmpdir(), "nscp-extscr-"));
+    fs.writeFileSync(path.join(scriptsDir, "sleeper.sh"), "#!/bin/sh\nsleep 30\necho done\n", { mode: 0o755 });
+    fs.writeFileSync(path.join(scriptsDir, "hello.sh"), "#!/bin/sh\necho hello-from-script\n", { mode: 0o755 });
+
+    nscp = new NscpInstance();
+  });
+
+  afterAll(() => {
+    fs.rmSync(scriptsDir, { recursive: true, force: true });
+  });
+
+  /** Boot the module and run one script command via the client-query path. */
+  async function query(command: string) {
+    const r = await nscp.run(["client", "--module", "CheckExternalScripts", "--boot", "--query", command], { allowFailure: true });
+    return { out: r.all ?? `${r.stdout}\n${r.stderr}`, code: r.exitCode };
+  }
+
+  it("kills a script that exceeds the timeout and reports it", async () => {
+    await nscp.configure({
+      "/modules": { CheckExternalScripts: "enabled" },
+      "/settings/external scripts": { timeout: "2" },
+      "/settings/external scripts/scripts": { check_sleeper: `/bin/sh ${path.join(scriptsDir, "sleeper.sh")}` },
+    });
+
+    const started = Date.now();
+    const { out } = await query("check_sleeper");
+    const elapsed = (Date.now() - started) / 1000;
+
+    // Enforced near the 2s timeout, nowhere near the script's 30s sleep.
+    expect(elapsed).toBeLessThan(20);
+    expect(out).toMatch(/did.?n.?t terminate|timeout/i);
+  });
+
+  it("runs a fast script to completion and returns its output", async () => {
+    await nscp.configure({
+      "/modules": { CheckExternalScripts: "enabled" },
+      "/settings/external scripts": { timeout: "10" },
+      "/settings/external scripts/scripts": { check_hello: `/bin/sh ${path.join(scriptsDir, "hello.sh")}` },
+    });
+
+    const { out } = await query("check_hello");
+    expect(out).toMatch(/hello-from-script/);
+  });
+});

--- a/tests/checkexternalscripts-commands.test.ts
+++ b/tests/checkexternalscripts-commands.test.ts
@@ -3,9 +3,9 @@
  * binary, over the one-shot CLI / client-query path (no server/port/docker).
  *
  * These cover the security-relevant behaviour of the module: the `ext-scr
- * install` argument-lockdown tool, the argument metacharacter guard, and the
- * timeout enforcement on a runaway script. They are cross-platform except where
- * a case explicitly guards on the OS.
+ * install` argument-lockdown tool (cross-platform), and — on the Unix launcher —
+ * the command timeout on a runaway script and the shell-fallback metacharacter
+ * guard.
  */
 import fs from "node:fs";
 import os from "node:os";
@@ -15,7 +15,9 @@ import { NscpInstance } from "@fixtures/index";
 
 jest.setTimeout(120_000);
 
-const onWindows = process.platform === "win32";
+// The timeout / shell-fallback cases drive the POSIX launcher (fork/execvp,
+// /bin/sh, /bin/echo), so they only run off Windows.
+const onUnix = process.platform === "win32" ? describe.skip : describe;
 
 describe("CheckExternalScripts — ext-scr install argument lockdown (settings path)", () => {
   let nscp: NscpInstance;
@@ -61,16 +63,11 @@ describe("CheckExternalScripts — ext-scr install argument lockdown (settings p
   });
 });
 
-describe("CheckExternalScripts — command timeout enforcement", () => {
+onUnix("CheckExternalScripts — command timeout enforcement (POSIX launcher)", () => {
   // A runaway script must be killed at the configured timeout and reported, not
   // left running. On Unix the shell-fallback path used to run through popen(),
   // which hid the child pid and blocked forever with the timeout unenforced;
   // both paths now go through the same fork/exec + deadline machinery.
-  if (onWindows) {
-    it.skip("timeout enforcement (Unix launcher only)", () => undefined);
-    return;
-  }
-
   let nscp: NscpInstance;
   let scriptsDir: string;
 
@@ -120,23 +117,19 @@ describe("CheckExternalScripts — command timeout enforcement", () => {
   });
 });
 
-describe("CheckExternalScripts — shell-fallback metacharacter guard", () => {
+onUnix("CheckExternalScripts — shell-fallback metacharacter guard (POSIX launcher)", () => {
   // When a command template is not argv-safe (e.g. it contains a backslash the
   // tokeniser rejects), the command degrades to the shell fallback and the
   // stricter SHELL_METACHARS set is applied to user arguments. `%` and `^`
   // (cmd.exe variable expansion / escape) must be blocked there.
-  if (onWindows) {
-    it.skip("shell-fallback guard (Unix launcher only)", () => undefined);
-    return;
-  }
-
   let nscp: NscpInstance;
 
-  beforeAll(async () => {
+  beforeAll(() => {
     nscp = new NscpInstance();
     // A backslash escape (`\x`) makes the template tokeniser throw, forcing the
     // shell-fallback path where the SHELL_METACHARS guard runs. Arguments are
-    // allowed but nasty characters are not.
+    // allowed but nasty characters are not. CSimpleIni stores values verbatim,
+    // so the backslash survives into the stored command template.
     const ini = [
       "[/modules]",
       "CheckExternalScripts = enabled",


### PR DESCRIPTION
## Summary

A security review of the `CheckExternalScripts` module and the process launcher it drives, with the findings implemented as one focused commit each. None is a remotely exploitable RCE on a default install (the argument guard is off by default; script management requires an authenticated administrator), but each closes a real gap. The module's existing argv-isolation hardening is left intact — these build on it.

Every change is on the POSIX/Windows launch path or the `ext-scr` CLI; there are new integration tests under `tests/` for the parts that are deterministically exercisable on Linux.

## Commits (one per finding)

| # | Commit | What it fixes |
|---|--------|---------------|
| 1 | `write ext-scr install lockdown to the read path` | **Fail-dangerous no-op.** `ext-scr install --arguments=…` read/wrote `allow arguments` / `allow nasty characters` under `/settings/external scripts/server`, but the module reads them from `/settings/external scripts`. So the lockdown tool "applied" a change nothing consulted — `install --arguments=false` on a host with `allow arguments=true` left arguments enabled while reporting them disabled. Now writes the effective path. |
| 2 | `correct null-provider deref and help-pb arg numbering` | `commandLineExec` fell through to `extscr_cli client(provider_)` with a null `shared_ptr` after reporting a provider failure (missing `return`); and `help-pb` incremented its index up to 4× per pass so `$ARGn$` numbers were skipped/mislabelled. |
| 3 | `process/win32: enforce script timeout by wall-clock, not iteration count` | The Windows read loop bounded **iterations**, not time; a continuously-chatty script exhausted the budget in microseconds and returned without ever entering the timeout/kill path, leaking an unkillable process each run despite `timeout=`. Now uses a `GetTickCount64` deadline. Also switches the dead-code `CTRL_C` graceful stop to `CTRL_BREAK` (the child is in its own process group). |
| 4 | `process: enforce timeout on the shell-fallback path and cap output` | The Unix single-string fallback ran through `popen()`, which hid the child PID: a hung script blocked forever with `timeout=` unenforced. Routed through the same fork/exec + deadline machinery (`/bin/sh -c`, exactly what popen execs) and removed the untimed helper. Both launchers now cap captured output at 8 MiB. |
| 5 | `resolve symlinks in the show/delete sandbox check` | `validate_sandbox` compared paths lexically, so a symlink inside the script root pointing outside it passed — letting `ext-scr show`/`delete` read/remove files anywhere the service account could reach. Now canonicalises with `weakly_canonical` before the containment test. |
| 6 | `honour add arguments and list --include-lib; clarify script root` | `add --no-config` (and the in-memory copy on a normal add) dropped the supplied `--arguments`; `list --include-lib` was parsed but ignored and its lib filter used a loose substring match; and the `script root` doc overstated the sandbox. |
| 7 | `clarify allow arguments does not gate aliases` | Documents that `allow arguments` governs external scripts only — aliases substitute client `$ARGn$` regardless (they dispatch to internal checks, no shell). |
| 8 | `block cmd.exe %VAR% and ^ on the shell fallback` | `SHELL_METACHARS` (applied to user args on the non-argv-safe fallback) omitted `%` and `^`, so an argument reaching a `.bat` through cmd.exe could smuggle `%VAR%` expansion / `^` escapes. Both added. |
| — | `warn on script path ACLs and record the hardening` | Adds a SECURITY note to the `script path` setting (every file there is a runnable command) and records the review on `docs/docs/security/notices.md` + `docs/docs/setup/upgrading.md` per project convention. |
| — | `test: use describe.skip platform selector` | Test-only cleanup. |

## Deliberately deferred

The review's larger Windows item — giving Windows a backslash-aware template tokeniser so `scripts\foo.bat` templates get full **argv isolation** instead of the string fallback, and pinning `lpApplicationName` on the legacy path (CWE-428) — is **not** in this PR. It switches the core Windows execution path and must be validated on Windows CI against the default `ps1`/`vbs`/`bat` wrappings; shipping it blind risks breaking every Windows install's checks. The finding-8 `%`/`^` guard is the compensating hardening in the meantime. Happy to do the tokeniser as a reviewed follow-up.

## Tests

New `tests/checkexternalscripts-commands.test.ts`:
- `ext-scr install --arguments=false|safe` actually changes the setting the module reads (finding 1), cross-platform.
- A script exceeding the timeout is killed and reported; a fast script still returns output (POSIX launcher).
- `%` and `^` arguments are refused on the forced shell-fallback path while a clean argument runs (POSIX launcher).

## Notes for the reviewer

- I could **not** compile or run this in the review environment (no toolchain/deps for a full NSClient++ build, no prebuilt binary), so the C++ changes are reviewed by hand and rely on CI to compile and run the integration tests. The changes are minimal and localized; please give the two launcher files a careful read.
- The docs entries assume the next version is **0.19.0** (0.18.0 was just released) — adjust the `Fixed in:` / heading if that's wrong.
- Commits are DCO-signed and carry `Assisted-by:` per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwkEzLNpGHpY4qJU8xfoC2)_