### PR TITLE
Unit-test the module classes behind a stub core

### DIFF
--- a/build.md
+++ b/build.md
@@ -976,12 +976,27 @@ gcovr --add-tracefile coverage/unit.json \
 nothing exercises a module whose only job is to crash the daemon, and if
 anything did, the crash would take the unflushed gcov counters with it.
 
-Three things are worth knowing before trusting the numbers:
+Four things are worth knowing before trusting the numbers:
 
 - **Stale `.gcda` are poison.** Once the sources move on, gcov rejects the old
   data with `stamp mismatch with notes file` and silently under-reports. The
   script deletes every `.gcda` before each suite; if you drive gcov by hand, do
   the same.
+- **Orphaned `.gcno` are worse.** gcovr reads every `.gcno` in the tree, so a
+  build directory reused across a `CMakeLists.txt` change accumulates objects
+  no target compiles any more and no rebuild will ever refresh. Edit such a
+  source and the same function is recorded at two different lines — the live
+  objects at the new one, the orphan at the old — which gcov reports as
+  `source file is newer than notes file` plus a whole file at
+  `Lines executed:0.00%`, and which makes gcovr's default strict function merge
+  abort the entire run (`AssertionError: Got function … on multiple lines: 89,
+  97`) after the build and the tests have already been paid for. An interrupted
+  build leaves the same mix. The script drops both kinds before building — an
+  object missing from its target's `build.make`, or one whose own source (from
+  the compiler depfile beside it) is newer than its notes — and with
+  `SKIP_BUILD=1` warns instead. It also passes
+  `--merge-mode-functions=merge-use-line-min` so any residual mismatch degrades
+  to a lowest-line report rather than losing the run.
 - **The daemon must shut down cleanly.** gcov flushes its counters in an
   `atexit` handler, so a SIGKILLed `nscp` contributes nothing. On Linux the
   harness stops it with SIGTERM and `CommandClient` turns that into a graceful

--- a/include/nscapi/test_helpers.hpp
+++ b/include/nscapi/test_helpers.hpp
@@ -1,0 +1,352 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+// A stub core for unit-testing module classes.
+//
+// A module class (nscapi::impl::simple_plugin) is not testable without a core:
+// loadModuleEx() registers and reads its settings through
+// nscapi::settings_proxy and registers its commands through
+// nscapi::core_helper, and both of those serialise a protobuf message into a
+// core entry point. None of them needs a *real* core though - answering the
+// settings queries out of a map, and acknowledging everything else, is enough
+// to drive the whole of loadModuleEx and every dispatch method in front of a
+// check.
+//
+// Typical use, in a test binary that has defined nscapi::plugin_singleton:
+//
+//   class MyModule : public ::testing::Test {
+//    protected:
+//     void SetUp() override { core().reset(); module_.set_id(42); }
+//     nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+//     MyModule module_;
+//   };
+//
+//   TEST_F(MyModule, ClampsTheInterval) {
+//     core().set_setting("interval", "0s");
+//     ASSERT_TRUE(module_.loadModuleEx("alias", NSCAPI::dontStart));
+//     ...
+//   }
+//
+// Always load with NSCAPI::dontStart: every module that starts a thread, a
+// socket or an interpreter guards it on `mode == NSCAPI::normalStart`, so
+// dontStart parses all the settings without any of that happening. (LUAScript
+// is the one module that does not guard, so it cannot use this yet.)
+//
+// The core entry points are plain C function pointers with no user data, so
+// the stub state is necessarily process-wide; reset() between tests.
+
+#include <NSCAPI.h>
+
+#include <cstring>
+#include <map>
+#include <nscapi/nscapi_core_wrapper.hpp>
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/protobuf/registry.hpp>
+#include <nscapi/protobuf/settings.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace nscapi {
+namespace test_helpers {
+
+// One settings key as the module registered it. Recorded so a test can assert
+// on the key/default matrix a module publishes - a renamed key or a changed
+// default silently breaks every existing configuration, and nothing else in
+// the build notices.
+struct registered_key {
+  std::string path;
+  std::string key;
+  std::string type;
+  std::string default_value;
+  std::string title;
+  std::string description;
+  bool advanced = false;
+  bool sample = false;
+  bool sensitive = false;
+};
+
+class stub_core {
+ public:
+  // The stub wired into the core that nscapi::plugin_singleton hands out -
+  // which is what simple_plugin::get_core() and the NSC_LOG_* macros resolve
+  // to. Loading the endpoints happens once, on the first call.
+  static stub_core &instance() {
+    static stub_core core;
+    return core;
+  }
+
+  // Forget everything recorded and configured. Call from the fixture's SetUp:
+  // the state is process-wide, so a leftover value would leak into the next
+  // test.
+  void reset() {
+    settings_.clear();
+    keys_.clear();
+    sections_.clear();
+    registered_keys_.clear();
+    registered_paths_.clear();
+    registrations_.clear();
+  }
+
+  // ----- configuring what the module reads ---------------------------------
+
+  // Value for a settings key, matched on the key name alone. Which alias path
+  // a module registers under is rarely what a test is about, and matching on
+  // it only makes the test brittle against a rename of the section.
+  void set_setting(const std::string &key, const std::string &value) { settings_[key] = value; }
+  // Same, but bound to one path - for the modules that read the same key name
+  // from more than one section.
+  void set_setting(const std::string &path, const std::string &key, const std::string &value) { settings_[path + "\x1f" + key] = value; }
+
+  // Keys present under a path, with their values. This is what a settings
+  // *path* handler (sh::fun_values_path, string_map_path - how every client
+  // module reads its `targets` and `handlers` sections) enumerates, so it is
+  // what makes add_target()/add_command() run at all.
+  //
+  // `path` may be the tail of the real path ("targets" matches
+  // "/settings/graphite/client/targets"), so a test does not have to know how
+  // the module spells its settings root.
+  void set_keys(const std::string &path, const std::vector<std::pair<std::string, std::string> > &keys) {
+    std::vector<std::string> names;
+    for (std::size_t i = 0; i < keys.size(); ++i) {
+      names.push_back(keys[i].first);
+      set_setting(path, keys[i].first, keys[i].second);
+    }
+    keys_[path] = names;
+  }
+  // Subsections under a path. A path handler stores these with an empty value
+  // (the section itself carries the configuration).
+  void set_sections(const std::string &path, const std::vector<std::string> &sections) { sections_[path] = sections; }
+
+  // ----- what the module registered ----------------------------------------
+
+  const std::vector<registered_key> &registered_keys() const { return registered_keys_; }
+  const std::vector<std::string> &registered_paths() const { return registered_paths_; }
+  // Queries and query aliases the module registered, in order.
+  std::vector<std::string> registered_commands() const { return names_of(PB::Registry::ItemType::QUERY, PB::Registry::ItemType::QUERY_ALIAS); }
+  // Channels (submission handlers) the module registered.
+  std::vector<std::string> registered_channels() const { return names_of(PB::Registry::ItemType::HANDLER, PB::Registry::ItemType::HANDLER); }
+  // Event subscriptions the module registered.
+  std::vector<std::string> registered_events() const { return names_of(PB::Registry::ItemType::EVENT, PB::Registry::ItemType::EVENT); }
+
+  bool has_key(const std::string &path, const std::string &key) const { return find_key(path, key) != nullptr; }
+  bool has_command(const std::string &name) const { return contains(registered_commands(), name); }
+  bool has_channel(const std::string &name) const { return contains(registered_channels(), name); }
+  bool has_event(const std::string &name) const { return contains(registered_events(), name); }
+
+  // Whether a key was registered as holding a credential. The core redacts
+  // those in the REST settings API, so the flag is security-relevant and
+  // worth pinning in a test.
+  bool is_sensitive(const std::string &key) const {
+    for (const registered_key &k : registered_keys_) {
+      if (k.key == key) return k.sensitive;
+    }
+    return false;
+  }
+  // The default a key was registered with, or "" if it was never registered.
+  std::string default_for(const std::string &path, const std::string &key) const {
+    const registered_key *k = find_key(path, key);
+    return k ? k->default_value : std::string();
+  }
+  // Convenience for the common case of a single settings section: first key
+  // with this name, whatever the path.
+  std::string default_for(const std::string &key) const {
+    for (const registered_key &k : registered_keys_) {
+      if (k.key == key) return k.default_value;
+    }
+    return std::string();
+  }
+
+ private:
+  stub_core() { nscapi::plugin_singleton->get_core()->load_endpoints(&load_endpoint); }
+
+  static bool contains(const std::vector<std::string> &haystack, const std::string &needle) {
+    for (std::size_t i = 0; i < haystack.size(); ++i) {
+      if (haystack[i] == needle) return true;
+    }
+    return false;
+  }
+
+  std::vector<std::string> names_of(const int type_a, const int type_b) const {
+    std::vector<std::string> ret;
+    for (std::size_t i = 0; i < registrations_.size(); ++i) {
+      if (registrations_[i].first == type_a || registrations_[i].first == type_b) ret.push_back(registrations_[i].second);
+    }
+    return ret;
+  }
+
+  const registered_key *find_key(const std::string &path, const std::string &key) const {
+    for (const registered_key &k : registered_keys_) {
+      if (k.path == path && k.key == key) return &k;
+    }
+    return nullptr;
+  }
+
+  std::string lookup(const std::string &path, const std::string &key, const std::string &def) const {
+    std::map<std::string, std::string>::const_iterator it = settings_.find(path + "\x1f" + key);
+    if (it != settings_.end()) return it->second;
+    for (it = settings_.begin(); it != settings_.end(); ++it) {
+      const std::size_t sep = it->first.find('\x1f');
+      if (sep == std::string::npos) continue;
+      if (it->first.compare(sep + 1, std::string::npos, key) == 0 && is_path_suffix(path, it->first.substr(0, sep))) return it->second;
+    }
+    it = settings_.find(key);
+    if (it != settings_.end()) return it->second;
+    return def;
+  }
+
+  // "targets" and "/settings/x/targets" both match "/settings/x/targets";
+  // lets a test name a section without spelling out the module's whole root.
+  static bool is_path_suffix(const std::string &path, const std::string &pattern) {
+    if (path == pattern) return true;
+    if (pattern.size() >= path.size()) return false;
+    return path.compare(path.size() - pattern.size(), pattern.size(), pattern) == 0 && path[path.size() - pattern.size() - 1] == '/';
+  }
+
+  const std::vector<std::string> *find_list(const std::map<std::string, std::vector<std::string> > &from, const std::string &path) const {
+    std::map<std::string, std::vector<std::string> >::const_iterator it = from.find(path);
+    if (it != from.end()) return &it->second;
+    for (it = from.begin(); it != from.end(); ++it) {
+      if (is_path_suffix(path, it->first)) return &it->second;
+    }
+    return nullptr;
+  }
+
+  // ----- the core entry points ---------------------------------------------
+
+  static void write_response(const std::string &payload, char **response, unsigned int *response_len) {
+    *response_len = static_cast<unsigned int>(payload.size());
+    *response = new char[payload.size() + 1];
+    std::memcpy(*response, payload.data(), payload.size());
+    (*response)[payload.size()] = '\0';
+  }
+
+  static NSCAPI::errorReturn settings_query(const char *request, const unsigned int request_len, char **response, unsigned int *response_len) {
+    stub_core &self = instance();
+    PB::Settings::SettingsRequestMessage req;
+    if (!req.ParseFromArray(request, static_cast<int>(request_len))) return NSCAPI::api_return_codes::hasFailed;
+
+    PB::Settings::SettingsResponseMessage resp;
+    for (int i = 0; i < req.payload_size(); ++i) {
+      const PB::Settings::SettingsRequestMessage::Request &in = req.payload(i);
+      PB::Settings::SettingsResponseMessage::Response *out = resp.add_payload();
+      out->mutable_result()->set_code(PB::Common::Result::STATUS_OK);
+
+      if (in.has_registration()) {
+        const PB::Settings::SettingsRequestMessage::Request::Registration &reg = in.registration();
+        if (reg.node().key().empty()) {
+          self.registered_paths_.push_back(reg.node().path());
+        } else {
+          registered_key key;
+          key.path = reg.node().path();
+          key.key = reg.node().key();
+          key.type = reg.info().type();
+          key.default_value = reg.info().default_value();
+          key.title = reg.info().title();
+          key.description = reg.info().description();
+          key.advanced = reg.info().advanced();
+          key.sample = reg.info().sample();
+          key.sensitive = reg.info().is_sensitive();
+          self.registered_keys_.push_back(key);
+        }
+      } else if (in.has_query()) {
+        const PB::Settings::SettingsRequestMessage::Request::Query &query = in.query();
+        const std::string path = query.node().path();
+        if (query.include_keys()) {
+          // get_keys(path): the key names under it, in `nodes`.
+          const std::vector<std::string> *keys = self.find_list(self.keys_, path);
+          if (keys != nullptr) {
+            for (const std::string &key : *keys) {
+              out->mutable_query()->add_nodes()->set_key(key);
+            }
+          }
+        } else if (query.recursive()) {
+          // get_sections(path): subsection paths, in `nodes`.
+          const std::vector<std::string> *sections = self.find_list(self.sections_, path);
+          if (sections != nullptr) {
+            for (const std::string &section : *sections) {
+              out->mutable_query()->add_nodes()->set_path(path + "/" + section);
+            }
+          }
+        } else {
+          PB::Settings::Node *node = out->mutable_query()->mutable_node();
+          node->set_path(path);
+          node->set_key(query.node().key());
+          node->set_value(self.lookup(path, query.node().key(), query.default_value()));
+        }
+      }
+      // Updates and everything else: an OK result is all the proxy reads.
+    }
+    write_response(resp.SerializeAsString(), response, response_len);
+    return NSCAPI::api_return_codes::isSuccess;
+  }
+
+  static NSCAPI::errorReturn registry_query(const char *request, const unsigned int request_len, char **response, unsigned int *response_len) {
+    stub_core &self = instance();
+    PB::Registry::RegistryRequestMessage req;
+    if (!req.ParseFromArray(request, static_cast<int>(request_len))) return NSCAPI::api_return_codes::hasFailed;
+
+    PB::Registry::RegistryResponseMessage resp;
+    for (int i = 0; i < req.payload_size(); ++i) {
+      PB::Registry::RegistryResponseMessage::Response *out = resp.add_payload();
+      out->mutable_result()->set_code(PB::Common::Result::STATUS_OK);
+      if (!req.payload(i).has_registration()) continue;
+      const PB::Registry::RegistryRequestMessage::Request::Registration &reg = req.payload(i).registration();
+      if (reg.unregister()) continue;
+      self.registrations_.push_back(std::make_pair(static_cast<int>(reg.type()), reg.name()));
+      for (int a = 0; a < reg.alias_size(); ++a) {
+        self.registrations_.push_back(std::make_pair(static_cast<int>(reg.type()), reg.alias(a)));
+      }
+    }
+    write_response(resp.SerializeAsString(), response, response_len);
+    return NSCAPI::api_return_codes::isSuccess;
+  }
+
+  // Storage is only read to restore state a unit test has none of; an empty
+  // response parses to zero payloads, which every caller treats as "nothing
+  // stored".
+  static NSCAPI::errorReturn empty_query(const char *, const unsigned int, char **response, unsigned int *response_len) {
+    write_response(std::string(), response, response_len);
+    return NSCAPI::api_return_codes::isSuccess;
+  }
+
+  // ${base-path} and friends expand to themselves: a test that cares about a
+  // path passes an absolute one.
+  static NSCAPI::errorReturn expand_path(const char *value, char *buffer, const unsigned int buf_len) {
+    const std::string in(value == nullptr ? "" : value);
+    if (in.size() >= buf_len) return NSCAPI::api_return_codes::hasFailed;
+    std::memcpy(buffer, in.data(), in.size());
+    buffer[in.size()] = '\0';
+    return NSCAPI::api_return_codes::isSuccess;
+  }
+
+  static void destroy_buffer(char **buffer) {
+    delete[] *buffer;
+    *buffer = nullptr;
+  }
+
+  static nscapi::core_api::FUNPTR load_endpoint(const char *name) {
+    const std::string n(name == nullptr ? "" : name);
+    if (n == "NSAPISettingsQuery") return reinterpret_cast<nscapi::core_api::FUNPTR>(&settings_query);
+    if (n == "NSAPIRegistryQuery") return reinterpret_cast<nscapi::core_api::FUNPTR>(&registry_query);
+    if (n == "NSAPIStorageQuery") return reinterpret_cast<nscapi::core_api::FUNPTR>(&empty_query);
+    if (n == "NSAPIExpandPath") return reinterpret_cast<nscapi::core_api::FUNPTR>(&expand_path);
+    if (n == "NSAPIDestroyBuffer") return reinterpret_cast<nscapi::core_api::FUNPTR>(&destroy_buffer);
+    // Everything else (logging above all) stays null, which the wrapper
+    // treats as a no-op.
+    return nullptr;
+  }
+
+  std::map<std::string, std::string> settings_;
+  std::map<std::string, std::vector<std::string> > keys_;
+  std::map<std::string, std::vector<std::string> > sections_;
+  std::vector<registered_key> registered_keys_;
+  std::vector<std::string> registered_paths_;
+  // (PB::Registry::ItemType, name) in registration order.
+  std::vector<std::pair<int, std::string> > registrations_;
+};
+
+}  // namespace test_helpers
+}  // namespace nscapi

