### PR TITLE
docs: drop leftover Sphinx roles from the plugin API page

### DIFF
--- a/docs/docs/extending/plugin-api.md
+++ b/docs/docs/extending/plugin-api.md
@@ -7,7 +7,7 @@
 
 `Plugin.QueryRequestMessage` Query request
 Used for querying the client this is the "normal" check_nrpe message request.
-Associated response is :py:class:`Plugin.QueryResponseMessage`
+Associated response is `Plugin.QueryResponseMessage`
 
 Modifier | Type    | Key     | Description
 -------- | ------- | ------- | -----------
@@ -73,8 +73,8 @@ repeated | PerformanceData | perf    |
 ## ExecuteRequestMessage
 
 `Plugin.ExecuteRequestMessage` Execute command request and response.
-Used for executing commands on clients similar to :py:class:`Plugin.QueryRequestMessage` but wont return Nagios check data
-Associated response is :py:class:`Plugin.ExecuteResponseMessage`
+Used for executing commands on clients similar to `Plugin.QueryRequestMessage` but wont return Nagios check data
+Associated response is `Plugin.ExecuteResponseMessage`
 
 Modifier | Type    | Key     | Description
 -------- | ------- | ------- | -----------
@@ -125,8 +125,8 @@ optional | bytes      | data      |
 
 `Plugin.SubmitRequestMessage` Submit result request message.
 Used for submitting a passive check results.
-The actual payload (Request) is a normal :py:class:`Plugin.QueryResponseMessage.Response`.
-Associated response is :py:class:`Plugin.SubmitResponseMessage`
+The actual payload (Request) is a normal `Plugin.QueryResponseMessage.Response`.
+Associated response is `Plugin.SubmitResponseMessage`
 
 Modifier | Type     | Key     | Description
 -------- | -------- | ------- | -----------
@@ -141,7 +141,7 @@ repeated | Response | payload |
 
 `Plugin.SubmitResponseMessage` Submit result response message.
 Response from submitting a passive check results.
-Associated request is :py:class:`Plugin.SubmitRequestMessage`
+Associated request is `Plugin.SubmitRequestMessage`
 
 Modifier | Type     | Key     | Description
 -------- | -------- | ------- | -----------
@@ -165,8 +165,8 @@ required | Result | result  |
 ## EventMessage
 
 `Plugin.EventMessage` Execute command request and response.
-Used for executing commands on clients similar to :py:class:`Plugin.QueryRequestMessage` but wont return Nagios check data
-Associated response is :py:class:`Plugin.ExecuteResponseMessage`
+Used for executing commands on clients similar to `Plugin.QueryRequestMessage` but wont return Nagios check data
+Associated response is `Plugin.ExecuteResponseMessage`
 
 Modifier | Type    | Key     | Description
 -------- | ------- | ------- | -----------


### PR DESCRIPTION
`docs/docs/extending/plugin-api.md` still carries eight `:py:class:` roles from the reStructuredText days. They used to render as literal text, but since `pymdownx.emoji` was enabled `:py:` is read as an emoji shortcode, so every message-type reference on the page now shows a Paraguay flag pulled from the twemoji CDN instead of the class name.

Dropping the role prefix leaves the backticked name, which is what the rest of the page already uses.

It is also the only remote asset left in the generated site, which matters to distributions shipping the manual offline — Debian's lintian reports it as a privacy breach. The `:fontawesome-*:` icons in the reference index are unaffected: those are bundled with mkdocs-material and inlined as SVG.