### PR TITLE
fix(CheckSystemUnix): take the dpkg install date from dpkg-query

### DIFF
--- a/docs/samples/CheckSystem_check_installed_software_desc.md
+++ b/docs/samples/CheckSystem_check_installed_software_desc.md
@@ -49,8 +49,10 @@ are kept. If the package-manager query itself fails, the check returns UNKNOWN
 rather than an empty "no installed software found" inventory, so a broken
 package database can never read as a clean OK.
 
-**Caveats:** install dates are exact on rpm (`INSTALLTIME`); dpkg does not
-record them, so they are approximated from the mtime of the package's
-`/var/lib/dpkg/info/<name>[:<arch>].list` file (rewritten on upgrade — treat as
-"last installed/upgraded"). `pacman -Q` exposes only name and version, so
-`publisher`, `size` and `install_date` stay unset there.
+**Caveats:** install dates are exact on rpm (`INSTALLTIME`). dpkg does not
+record them; the date is the one `dpkg-query` reports as `db-fsys:Last-Modified`,
+the last time dpkg rewrote the package's file list, which it also does on
+upgrade — treat it as "last installed/upgraded". A dpkg older than 1.19.3 does
+not have that field, so `install_date` stays unset there. `pacman -Q` exposes
+only name and version, so `publisher`, `size` and `install_date` stay unset
+there.

--- a/docs/upgrades/next/dpkg-install-date-from-dpkg-query.md
+++ b/docs/upgrades/next/dpkg-install-date-from-dpkg-query.md
@@ -1,0 +1,13 @@
+---
+icon: "📅"
+modules: [CheckSystemUnix]
+action: conditional
+---
+**`check_installed_software` takes dpkg install dates from `dpkg-query`.**
+Nothing to do on a current Debian or Ubuntu host: the date is the same as
+before, now read from `dpkg-query`'s `db-fsys:Last-Modified` field instead of
+from dpkg's internal database. That field needs dpkg 1.19.3 or later; with an
+older dpkg `install_date` is now left unset, so an expression on it such as
+`warning=install_date > -7d` no longer matches anything there. The check also
+returns UNKNOWN when dpkg cannot read a package's file list for a reason other
+than the file being missing, where it used to leave only that package undated.

--- a/modules/CheckSystemUnix/check_installed_software.cpp
+++ b/modules/CheckSystemUnix/check_installed_software.cpp
@@ -3,7 +3,6 @@
 
 #include "check_installed_software.h"
 
-#include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -68,12 +67,6 @@ command_result run_command(const std::string &cmd) {
 
 bool binary_exists(const std::string &path) { return access(path.c_str(), X_OK) == 0; }
 
-long long file_mtime(const std::string &path) {
-  struct stat st{};
-  if (stat(path.c_str(), &st) != 0) return 0;
-  return static_cast<long long>(st.st_mtime);
-}
-
 // "Name <email>" → "Name" (the email part adds noise to publisher filters).
 std::string strip_email(const std::string &maintainer) {
   const std::size_t angle = maintainer.find(" <");
@@ -112,7 +105,7 @@ package_manager detect_manager() {
 }
 
 // Parse dpkg-query -W output with the format
-//   ${Package}\t${Version}\t${Architecture}\t${Maintainer}\t${Installed-Size}\t${Status}
+//   ${Package}\t${Version}\t${Architecture}\t${Maintainer}\t${Installed-Size}\t${Status}\t${db-fsys:Last-Modified}
 // Status is three words ("<desired> <error> <state>"). Only a state of exactly
 // "installed" counts: the states that merely end in it ("not-installed",
 // "half-installed") are removed or broken packages, not installed ones.
@@ -142,6 +135,17 @@ std::vector<software_entry> parse_dpkg_output(const std::string &output) {
     } catch (...) {
       e.size_bytes = 0;
     }
+    // The install date is the last field. dpkg-query grew db-fsys:Last-Modified
+    // in 1.19.3; an older one leaves the column empty, which reads as "unknown"
+    // just like a manager that records no date at all.
+    if (parts.size() >= 7) {
+      try {
+        e.install_date_epoch = std::stoll(boost::trim_copy(parts[6]));
+      } catch (...) {
+        e.install_date_epoch = 0;
+      }
+    }
+    e.install_date_str = format_epoch_date(e.install_date_epoch);
     if (e.name.empty()) continue;
     out.push_back(e);
   }
@@ -204,23 +208,12 @@ std::vector<software_entry> parse_pacman_output(const std::string &output) {
   return out;
 }
 
