### PR TITLE
SMTP client hardening: reply limits, scrubbing, and validation

### DIFF
--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -509,9 +509,10 @@ or destabilise the agent.
   permits a real server to send.
 - **Reply text is rendered inert before it reaches the log.** Error messages
   quoted server replies verbatim into the agent log and the submit response.
-  Control bytes (terminal escapes for whoever tails the log) are now replaced,
-  multi-line replies can no longer forge additional log lines, and oversized
-  replies are truncated.
+  Anything outside printable US-ASCII is now replaced — both the C0 controls
+  and the C1 range (0x80–0x9F), which carries single-byte terminal escapes
+  such as CSI — multi-line replies can no longer forge additional log lines,
+  and oversized replies are truncated.
 - **Smaller items:** the reply to `STARTTLS` must now be exactly `220` per
   RFC 3207 rather than any `2xx`; AUTH credentials containing a NUL byte are
   refused before connecting (a NUL would shift the RFC 4616 `AUTH PLAIN`

--- a/docs/docs/security/notices.md
+++ b/docs/docs/security/notices.md
@@ -484,6 +484,40 @@ rules keyed on the old malformed format (no HOSTNAME field), adjust them —
 records now arrive attributed to the agent's host name instead of the tag.
 See [Upgrading](../setup/upgrading.md#unreleased).
 
+### SMTP client hardening, second round
+
+**Fixed in:** 0.18.0 · **Severity:** Low–Medium
+
+A follow-up review of the `SMTPClient` module hardened how the client behaves
+against a hostile or misbehaving peer. As with the first round, none of these
+is exploitable by an unauthenticated third party on its own; each removes a
+way the mail server (or whoever controls DNS or the path to it) could degrade
+or destabilise the agent.
+
+- **A timed-out submission no longer runs stale I/O handlers.** When the
+  submission budget expired mid-connect, the cancelled operation's completion
+  handler stayed queued and was executed by the retry against the next
+  resolved address — with references into a stack frame that no longer
+  existed (a use-after-return, so undefined behaviour in a long-running
+  service). Handler state now lives on the heap, co-owned by the handler, and
+  a spent budget ends the endpoint walk instead of retrying into it.
+- **Server replies are bounded.** Nothing capped how much reply data the
+  client would buffer inside its timeout window, so a peer streaming bytes
+  without a line ending — or endless `250-` continuation lines — could turn a
+  30-second budget into gigabytes of agent memory. A reply line is now capped
+  at 64 KB and a reply at 100 lines; both are far above anything RFC 5321
+  permits a real server to send.
+- **Reply text is rendered inert before it reaches the log.** Error messages
+  quoted server replies verbatim into the agent log and the submit response.
+  Control bytes (terminal escapes for whoever tails the log) are now replaced,
+  multi-line replies can no longer forge additional log lines, and oversized
+  replies are truncated.
+- **Smaller items:** the reply to `STARTTLS` must now be exactly `220` per
+  RFC 3207 rather than any `2xx`; AUTH credentials containing a NUL byte are
+  refused before connecting (a NUL would shift the RFC 4616 `AUTH PLAIN`
+  field boundaries); and the test SMTP server's entrypoint no longer echoes
+  its password into the container log.
+
 ### SMTP client security-review hardening
 
 **Fixed in:** 0.18.0 · **Severity:** Low–Medium

--- a/modules/SMTPClient/smtp.cpp
+++ b/modules/SMTPClient/smtp.cpp
@@ -30,8 +30,21 @@ namespace detail {
 // into the agent log (NSC_LOG_ERROR) and the submit response. Left raw, a
 // reply can embed terminal escape sequences for whoever tails the log, and
 // the '\n' that read_reply() joins a multi-line reply with lets one reply
-// masquerade as several log lines. Render it inert instead: control bytes
-// become '?', the line join becomes " / ", and the result is truncated.
+// masquerade as several log lines. Render it inert instead: the line join
+// becomes " / ", anything that is not printable US-ASCII becomes '?', and
+// the result is truncated.
+//
+// Printable ASCII is the whole allowlist rather than "everything except the
+// C0 controls", because a byte does not have to be C0 to steer a terminal.
+// The C1 range (0x80-0x9F) carries single-byte equivalents of the escape
+// sequences - 0x9B is CSI - which a terminal in a non-UTF-8 locale acts on,
+// and their UTF-8 spellings (0xC2 0x80..0x9F) reach the same code points in
+// a terminal that does decode UTF-8. Allowlisting covers both without
+// enumerating either, and it cannot emit the half-scrubbed byte sequences
+// that dropping individual bytes out of a multi-byte character would. The
+// cost is that legitimately non-ASCII reply text (RFC 6531 permits it)
+// flattens to '?' - acceptable for a diagnostic string whose reason for
+// existing is to be safe to display.
 std::string scrub_reply(const std::string& reply) {
   constexpr std::size_t max_len = 500;
   std::string out;
@@ -44,7 +57,7 @@ std::string scrub_reply(const std::string& reply) {
     const auto u = static_cast<unsigned char>(c);
     if (c == '\n') {
       out += " / ";
-    } else if (u < 0x20 || u == 0x7f) {
+    } else if (u < 0x20 || u >= 0x7f) {
       out.push_back('?');
     } else {
       out.push_back(c);

--- a/modules/SMTPClient/smtp.cpp
+++ b/modules/SMTPClient/smtp.cpp
@@ -26,6 +26,16 @@ namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
 using ssl_stream = asio::ssl::stream<tcp::socket>;
 
+// The timeout bounds how long a submission may take; these bound how much a
+// peer can make it buffer. Without them read_until() accumulates until the
+// deadline - and the deadline is seconds, so a server (or a MITM on a
+// security=none target) that streams bytes without ever sending CRLF turns
+// the budget into gigabytes of agent memory at line rate. RFC 5321 4.5.3.1
+// caps a reply line at 512 bytes and no real server sends EHLO replies
+// hundreds of lines long, so both limits are far above anything legitimate.
+constexpr std::size_t max_reply_line_bytes = 64 * 1024;
+constexpr std::size_t max_reply_lines = 100;
+
 // ---------------------------------------------------------------------------
 // Tiny synchronous IO with deadline
 // ---------------------------------------------------------------------------
@@ -155,7 +165,11 @@ class sync_io {
   // unreadable.
   std::string read_reply() {
     std::string out;
+    std::size_t lines = 0;
     while (true) {
+      if (++lines > max_reply_lines) {
+        throw smtp_exception("SMTP reply exceeds " + std::to_string(max_reply_lines) + " lines; giving up");
+      }
       const std::string line = read_line();
       if (!out.empty()) out.push_back('\n');
       out += line;
@@ -185,6 +199,12 @@ class sync_io {
           }
         },
         ec, &bytes);
+    // not_found is read_until() reporting that buf_ hit its size cap without
+    // a CRLF anywhere in it - a peer streaming an endless line, not a socket
+    // problem, so name it as the protocol violation it is.
+    if (ec == asio::error::not_found) {
+      throw smtp_exception("SMTP reply line exceeds " + std::to_string(max_reply_line_bytes) + " bytes; giving up");
+    }
     if (ec) throw smtp_exception("read failed: " + describe(ec));
     std::istream is(&buf_);
     std::string line;
@@ -254,7 +274,9 @@ class sync_io {
   asio::io_context& io_;
   tcp::socket& socket_ref_;
   ssl_stream* tls_stream_;
-  asio::streambuf buf_;
+  // Capped so read_until() fails with not_found instead of buffering without
+  // bound; the leftover-data check in handshake() counts against it too.
+  asio::streambuf buf_{max_reply_line_bytes};
   int timeout_seconds_;
   std::chrono::steady_clock::time_point deadline_;
 };

--- a/modules/SMTPClient/smtp.cpp
+++ b/modules/SMTPClient/smtp.cpp
@@ -21,6 +21,40 @@
 #include <vector>
 
 namespace smtp {
+
+// Defined ahead of the connection code because every error path below that
+// quotes server text routes it through here first.
+namespace detail {
+
+// Reply bytes are the peer's to choose, and exception messages carry them
+// into the agent log (NSC_LOG_ERROR) and the submit response. Left raw, a
+// reply can embed terminal escape sequences for whoever tails the log, and
+// the '\n' that read_reply() joins a multi-line reply with lets one reply
+// masquerade as several log lines. Render it inert instead: control bytes
+// become '?', the line join becomes " / ", and the result is truncated.
+std::string scrub_reply(const std::string& reply) {
+  constexpr std::size_t max_len = 500;
+  std::string out;
+  out.reserve(std::min(reply.size(), max_len) + 4);
+  for (const char c : reply) {
+    if (out.size() >= max_len) {
+      out += "...";
+      break;
+    }
+    const auto u = static_cast<unsigned char>(c);
+    if (c == '\n') {
+      out += " / ";
+    } else if (u < 0x20 || u == 0x7f) {
+      out.push_back('?');
+    } else {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
+}  // namespace detail
+
 namespace {
 namespace asio = boost::asio;
 using tcp = asio::ip::tcp;
@@ -177,10 +211,10 @@ class sync_io {
       // "NNN text" for the final line. A line shorter than 4 bytes is a
       // protocol error.
       if (line.size() < 4) {
-        throw smtp_exception("malformed SMTP reply: '" + line + "'");
+        throw smtp_exception("malformed SMTP reply: '" + detail::scrub_reply(line) + "'");
       }
       if (line[3] == ' ') break;
-      if (line[3] != '-') throw smtp_exception("malformed SMTP reply: '" + line + "'");
+      if (line[3] != '-') throw smtp_exception("malformed SMTP reply: '" + detail::scrub_reply(line) + "'");
     }
     return out;
   }
@@ -287,7 +321,7 @@ class sync_io {
 
 void expect_status(const std::string& reply, char expected_first, const std::string& context) {
   if (reply.size() < 3 || reply[0] != expected_first) {
-    throw smtp_exception(context + " unexpected reply: " + reply);
+    throw smtp_exception(context + " unexpected reply: " + detail::scrub_reply(reply));
   }
 }
 
@@ -505,10 +539,11 @@ void do_auth(sync_io& io, const std::string& user, const std::string& pass, cons
   const auto advertises = [&mechanisms](const char* m) { return std::find(mechanisms.begin(), mechanisms.end(), m) != mechanisms.end(); };
 
   if (mechanisms.empty()) {
-    throw smtp_exception("a username is configured but the server does not advertise AUTH: " + ehlo_response);
+    throw smtp_exception("a username is configured but the server does not advertise AUTH: " + detail::scrub_reply(ehlo_response));
   }
   if (!advertises("PLAIN") && !advertises("LOGIN")) {
-    throw smtp_exception("server advertises no AUTH mechanism we support (offered: " + boost::algorithm::join(mechanisms, ", ") + "; supported: PLAIN, LOGIN)");
+    throw smtp_exception("server advertises no AUTH mechanism we support (offered: " + detail::scrub_reply(boost::algorithm::join(mechanisms, ", ")) +
+                         "; supported: PLAIN, LOGIN)");
   }
 
   if (advertises("PLAIN")) {
@@ -520,18 +555,18 @@ void do_auth(sync_io& io, const std::string& user, const std::string& pass, cons
     sasl += pass;
     io.write("AUTH PLAIN " + b64(sasl) + "\r\n");
     const std::string r = io.read_reply();
-    if (!reply_starts_with(r, "235")) throw smtp_exception("AUTH PLAIN rejected: " + r);
+    if (!reply_starts_with(r, "235")) throw smtp_exception("AUTH PLAIN rejected: " + detail::scrub_reply(r));
     return;
   }
   io.write("AUTH LOGIN\r\n");
   std::string r = io.read_reply();
-  if (!reply_starts_with(r, "334")) throw smtp_exception("AUTH LOGIN not accepted: " + r);
+  if (!reply_starts_with(r, "334")) throw smtp_exception("AUTH LOGIN not accepted: " + detail::scrub_reply(r));
   io.write(b64(user) + "\r\n");
   r = io.read_reply();
-  if (!reply_starts_with(r, "334")) throw smtp_exception("AUTH LOGIN username rejected: " + r);
+  if (!reply_starts_with(r, "334")) throw smtp_exception("AUTH LOGIN username rejected: " + detail::scrub_reply(r));
   io.write(b64(pass) + "\r\n");
   r = io.read_reply();
-  if (!reply_starts_with(r, "235")) throw smtp_exception("AUTH LOGIN password rejected: " + r);
+  if (!reply_starts_with(r, "235")) throw smtp_exception("AUTH LOGIN password rejected: " + detail::scrub_reply(r));
 }
 
 }  // namespace
@@ -667,7 +702,7 @@ void send(const connection_config& cfg, const message& msg) {
   // DATA
   conn.write("DATA\r\n");
   r = conn.read_reply();
-  if (!reply_starts_with(r, "354")) throw smtp_exception("DATA rejected: " + r);
+  if (!reply_starts_with(r, "354")) throw smtp_exception("DATA rejected: " + detail::scrub_reply(r));
 
   // Construct headers + body. The body is dot-stuffed / CRLF-normalised.
   std::ostringstream headers;

--- a/modules/SMTPClient/smtp.cpp
+++ b/modules/SMTPClient/smtp.cpp
@@ -582,6 +582,14 @@ void send(const connection_config& cfg, const message& msg) {
   detail::validate_address(msg.to, "to");
   const std::string subject = detail::sanitise_header(msg.subject);
 
+  // RFC 4616 frames AUTH PLAIN as NUL-separated fields, so a NUL inside the
+  // username would shift the authcid/password boundary and authenticate as
+  // someone else's credential split. Config strings should never carry one;
+  // refuse rather than reinterpret if one does.
+  if (cfg.username.find('\0') != std::string::npos || cfg.password.find('\0') != std::string::npos) {
+    throw smtp_exception("AUTH username/password must not contain NUL bytes");
+  }
+
   // Validated up here with the addresses, before anything is put on the wire.
   const std::string ehlo_name = cfg.canonical_name.empty() ? std::string("localhost") : cfg.canonical_name;
   detail::validate_ehlo_name(ehlo_name);
@@ -670,7 +678,9 @@ void send(const connection_config& cfg, const message& msg) {
     }
     conn.write("STARTTLS\r\n");
     r = conn.read_reply();
-    expect_status(r, '2', "STARTTLS");
+    // Exactly 220, per RFC 3207 4: any other 2xx here is not "ready to start
+    // TLS", and proceeding to handshake against it helps nobody.
+    if (!reply_starts_with(r, "220")) throw smtp_exception("STARTTLS unexpected reply: " + detail::scrub_reply(r));
     conn.handshake(tls, "TLS handshake (STARTTLS)");
     // Re-EHLO over the secure channel; capabilities can change after TLS.
     conn.write("EHLO " + ehlo_name + "\r\n");

--- a/modules/SMTPClient/smtp.cpp
+++ b/modules/SMTPClient/smtp.cpp
@@ -15,6 +15,7 @@
 #include <bytes/base64.hpp>
 #include <chrono>
 #include <cstring>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -124,6 +125,10 @@ class sync_io {
       socket_ref_.close(close_ec);
       const auto ep = it->endpoint();
       run_with_deadline([&](auto&& done) { socket_ref_.async_connect(ep, [done = std::move(done)](const boost::system::error_code& e) { done(e); }); }, ec);
+      // A spent budget ends the walk, not just this attempt: the deadline
+      // covers the whole submission, so every remaining endpoint would time
+      // out the same way before its connect could complete.
+      if (ec == asio::error::timed_out) break;
     }
     if (ec) throw smtp_exception("connect failed: " + describe(ec));
   }
@@ -189,19 +194,38 @@ class sync_io {
   }
 
   // Run a single async op until it completes or the deadline expires. Sets
-  // `out_ec` to the operation's result, or operation_aborted on timeout.
+  // `out_ec` to the operation's result, or timed_out on timeout.
+  //
+  // The op's completion handler can outlive this frame. On timeout the timer
+  // handler stop()s the io_context, and the cancelled op's handler - already
+  // queued, or queued by the cancel - is left unexecuted; it runs on the NEXT
+  // restart()/run(), which happens when a caller issues another operation
+  // after a timeout (connect() walking its endpoint list). A handler that
+  // captured this frame's locals by reference would then write through
+  // dangling references into whatever occupies the stack now. So everything
+  // the handler touches lives in `op`, co-owned by the handler itself: a
+  // stale handler completes against its own orphaned state, which nobody
+  // reads, and the current operation's state is untouchable by it.
+  //
+  // The timer handler needs no such care: run() drains it before returning
+  // in every case (it is either what called stop(), or it completes as
+  // aborted before run() runs out of work), so its frame is always alive.
   template <typename Init>
   void run_with_deadline(Init&& init, boost::system::error_code& out_ec, std::size_t* out_bytes = nullptr) {
-    out_ec = asio::error::would_block;
-    std::size_t bytes = 0;
-    asio::steady_timer timer(io_);
+    struct op_state {
+      explicit op_state(asio::io_context& io) : timer(io), ec(asio::error::would_block), bytes(0), timed_out(false) {}
+      asio::steady_timer timer;
+      boost::system::error_code ec;
+      std::size_t bytes;
+      bool timed_out;
+    };
+    const auto op = std::make_shared<op_state>(io_);
     // A deadline already in the past fires immediately, which is what we want
     // once the budget is spent.
-    timer.expires_at(deadline_);
-    bool timed_out = false;
-    timer.async_wait([&](const boost::system::error_code& e) {
+    op->timer.expires_at(deadline_);
+    op->timer.async_wait([this, op](const boost::system::error_code& e) {
       if (e == asio::error::operation_aborted) return;
-      timed_out = true;
+      op->timed_out = true;
       // Cancel any outstanding I/O so run() returns. stop() covers the
       // operations cancelling the socket does not reach - a resolve in
       // particular runs off on its own thread and would otherwise keep run()
@@ -210,23 +234,21 @@ class sync_io {
       socket_ref_.cancel(ignore);
       io_.stop();
     });
-    init([&](const boost::system::error_code& e, std::size_t n = 0) {
-      out_ec = e;
-      bytes = n;
+    init([op](const boost::system::error_code& e, std::size_t n = 0) {
+      op->ec = e;
+      op->bytes = n;
       // cancel() can throw (the non-throwing cancel(ec) overload is removed
       // under BOOST_ASIO_NO_DEPRECATED). Swallow it so an incidental failure
       // can't escape this handler and misreport a successful operation.
       try {
-        timer.cancel();
+        op->timer.cancel();
       } catch (...) {
       }
     });
     io_.restart();
     io_.run();
-    if (timed_out) {
-      out_ec = asio::error::timed_out;
-    }
-    if (out_bytes) *out_bytes = bytes;
+    out_ec = op->timed_out ? asio::error::timed_out : op->ec;
+    if (out_bytes) *out_bytes = op->bytes;
   }
 
   asio::io_context& io_;

--- a/modules/SMTPClient/smtp.hpp
+++ b/modules/SMTPClient/smtp.hpp
@@ -93,6 +93,14 @@ bool has_capability(const std::string& ehlo_reply, const std::string& keyword);
 // the order the server listed them. Empty when AUTH was not advertised.
 std::vector<std::string> auth_mechanisms(const std::string& ehlo_reply);
 
+// Renders server reply text for inclusion in an error message. Replies end up
+// in the agent log and in the submit response, and their bytes are chosen by
+// the peer: control characters (terminal escapes when the log is tailed) are
+// replaced with '?', the '\n' separating the lines of a multi-line reply is
+// rendered as " / " so one reply cannot forge additional log lines, and the
+// result is truncated so a large reply cannot flood the log.
+std::string scrub_reply(const std::string& reply);
+
 // Builds the RFC 5322 Message-ID for one submission, angle brackets included.
 // The right hand side is the sender's domain, falling back to `ehlo_name`;
 // the left hand side is random. Callers get a different value every time.

--- a/modules/SMTPClient/smtp.hpp
+++ b/modules/SMTPClient/smtp.hpp
@@ -95,10 +95,11 @@ std::vector<std::string> auth_mechanisms(const std::string& ehlo_reply);
 
 // Renders server reply text for inclusion in an error message. Replies end up
 // in the agent log and in the submit response, and their bytes are chosen by
-// the peer: control characters (terminal escapes when the log is tailed) are
-// replaced with '?', the '\n' separating the lines of a multi-line reply is
-// rendered as " / " so one reply cannot forge additional log lines, and the
-// result is truncated so a large reply cannot flood the log.
+// the peer: everything outside printable US-ASCII is replaced with '?' (both
+// the C0 controls and the C1 range that carries single-byte terminal escapes),
+// the '\n' separating the lines of a multi-line reply is rendered as " / " so
+// one reply cannot forge additional log lines, and the result is truncated so
+// a large reply cannot flood the log.
 std::string scrub_reply(const std::string& reply);
 
 // Builds the RFC 5322 Message-ID for one submission, angle brackets included.

--- a/modules/SMTPClient/smtp_handler.hpp
+++ b/modules/SMTPClient/smtp_handler.hpp
@@ -60,8 +60,8 @@ struct smtp_target_object : nscapi::targets::target_object {
                     "Microsoft 365 use the UPN. App passwords work for both.")
 
         .add_password("password", sh::string_fun_key([this](auto value) { this->set_property_string("password", value); }, ""), "AUTH PASSWORD",
-                      "SMTP AUTH password. Stored sensitive. Credentials are only sent over a TLS / STARTTLS-secured connection; configuring a password "
-                      "with security=none refuses to start.")
+                      "SMTP AUTH password. Stored sensitive. Credentials are only sent over a TLS / STARTTLS-secured connection; a submission with a "
+                      "password configured and security=none fails instead of sending them in clear.")
 
         .add_string("security", sh::string_fun_key([this](auto value) { this->set_property_string("security", value); }, "starttls"), "TRANSPORT SECURITY",
                     "Connection security. `starttls` (default, port 587) connects in clear and upgrades to TLS before AUTH; `tls` (alias `ssl`) connects "

--- a/modules/SMTPClient/smtp_test.cpp
+++ b/modules/SMTPClient/smtp_test.cpp
@@ -444,6 +444,35 @@ TEST(SmtpScrubReply, NeutralisesTerminalEscapes) {
   EXPECT_EQ(scrubbed, "554 go ?]0;owned? away");
 }
 
+TEST(SmtpScrubReply, NeutralisesSingleByteC1Escapes) {
+  // A byte does not have to be C0 to steer a terminal: the C1 range carries
+  // single-byte equivalents of the escape sequences, 0x9B being CSI. A
+  // terminal in a non-UTF-8 locale acts on those directly.
+  //
+  // The literals stay split around each escape on purpose: a hex escape in
+  // C++ consumes every hex digit that follows it, so "\x9b31m" is one
+  // (overflowing) escape rather than 0x9B then "31m".
+  const std::string scrubbed = scrub_reply(std::string("550 \x9b"
+                                                       "31m red \x84 next"));
+
+  EXPECT_EQ(scrubbed.find('\x9b'), std::string::npos) << scrubbed;
+  EXPECT_EQ(scrubbed.find('\x84'), std::string::npos) << scrubbed;
+  EXPECT_EQ(scrubbed, "550 ?31m red ? next");
+}
+
+TEST(SmtpScrubReply, NeutralisesTheUtf8SpellingOfAC1Escape) {
+  // U+009B encoded as UTF-8 is 0xC2 0x9B, which a terminal that does decode
+  // UTF-8 turns back into CSI. Both bytes have to go, and scrubbing the whole
+  // character rather than one byte of it keeps the output from carrying a
+  // half-scrubbed sequence.
+  const std::string scrubbed = scrub_reply(std::string("550 \xc2\x9b"
+                                                       "31m red"));
+
+  EXPECT_EQ(scrubbed.find('\xc2'), std::string::npos) << scrubbed;
+  EXPECT_EQ(scrubbed.find('\x9b'), std::string::npos) << scrubbed;
+  EXPECT_EQ(scrubbed, "550 ??31m red");
+}
+
 TEST(SmtpScrubReply, FlattensTheMultiLineJoinSoOneReplyIsOneLogLine) {
   // read_reply() joins a multi-line reply with '\n'. Passed through raw, a
   // reply of "250-innocent\n250 ERROR forged line" writes two lines into the

--- a/modules/SMTPClient/smtp_test.cpp
+++ b/modules/SMTPClient/smtp_test.cpp
@@ -316,6 +316,71 @@ TEST(SmtpTimeout, ASpentBudgetIsReportedInOurOwnWords) {
 }
 
 // =============================================================================
+// Reply size limits
+// =============================================================================
+//
+// The timeout bounds how long a submission may take; these bound how much a
+// hostile peer can make it buffer within that time. Both scripts fail at the
+// banner, before any TLS is involved, so a plain session is enough.
+
+namespace {
+
+// Run a security=none submission against a scripted server and return the
+// resulting error message.
+std::string plain_failure(std::vector<std::string> responses) {
+  scripted_server server(std::move(responses));
+
+  smtp::connection_config cfg;
+  cfg.server = "127.0.0.1";
+  cfg.port = server.port();
+  cfg.security = "none";
+  cfg.timeout_seconds = 5;
+
+  smtp::message msg;
+  msg.from = "agent@example.com";
+  msg.to = "ops@example.com";
+  msg.body = "body";
+
+  try {
+    smtp::send(cfg, msg);
+  } catch (const smtp_exception &e) {
+    return e.what();
+  }
+  return "<no exception>";
+}
+
+}  // namespace
+
+TEST(SmtpReplyLimits, AReplyLineThatNeverEndsIsRefusedNotBuffered) {
+  // 80 KB with no CRLF anywhere: read_until() can never complete, and without
+  // a cap it buffers at line rate until the timeout budget is spent - seconds
+  // of a fast peer's output is gigabytes of agent memory.
+  const std::string error = plain_failure({std::string(80 * 1024, 'x')});
+
+  EXPECT_NE(error.find("reply line exceeds"), std::string::npos) << error;
+}
+
+TEST(SmtpReplyLimits, AReplyWithEndlessContinuationLinesIsRefused) {
+  // Continuation lines ("250-...") keep a single reply open indefinitely; the
+  // per-line cap never fires, so the reply as a whole needs a ceiling too.
+  std::string endless;
+  for (int i = 0; i < 200; ++i) endless += "250-mx.example.com keeps going\r\n";
+  const std::string error = plain_failure({endless});
+
+  EXPECT_NE(error.find("reply exceeds"), std::string::npos) << error;
+  EXPECT_NE(error.find("lines"), std::string::npos) << error;
+}
+
+TEST(SmtpReplyLimits, ALegitimateMultiLineReplyStaysUnderTheCaps) {
+  // Negative control: a normal session walks past the banner and EHLO and
+  // fails at its own scripted rejection, proving the caps stay out of the way.
+  const std::string error = plain_failure({kBanner, "250-mx.example.com\r\n250 HELP\r\n", "550 no\r\n"});
+
+  EXPECT_EQ(error.find("exceeds"), std::string::npos) << error;
+  EXPECT_NE(error.find("MAIL FROM"), std::string::npos) << error;
+}
+
+// =============================================================================
 // CA bundle
 // =============================================================================
 

--- a/modules/SMTPClient/smtp_test.cpp
+++ b/modules/SMTPClient/smtp_test.cpp
@@ -381,6 +381,57 @@ TEST(SmtpReplyLimits, ALegitimateMultiLineReplyStaysUnderTheCaps) {
 }
 
 // =============================================================================
+// scrub_reply
+// =============================================================================
+//
+// Server reply text ends up in exception messages, which land in the agent
+// log and in the submit response. The bytes are the peer's to choose, so they
+// are rendered inert before they travel.
+
+using smtp::detail::scrub_reply;
+
+TEST(SmtpScrubReply, PassesOrdinaryReplyTextThrough) {
+  EXPECT_EQ(scrub_reply("550 5.7.1 relay access denied"), "550 5.7.1 relay access denied");
+  EXPECT_EQ(scrub_reply(""), "");
+}
+
+TEST(SmtpScrubReply, NeutralisesTerminalEscapes) {
+  // ESC starts a terminal control sequence for whoever tails the log; every
+  // control byte is replaced, not just the ones with a known trick.
+  const std::string scrubbed = scrub_reply(std::string("554 go \x1b]0;owned\x07 away"));
+
+  EXPECT_EQ(scrubbed.find('\x1b'), std::string::npos) << scrubbed;
+  EXPECT_EQ(scrubbed.find('\x07'), std::string::npos) << scrubbed;
+  EXPECT_EQ(scrubbed, "554 go ?]0;owned? away");
+}
+
+TEST(SmtpScrubReply, FlattensTheMultiLineJoinSoOneReplyIsOneLogLine) {
+  // read_reply() joins a multi-line reply with '\n'. Passed through raw, a
+  // reply of "250-innocent\n250 ERROR forged line" writes two lines into the
+  // log, and only the first one is labelled as server output.
+  const std::string scrubbed = scrub_reply("250-first\n250 second");
+
+  EXPECT_EQ(scrubbed.find('\n'), std::string::npos) << scrubbed;
+  EXPECT_EQ(scrubbed, "250-first / 250 second");
+}
+
+TEST(SmtpScrubReply, TruncatesAnOversizedReply) {
+  const std::string scrubbed = scrub_reply("550 " + std::string(2000, 'x'));
+
+  EXPECT_LT(scrubbed.size(), 600u);
+  EXPECT_EQ(scrubbed.compare(scrubbed.size() - 3, 3, "..."), 0) << scrubbed;
+}
+
+TEST(SmtpScrubReply, TheScrubbedFormIsWhatTheErrorMessageCarries) {
+  // End to end: a scripted rejection carrying an ESC byte must surface with
+  // the byte neutralised, in the same exception operators see in the log.
+  const std::string error = plain_failure({std::string("554 no \x1b[31mred\x1b[0m entry\r\n")});
+
+  EXPECT_EQ(error.find('\x1b'), std::string::npos) << error;
+  EXPECT_NE(error.find("banner unexpected reply: 554 no ?[31mred?[0m entry"), std::string::npos) << error;
+}
+
+// =============================================================================
 // CA bundle
 // =============================================================================
 

--- a/modules/SMTPClient/smtp_test.cpp
+++ b/modules/SMTPClient/smtp_test.cpp
@@ -272,6 +272,15 @@ TEST(SmtpStarttls, ForgedDeliveryAcknowledgementsAreNotAccepted) {
   EXPECT_NE(error.find("STARTTLS response injection"), std::string::npos) << error;
 }
 
+TEST(SmtpStarttls, OnlyA220MayStartTheHandshake) {
+  // RFC 3207 4: the reply to STARTTLS is 220. Another 2xx is not "ready to
+  // start TLS", and handshaking against whatever sent it helps nobody.
+  const std::string error = starttls_failure("250 sure why not\r\n");
+
+  EXPECT_NE(error.find("STARTTLS unexpected reply"), std::string::npos) << error;
+  EXPECT_EQ(error.find("TLS handshake"), std::string::npos) << error;
+}
+
 TEST(SmtpStarttls, AWellBehavedGreetingReachesTheHandshake) {
   // Negative control: with nothing pipelined the guard must stay out of the
   // way. The scripted server does not speak TLS, so the session still fails -
@@ -378,6 +387,36 @@ TEST(SmtpReplyLimits, ALegitimateMultiLineReplyStaysUnderTheCaps) {
 
   EXPECT_EQ(error.find("exceeds"), std::string::npos) << error;
   EXPECT_NE(error.find("MAIL FROM"), std::string::npos) << error;
+}
+
+// =============================================================================
+// AUTH credential validation
+// =============================================================================
+
+TEST(SmtpAuthCredentials, ANulByteInTheCredentialsIsRefusedBeforeConnecting) {
+  // RFC 4616 frames AUTH PLAIN as NUL-separated fields, so a NUL inside the
+  // username would shift the authcid/password boundary. Port 1 would fail to
+  // connect if we got that far; seeing the NUL error proves we did not.
+  smtp::connection_config cfg;
+  cfg.server = "127.0.0.1";
+  cfg.port = "1";
+  cfg.security = "tls";
+  cfg.username = std::string("user\0extra", 10);
+  cfg.password = "secret";
+  cfg.timeout_seconds = 5;
+
+  smtp::message msg;
+  msg.from = "agent@example.com";
+  msg.to = "ops@example.com";
+  msg.body = "body";
+
+  try {
+    smtp::send(cfg, msg);
+    FAIL() << "expected the NUL byte to be refused";
+  } catch (const smtp_exception &e) {
+    EXPECT_NE(std::string(e.what()).find("must not contain NUL"), std::string::npos) << e.what();
+    EXPECT_EQ(std::string(e.what()).find("connect failed"), std::string::npos) << "must be refused before connecting: " << e.what();
+  }
 }
 
 // =============================================================================

--- a/tests/Dockerfiles/entrypoints/smtp.sh
+++ b/tests/Dockerfiles/entrypoints/smtp.sh
@@ -43,7 +43,9 @@ chmod 0666 /inbox/messages.txt
 echo ">> Starting test SMTP server"
 echo "   plain+STARTTLS on :1025"
 echo "   implicit TLS    on :1465"
-echo "   credentials: $SMTP_USERNAME / $SMTP_PASSWORD"
+# The password stays out of the container log: harmless for the hardcoded
+# test default, a leak the moment someone overrides it with a real one.
+echo "   credentials: $SMTP_USERNAME / <set via SMTP_PASSWORD>"
 echo "   inbox:       /inbox/messages.txt"
 
 exec python3 /app/server.py


### PR DESCRIPTION
## Summary

This change hardens the SMTP client against hostile or misbehaving peers by adding reply size limits, sanitizing server replies before logging, validating AUTH credentials, and fixing a use-after-return bug in timeout handling.

## Key Changes

- **Reply size limits:** Added per-line (64 KB) and per-reply (100 lines) caps to prevent a peer streaming bytes without line endings or endless continuation lines from exhausting agent memory within the timeout window.

- **Reply text sanitization:** Implemented `scrub_reply()` to render server replies inert before they reach error messages, logs, and submit responses:
  - Control bytes (including terminal escape sequences) are replaced with `?`
  - Multi-line replies have their `\n` joins replaced with ` / ` to prevent forging additional log lines
  - Oversized replies are truncated to 500 bytes

- **AUTH credential validation:** NUL bytes in username/password are now rejected before connecting, preventing RFC 4616 `AUTH PLAIN` field boundary shifts.

- **Timeout handling fix:** Fixed a use-after-return bug where cancelled I/O handlers from a timed-out connect attempt would execute against stale stack frames when retrying the next endpoint. Handler state now lives on the heap, co-owned by the handler, and a spent budget ends the endpoint walk.

- **STARTTLS reply validation:** The reply to `STARTTLS` must now be exactly `220` per RFC 3207 rather than any `2xx`, preventing handshake against an incorrect response.

- **Test coverage:** Added comprehensive tests for reply limits, credential validation, and reply scrubbing, plus a negative control test for legitimate multi-line replies.

- **Documentation:** Updated security notices and handler documentation; removed password echo from test SMTP server entrypoint.

## Implementation Details

- `scrub_reply()` is defined in the `detail` namespace and called throughout error paths to sanitize all server-provided text before it enters exception messages.
- The `sync_io::run_with_deadline()` refactor uses a heap-allocated `op_state` struct shared between the timer and operation handlers via `std::shared_ptr`, ensuring handler state outlives the frame.
- Reply buffer is now constructed with an explicit size cap: `asio::streambuf buf_{max_reply_line_bytes}`.
- All changes are backward-compatible; legitimate servers remain unaffected.

https://claude.ai/code/session_017VLaPYQnyXnwoRdK3KWv7Z