--- a/modules/CheckDisk/CMakeLists.txt
+++ b/modules/CheckDisk/CMakeLists.txt
@@ -178,6 +178,15 @@ else()
         check_disk_unix_test
         SOURCES
             check_disk_unix_test.cpp
+            # The module class itself: its settings parsing and dispatch
+            # wrappers are ordinary C++ that only needs a stubbed core, and
+            # the branches they add (bad intervals, "collector not started",
+            # the legacy deprecation responses) are unreachable from a running
+            # daemon - so the integration suite cannot cover them.
+            check_disk_module_test.cpp
+            "${TARGET}.cpp"
+            ${NSCP_INCLUDEDIR}/compat.cpp
+            ${NSCP_INCLUDEDIR}/nscapi/nscapi_plugin_impl.cpp
             check_disk_health_test.cpp
             check_disk_io_check_test.cpp
             check_disk_health.cpp

--- a/modules/CheckDisk/CheckDisk.h
+++ b/modules/CheckDisk/CheckDisk.h
@@ -47,4 +47,10 @@ class CheckDisk : public nscapi::impl::simple_plugin {
   // Legacy checks
   void checkDriveSize(PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
   void checkFiles(PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+
+  // Read-only view of the collector the module owns; null until loadModuleEx()
+  // has created it. Exists so the unit test can assert on the intervals
+  // loadModuleEx parsed out of the settings - the clamping and the fallbacks
+  // it applies have no other observable effect.
+  const collector_thread *get_collector() const { return collector_.get(); }
 };

--- a/modules/CheckDisk/check_disk_module_test.cpp
+++ b/modules/CheckDisk/check_disk_module_test.cpp
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the CheckDisk module class itself - the settings it parses in
+// loadModuleEx() and the dispatch wrappers it puts in front of the individual
+// checks. The checks themselves are covered by their own *_test.cpp files;
+// what is tested here is only what the plugin shell adds on top of them:
+//
+//   * the collector settings: parsing, the 1s floor, the int ceiling, and the
+//     fallback-to-default on anything unparseable;
+//   * the "Collector not started" guard every collector-backed check opens
+//     with, and the catch-all each of them wraps its check in;
+//   * the deprecation responses the legacy shims return off Windows.
+//
+// None of those branches is reachable from the integration suite (a running
+// daemon has a collector and valid settings by construction), which is exactly
+// why they belong here.
+
+#include "CheckDisk.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/test_helpers.hpp>
+#include <string>
+#include <vector>
+
+#include "test_support.hpp"
+
+namespace {
+
+using check_disk_test_support::join_lines;
+using ScratchDir = check_disk_test_support::ScratchDir;
+
+// The stub core (include/nscapi/test_helpers.hpp) answers the settings queries
+// loadModuleEx makes; its state is process-wide, so it is reset per test.
+class CheckDiskModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  // dontStart, never normalStart: the collector settings are parsed either
+  // way, but no collector thread is spawned and no host tag is published.
+  bool load() { return module_.loadModuleEx("test_disk", NSCAPI::dontStart); }
+
+  const collector_thread &collector() const { return *module_.get_collector(); }
+
+  CheckDisk module_;
+};
+
+PB::Commands::QueryRequestMessage::Request make_request(const std::string &command, const std::vector<std::string> &args = {}) {
+  PB::Commands::QueryRequestMessage::Request request;
+  request.set_command(command);
+  for (const std::string &a : args) request.add_arguments(a);
+  return request;
+}
+
+}  // namespace
+
+// ============================================================================
+// Collector settings: the defaults
+// ============================================================================
+
+TEST_F(CheckDiskModule, LoadModuleCreatesCollectorWithDefaults) {
+  ASSERT_TRUE(load());
+  ASSERT_NE(module_.get_collector(), nullptr);
+  EXPECT_EQ(collector().collection_interval, 10);
+  EXPECT_EQ(collector().trend_interval, 300);
+  EXPECT_EQ(collector().trend_retention, 7 * 24 * 3600);
+  EXPECT_EQ(collector().max_collection_errors, 10);
+  EXPECT_TRUE(collector().disable_.empty());
+}
+
+TEST_F(CheckDiskModule, NoCollectorBeforeLoadModule) { EXPECT_EQ(module_.get_collector(), nullptr); }
+
+// ============================================================================
+// Collector settings: values that parse
+// ============================================================================
+
+TEST_F(CheckDiskModule, ConfiguredIntervalsAreApplied) {
+  core().set_setting("collection interval", "30s");
+  core().set_setting("trend interval", "10m");
+  core().set_setting("trend retention", "1d");
+  core().set_setting("max collection errors", "3");
+  core().set_setting("disable", "disk_io,trend");
+
+  ASSERT_TRUE(load());
+  EXPECT_EQ(collector().collection_interval, 30);
+  EXPECT_EQ(collector().trend_interval, 600);
+  EXPECT_EQ(collector().trend_retention, 24 * 3600);
+  EXPECT_EQ(collector().max_collection_errors, 3);
+  EXPECT_EQ(collector().disable_, "disk_io,trend");
+}
+
+TEST_F(CheckDiskModule, BareNumberIsSeconds) {
+  core().set_setting("collection interval", "45");
+
+  ASSERT_TRUE(load());
+  EXPECT_EQ(collector().collection_interval, 45);
+}
+
+// ============================================================================
+// Collector settings: values that do not - each must fall back, not propagate
+// ============================================================================
+
+TEST_F(CheckDiskModule, CollectionIntervalBelowOneSecondFallsBackToDefault) {
+  core().set_setting("collection interval", "0s");
+
+  ASSERT_TRUE(load());
+  EXPECT_EQ(collector().collection_interval, 10);
+}
+
+TEST_F(CheckDiskModule, CollectionIntervalPastIntMaxFallsBackToDefault) {
+  // Would wrap to a negative wait in the collector, which then spins.
+  core().set_setting("collection interval", "999999999999s");
+
+  ASSERT_TRUE(load());
+  EXPECT_EQ(collector().collection_interval, 10);
+}
+
+TEST_F(CheckDiskModule, UnparseableCollectionIntervalFallsBackToDefault) {
+  core().set_setting("collection interval", "banana");
+
+  ASSERT_TRUE(load());
+  EXPECT_EQ(collector().collection_interval, 10);
+}
+
+TEST_F(CheckDiskModule, NonPositiveTrendIntervalFallsBackToDefaults) {
+  core().set_setting("trend interval", "0");
+  core().set_setting("trend retention", "1d");
+
+  ASSERT_TRUE(load());
+  // Interval and retention are validated together, so both go back to their
+  // defaults - a 1d retention with a bad interval is not carried over.
+  EXPECT_EQ(collector().trend_interval, 300);
+  EXPECT_EQ(collector().trend_retention, 7 * 24 * 3600);
+}
+
+TEST_F(CheckDiskModule, UnparseableTrendRetentionFallsBackToDefaults) {
+  core().set_setting("trend retention", "banana");
+
+  ASSERT_TRUE(load());
+  EXPECT_EQ(collector().trend_interval, 300);
+  EXPECT_EQ(collector().trend_retention, 7 * 24 * 3600);
+}
+
+TEST_F(CheckDiskModule, NegativeMaxCollectionErrorsIsClampedToNeverGiveUp) {
+  core().set_setting("max collection errors", "-1");
+
+  ASSERT_TRUE(load());
+  EXPECT_EQ(collector().max_collection_errors, 0);
+}
+
+// A bad collection interval must not take the trend settings down with it, nor
+// the other way around: they are parsed in separate try blocks.
+TEST_F(CheckDiskModule, BadCollectionIntervalLeavesTrendSettingsIntact) {
+  core().set_setting("collection interval", "banana");
+  core().set_setting("trend interval", "10m");
+  core().set_setting("trend retention", "2d");
+
+  ASSERT_TRUE(load());
+  EXPECT_EQ(collector().collection_interval, 10);
+  EXPECT_EQ(collector().trend_interval, 600);
+  EXPECT_EQ(collector().trend_retention, 2 * 24 * 3600);
+}
+
+// ============================================================================
+// unloadModule
+// ============================================================================
+
+TEST_F(CheckDiskModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(CheckDiskModule, UnloadStopsANeverStartedCollector) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  // Idempotent: the module is unloaded twice on a reload race.
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+// ============================================================================
+// The collector-backed checks refuse to run without a collector
+// ============================================================================
+
+TEST_F(CheckDiskModule, CheckDiskIoWithoutCollectorIsUnknown) {
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.check_disk_io(make_request("check_disk_io"), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Collector not started"), std::string::npos) << join_lines(response);
+}
+
+TEST_F(CheckDiskModule, CheckDiskHealthWithoutCollectorIsUnknown) {
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.check_disk_health(make_request("check_disk_health"), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Collector not started"), std::string::npos) << join_lines(response);
+}
+
+// With a collector present (but never started, so its data is empty) the same
+// checks go down the real path instead.
+TEST_F(CheckDiskModule, CheckDiskIoWithIdleCollectorRuns) {
+  ASSERT_TRUE(load());
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.check_disk_io(make_request("check_disk_io", {"empty-state=ok"}), &response);
+
+  EXPECT_EQ(join_lines(response).find("Collector not started"), std::string::npos);
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+}
+
+TEST_F(CheckDiskModule, CheckDiskHealthWithIdleCollectorRuns) {
+  ASSERT_TRUE(load());
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.check_disk_health(make_request("check_disk_health", {"empty-state=ok"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+}
+
+// ============================================================================
+// Dispatch wrappers that only delegate: the response must come back from the
+// check, not from the wrapper's catch block.
+// ============================================================================
+
+TEST_F(CheckDiskModule, CheckSingleFileDelegates) {
+  const ScratchDir dir;
+  const std::string file = dir.make_file("hello.txt", "hello world");
+
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.check_single_file(make_request("check_single_file", {"file=" + file}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+}
+
+TEST_F(CheckDiskModule, CheckFilesDelegates) {
+  const ScratchDir dir;
+  dir.touch("a.txt");
+
+  PB::Commands::QueryResponseMessage::Response response;
+  // top-syntax=${list} so the scanned file names reach the rendered message -
+  // the default top syntax only reports a count.
+  module_.check_files(make_request("check_files", {"path=" + dir.string(), "pattern=*.txt", "detail-syntax=${filename}", "top-syntax=${list}"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  EXPECT_NE(join_lines(response).find("a.txt"), std::string::npos) << join_lines(response);
+}
+
+TEST_F(CheckDiskModule, CheckDiskWriteDelegates) {
+  // The only check here that needs no collector and writes for real; a 2k
+  // round trip inside the scratch directory keeps it hermetic.
+  const ScratchDir dir;
+
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.check_disk_write(make_request("check_disk_write", {"file=" + dir.string() + "/probe.dat", "size=2k"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+}
+
+TEST_F(CheckDiskModule, CheckMountDelegates) {
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.check_mount(make_request("check_mount", {"mount=/"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+}
+
+TEST_F(CheckDiskModule, CheckDrivesizeDelegatesWithoutTrends) {
+  // No collector, so the trend map handed to the check is the empty static
+  // one - the check must still run and render.
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.check_drivesize(make_request("check_drivesize", {"drive=/", "warning=none", "critical=none", "empty-state=ok"}), &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+}
+
+// ============================================================================
+// The Windows-only checks: off Windows their data acquisition is compiled out,
+// so what the module contributes is the wrapper. Each must return a response
+// rather than propagating an exception out of the plugin.
+// ============================================================================
+
+TEST_F(CheckDiskModule, WindowsOnlyChecksReturnAResponse) {
+  {
+    PB::Commands::QueryResponseMessage::Response response;
+    module_.check_uncpath(make_request("check_uncpath", {"path=\\\\host\\share"}), &response);
+    EXPECT_FALSE(join_lines(response).empty());
+  }
+  {
+    PB::Commands::QueryResponseMessage::Response response;
+    module_.check_storagepool(make_request("check_storagepool", {"empty-state=ok"}), &response);
+    EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  }
+  {
+    PB::Commands::QueryResponseMessage::Response response;
+    module_.check_shadowcopy(make_request("check_shadowcopy", {"empty-state=ok"}), &response);
+    EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  }
+  {
+    PB::Commands::QueryResponseMessage::Response response;
+    module_.check_share(make_request("check_share", {"empty-state=ok"}), &response);
+    EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
+  }
+}
+
+// ============================================================================
+// Legacy shims - deprecated and unsupported off Windows
+// ============================================================================
+
+TEST_F(CheckDiskModule, LegacyCheckDriveSizeIsUnsupportedHere) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("CheckDriveSize", {"CheckAll=true"});
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.checkDriveSize(request, &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  const std::string out = join_lines(response);
+  EXPECT_NE(out.find("deprecated legacy command"), std::string::npos) << out;
+  EXPECT_NE(out.find("check_drivesize"), std::string::npos) << out;
+}
+
+TEST_F(CheckDiskModule, LegacyCheckFilesIsUnsupportedHere) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("CheckFiles", {"path=/tmp"});
+  PB::Commands::QueryResponseMessage::Response response;
+  module_.checkFiles(request, &response);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  const std::string out = join_lines(response);
+  EXPECT_NE(out.find("deprecated legacy command"), std::string::npos) << out;
+  EXPECT_NE(out.find("check_files"), std::string::npos) << out;
+}
+
+// ============================================================================
+// Metrics
+// ============================================================================
+
+TEST_F(CheckDiskModule, FetchMetricsWithoutCollectorProducesNothing) {
+  PB::Metrics::MetricsMessage::Response response;
+  module_.fetchMetrics(&response);
+
+  EXPECT_EQ(response.bundles_size(), 0);
+}
+
+TEST_F(CheckDiskModule, FetchMetricsWithIdleCollectorProducesTheDiskBundle) {
+  ASSERT_TRUE(load());
+  PB::Metrics::MetricsMessage::Response response;
+  module_.fetchMetrics(&response);
+
+  ASSERT_EQ(response.bundles_size(), 1);
+  EXPECT_EQ(response.bundles(0).key(), "disk");
+  // Nothing has been collected, so the bundle carries no io/free sections.
+  EXPECT_EQ(response.bundles(0).children_size(), 0);
+}

--- a/modules/CheckMKClient/CMakeLists.txt
+++ b/modules/CheckMKClient/CMakeLists.txt
@@ -95,6 +95,43 @@ NSCP_CREATE_TEST(
         ${Boost_THREAD_LIBRARY}
         ${Boost_DATE_TIME_LIBRARY}
         ${EXTRA_LIBS}
+        ${LUA_LIBRARIES}
+        lua_nscp
+        # lua_nscp pulls in boost::this_thread, so the thread library has to
+        # come after it on the link line as well.
+        ${Boost_THREAD_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    check_mk_module_test
+    SOURCES
+        check_mk_module_test.cpp
+        "${TARGET}.cpp"
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/net/check_mk/lua/lua_check_mk.cpp
+        ${NSCP_INCLUDEDIR}/metrics/metrics_store_map.cpp
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+        ${LUA_LIBRARIES}
+        lua_nscp
+        # lua_nscp pulls in boost::this_thread, so the thread library has to
+        # come after it on the link line as well.
+        ${Boost_THREAD_LIBRARY}
+        ${CMAKE_THREAD_LIBS_INIT}
     INCLUDES
         ${NSCP_INCLUDEDIR}
         ${CMAKE_CURRENT_SOURCE_DIR}

--- a/modules/CheckMKClient/check_mk_module_test.cpp
+++ b/modules/CheckMKClient/check_mk_module_test.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the CheckMKClient module class - the settings it registers
+// and reads in loadModuleEx(), and the target/handler sections it turns into
+// client targets and relay commands. The check_mk wire format and the option
+// parsing live in check_mk_handler.hpp and have their own tests.
+
+#include "CheckMKClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class CheckMkModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its tail
+  // rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  CheckMKClient module_;
+};
+
+}  // namespace
+
+TEST_F(CheckMkModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+  EXPECT_EQ(core().default_for("channel"), "CheckMK");
+}
+
+TEST_F(CheckMkModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+  EXPECT_TRUE(has_section("handlers")) << "no handlers section registered";
+}
+
+TEST_F(CheckMkModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("CheckMK"));
+}
+
+TEST_F(CheckMkModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_CHANNEL");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_CHANNEL"));
+  EXPECT_FALSE(core().has_channel("CheckMK"));
+}
+
+TEST_F(CheckMkModule, HandlerKeysAreRegisteredAsCommands) {
+  core().set_keys("handlers", {{"submit_check_mk", "host=127.0.0.1"}});
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_command("submit_check_mk")) << "handler key was not registered as a command";
+}
+
+TEST_F(CheckMkModule, EmptyHandlerKeyRegistersNoCommand) {
+  core().set_keys("handlers", {{"", ""}});
+
+  ASSERT_TRUE(load());
+  EXPECT_FALSE(core().has_command(""));
+}
+
+TEST_F(CheckMkModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "host=127.0.0.1,port=6556"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(CheckMkModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+TEST_F(CheckMkModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(CheckMkModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(CheckMkModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/modules/CollectdClient/CMakeLists.txt
+++ b/modules/CollectdClient/CMakeLists.txt
@@ -62,3 +62,29 @@ NSCP_CREATE_TEST(
         ${NSCP_INCLUDEDIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    collectd_module_test
+    SOURCES
+        collectd_module_test.cpp
+        "${TARGET}.cpp"
+        ${NSCP_INCLUDEDIR}/net/collectd/collectd_packet.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        expression_parser
+        ${Boost_REGEX_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/CollectdClient/collectd_module_test.cpp
+++ b/modules/CollectdClient/collectd_module_test.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the CollectdClient module class - the settings it registers and
+// reads in loadModuleEx(), and the targets and variables and metrics sections it turns into
+// client targets. The wire format and the option parsing live in the
+// module's other translation units and have their own tests; what is covered
+// here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "CollectdClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class CollectdModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its
+  // tail rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  CollectdClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(CollectdModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("hostname"), "auto");
+  EXPECT_EQ(core().default_for("interval"), "10");
+}
+
+TEST_F(CollectdModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+  EXPECT_TRUE(has_section("variables")) << "no variables section registered";
+  EXPECT_TRUE(has_section("metrics")) << "no metrics section registered";
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(CollectdModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "host=127.0.0.1,port=25826"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(CollectdModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle
+// ============================================================================
+
+TEST_F(CollectdModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(CollectdModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}

--- a/modules/ElasticClient/CMakeLists.txt
+++ b/modules/ElasticClient/CMakeLists.txt
@@ -68,3 +68,28 @@ NSCP_CREATE_TEST(
         ${NSCP_INCLUDEDIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Unit tests for the module class itself: the settings it registers/reads, the
+# event subscription and the submit guard. The stub core
+# (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    elastic_module_test
+    SOURCES
+        elastic_module_test.cpp
+        "${TARGET}.cpp"
+        ${NSCP_INCLUDEDIR}/nsclient/logger/logger_helper.cpp
+        ${NSCP_INCLUDEDIR}/json/use_json.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/bytes/base64.c
+        ${NSCP_DEF_PLUGIN_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/ElasticClient/elastic_module_test.cpp
+++ b/modules/ElasticClient/elastic_module_test.cpp
@@ -1,0 +1,143 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the ElasticClient module class - the settings it registers
+// and reads in loadModuleEx(), the event subscription it takes out, and the
+// guard that keeps the submit paths quiet until the module has been started.
+// The bulk payload format lives in elastic_bulk and has its own tests.
+//
+// This module carries credentials (password, api key) and TLS settings, so
+// their defaults and their sensitive flags are pinned here: the flag is what
+// makes the core redact the value in the REST settings API, and a default that
+// silently loosens TLS is a security change.
+
+#include "ElasticClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class ElasticModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const NSCAPI::moduleLoadMode mode = NSCAPI::dontStart) { return module_.loadModuleEx("", mode); }
+
+  ElasticClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(ElasticModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("hostname"), "auto");
+  EXPECT_EQ(core().default_for("events"), "eventlog:*,logfile:*");
+  EXPECT_EQ(core().default_for("timeout"), "30");
+  EXPECT_EQ(core().default_for("event index"), "nsclient_event-%(date)");
+  EXPECT_EQ(core().default_for("metrics index"), "nsclient_metrics-%(date)");
+  EXPECT_EQ(core().default_for("nsclient log index"), "nsclient_log-%(date)");
+}
+
+// Mapping types were removed in Elasticsearch 8, which rejects a request that
+// carries one - so the types must default to unset.
+TEST_F(ElasticModule, MappingTypesDefaultToUnset) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("event type"), "");
+  EXPECT_EQ(core().default_for("metrics type"), "");
+  EXPECT_EQ(core().default_for("nsclient log type"), "");
+}
+
+TEST_F(ElasticModule, TlsDefaultsAreTheHardenedOnes) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("tls version"), "1.2+");
+  EXPECT_EQ(core().default_for("verify mode"), "peer");
+  EXPECT_EQ(core().default_for("ca"), "${ca-path}");
+}
+
+TEST_F(ElasticModule, CredentialsAreRegisteredAsSensitive) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(core().is_sensitive("password")) << "password is not redacted by the settings API";
+  EXPECT_TRUE(core().is_sensitive("api key")) << "api key is not redacted by the settings API";
+  EXPECT_FALSE(core().is_sensitive("user"));
+}
+
+// ============================================================================
+// The event subscription
+// ============================================================================
+
+TEST_F(ElasticModule, LoadSubscribesToTheDefaultEvents) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_event("eventlog:*,logfile:*"));
+}
+
+TEST_F(ElasticModule, ConfiguredEventsAreSubscribedInstead) {
+  core().set_setting("events", "logfile:mylog");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_event("logfile:mylog"));
+  EXPECT_FALSE(core().has_event("eventlog:*,logfile:*"));
+}
+
+// ============================================================================
+// Start mode and the submit guard
+// ============================================================================
+
+TEST_F(ElasticModule, LoadsInEveryMode) {
+  EXPECT_TRUE(load(NSCAPI::dontStart));
+  EXPECT_TRUE(load(NSCAPI::normalStart));
+  EXPECT_TRUE(load(NSCAPI::reloadStart));
+}
+
+// Not started: every submit path must return without touching the network.
+TEST_F(ElasticModule, SubmitPathsAreQuietBeforeStart) {
+  ASSERT_TRUE(load(NSCAPI::dontStart));
+
+  PB::Metrics::MetricsMessage metrics;
+  EXPECT_NO_THROW(module_.submitMetrics(metrics));
+
+  PB::Log::LogEntry::Entry entry;
+  entry.set_message("hello");
+  EXPECT_NO_THROW(module_.handleLogMessage(entry));
+}
+
+// Started but with no address configured: the module must report the bad
+// address and drop the payload rather than throw out of the callback.
+TEST_F(ElasticModule, SubmitWithoutAnAddressIsHandled) {
+  ASSERT_TRUE(load(NSCAPI::reloadStart));
+
+  PB::Log::LogEntry::Entry entry;
+  entry.set_message("hello");
+  EXPECT_NO_THROW(module_.handleLogMessage(entry));
+}
+
+TEST_F(ElasticModule, UnloadStopsTheSubmitPaths) {
+  ASSERT_TRUE(load(NSCAPI::reloadStart));
+  EXPECT_TRUE(module_.unloadModule());
+
+  PB::Metrics::MetricsMessage metrics;
+  EXPECT_NO_THROW(module_.submitMetrics(metrics));
+}
+
+TEST_F(ElasticModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }

--- a/modules/GraphiteClient/CMakeLists.txt
+++ b/modules/GraphiteClient/CMakeLists.txt
@@ -55,3 +55,28 @@ target_link_libraries(
     ${EXTRA_LIBS}
 )
 include(${BUILD_CMAKE_FOLDER}/module.cmake)
+
+NSCP_CREATE_TEST(
+    graphite_module_test
+    SOURCES
+        graphite_module_test.cpp
+        "${TARGET}.cpp"
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_program_options.cpp
+        ${NSCP_INCLUDEDIR}/nscapi/nscapi_plugin_impl.cpp
+        # The Windows plugin_api DLL does not export the settings_helper
+        # symbols the target objects' read() needs, so compile them in
+        # (see client_command_line_parser_test).
+        ${NSCP_INCLUDEDIR}/nscapi/settings/helper.cpp
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/GraphiteClient/graphite_module_test.cpp
+++ b/modules/GraphiteClient/graphite_module_test.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the GraphiteClient module class - the settings it registers
+// and reads in loadModuleEx(), and the target/handler sections it turns into
+// client targets and relay commands. The wire format and the option parsing
+// live in graphite_client.hpp / graphite_handler.hpp and have their own tests;
+// what is covered here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "GraphiteClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class GraphiteModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  // dontStart: nothing in this module starts a thread, but every module test
+  // loads the same way so the pattern stays copyable.
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  GraphiteClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(GraphiteModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("hostname"), "auto");
+  EXPECT_EQ(core().default_for("channel"), "GRAPHITE");
+}
+
+TEST_F(GraphiteModule, LoadRegistersTheTargetAndHandlerSections) {
+  ASSERT_TRUE(load());
+
+  bool targets = false, handlers = false;
+  for (const std::string &path : core().registered_paths()) {
+    if (path.size() >= 7 && path.compare(path.size() - 7, 7, "targets") == 0) targets = true;
+    if (path.size() >= 8 && path.compare(path.size() - 8, 8, "handlers") == 0) handlers = true;
+  }
+  EXPECT_TRUE(targets) << "no targets section registered";
+  EXPECT_TRUE(handlers) << "no handlers section registered";
+}
+
+// ============================================================================
+// The channel: what the core routes submissions on
+// ============================================================================
+
+TEST_F(GraphiteModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("GRAPHITE")) << "GRAPHITE channel not registered";
+}
+
+TEST_F(GraphiteModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_GRAPHITE");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_GRAPHITE"));
+  EXPECT_FALSE(core().has_channel("GRAPHITE"));
+}
+
+// ============================================================================
+// The handlers section becomes relay commands
+// ============================================================================
+
+TEST_F(GraphiteModule, HandlerKeysAreRegisteredAsCommands) {
+  core().set_keys("handlers", {{"submit_graphite", "host=127.0.0.1"}});
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_command("submit_graphite")) << "handler key was not registered as a command";
+}
+
+// A handler the client cannot make a command out of must not be registered -
+// and must not take the module load down with it.
+TEST_F(GraphiteModule, EmptyHandlerKeyRegistersNoCommand) {
+  core().set_keys("handlers", {{"", ""}});
+
+  ASSERT_TRUE(load());
+  EXPECT_FALSE(core().has_command(""));
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(GraphiteModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "host=127.0.0.1,port=2003"}});
+
+  // A target that does not parse must be reported and skipped, not thrown out
+  // of loadModuleEx - one bad target in nsclient.ini would otherwise take the
+  // whole module offline.
+  EXPECT_TRUE(load());
+}
+
+TEST_F(GraphiteModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle and dispatch
+// ============================================================================
+
+TEST_F(GraphiteModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(GraphiteModule, UnloadAfterLoadClearsTheClient) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(GraphiteModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/modules/IcingaClient/CMakeLists.txt
+++ b/modules/IcingaClient/CMakeLists.txt
@@ -58,3 +58,29 @@ target_link_libraries(
 )
 OPENSSL_LINK_FIX(${TARGET})
 include(${BUILD_CMAKE_FOLDER}/module.cmake)
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    icinga_module_test
+    SOURCES
+        icinga_module_test.cpp
+        "${TARGET}.cpp"
+        icinga.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/json/use_json.cpp
+        ${NSCP_INCLUDEDIR}/bytes/base64.c
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/IcingaClient/icinga_module_test.cpp
+++ b/modules/IcingaClient/icinga_module_test.cpp
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the IcingaClient module class - the settings it registers and
+// reads in loadModuleEx(), and the targets sections it turns into
+// client targets. The wire format and the option parsing live in the
+// module's other translation units and have their own tests; what is covered
+// here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "IcingaClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class IcingaModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its
+  // tail rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  IcingaClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(IcingaModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("hostname"), "auto");
+  EXPECT_EQ(core().default_for("channel"), "ICINGA");
+}
+
+TEST_F(IcingaModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+}
+
+// ============================================================================
+// The channel: what the core routes submissions on
+// ============================================================================
+
+TEST_F(IcingaModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("ICINGA")) << "ICINGA channel not registered";
+}
+
+TEST_F(IcingaModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_CHANNEL");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_CHANNEL"));
+  EXPECT_FALSE(core().has_channel("ICINGA"));
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(IcingaModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "address=https://localhost:5665"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(IcingaModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle and dispatch
+// ============================================================================
+
+TEST_F(IcingaModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(IcingaModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(IcingaModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/modules/NRDPClient/CMakeLists.txt
+++ b/modules/NRDPClient/CMakeLists.txt
@@ -106,3 +106,30 @@ NSCP_CREATE_TEST(
         ${TINYXML2_INCLUDE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    nrdp_module_test
+    SOURCES
+        nrdp_module_test.cpp
+        "${TARGET}.cpp"
+        nrdp.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/bytes/base64.c
+        ${TINYXML2_SRCS}
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${TINYXML2_EXTRA_LIBS}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/NRDPClient/nrdp_module_test.cpp
+++ b/modules/NRDPClient/nrdp_module_test.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the NRDPClient module class - the settings it registers and
+// reads in loadModuleEx(), and the targets and handlers sections it turns into
+// client targets and relay commands. The wire format and the option parsing live in the
+// module's other translation units and have their own tests; what is covered
+// here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "NRDPClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class NrdpModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its
+  // tail rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  NRDPClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(NrdpModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("hostname"), "auto");
+  EXPECT_EQ(core().default_for("channel"), "NRDP");
+}
+
+TEST_F(NrdpModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+  EXPECT_TRUE(has_section("handlers")) << "no handlers section registered";
+}
+
+// ============================================================================
+// The channel: what the core routes submissions on
+// ============================================================================
+
+TEST_F(NrdpModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("NRDP")) << "NRDP channel not registered";
+}
+
+TEST_F(NrdpModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_CHANNEL");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_CHANNEL"));
+  EXPECT_FALSE(core().has_channel("NRDP"));
+}
+
+// ============================================================================
+// The handlers section becomes relay commands
+// ============================================================================
+
+TEST_F(NrdpModule, HandlerKeysAreRegisteredAsCommands) {
+  core().set_keys("handlers", {{"submit_nrdp", "address=http://localhost/nrdp"}});
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_command("submit_nrdp")) << "handler key was not registered as a command";
+}
+
+// A handler the client cannot make a command out of must not be registered -
+// and must not take the module load down with it.
+TEST_F(NrdpModule, EmptyHandlerKeyRegistersNoCommand) {
+  core().set_keys("handlers", {{"", ""}});
+
+  ASSERT_TRUE(load());
+  EXPECT_FALSE(core().has_command(""));
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(NrdpModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "address=http://localhost/nrdp"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(NrdpModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle and dispatch
+// ============================================================================
+
+TEST_F(NrdpModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(NrdpModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(NrdpModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/modules/NSCAClient/CMakeLists.txt
+++ b/modules/NSCAClient/CMakeLists.txt
@@ -65,3 +65,30 @@ target_link_libraries(
 include(${BUILD_CMAKE_FOLDER}/module.cmake)
 source_group("Client" REGULAR_EXPRESSION .*include/nsca/.*)
 source_group("Socket" REGULAR_EXPRESSION .*include/socket/.*)
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    nsca_module_test
+    SOURCES
+        nsca_module_test.cpp
+        "${TARGET}.cpp"
+        ${NSCP_INCLUDEDIR}/net/nsca/nsca_packet.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/bytes/crc32.cpp
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${CRYPTOPP_LIBRARIES}
+        ${EXTRA_LIBS}
+        nscpcrypt
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/NSCAClient/nsca_module_test.cpp
+++ b/modules/NSCAClient/nsca_module_test.cpp
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the NSCAClient module class - the settings it registers and
+// reads in loadModuleEx(), and the targets and handlers sections it turns into
+// client targets and relay commands. The wire format and the option parsing live in the
+// module's other translation units and have their own tests; what is covered
+// here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "NSCAClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class NscaModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its
+  // tail rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  NSCAClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(NscaModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("hostname"), "auto");
+  EXPECT_EQ(core().default_for("encoding"), "");
+  EXPECT_EQ(core().default_for("channel"), "NSCA");
+}
+
+TEST_F(NscaModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+  EXPECT_TRUE(has_section("handlers")) << "no handlers section registered";
+}
+
+// ============================================================================
+// The channel: what the core routes submissions on
+// ============================================================================
+
+TEST_F(NscaModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("NSCA")) << "NSCA channel not registered";
+}
+
+TEST_F(NscaModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_CHANNEL");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_CHANNEL"));
+  EXPECT_FALSE(core().has_channel("NSCA"));
+}
+
+// ============================================================================
+// The handlers section becomes relay commands
+// ============================================================================
+
+TEST_F(NscaModule, HandlerKeysAreRegisteredAsCommands) {
+  core().set_keys("handlers", {{"submit_nsca", "host=127.0.0.1,port=5667"}});
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_command("submit_nsca")) << "handler key was not registered as a command";
+}
+
+// A handler the client cannot make a command out of must not be registered -
+// and must not take the module load down with it.
+TEST_F(NscaModule, EmptyHandlerKeyRegistersNoCommand) {
+  core().set_keys("handlers", {{"", ""}});
+
+  ASSERT_TRUE(load());
+  EXPECT_FALSE(core().has_command(""));
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(NscaModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "host=127.0.0.1,port=5667"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(NscaModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle and dispatch
+// ============================================================================
+
+TEST_F(NscaModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(NscaModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(NscaModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/modules/NSCANgClient/CMakeLists.txt
+++ b/modules/NSCANgClient/CMakeLists.txt
@@ -100,3 +100,31 @@ NSCP_CREATE_TEST(
         ${OPENSSL_INCLUDE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    nscang_module_test
+    SOURCES
+        nscang_module_test.cpp
+        "${TARGET}.cpp"
+        nsca_ng.cpp
+        nsca_ng_client.cpp
+        nsca_ng_handler.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${OPENSSL_LIBRARIES}
+        ${NSCA_NG_TEST_EXTRA_LIBS}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/NSCANgClient/nscang_module_test.cpp
+++ b/modules/NSCANgClient/nscang_module_test.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the NSCANgClient module class - the settings it registers and
+// reads in loadModuleEx(), and the targets and handlers sections it turns into
+// client targets and relay commands. The wire format and the option parsing live in the
+// module's other translation units and have their own tests; what is covered
+// here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "NSCANgClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class NscaNgModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its
+  // tail rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  NSCANgClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(NscaNgModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("hostname"), "auto");
+  EXPECT_EQ(core().default_for("channel"), "NSCA-NG");
+}
+
+TEST_F(NscaNgModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+  EXPECT_TRUE(has_section("handlers")) << "no handlers section registered";
+}
+
+// ============================================================================
+// The channel: what the core routes submissions on
+// ============================================================================
+
+TEST_F(NscaNgModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("NSCA-NG")) << "NSCA-NG channel not registered";
+}
+
+TEST_F(NscaNgModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_CHANNEL");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_CHANNEL"));
+  EXPECT_FALSE(core().has_channel("NSCA-NG"));
+}
+
+// ============================================================================
+// The handlers section becomes relay commands
+// ============================================================================
+
+TEST_F(NscaNgModule, HandlerKeysAreRegisteredAsCommands) {
+  core().set_keys("handlers", {{"submit_nsca_ng", "host=127.0.0.1,port=5668"}});
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_command("submit_nsca_ng")) << "handler key was not registered as a command";
+}
+
+// A handler the client cannot make a command out of must not be registered -
+// and must not take the module load down with it.
+TEST_F(NscaNgModule, EmptyHandlerKeyRegistersNoCommand) {
+  core().set_keys("handlers", {{"", ""}});
+
+  ASSERT_TRUE(load());
+  EXPECT_FALSE(core().has_command(""));
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(NscaNgModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "host=127.0.0.1,port=5668"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(NscaNgModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle and dispatch
+// ============================================================================
+
+TEST_F(NscaNgModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(NscaNgModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(NscaNgModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/modules/NSCPClient/CMakeLists.txt
+++ b/modules/NSCPClient/CMakeLists.txt
@@ -80,3 +80,26 @@ NSCP_CREATE_TEST(
         ${NSCP_INCLUDEDIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    nscp_client_module_test
+    SOURCES
+        nscp_client_module_test.cpp
+        "${TARGET}.cpp"
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/NSCPClient/nscp_client_module_test.cpp
+++ b/modules/NSCPClient/nscp_client_module_test.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the NSCPClient module class - the settings it registers and
+// reads in loadModuleEx(), and the targets and handlers sections it turns into
+// client targets and relay commands. The wire format and the option parsing live in the
+// module's other translation units and have their own tests; what is covered
+// here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "NSCPClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class NscpClientModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its
+  // tail rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  NSCPClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(NscpClientModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("channel"), "NSCP");
+}
+
+TEST_F(NscpClientModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+  EXPECT_TRUE(has_section("handlers")) << "no handlers section registered";
+}
+
+// ============================================================================
+// The channel: what the core routes submissions on
+// ============================================================================
+
+TEST_F(NscpClientModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("NSCP")) << "NSCP channel not registered";
+}
+
+TEST_F(NscpClientModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_CHANNEL");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_CHANNEL"));
+  EXPECT_FALSE(core().has_channel("NSCP"));
+}
+
+// ============================================================================
+// The handlers section becomes relay commands
+// ============================================================================
+
+TEST_F(NscpClientModule, HandlerKeysAreRegisteredAsCommands) {
+  core().set_keys("handlers", {{"submit_nscp", "host=127.0.0.1,port=5668"}});
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_command("submit_nscp")) << "handler key was not registered as a command";
+}
+
+// A handler the client cannot make a command out of must not be registered -
+// and must not take the module load down with it.
+TEST_F(NscpClientModule, EmptyHandlerKeyRegistersNoCommand) {
+  core().set_keys("handlers", {{"", ""}});
+
+  ASSERT_TRUE(load());
+  EXPECT_FALSE(core().has_command(""));
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(NscpClientModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "host=127.0.0.1,port=5668"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(NscpClientModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle and dispatch
+// ============================================================================
+
+TEST_F(NscpClientModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(NscpClientModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(NscpClientModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/modules/SMTPClient/CMakeLists.txt
+++ b/modules/SMTPClient/CMakeLists.txt
@@ -111,3 +111,28 @@ NSCP_CREATE_TEST(
         ${NSCP_INCLUDEDIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    smtp_module_test
+    SOURCES
+        smtp_module_test.cpp
+        "${TARGET}.cpp"
+        smtp.cpp
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_INCLUDEDIR}/bytes/base64.c
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/SMTPClient/smtp_module_test.cpp
+++ b/modules/SMTPClient/smtp_module_test.cpp
@@ -1,0 +1,144 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the SMTPClient module class - the settings it registers and
+// reads in loadModuleEx(), and the targets and handlers sections it turns into
+// client targets and relay commands. The wire format and the option parsing live in the
+// module's other translation units and have their own tests; what is covered
+// here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "SMTPClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class SmtpModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its
+  // tail rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  SMTPClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(SmtpModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("channel"), "SMTP");
+}
+
+TEST_F(SmtpModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+  EXPECT_TRUE(has_section("handlers")) << "no handlers section registered";
+}
+
+// ============================================================================
+// The channel: what the core routes submissions on
+// ============================================================================
+
+TEST_F(SmtpModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("SMTP")) << "SMTP channel not registered";
+}
+
+TEST_F(SmtpModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_CHANNEL");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_CHANNEL"));
+  EXPECT_FALSE(core().has_channel("SMTP"));
+}
+
+// ============================================================================
+// The handlers section becomes relay commands
+// ============================================================================
+
+TEST_F(SmtpModule, HandlerKeysAreRegisteredAsCommands) {
+  core().set_keys("handlers", {{"submit_smtp", "address=smtp://localhost"}});
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_command("submit_smtp")) << "handler key was not registered as a command";
+}
+
+// A handler the client cannot make a command out of must not be registered -
+// and must not take the module load down with it.
+TEST_F(SmtpModule, EmptyHandlerKeyRegistersNoCommand) {
+  core().set_keys("handlers", {{"", ""}});
+
+  ASSERT_TRUE(load());
+  EXPECT_FALSE(core().has_command(""));
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(SmtpModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "address=smtp://localhost"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(SmtpModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle and dispatch
+// ============================================================================
+
+TEST_F(SmtpModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(SmtpModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(SmtpModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/modules/SyslogClient/CMakeLists.txt
+++ b/modules/SyslogClient/CMakeLists.txt
@@ -66,3 +66,26 @@ NSCP_CREATE_TEST(
         ${NSCP_INCLUDEDIR}
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Unit tests for the module class itself: the settings it registers/reads and
+# the target/handler sections it turns into client targets and commands. The
+# stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
+NSCP_CREATE_TEST(
+    syslog_module_test
+    SOURCES
+        syslog_module_test.cpp
+        "${TARGET}.cpp"
+        ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
+        ${NSCP_DEF_PLUGIN_CPP}
+        ${NSCP_CLIENT_CPP}
+    LIBRARIES
+        GTest::gtest_main
+        ${NSCP_DEF_PLUGIN_LIB}
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_THREAD_LIBRARY}
+        ${Boost_DATE_TIME_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)

--- a/modules/SyslogClient/syslog_module_test.cpp
+++ b/modules/SyslogClient/syslog_module_test.cpp
@@ -1,0 +1,145 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the SyslogClient module class - the settings it registers and
+// reads in loadModuleEx(), and the targets and handlers sections it turns into
+// client targets and relay commands. The wire format and the option parsing live in the
+// module's other translation units and have their own tests; what is covered
+// here is only the plugin shell around them.
+//
+// The settings keys and their defaults are part of the module's contract with
+// every existing nsclient.ini, so a rename or a changed default is a breaking
+// change: asserting on them here is what makes that visible in review.
+
+#include "SyslogClient.h"
+
+#include <gtest/gtest.h>
+
+#include <nscapi/nscapi_helper_singleton.hpp>
+#include <nscapi/test_helpers.hpp>
+#include <string>
+
+// Test binaries have no generated module glue, so the plugin singleton
+// (normally provided by NSC_WRAP_DLL()) must be defined here.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
+namespace {
+
+class SyslogModule : public ::testing::Test {
+ protected:
+  nscapi::test_helpers::stub_core &core() { return nscapi::test_helpers::stub_core::instance(); }
+
+  void SetUp() override {
+    core().reset();
+    module_.set_id(42);
+  }
+  void TearDown() override { core().reset(); }
+
+  bool load(const std::string &alias = "") { return module_.loadModuleEx(alias, NSCAPI::dontStart); }
+
+  // The settings root differs per module, so a section is matched by its
+  // tail rather than its full path.
+  bool has_section(const std::string &name) const {
+    for (const std::string &path : nscapi::test_helpers::stub_core::instance().registered_paths()) {
+      if (path.size() > name.size() && path.compare(path.size() - name.size(), name.size(), name) == 0) return true;
+    }
+    return false;
+  }
+
+  SyslogClient module_;
+};
+
+}  // namespace
+
+// ============================================================================
+// The settings contract
+// ============================================================================
+
+TEST_F(SyslogModule, LoadRegistersItsKeysWithTheDocumentedDefaults) {
+  ASSERT_TRUE(load());
+
+  EXPECT_EQ(core().default_for("hostname"), "auto");
+  EXPECT_EQ(core().default_for("channel"), "syslog");
+}
+
+TEST_F(SyslogModule, LoadRegistersItsSettingsSections) {
+  ASSERT_TRUE(load());
+
+  EXPECT_TRUE(has_section("targets")) << "no targets section registered";
+  EXPECT_TRUE(has_section("handlers")) << "no handlers section registered";
+}
+
+// ============================================================================
+// The channel: what the core routes submissions on
+// ============================================================================
+
+TEST_F(SyslogModule, LoadRegistersTheDefaultChannel) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("syslog")) << "syslog channel not registered";
+}
+
+TEST_F(SyslogModule, ConfiguredChannelIsRegisteredInsteadOfTheDefault) {
+  core().set_setting("channel", "MY_CHANNEL");
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_channel("MY_CHANNEL"));
+  EXPECT_FALSE(core().has_channel("syslog"));
+}
+
+// ============================================================================
+// The handlers section becomes relay commands
+// ============================================================================
+
+TEST_F(SyslogModule, HandlerKeysAreRegisteredAsCommands) {
+  core().set_keys("handlers", {{"submit_syslog", "host=127.0.0.1,port=514"}});
+
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(core().has_command("submit_syslog")) << "handler key was not registered as a command";
+}
+
+// A handler the client cannot make a command out of must not be registered -
+// and must not take the module load down with it.
+TEST_F(SyslogModule, EmptyHandlerKeyRegistersNoCommand) {
+  core().set_keys("handlers", {{"", ""}});
+
+  ASSERT_TRUE(load());
+  EXPECT_FALSE(core().has_command(""));
+}
+
+// ============================================================================
+// The targets section
+// ============================================================================
+
+TEST_F(SyslogModule, TargetKeysAreAccepted) {
+  core().set_keys("targets", {{"default", "host=127.0.0.1,port=514"}});
+
+  EXPECT_TRUE(load());
+}
+
+// One unparseable target in nsclient.ini must be reported and skipped, not
+// take the whole module offline.
+TEST_F(SyslogModule, UnparseableTargetDoesNotFailTheLoad) {
+  core().set_keys("targets", {{"broken", "this is not a target definition"}});
+
+  EXPECT_TRUE(load());
+}
+
+// ============================================================================
+// Lifecycle and dispatch
+// ============================================================================
+
+TEST_F(SyslogModule, UnloadWithoutLoadIsSafe) { EXPECT_TRUE(module_.unloadModule()); }
+
+TEST_F(SyslogModule, UnloadAfterLoadIsIdempotent) {
+  ASSERT_TRUE(load());
+  EXPECT_TRUE(module_.unloadModule());
+  EXPECT_TRUE(module_.unloadModule());
+}
+
+TEST_F(SyslogModule, CommandLineExecOnlyHandlesItsOwnTargetMode) {
+  ASSERT_TRUE(load());
+  PB::Commands::ExecuteRequestMessage request;
+  PB::Commands::ExecuteResponseMessage response;
+
+  EXPECT_FALSE(module_.commandLineExec(NSCAPI::target_any, request, response));
+}

--- a/tools/coverage/run.sh
+++ b/tools/coverage/run.sh
@@ -71,6 +71,72 @@ wipe_gcda() {
     find "$BUILD_DIR" -name '*.gcda' -delete
 }
 
+# .gcno notes are written when an object is compiled and carry the line numbers
+# of every function in it. gcovr reads every .gcno in the tree, including ones
+# no current target compiles any more, so a build directory reused across a
+# CMakeLists change accumulates objects that no rebuild will ever refresh (the
+# client sources ElasticClient dropped, for instance). Edit such a source and
+# the same function is now recorded at two different lines - the live objects at
+# the new line, the orphan at the old one - and gcovr's default (strict)
+# function merge aborts the entire run on that, after the build and the tests
+# have already been paid for:
+#
+#   AssertionError: Got function client::destination_container::to_string() const
+#   on multiple lines: 89, 97
+#
+# The quiet half of the same failure is worse: gcov rejects the old notes with
+# "source file is newer than notes file" and reports that whole file as
+# "Lines executed:0.00%", which just looks like a coverage gap. An interrupted
+# build produces the same mix for a different reason.
+#
+# Nothing downstream can repair either, so drop the object, its notes and its
+# data. Two rules, both per-object rather than against a global timestamp:
+#
+#   orphan - the object is no longer listed in its target's build.make (which
+#            cmake has just regenerated, so it is authoritative). Dead wood; it
+#            is not rebuilt because nothing compiles it any more.
+#   stale  - its source, taken from the first dependency in the compiler depfile
+#            beside it, is newer than the notes. The build recompiles it.
+#
+# The orphan rule needs a Makefiles generator; under Ninja it simply never
+# fires and the mtime rule carries the load.
+prune_stale_notes() {
+    local mode="$1" gcno dep src obj dir mk stale=0
+    [ -d "$BUILD_DIR" ] || return 0
+    while IFS= read -r gcno; do
+        obj="${gcno%.gcno}.o"
+        # Walk up to the enclosing <target>.dir to find the target's build.make.
+        dir="$(dirname "$gcno")"
+        while [ "$dir" != "$BUILD_DIR" ] && [ "$dir" != . ] && [ "$dir" != / ]; do
+            case "$dir" in *.dir) break ;; esac
+            dir="$(dirname "$dir")"
+        done
+        mk="$dir/build.make"
+        if [ -f "$mk" ] && ! grep -qF "${obj#"$dir/"}" "$mk"; then
+            : # orphan: no current target compiles it
+        else
+            dep="${gcno%.gcno}.o.d"
+            [ -f "$dep" ] || continue
+            src="$(sed -n '2{s/^[[:space:]]*//;s/[[:space:]]*\\$//;p;q}' "$dep")"
+            { [ -n "$src" ] && [ -f "$src" ] && [ "$src" -nt "$gcno" ]; } || continue
+        fi
+        stale=$((stale + 1))
+        if [ "$mode" = prune ]; then
+            rm -f "$gcno" "$obj" "${gcno%.gcno}.gcda"
+        elif [ "$stale" -le 5 ]; then
+            echo "    stale: $gcno" >&2
+        fi
+    done < <(find "$BUILD_DIR" -name '*.gcno')
+    if [ "$stale" != 0 ]; then
+        if [ "$mode" = prune ]; then
+            echo "==> Dropped $stale stale/orphaned object(s)"
+        else
+            echo "!!! $stale object(s) are stale or orphaned (SKIP_BUILD is set)." >&2
+            echo "!!! Those files will report as 0% covered - re-run without SKIP_BUILD." >&2
+        fi
+    fi
+}
+
 if [ -z "${SKIP_BUILD:-}" ]; then
     echo "==> Configuring $BUILD_DIR with NSCP_COVERAGE=ON"
     # shellcheck disable=SC2206
@@ -86,8 +152,12 @@ if [ -z "${SKIP_BUILD:-}" ]; then
         -DBUILD_MODULE_CauseCrashes=OFF \
         "${EXTRA_CMAKE_ARGS[@]}"
 
+    prune_stale_notes prune
+
     echo "==> Building (-j$JOBS)"
     cmake --build "$BUILD_DIR" -j"$JOBS"
+else
+    prune_stale_notes check
 fi
 
 mkdir -p "$OUT_DIR"
@@ -98,6 +168,16 @@ mkdir -p "$OUT_DIR"
 # changed since. Only the suites that run here belong in the merge (see the
 # one-suite note above), so drop the leftovers before starting.
 rm -f "$OUT_DIR/unit.json" "$OUT_DIR/integration.json"
+
+# Safety net for the function-line mismatch prune_stale_notes() cannot reach: a
+# SKIP_BUILD run, or a header whose inline function genuinely lands on different
+# lines in two translation units. Report it at its lowest line instead of
+# aborting the whole run - every report below reads the same data back, so they
+# all need the setting. Added in gcovr 6.0 - probe rather than assume.
+gcovr_merge=()
+if gcovr --help 2>&1 | grep -q -- '--merge-mode-functions'; then
+    gcovr_merge=(--merge-mode-functions=merge-use-line-min)
+fi
 
 # gcovr filters shared by every report. --root is the repo, so only our own
 # sources are considered; the excludes drop the test bodies themselves,
@@ -117,6 +197,7 @@ gcovr_common=(
     --root "$ROOT"
     --gcov-executable "$GCOV"
     "$BUILD_ABS"
+    "${gcovr_merge[@]}"
     --exclude '.*_test\.cpp'
     --exclude '.*\.pb\.(cc|h)$'
     --exclude '.*/_deps/.*'
@@ -164,7 +245,7 @@ if [ "$run_unit" = 1 ]; then
     echo "==> Collecting unit coverage"
     gcovr "${gcovr_common[@]}" --json "$ROOT/$OUT_DIR/unit.json"
     gcovr --root "$ROOT" --add-tracefile "$ROOT/$OUT_DIR/unit.json" \
-        "${gcovr_report_excludes[@]}" \
+        "${gcovr_merge[@]}" "${gcovr_report_excludes[@]}" \
         --html "$ROOT/$OUT_DIR/unit.html" \
         --print-summary
 fi
@@ -193,7 +274,7 @@ if [ "$run_integration" = 1 ]; then
     echo "==> Collecting integration coverage"
     gcovr "${gcovr_common[@]}" --json "$ROOT/$OUT_DIR/integration.json"
     gcovr --root "$ROOT" --add-tracefile "$ROOT/$OUT_DIR/integration.json" \
-        "${gcovr_report_excludes[@]}" \
+        "${gcovr_merge[@]}" "${gcovr_report_excludes[@]}" \
         --html "$ROOT/$OUT_DIR/integration.html" \
         --print-summary
 fi
@@ -205,7 +286,7 @@ for f in "$OUT_DIR/unit.json" "$OUT_DIR/integration.json"; do
 done
 mkdir -p "$OUT_DIR/html"
 gcovr --root "$ROOT" "${merge_args[@]}" \
-    "${gcovr_report_excludes[@]}" \
+    "${gcovr_merge[@]}" "${gcovr_report_excludes[@]}" \
     --html-details "$ROOT/$OUT_DIR/html/index.html" \
     --cobertura "$ROOT/$OUT_DIR/cobertura.xml" \
     --cobertura-pretty \


### PR DESCRIPTION
Every `modules/<X>/<X>.cpp` sat at 0% in the unit report, and the branches those shells add — a setting that does not parse, a guard that refuses to run, a target definition that is rejected, a CLI subcommand that rewrites the TLS configuration — were reachable from no suite at all: a running daemon has valid settings and a started collector by construction.

**17 module shells, 220 tests, 0% → 63% line coverage across them (1214/1935).**

## The stub core

`include/nscapi/test_helpers.hpp` (new, header-only, next to the existing `include/settings/test_helpers.hpp`) answers `NSAPISettingsQuery` out of a map, acknowledges and records registrations and writes, and loads itself into the core `nscapi::plugin_singleton` hands out — which is what `simple_plugin::get_core()` and the `NSC_LOG_*` macros resolve to.

Modules that start a thread, a socket or an interpreter already guard it on `mode == NSCAPI::normalStart`, so loading with `dontStart` parses all the settings without any of that happening. (LUAScript is the one module that does not guard, so it is left out.)

Two things make this reach past the settings:

- **`get_keys()`/`get_sections()`** — a settings *path* handler (`sh::fun_values_path`) is how every client module reads its `targets` and `handlers` sections, so the stub drives `add_target()` and `add_command()` too.
- **Recording settings writes** — `nscp op5 install`, `nscp nrpe install` and friends read and write settings through the core and never touch the network, so what they persist can be asserted directly.

## Coverage

| module | unit coverage | tests |
|---|---|---|
| SimpleFileWriter | 107/128 (84%) | 16 |
| Op5Client | 162/211 (77%) | 16 |
| CheckDisk | 95/125 (76%) | 27 |
| CheckMKServer | 87/122 (71%) | 11 |
| CollectdClient | 33/48 (69%) | 6 |
| NRPEClient | 173/264 (66%) | 21 |
| CheckMKClient | 54/85 (64%) | 11 |
| SyslogClient | 40/64 (63%) | 11 |
| NSCAClient | 40/65 (62%) | 11 |
| GraphiteClient / NRDPClient | 39/64, 38/62 (61%) | 11 each |
| IcingaClient / NSCANgClient | 31/52, 38/63 (60%) | 9 / 11 |
| SMTPClient | 37/61 (61%) | 11 |
| NSCPClient | 33/58 (57%) | 11 |
| CheckNSCP | 164/302 (54%) | 15 |
| ElasticClient | 43/161 (27%) | 11 |

All were 0% before. ElasticClient is the outlier because most of its body is the HTTP submit path.

## What is covered

**Every module:** the key/default matrix (a renamed key or a changed default breaks every existing `nsclient.ini` and nothing else in the build notices), the sensitive flag on credentials (it is what makes the REST settings API redact them), channel/event registrations, handler keys becoming relay commands, and that one unparseable target is reported and skipped rather than taking the whole module offline.

**CheckDisk:** the 1s floor and the int ceiling on the collection interval, the fallback-to-default on anything unparseable, the "Collector not started" guard, the legacy shims' deprecation responses. `get_collector()` is added for it, since the clamping `loadModuleEx` does has no other observable effect.

**CheckNSCP:** the update-check TLS defaults, the error counter fed by the log stream, and `check_nscp`'s health verdict from crash reports and logged errors. The update check's network path is never entered — only the branches that return before it.

**NRPEClient:** `nscp nrpe install`, which writes the NRPE *server's* TLS configuration. Which settings the hardened and the legacy `--insecure` profiles write is pinned, along with the argument policy (off / safe / all).

**Op5Client:** `nscp op5 install|add` — what they persist, and what they leave alone.

**SimpleFileWriter:** the whole `${...}` keyword table, the host/service syntax fallback and the file write, end to end.

**CheckMKServer:** the shared socket/SSL options, both passive submission channels, and the script manager's load/unload/reload lifecycle.

## Two discrepancies found, pinned rather than changed

Both would alter what existing installations do, so they are documented in the tests and left for a separate decision:

1. **`SimpleFileWriter`'s `${channel}` renders the command, not the channel.** `handleNotification` drops its channel argument and passes `request.command()` into the functor's channel slot.
2. **`nscp nrpe install` never applies its own `peer-cert` default.** `install()` reads the server's current `verify mode` with an empty default and assigns it unconditionally, wiping the `"peer-cert"` initialiser before the option's `default_value` captures it. A clean `install --ca ...` therefore configures encryption without a client-certificate requirement — which the command's output does report as "no authentication".

## Coverage runner fix (first commit)

The gcovr run that surfaced all this was itself aborting:

```
AssertionError: Got function client::destination_container::to_string() const
on multiple lines: 89, 97
```

gcovr reads every `.gcno` in the build tree, including objects no target compiles any more — a build dir reused across a CMakeLists change accumulates notes no rebuild will ever refresh (the client sources ElasticClient dropped). Edit such a source and the same function is recorded at two lines; gcov reports `source file is newer than notes file` plus a whole file at `Lines executed:0.00%`, and the default strict function merge kills the run after the build and tests are already paid for.

`tools/coverage/run.sh` now finds both kinds before building — an object missing from its target's `build.make`, or one whose own source (from the compiler depfile beside it) is newer than its notes — and deletes object, notes and data. `--merge-mode-functions=merge-use-line-min` on every invocation keeps anything the prune cannot reach from losing the run.

## Testing

`ctest -R "_module_test$|check_disk_unix_test"` — 18/18 targets pass. NSCAClient needs `nscpcrypt` on the link line and CheckMKClient `lua_nscp`, both as their module targets do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lx4cTmmLqW4Fbw2CGo8ijT