-void apply_dpkg_install_dates(std::vector<software_entry> &entries, const mtime_fn &mtime) {
-  for (software_entry &e : entries) {
-    if (e.manager != "dpkg" || e.install_date_epoch > 0) continue;
-    // Multi-arch packages use <name>:<arch>.list; older/same-arch ones plain <name>.list.
-    long long t = 0;
-    if (!e.architecture.empty()) t = mtime("/var/lib/dpkg/info/" + e.name + ":" + e.architecture + ".list");
-    if (t == 0) t = mtime("/var/lib/dpkg/info/" + e.name + ".list");
-    e.install_date_epoch = t;
-    e.install_date_str = format_epoch_date(t);
-  }
-}
-
 fetch_result fetch_installed(const package_manager &manager, const exec_fn &exec) {
   fetch_result result;
   if (manager.name == "dpkg") {
     const command_result r =
-        exec(manager.binary + " -W -f='${Package}\\t${Version}\\t${Architecture}\\t${Maintainer}\\t${Installed-Size}\\t${Status}\\n' 2>/dev/null");
+        exec(manager.binary +
+             " -W -f='${Package}\\t${Version}\\t${Architecture}\\t${Maintainer}\\t${Installed-Size}\\t${Status}\\t${db-fsys:Last-Modified}\\n' 2>/dev/null");
     result.ok = r.ok;
     if (r.ok) result.entries = parse_dpkg_output(r.output);
     return result;
@@ -284,8 +277,6 @@ void check_installed_software(const PB::Commands::QueryRequestMessage::Request &
     // software found" would turn a broken package database into a clean OK.
     return nscapi::protobuf::functions::set_response_bad(*response, "Failed to query installed software from " + manager.name + " (" + manager.binary + ")");
   }
-  if (manager.name == "dpkg") apply_dpkg_install_dates(fetched.entries, file_mtime);
-
   check_from(request, response, fetched.entries);
 }
 

--- a/modules/CheckSystemUnix/check_installed_software.h
+++ b/modules/CheckSystemUnix/check_installed_software.h
@@ -64,9 +64,8 @@ struct command_result {
   command_result(std::string out, const bool success) : output(std::move(out)), ok(success) {}
 };
 
-// Helpers for command execution / filesystem access (injectable for tests).
+// Helper for command execution (injectable for tests).
 typedef std::function<command_result(const std::string &)> exec_fn;
-typedef std::function<long long(const std::string &)> mtime_fn;
 
 // The package manager owning this host: the manager name plus the absolute
 // path of its query binary (commands are invoked by absolute path so a
@@ -95,11 +94,6 @@ std::string format_epoch_date(long long epoch);
 std::vector<software_entry> parse_dpkg_output(const std::string &output);
 std::vector<software_entry> parse_rpm_output(const std::string &output);
 std::vector<software_entry> parse_pacman_output(const std::string &output);
-
-// dpkg does not record install dates; approximate them from the mtime of the
-// package's /var/lib/dpkg/info/<name>[:<arch>].list file. mtime must return
-// epoch seconds, or 0 when the path does not exist.
-void apply_dpkg_install_dates(std::vector<software_entry> &entries, const mtime_fn &mtime);
 
 // Detection of the available package manager (name is empty if none found).
 // Order: dpkg-query, rpm, pacman — dpkg first because Debian-family hosts

--- a/modules/CheckSystemUnix/check_installed_software_test.cpp
+++ b/modules/CheckSystemUnix/check_installed_software_test.cpp
@@ -6,7 +6,6 @@
 #include <gtest/gtest.h>
 
 #include <ctime>
-#include <map>
 
 using installed_software::software_entry;
 
@@ -64,9 +63,9 @@ PB::Common::ResultCode run_check(const std::vector<software_entry> &entries, con
 
 TEST(CheckInstalledSoftware, ParsesDpkgOutput) {
   const std::string output =
-      "bash\t5.1-6ubuntu1\tamd64\tUbuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\t1864\tinstall ok installed\n"
-      "removed-pkg\t1.0\tamd64\tSomeone <x@y.z>\t10\tdeinstall ok config-files\n"
-      "libc6\t2.35-0ubuntu3\tamd64\tUbuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\t13597\tinstall ok installed\n";
+      "bash\t5.1-6ubuntu1\tamd64\tUbuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\t1864\tinstall ok installed\t1717200000\n"
+      "removed-pkg\t1.0\tamd64\tSomeone <x@y.z>\t10\tdeinstall ok config-files\t1717200000\n"
+      "libc6\t2.35-0ubuntu3\tamd64\tUbuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>\t13597\tinstall ok installed\t1700000000\n";
   const std::vector<software_entry> entries = installed_software::parse_dpkg_output(output);
   ASSERT_EQ(entries.size(), 2u);  // config-files leftover is skipped
   EXPECT_EQ(entries[0].name, "bash");
@@ -75,8 +74,10 @@ TEST(CheckInstalledSoftware, ParsesDpkgOutput) {
   EXPECT_EQ(entries[0].publisher, "Ubuntu Developers");  // email stripped
   EXPECT_EQ(entries[0].size_bytes, 1864LL * 1024);
   EXPECT_EQ(entries[0].manager, "dpkg");
-  EXPECT_EQ(entries[0].install_date_epoch, 0);  // dpkg has no date until apply_dpkg_install_dates
+  EXPECT_EQ(entries[0].install_date_epoch, 1717200000);
+  EXPECT_EQ(entries[0].install_date_str, "2024-06-01");
   EXPECT_EQ(entries[1].name, "libc6");
+  EXPECT_EQ(entries[1].install_date_epoch, 1700000000);
 }
 
 TEST(CheckInstalledSoftware, SkipsNonInstalledDpkgStates) {
@@ -137,22 +138,18 @@ TEST(CheckInstalledSoftware, ParsesPacmanOutput) {
   EXPECT_EQ(entries[0].manager, "pacman");
 }
 
-TEST(CheckInstalledSoftware, DpkgInstallDatesComeFromListFileMtime) {
-  std::vector<software_entry> entries = installed_software::parse_dpkg_output(
+// A dpkg-query older than 1.19.3 does not know db-fsys:Last-Modified and leaves
+// the column out (or empty): the entry keeps its unknown date rather than being
+// dropped.
+TEST(CheckInstalledSoftware, DpkgEntriesSurviveAMissingInstallDate) {
+  const std::vector<software_entry> entries = installed_software::parse_dpkg_output(
       "bash\t5.1\tamd64\tX\t1\tinstall ok installed\n"
-      "libc6\t2.35\tamd64\tX\t1\tinstall ok installed\n");
-  const std::map<std::string, long long> mtimes = {
-      // bash only has the multi-arch variant; libc6 only the legacy name.
-      {"/var/lib/dpkg/info/bash:amd64.list", 1717200000},
-      {"/var/lib/dpkg/info/libc6.list", 1700000000},
-  };
-  installed_software::apply_dpkg_install_dates(entries, [&mtimes](const std::string &path) -> long long {
-    const auto it = mtimes.find(path);
-    return it == mtimes.end() ? 0 : it->second;
-  });
-  EXPECT_EQ(entries[0].install_date_epoch, 1717200000);
-  EXPECT_EQ(entries[0].install_date_str, "2024-06-01");
-  EXPECT_EQ(entries[1].install_date_epoch, 1700000000);
+      "libc6\t2.35\tamd64\tX\t1\tinstall ok installed\t\n");
+  ASSERT_EQ(entries.size(), 2u);
+  EXPECT_EQ(entries[0].install_date_epoch, 0);
+  EXPECT_EQ(entries[0].install_date_str, "");
+  EXPECT_EQ(entries[1].install_date_epoch, 0);
+  EXPECT_EQ(entries[1].install_date_str, "");
 }
 
 // --- check_from --------------------------------------------------------------

--- a/tests/checksystem-commands.test.ts
+++ b/tests/checksystem-commands.test.ts
@@ -839,6 +839,19 @@ describe("CheckSystem commands", () => {
     expect(perfValue(q, "count")).toBeGreaterThan(0);
   });
 
+  it("check_installed_software dates every package on dpkg and rpm (Linux)", async () => {
+    if (onWindows) return; // manager is the unix package-manager keyword.
+    // dpkg-query (db-fsys:Last-Modified) and rpm (INSTALLTIME) date every
+    // installed package, so an entry with no date means the date query broke;
+    // pacman records none and is left out.
+    const q = await executeQuery(key, "check_installed_software", {
+      filter: "manager = 'dpkg' or manager = 'rpm'",
+      critical: "install_date_s = ''",
+    });
+    expect(q.result).toBe(OK);
+    expect(perfValue(q, "count")).toBeGreaterThan(0);
+  });
+
   // --- check_kernel_memory (both platforms) -------------------------------------
 
   it("check_kernel_memory reports kernel gauges and fault rates with perf", async () => {


### PR DESCRIPTION
`check_installed_software` dated every installed package by `stat()`ing `/var/lib/dpkg/info/<name>[:<arch>].list`. That is dpkg's internal database rather than an interface: which file belongs to a package depends on its `Multi-Arch` field and on the database format version, so the code had to guess, trying `<name>:<arch>.list` and falling back to `<name>.list`.

`dpkg-query` exposes the same timestamp as `${db-fsys:Last-Modified}` (since dpkg 1.19.3), resolved by dpkg itself, so this asks for it in the query already being made and drops the stat pass. It returns exactly the mtime the old code read. This lines the dpkg path up with the rpm one, which has always taken `%{INSTALLTIME}` from rpm, and as a consequence silences lintian's `uses-dpkg-database-directly` warning on the built module.

Behaviour changes:

- An older `dpkg-query` leaves the column empty and still exits 0, so `install_date` stays unset there (unit test and upgrade note).
- dpkg-query aborts on a `stat()` error other than `ENOENT`, so an unreadable dpkg database now makes the check UNKNOWN instead of leaving one package undated (described in the commit message).

Also updates the check's documentation and adds an integration test that every package gets a date on dpkg and rpm hosts.