### PR TITLE
fix(reuse): match the bundled headers' copyright years

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -28,13 +28,13 @@ SPDX-License-Identifier = "Apache-2.0 OR GPL-2.0-only"
 [[annotations]]
 path = ["include/net/icmp_header.hpp", "include/net/ipv4_header.hpp"]
 precedence = "override"
-SPDX-FileCopyrightText = "2003-2016 Christopher M. Kohlhoff"
+SPDX-FileCopyrightText = "2003-2008 Christopher M. Kohlhoff"
 SPDX-License-Identifier = "BSL-1.0"
 
 [[annotations]]
 path = "include/simpleini/simpleini.h"
 precedence = "override"
-SPDX-FileCopyrightText = "2006-2012 Brodie Thiesfield"
+SPDX-FileCopyrightText = "2006-2008 Brodie Thiesfield"
 SPDX-License-Identifier = "MIT"
 
 [[annotations]]


### PR DESCRIPTION
The two `REUSE.toml` overrides for the bundled asio and SimpleIni headers exist to transcribe headers that predate SPDX tags — as the comment right above them says — but they carry years the files do not:

| file | header says | REUSE.toml said |
|---|---|---|
| `include/net/icmp_header.hpp`, `include/net/ipv4_header.hpp` | `Copyright (c) 2003-2008 Christopher M. Kohlhoff` | `2003-2016` |
| `include/simpleini/simpleini.h` | `Copyright (c) 2006-2008, Brodie Thiesfield` | `2006-2012` |

Those wider ranges are the ones later releases of asio and SimpleIni carry, not the copies vendored here.

It matters because this is the machine-readable statement about what is in this tree: downstream packagers copy it into their own copyright files, and it is what a `reuse` run reports.

Found while reviewing the Debian package's `debian/copyright` against the 0.18.1 tree.