### PR TITLE
Fix the build with GCC 16

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ project(
     C
 )
 
+# Build against a known language level instead of whatever the compiler happens
+# to default to: that default moves (GCC 16 switched to C++20).
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 include(CTest)
 if(COMMAND CMAKE_POLICY)
     cmake_policy(SET CMP0011 NEW)

--- a/clients/nrpe/check_nrpe.cpp
+++ b/clients/nrpe/check_nrpe.cpp
@@ -17,6 +17,10 @@
 #include "../../modules/NRPEClient/nrpe_client.hpp"
 #include "../../modules/NRPEClient/nrpe_handler.hpp"
 
+// Never called - this client uses its own handler - but the module handler
+// included above references it, and an optimizing compiler emits it.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
 std::string gLog = "";
 
 int main(int argc, char *argv[]) {

--- a/clients/nscp/check_nscp.cpp
+++ b/clients/nscp/check_nscp.cpp
@@ -14,6 +14,10 @@
 
 #include "../modules/NSCPClient/nscp_handler.hpp"
 
+// Never called - this client uses its own handler - but the module handler
+// included above references it, and an optimizing compiler emits it.
+nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
+
 std::string gLog = "";
 
 int main(int argc, char *argv[]) {

--- a/include/nscapi/nscapi_plugin_wrapper.hpp
+++ b/include/nscapi/nscapi_plugin_wrapper.hpp
@@ -25,6 +25,9 @@ struct module_version {
 };
 template <class impl_type>
 struct plugin_instance_data {
+  // The deleted copy constructor below suppresses the implicit default one,
+  // and in C++20 the class is not an aggregate either.
+  plugin_instance_data() = default;
   plugin_instance_data(const plugin_instance_data &) = delete;
   plugin_instance_data &operator=(const plugin_instance_data &) = delete;
 


### PR DESCRIPTION
Two independent build failures with GCC 16 (Debian unstable, `g++ 16.2.0`), reported in #1479. Neither is a regression: both reproduce on 0.14.1, and CI cannot see them because the Linux jobs run on Ubuntu 24.04 and Rocky.

- **The plugin instance no longer aggregate-initialises.** GCC 16 defaults to `-std=gnu++20`, where `plugin_instance_data` is not an aggregate any more — its copy constructor is `= delete`, which also suppressed the implicit default one — so the `plugin_instance{}` line generated for *every* module has no constructor to call. A defaulted constructor makes it valid under both standards.
- **`nscapi::plugin_singleton` is missing from the standalone clients.** `check_nscp` and `check_nscp_nrpe` include a module client handler whose inline members log through `GET_CORE()`. They never call them, but GCC 16 emits them anyway (speculative devirtualization) and the link fails. Defined in both, the way the unit-test binaries already do.

Verified: with both applied, a full Debian package build on unstable succeeds with GCC 16 in its default C++20 mode, 70/70 tests passing.

This does not settle the wider question in #1479 — the project still never declares a C++ standard, so the language level follows whatever the compiler defaults to. Happy to add `set(CMAKE_CXX_STANDARD ...)` here if you tell me which one you want.