### PR TITLE
CollectdClient: fix the open findings from the collectd security review

### DIFF
--- a/docs/docs/reference/client/CollectdClient.md
+++ b/docs/docs/reference/client/CollectdClient.md
@@ -119,14 +119,15 @@ This is a section of objects. This means that you will create objects below this
 **Keys:**
 
 
-| Key      | Default Value | Description      |
-|----------|---------------|------------------|
-| address  |               | TARGET ADDRESS   |
-| host     |               | TARGET HOST      |
-| interval |               | METRICS INTERVAL |
-| port     |               | TARGET PORT      |
-| retries  | 3             | RETRIES          |
-| timeout  | 30            | TIMEOUT          |
+| Key                 | Default Value | Description         |
+|---------------------|---------------|---------------------|
+| address             |               | TARGET ADDRESS      |
+| host                |               | TARGET HOST         |
+| interval            |               | METRICS INTERVAL    |
+| multicast interface | auto          | MULTICAST INTERFACE |
+| port                |               | TARGET PORT         |
+| retries             | 3             | RETRIES             |
+| timeout             | 30            | TIMEOUT             |
 
 
 **Sample:**
@@ -137,6 +138,7 @@ This is a section of objects. This means that you will create objects below this
 #address=...
 #host=...
 #interval=...
+multicast interface=auto
 #port=...
 retries=3
 timeout=30

--- a/docs/reference/CollectdClient.yaml
+++ b/docs/reference/CollectdClient.yaml
@@ -66,6 +66,18 @@ common:
               Overrides the client-level interval; should match the core 'metrics interval'.
             sample: true
             title: METRICS INTERVAL
+          multicast interface:
+            advanced: false
+            default_value: auto
+            description: Which local interface a multicast target's metrics leave through. A target with
+              no address is sent to collectd's default multicast group (239.192.74.66), so this decides
+              how far those metrics travel. 'auto' (the default) sends one copy through the interface
+              the routing table picks; 'all' sends a copy through every local interface of the target's
+              address family, which puts the metrics on every attached segment; a comma-separated list
+              of local IP addresses sends one copy through each of them and nothing else. Ignored for
+              unicast targets.
+            sample: true
+            title: MULTICAST INTERFACE
           port:
             advanced: true
             default_value: ''

--- a/docs/security/130-collectd-multicast-fan-out.md
+++ b/docs/security/130-collectd-multicast-fan-out.md
@@ -1,0 +1,32 @@
+---
+title: "collectd metrics no longer fan out over every local interface"
+fixed_in: 0.18.2
+severity: "Low"
+modules: [CollectdClient]
+action: conditional
+---
+A `CollectdClient` target with no address configured falls back to collectd's
+default multicast group, `239.192.74.66:25826`. For a multicast target the
+sender used to enumerate every local interface of the matching address family
+and send a copy of every datagram through each one, so a half-configured target
+put the machine's host name, CPU, memory, uptime and process counts on every
+attached layer-2 segment — including ones the operator never meant to reach,
+such as a DMZ or guest-network NIC. The collectd network protocol carries no
+credentials, and these datagrams were unauthenticated cleartext.
+
+The fan-out is now opt-in. A multicast target sends one copy through the
+interface the routing table picks (`multicast interface = auto`, the default).
+`multicast interface = all` restores the old behaviour, and a comma-separated
+list of local IP addresses restricts the fan-out to exactly those interfaces —
+an entry that is not a usable local address for the target's family is reported
+and skipped, and a target whose whole list is unusable sends nothing rather
+than falling back to the default route.
+
+The metrics themselves are unchanged: the collectd binary protocol as this
+module speaks it is unsigned cleartext, so a collectd target still belongs on a
+trusted network or inside a tunnel.
+
+**What to do:** nothing on a unicast target — the setting is ignored there. If
+you rely on a multicast target reaching several segments, set
+`multicast interface = all` (or list the local addresses to send through) on
+that target.

--- a/docs/upgrades/0.18.2/010-collectd-timeout-and-retries.md
+++ b/docs/upgrades/0.18.2/010-collectd-timeout-and-retries.md
@@ -1,0 +1,16 @@
+---
+icon: "⏱️"
+modules: [CollectdClient]
+action: conditional
+---
+**collectd submissions now honour `timeout` and `retries`, and report failed
+sends.** Both target settings were read into the connection but never used on
+the UDP path, and the send discarded its result entirely — an unreachable
+target, a full socket buffer or an oversized datagram looked exactly like a
+successful send, so metrics that never arrived left nothing in the log. A
+failed send is now retried up to `retries` times (default 3, 20 ms apart) and
+logged once per distinct failure; the whole send is bounded by `timeout`
+(default 30 seconds), after which the remaining datagrams are abandoned with a
+message. Retries apply to sends that failed locally, so no datagram the
+receiver already has is ever sent twice. Nothing to do unless you set a large
+`retries` on a collectd target — it now costs real time, bounded by `timeout`.

--- a/docs/upgrades/0.18.2/010-collectd-timeout-and-retries.md
+++ b/docs/upgrades/0.18.2/010-collectd-timeout-and-retries.md
@@ -9,8 +9,8 @@ the UDP path, and the send discarded its result entirely — an unreachable
 target, a full socket buffer or an oversized datagram looked exactly like a
 successful send, so metrics that never arrived left nothing in the log. A
 failed send is now retried up to `retries` times (default 3, 20 ms apart) and
-logged once per distinct failure; the whole send is bounded by `timeout`
-(default 30 seconds), after which the remaining datagrams are abandoned with a
-message. Retries apply to sends that failed locally, so no datagram the
+logged once per distinct failure; the whole send — name resolution included —
+is bounded by `timeout` (default 30 seconds), after which the remaining
+datagrams are abandoned with a message. Retries apply to sends that failed locally, so no datagram the
 receiver already has is ever sent twice. Nothing to do unless you set a large
 `retries` on a collectd target — it now costs real time, bounded by `timeout`.

--- a/docs/upgrades/0.18.2/020-collectd-multicast-interface.md
+++ b/docs/upgrades/0.18.2/020-collectd-multicast-interface.md
@@ -1,0 +1,17 @@
+---
+icon: "🔒 💥"
+modules: [CollectdClient]
+action: conditional
+---
+**A multicast collectd target now sends through one interface, not all of
+them.** A `CollectdClient` target with no address goes to collectd's default
+multicast group (`239.192.74.66:25826`), and every such target used to send a
+copy of the metrics through every local interface of the matching address
+family — putting them on segments the operator never meant to reach. The new
+per-target `multicast interface` setting decides this: `auto` (the default)
+sends one copy through the interface the routing table picks, `all` restores
+the previous fan-out, and a comma-separated list of local IP addresses sends
+through exactly those. Unicast targets are unaffected. If you depend on a
+multicast target reaching several segments, set `multicast interface = all` on
+it. See the
+[security notice](../security/notices.md#collectd-metrics-no-longer-fan-out-over-every-local-interface).

--- a/include/net/collectd/collectd_packet.hpp
+++ b/include/net/collectd/collectd_packet.hpp
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+#include <algorithm>
 #include <boost/endian/conversion.hpp>
 #include <boost/optional.hpp>
 #include <cstring>
@@ -38,9 +39,29 @@ enum value_type : uint8_t {
 // `MaxPacketSize`, default 1452).
 static const std::size_t max_packet_size = 1452;
 
-// Longest string a single part may carry: it must fit in one datagram alongside
-// the 4-byte part header and the trailing NUL.
-static const std::size_t max_string_length = max_packet_size - 5;
+// Longest identifier a single string part may carry. The receiver keeps
+// host/plugin/type and their instances in DATA_MAX_NAME_LEN (128) byte buffers
+// and truncates anything longer, so clamp to the same limit rather than to the
+// datagram: bytes past it are dropped on arrival anyway, and a part sized off
+// the datagram budget alone leaves no room for the value-list it describes.
+static const std::size_t max_string_length = 127;
+
+// Bytes a string part costs on the wire beyond its payload: the 4-byte part
+// header plus the trailing NUL.
+static const std::size_t string_part_overhead = 5;
+
+// Bytes a values part costs beyond its values: type(2) + length(2) + count(2).
+static const std::size_t values_part_overhead = 6;
+
+// Bytes one value costs inside a values part: its type code plus the value.
+static const std::size_t bytes_per_value = 9;
+
+// Headroom left free before a packet is considered full: enough for one more
+// value-list at its worst case - five identifier parts at the clamped maximum,
+// the time and interval parts, a values header and a handful of values - so a
+// metric that lands on the boundary is flushed into the next packet instead of
+// having its parts clamped by append_string()/append_values().
+static const std::size_t value_list_headroom = 5 * (max_string_length + string_part_overhead) + 2 * 12 + values_part_overhead + 8 * bytes_per_value;
 
 class collectd_exception : public std::exception {
   std::string msg_;
@@ -58,9 +79,10 @@ class packet {
 
  public:
   packet() {}
-  packet(const packet &other) : buffer(other.buffer) {}
+  packet(const packet &other) : buffer(other.buffer), clamped_values_(other.clamped_values_) {}
   packet operator=(const packet &other) {
     buffer = other.buffer;
+    clamped_values_ = other.clamped_values_;
     return *this;
   }
 
@@ -81,9 +103,19 @@ class packet {
   void add_interval_hr(unsigned long long time) { append_int(part_interval_hr, time); }
 
   // A packet is "full" once adding another value-list could overflow the
-  // network buffer. Leave headroom for one more value-list (a handful of
-  // string parts plus the values) so render() never emits an oversized packet.
-  bool is_full() const { return buffer.size() > max_packet_size - 128; }
+  // network buffer, so render() flushes it and starts a new one. This is the
+  // soft limit that keeps whole value-lists intact; the hard guarantee that a
+  // datagram never exceeds max_packet_size lives in append_string() and
+  // append_values(), which clamp against what is actually left.
+  bool is_full() const { return buffer.size() > max_packet_size - value_list_headroom; }
+
+  // Bytes still available in this datagram.
+  std::size_t remaining() const { return buffer.size() >= max_packet_size ? 0 : max_packet_size - buffer.size(); }
+
+  // Values dropped because they did not fit the datagram. Non-zero means the
+  // configuration asks for a value-list larger than the collectd protocol can
+  // carry; the caller logs it rather than silently shipping a partial list.
+  std::size_t clamped_values() const { return clamped_values_; }
 
   // All multi-byte integers in the collectd protocol are big-endian. Build the
   // big-endian value in a properly aligned local and append its bytes, rather
@@ -100,11 +132,14 @@ class packet {
   //
   // The length field is an (unsigned) 16-bit value and the whole part must fit
   // inside one datagram, so clamp pathologically long strings — e.g. a
-  // misconfigured hostname/plugin/type — instead of letting the cast to int16_t
-  // silently wrap and emit a malformed part.
+  // misconfigured hostname/plugin/type — to the identifier limit and to what is
+  // left of the datagram, instead of letting the cast to int16_t silently wrap
+  // and emit a malformed part.
   void append_string(int16_t type, const std::string &string_data) {
-    const std::size_t data_len = string_data.size() > max_string_length ? max_string_length : string_data.size();
-    const int16_t len = static_cast<int16_t>(data_len + 5);
+    const std::size_t budget = remaining();
+    if (budget < string_part_overhead) return;  // no room left for even an empty part
+    const std::size_t data_len = (std::min)(string_data.size(), (std::min)(max_string_length, budget - string_part_overhead));
+    const int16_t len = static_cast<int16_t>(data_len + string_part_overhead);
     append_be<int16_t>(buffer, type);
     append_be<int16_t>(buffer, len);
     buffer.append(string_data, 0, data_len);
@@ -120,20 +155,37 @@ class packet {
   // count 8-byte values. Gauge values are little-endian IEEE-754 doubles;
   // derive values are big-endian int64. Build the body first, then prefix the
   // header with the now-known length.
+  //
+  // Both the length and the count are 16-bit fields and the part must fit the
+  // datagram, so the number of values is capped at what is actually left: a
+  // configured value-list of a few hundred entries would otherwise overflow the
+  // receiver's read size, and past ~3600 entries the length cast wraps and emits
+  // a malformed part. Dropped values are counted for the caller to log - a
+  // truncated list is still valid on the wire, but it is not what was asked for.
   template <class T>
   void append_values(uint8_t value_type, const std::list<T> &value_data) {
+    const std::size_t budget = remaining();
+    if (budget < values_part_overhead + bytes_per_value) {
+      clamped_values_ += value_data.size();
+      return;
+    }
+    const std::size_t count = (std::min)(value_data.size(), (budget - values_part_overhead) / bytes_per_value);
+    clamped_values_ += value_data.size() - count;
+
     std::string body;
-    body.reserve(value_data.size() * 9);
-    for (std::size_t i = 0; i < value_data.size(); i++) {
+    body.reserve(count * bytes_per_value);
+    for (std::size_t i = 0; i < count; i++) {
       body.push_back(static_cast<char>(value_type));
     }
+    std::size_t emitted = 0;
     for (const T &v : value_data) {
+      if (emitted++ >= count) break;
       append_value(body, v);
     }
-    const int16_t len = static_cast<int16_t>(6 + body.size());
+    const int16_t len = static_cast<int16_t>(values_part_overhead + body.size());
     append_be<int16_t>(buffer, part_values);
     append_be<int16_t>(buffer, len);
-    append_be<int16_t>(buffer, static_cast<int16_t>(value_data.size()));
+    append_be<int16_t>(buffer, static_cast<int16_t>(count));
     buffer.append(body);
   }
 
@@ -150,6 +202,9 @@ class packet {
   std::string get_buffer() const { return buffer; }
 
   std::size_t get_size() const { return buffer.size(); }
+
+ private:
+  std::size_t clamped_values_ = 0;
 };
 
 struct collectd_builder {

--- a/include/net/collectd/collectd_packet.hpp
+++ b/include/net/collectd/collectd_packet.hpp
@@ -53,15 +53,11 @@ static const std::size_t string_part_overhead = 5;
 // Bytes a values part costs beyond its values: type(2) + length(2) + count(2).
 static const std::size_t values_part_overhead = 6;
 
+// A number part (time / interval) is a fixed type(2) + length(2) + uint64(8).
+static const std::size_t number_part_size = 12;
+
 // Bytes one value costs inside a values part: its type code plus the value.
 static const std::size_t bytes_per_value = 9;
-
-// Headroom left free before a packet is considered full: enough for one more
-// value-list at its worst case - five identifier parts at the clamped maximum,
-// the time and interval parts, a values header and a handful of values - so a
-// metric that lands on the boundary is flushed into the next packet instead of
-// having its parts clamped by append_string()/append_values().
-static const std::size_t value_list_headroom = 5 * (max_string_length + string_part_overhead) + 2 * 12 + values_part_overhead + 8 * bytes_per_value;
 
 class collectd_exception : public std::exception {
   std::string msg_;
@@ -80,7 +76,7 @@ class packet {
  public:
   packet() {}
   packet(const packet &other) : buffer(other.buffer), clamped_values_(other.clamped_values_) {}
-  packet operator=(const packet &other) {
+  packet &operator=(const packet &other) {
     buffer = other.buffer;
     clamped_values_ = other.clamped_values_;
     return *this;
@@ -102,14 +98,10 @@ class packet {
   void add_time_hr(unsigned long long time) { append_int(part_time_hr, time); }
   void add_interval_hr(unsigned long long time) { append_int(part_interval_hr, time); }
 
-  // A packet is "full" once adding another value-list could overflow the
-  // network buffer, so render() flushes it and starts a new one. This is the
-  // soft limit that keeps whole value-lists intact; the hard guarantee that a
-  // datagram never exceeds max_packet_size lives in append_string() and
-  // append_values(), which clamp against what is actually left.
-  bool is_full() const { return buffer.size() > max_packet_size - value_list_headroom; }
-
-  // Bytes still available in this datagram.
+  // Bytes still available in this datagram. render() sizes each value-list
+  // against this before appending it, so the clamps in append_string() and
+  // append_values() only ever bite on a value-list too large for a datagram of
+  // its own.
   std::size_t remaining() const { return buffer.size() >= max_packet_size ? 0 : max_packet_size - buffer.size(); }
 
   // Values dropped because they did not fit the datagram. Non-zero means the
@@ -148,7 +140,7 @@ class packet {
   // A number part: type(2) + length(2, always 12) + uint64(8).
   void append_int(int16_t type, unsigned long long int_data) {
     append_be<int16_t>(buffer, type);
-    append_be<int16_t>(buffer, static_cast<int16_t>(12));
+    append_be<int16_t>(buffer, static_cast<int16_t>(number_part_size));
     append_be<uint64_t>(buffer, static_cast<uint64_t>(int_data));
   }
   // A values part: type(2) + length(2) + count(2) + count value-type bytes +
@@ -365,7 +357,50 @@ struct collectd_builder {
     std::string last_plugin_instance = "";
     std::string last_type = "";
     std::string last_type_instance = "";
+
+    const auto string_part_size = [](const std::string &value) {
+      return collectd::string_part_overhead + (std::min)(value.size(), collectd::max_string_length);
+    };
+    // Bytes this metric will add to the current packet, given the identifier
+    // context that packet already carries (`fresh` sizes it against an empty
+    // one, where every part has to be repeated). It mirrors the appends below
+    // exactly, so the flush decision is made on the real cost rather than a
+    // fixed headroom guess.
+    const auto metric_size = [&](const metric_container &m, const bool fresh) {
+      const std::string plugin = fresh ? "" : last_plugin;
+      const std::string plugin_instance = fresh ? "" : last_plugin_instance;
+      const std::string type = fresh ? "" : last_type;
+      const std::string type_instance = fresh ? "" : last_type_instance;
+
+      std::size_t size = 0;
+      if (fresh) size += string_part_size(host) + 2 * collectd::number_part_size;
+      if (m.plugin_name != plugin) size += string_part_size(m.plugin_name);
+      if (m.plugin_instance) {
+        if (plugin_instance != m.plugin_instance.get()) size += string_part_size(m.plugin_instance.get());
+      } else if (!plugin_instance.empty()) {
+        size += string_part_size("");
+      }
+      if (m.type_name != type) size += string_part_size(m.type_name);
+      if (m.type_instance) {
+        if (type_instance != m.type_instance.get()) size += string_part_size(m.type_instance.get());
+      } else if (!type_instance.empty()) {
+        size += string_part_size("");
+      }
+      if (!m.gauges.empty()) size += collectd::values_part_overhead + collectd::bytes_per_value * m.gauges.size();
+      if (!m.derives.empty()) size += collectd::values_part_overhead + collectd::bytes_per_value * m.derives.size();
+      return size;
+    };
+
     for (const metric_container &m : rendererd_metrics) {
+      // Flush before appending rather than after: a value-list that fits a
+      // datagram of its own must never be clamped into a partly filled one.
+      // Sizing the metric first also packs each datagram to the real limit
+      // instead of stopping at a worst-case headroom.
+      if (!is_new && packet.remaining() < metric_size(m, false)) {
+        packets.push_back(packet);
+        packet = collectd::packet();
+        is_new = true;
+      }
       if (is_new) {
         last_plugin = "";
         last_plugin_instance = "";
@@ -405,11 +440,6 @@ struct collectd_builder {
       }
       if (!m.derives.empty()) {
         packet.add_derive_value(m.derives);
-      }
-      if (packet.is_full()) {
-        packets.push_back(packet);
-        packet = collectd::packet();
-        is_new = true;
       }
     }
     // Only emit the trailing packet if it actually holds data. When nothing

--- a/include/net/collectd/collectd_sender.cpp
+++ b/include/net/collectd/collectd_sender.cpp
@@ -5,6 +5,8 @@
 
 #include <boost/asio.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <memory>
 #include <set>
@@ -38,6 +40,36 @@ class udp_sender {
 
 bool is_multicast(const boost::asio::ip::address &address) {
   return (address.is_v4() && address.to_v4().is_multicast()) || (address.is_v6() && address.to_v6().is_multicast());
+}
+
+std::string trim_lower(const std::string &value) {
+  std::string out;
+  for (const char c : value) {
+    if (std::isspace(static_cast<unsigned char>(c))) continue;
+    out.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+  }
+  return out;
+}
+
+// Split a comma-separated interface list, dropping empty entries and
+// surrounding whitespace.
+std::list<std::string> split_list(const std::string &value) {
+  std::list<std::string> out;
+  std::string current;
+  for (const char c : value) {
+    if (c == ',') {
+      if (!current.empty()) out.push_back(current);
+      current.clear();
+      continue;
+    }
+    if (std::isspace(static_cast<unsigned char>(c)) && current.empty()) continue;
+    current.push_back(c);
+  }
+  if (!current.empty()) out.push_back(current);
+  for (std::string &entry : out) {
+    while (!entry.empty() && std::isspace(static_cast<unsigned char>(entry.back()))) entry.pop_back();
+  }
+  return out;
 }
 }  // namespace
 
@@ -76,22 +108,59 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
     }
     const udp::endpoint target = *targets.begin();
 
-    // Build the set of sockets to send through. For unicast that is a single
-    // OS-routed socket; for multicast we send out every local interface of the
-    // matching address family.
+    // Build the set of sockets to send through. A unicast target - and a
+    // multicast target left on "auto" - is one socket whose source the routing
+    // table picks. "all" and an explicit list bind a socket per local
+    // interface, so the datagram leaves through each of them.
     std::list<std::shared_ptr<udp_sender> > senders;
     if (is_multicast(target.address())) {
-      udp::resolver resolver(io_service);
-      boost::system::error_code local_ec;
-      for (const auto &entry : resolver.resolve(boost::asio::ip::host_name(), "", local_ec)) {
-        if (entry.endpoint().address().is_v4() == target.address().is_v4()) {
-          senders.push_back(std::make_shared<udp_sender>(io_service, entry.endpoint(), target));
+      const std::string mode = trim_lower(config.multicast_interfaces);
+      if (mode == "all") {
+        // Every local interface of the matching address family. Note that this
+        // enumerates what the host name resolves to, which on a host whose name
+        // maps to a loopback address (the 127.0.1.1 convention) is loopback and
+        // nothing else - one reason "auto" is the default.
+        udp::resolver resolver(io_service);
+        boost::system::error_code local_ec;
+        for (const auto &entry : resolver.resolve(boost::asio::ip::host_name(), "", local_ec)) {
+          if (entry.endpoint().address().is_v4() == target.address().is_v4()) {
+            senders.push_back(std::make_shared<udp_sender>(io_service, entry.endpoint(), target));
+          }
+        }
+        if (senders.empty()) {
+          report("No local interface of the target's address family could be enumerated for collectd target " + target_name +
+                 " with 'multicast interface = all'; sending through the default route instead");
+        }
+      } else if (!mode.empty() && mode != "auto") {
+        for (const std::string &entry : split_list(config.multicast_interfaces)) {
+          boost::system::error_code address_ec;
+          const boost::asio::ip::address local = boost::asio::ip::make_address(entry, address_ec);
+          if (address_ec) {
+            report("Ignoring 'multicast interface' entry '" + entry + "' for collectd target " + target_name +
+                   ": not a local IP address (host names are not accepted here)");
+            continue;
+          }
+          if (local.is_v4() != target.address().is_v4()) {
+            report("Ignoring 'multicast interface' entry '" + entry + "' for collectd target " + target_name +
+                   ": wrong address family for the target group");
+            continue;
+          }
+          try {
+            senders.push_back(std::make_shared<udp_sender>(io_service, udp::endpoint(local, 0), target));
+          } catch (const std::exception &e) {
+            report("Cannot send to collectd target " + target_name + " through local address " + entry + ": " + e.what());
+          }
+        }
+        if (senders.empty()) {
+          result.failed = datagrams.size();
+          report("No usable 'multicast interface' entry for collectd target " + target_name + "; no metrics sent");
+          return result;
         }
       }
     }
     if (senders.empty()) {
-      // Unicast, or multicast with no enumerable matching interface: fall back
-      // to a default-bound socket for the target's address family.
+      // Unicast, or multicast on "auto": a default-bound socket for the
+      // target's address family, routed like any other datagram.
       senders.push_back(std::make_shared<udp_sender>(io_service, target));
     }
 

--- a/include/net/collectd/collectd_sender.cpp
+++ b/include/net/collectd/collectd_sender.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include "collectd_sender.hpp"
+
+#include <boost/asio.hpp>
+
+#include <memory>
+
+namespace {
+using boost::asio::ip::udp;
+
+// One socket aimed at the target endpoint. Multicast targets get one of these
+// per local interface (bound to that interface's address so the datagram
+// leaves through it); everything else gets a single socket whose source the
+// routing table picks.
+class udp_sender {
+ public:
+  udp_sender(boost::asio::io_context &io_service, const udp::endpoint &source, const udp::endpoint &target)
+      : target_(target), socket_(io_service, source) {}
+  udp_sender(boost::asio::io_context &io_service, const udp::endpoint &target) : target_(target), socket_(io_service, target.protocol()) {}
+
+  // Queue one datagram. The payload is owned by a shared_ptr captured in the
+  // completion handler so it stays alive until the async send finishes - this
+  // lets us queue several packets before a single io_context.run() drains them.
+  void send_data(const std::string &data) {
+    auto payload = std::make_shared<std::string>(data);
+    socket_.async_send_to(boost::asio::buffer(*payload), target_, [payload](const boost::system::error_code &, std::size_t) {});
+  }
+
+ private:
+  udp::endpoint target_;
+  udp::socket socket_;
+};
+
+bool is_multicast(const boost::asio::ip::address &address) {
+  return (address.is_v4() && address.to_v4().is_multicast()) || (address.is_v6() && address.to_v6().is_multicast());
+}
+}  // namespace
+
+collectd::sender_result collectd::send_datagrams(const sender_config &config, const std::list<std::string> &datagrams) {
+  sender_result result;
+  if (datagrams.empty()) return result;
+
+  try {
+    boost::asio::io_context io_service;
+
+    // Resolve the configured address. This accepts host names as well as IP
+    // literals: parsing only literals meant a target named by host name threw
+    // on every metrics cycle - visible as a repeated log line and nothing
+    // else - so the metrics silently never arrived.
+    udp::resolver target_resolver(io_service);
+    boost::system::error_code ec;
+    const udp::resolver::results_type targets = target_resolver.resolve(config.address, config.port, ec);
+    if (ec || targets.empty()) {
+      result.failed = datagrams.size();
+      result.errors.push_back("Failed to resolve collectd target " + config.address + ":" + config.port + ": " +
+                              (ec ? ec.message() : std::string("no addresses returned")));
+      return result;
+    }
+    const udp::endpoint target = *targets.begin();
+
+    // Build the set of sockets to send through. For unicast that is a single
+    // OS-routed socket; for multicast we send out every local interface of the
+    // matching address family.
+    std::list<std::shared_ptr<udp_sender> > senders;
+    if (is_multicast(target.address())) {
+      udp::resolver resolver(io_service);
+      boost::system::error_code local_ec;
+      for (const auto &entry : resolver.resolve(boost::asio::ip::host_name(), "", local_ec)) {
+        if (entry.endpoint().address().is_v4() == target.address().is_v4()) {
+          senders.push_back(std::make_shared<udp_sender>(io_service, entry.endpoint(), target));
+        }
+      }
+    }
+    if (senders.empty()) {
+      // Unicast, or multicast with no enumerable matching interface: fall back
+      // to a default-bound socket for the target's address family.
+      senders.push_back(std::make_shared<udp_sender>(io_service, target));
+    }
+
+    for (const std::string &datagram : datagrams) {
+      if (datagram.empty()) continue;  // never put an empty datagram on the wire
+      for (const std::shared_ptr<udp_sender> &sender : senders) {
+        sender->send_data(datagram);
+      }
+      result.sent++;
+    }
+    io_service.run();
+  } catch (const std::exception &e) {
+    result.failed = datagrams.size() - result.sent;
+    result.errors.push_back("Failed to send metrics to collectd target " + config.address + ":" + config.port + ": " + e.what());
+  }
+  return result;
+}

--- a/include/net/collectd/collectd_sender.cpp
+++ b/include/net/collectd/collectd_sender.cpp
@@ -5,7 +5,10 @@
 
 #include <boost/asio.hpp>
 
+#include <chrono>
 #include <memory>
+#include <set>
+#include <thread>
 
 namespace {
 using boost::asio::ip::udp;
@@ -14,19 +17,19 @@ using boost::asio::ip::udp;
 // per local interface (bound to that interface's address so the datagram
 // leaves through it); everything else gets a single socket whose source the
 // routing table picks.
+//
+// The send is synchronous: a datagram either reaches the kernel or reports why
+// it did not. The previous async send discarded the completion error code, so
+// every failure - an unreachable target, a full socket buffer - looked exactly
+// like a successful send, and a target that never received anything gave the
+// operator nothing to go on.
 class udp_sender {
  public:
   udp_sender(boost::asio::io_context &io_service, const udp::endpoint &source, const udp::endpoint &target)
       : target_(target), socket_(io_service, source) {}
   udp_sender(boost::asio::io_context &io_service, const udp::endpoint &target) : target_(target), socket_(io_service, target.protocol()) {}
 
-  // Queue one datagram. The payload is owned by a shared_ptr captured in the
-  // completion handler so it stays alive until the async send finishes - this
-  // lets us queue several packets before a single io_context.run() drains them.
-  void send_data(const std::string &data) {
-    auto payload = std::make_shared<std::string>(data);
-    socket_.async_send_to(boost::asio::buffer(*payload), target_, [payload](const boost::system::error_code &, std::size_t) {});
-  }
+  void send_data(const std::string &data, boost::system::error_code &ec) { socket_.send_to(boost::asio::buffer(data), target_, 0, ec); }
 
  private:
   udp::endpoint target_;
@@ -42,6 +45,20 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
   sender_result result;
   if (datagrams.empty()) return result;
 
+  const std::string target_name = config.address + ":" + config.port;
+  // Distinct failures only: the same error on every datagram of every cycle is
+  // one log line, not hundreds.
+  std::set<std::string> reported;
+  const auto report = [&result, &reported](const std::string &message) {
+    if (reported.insert(message).second) result.errors.push_back(message);
+  };
+
+  const auto started = std::chrono::steady_clock::now();
+  const auto expired = [&config, &started]() {
+    if (config.timeout_seconds == 0) return false;
+    return std::chrono::steady_clock::now() - started >= std::chrono::seconds(config.timeout_seconds);
+  };
+
   try {
     boost::asio::io_context io_service;
 
@@ -54,8 +71,7 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
     const udp::resolver::results_type targets = target_resolver.resolve(config.address, config.port, ec);
     if (ec || targets.empty()) {
       result.failed = datagrams.size();
-      result.errors.push_back("Failed to resolve collectd target " + config.address + ":" + config.port + ": " +
-                              (ec ? ec.message() : std::string("no addresses returned")));
+      report("Failed to resolve collectd target " + target_name + ": " + (ec ? ec.message() : std::string("no addresses returned")));
       return result;
     }
     const udp::endpoint target = *targets.begin();
@@ -79,17 +95,37 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
       senders.push_back(std::make_shared<udp_sender>(io_service, target));
     }
 
+    std::size_t remaining = datagrams.size();
     for (const std::string &datagram : datagrams) {
+      remaining--;
       if (datagram.empty()) continue;  // never put an empty datagram on the wire
-      for (const std::shared_ptr<udp_sender> &sender : senders) {
-        sender->send_data(datagram);
+      if (expired()) {
+        result.failed += remaining + 1;
+        report("Timed out after " + std::to_string(config.timeout_seconds) + "s sending metrics to collectd target " + target_name + ": " +
+               std::to_string(remaining + 1) + " datagram(s) not sent");
+        break;
       }
-      result.sent++;
+      for (const std::shared_ptr<udp_sender> &sender : senders) {
+        for (int attempt = 0;; attempt++) {
+          boost::system::error_code send_ec;
+          result.attempts++;
+          sender->send_data(datagram, send_ec);
+          if (!send_ec) {
+            result.sent++;
+            break;
+          }
+          if (attempt >= config.retries || expired()) {
+            result.failed++;
+            report("Failed to send metrics to collectd target " + target_name + ": " + send_ec.message());
+            break;
+          }
+          std::this_thread::sleep_for(std::chrono::milliseconds(retry_backoff_ms));
+        }
+      }
     }
-    io_service.run();
   } catch (const std::exception &e) {
     result.failed = datagrams.size() - result.sent;
-    result.errors.push_back("Failed to send metrics to collectd target " + config.address + ":" + config.port + ": " + e.what());
+    report("Failed to send metrics to collectd target " + target_name + ": " + e.what());
   }
   return result;
 }

--- a/include/net/collectd/collectd_sender.cpp
+++ b/include/net/collectd/collectd_sender.cpp
@@ -28,7 +28,18 @@ using boost::asio::ip::udp;
 class udp_sender {
  public:
   udp_sender(boost::asio::io_context &io_service, const udp::endpoint &source, const udp::endpoint &target)
-      : target_(target), socket_(io_service, source) {}
+      : target_(target), socket_(io_service, source) {
+    // Binding the source address is not by itself what steers multicast egress
+    // on every platform - IP_MULTICAST_IF is what selects the outgoing
+    // interface - so set it too, or "through exactly these interfaces" holds
+    // on some hosts and not others. Best effort: where the option is refused
+    // the bound source and the routing table still apply. The IPv6 option
+    // selects by interface index, which an address alone does not give us.
+    if (target.address().is_v4() && source.address().is_v4()) {
+      boost::system::error_code ec;
+      socket_.set_option(boost::asio::ip::multicast::outbound_interface(source.address().to_v4()), ec);
+    }
+  }
   udp_sender(boost::asio::io_context &io_service, const udp::endpoint &target) : target_(target), socket_(io_service, target.protocol()) {}
 
   void send_data(const std::string &data, boost::system::error_code &ec) { socket_.send_to(boost::asio::buffer(data), target_, 0, ec); }
@@ -75,7 +86,19 @@ std::list<std::string> split_list(const std::string &value) {
 
 collectd::sender_result collectd::send_datagrams(const sender_config &config, const std::list<std::string> &datagrams) {
   sender_result result;
-  if (datagrams.empty()) return result;
+
+  // An empty datagram is never put on the wire, so it is not a payload and
+  // must not appear in the accounting either - counting it made a timeout
+  // report more outstanding datagrams than there were.
+  std::list<const std::string *> payloads;
+  for (const std::string &datagram : datagrams) {
+    if (!datagram.empty()) payloads.push_back(&datagram);
+  }
+  if (payloads.empty()) return result;
+  const std::size_t total = payloads.size();
+  // Payloads whose outcome has been recorded; the rest are still outstanding
+  // if the send is cut short.
+  std::size_t processed = 0;
 
   const std::string target_name = config.address + ":" + config.port;
   // Distinct failures only: the same error on every datagram of every cycle is
@@ -98,11 +121,36 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
     // literals: parsing only literals meant a target named by host name threw
     // on every metrics cycle - visible as a repeated log line and nothing
     // else - so the metrics silently never arrived.
+    //
+    // The lookup is asynchronous so it runs under the same budget as the send.
+    // A blocking resolve() answers to the resolver's own timeout, which can be
+    // tens of seconds on an unreachable DNS server - spent on the core metrics
+    // thread, and outside the `timeout` this target documents.
     udp::resolver target_resolver(io_service);
     boost::system::error_code ec;
-    const udp::resolver::results_type targets = target_resolver.resolve(config.address, config.port, ec);
+    udp::resolver::results_type targets;
+    bool resolved = false;
+    target_resolver.async_resolve(config.address, config.port, [&](const boost::system::error_code &e, const udp::resolver::results_type &r) {
+      ec = e;
+      targets = r;
+      resolved = true;
+    });
+    if (config.timeout_seconds > 0) {
+      io_service.run_for(std::chrono::seconds(config.timeout_seconds));
+    } else {
+      io_service.run();
+    }
+    if (!resolved) {
+      target_resolver.cancel();
+      io_service.restart();
+      io_service.run();
+      result.failed = total;
+      report("Timed out after " + std::to_string(config.timeout_seconds) + "s resolving collectd target " + target_name + "; no metrics sent");
+      return result;
+    }
+    io_service.restart();
     if (ec || targets.empty()) {
-      result.failed = datagrams.size();
+      result.failed = total;
       report("Failed to resolve collectd target " + target_name + ": " + (ec ? ec.message() : std::string("no addresses returned")));
       return result;
     }
@@ -123,8 +171,15 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
         udp::resolver resolver(io_service);
         boost::system::error_code local_ec;
         for (const auto &entry : resolver.resolve(boost::asio::ip::host_name(), "", local_ec)) {
-          if (entry.endpoint().address().is_v4() == target.address().is_v4()) {
+          if (entry.endpoint().address().is_v4() != target.address().is_v4()) continue;
+          // Skip an address that cannot be bound (an interface that went away,
+          // a privileged or already-taken source) instead of letting it throw:
+          // one bad entry must not stop the metrics leaving through the good
+          // interfaces.
+          try {
             senders.push_back(std::make_shared<udp_sender>(io_service, entry.endpoint(), target));
+          } catch (const std::exception &e) {
+            report("Cannot send to collectd target " + target_name + " through local address " + entry.endpoint().address().to_string() + ": " + e.what());
           }
         }
         if (senders.empty()) {
@@ -137,7 +192,7 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
           const boost::asio::ip::address local = boost::asio::ip::make_address(entry, address_ec);
           if (address_ec) {
             report("Ignoring 'multicast interface' entry '" + entry + "' for collectd target " + target_name +
-                   ": not a local IP address (host names are not accepted here)");
+                   ": not an IP address literal (host names are not accepted here)");
             continue;
           }
           if (local.is_v4() != target.address().is_v4()) {
@@ -152,7 +207,7 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
           }
         }
         if (senders.empty()) {
-          result.failed = datagrams.size();
+          result.failed = total;
           report("No usable 'multicast interface' entry for collectd target " + target_name + "; no metrics sent");
           return result;
         }
@@ -164,36 +219,40 @@ collectd::sender_result collectd::send_datagrams(const sender_config &config, co
       senders.push_back(std::make_shared<udp_sender>(io_service, target));
     }
 
-    std::size_t remaining = datagrams.size();
-    for (const std::string &datagram : datagrams) {
-      remaining--;
-      if (datagram.empty()) continue;  // never put an empty datagram on the wire
+    for (const std::string *payload : payloads) {
       if (expired()) {
-        result.failed += remaining + 1;
+        const std::size_t outstanding = total - processed;
+        result.failed += outstanding;
         report("Timed out after " + std::to_string(config.timeout_seconds) + "s sending metrics to collectd target " + target_name + ": " +
-               std::to_string(remaining + 1) + " datagram(s) not sent");
+               std::to_string(outstanding) + " datagram(s) not sent");
         break;
       }
+      // One datagram is one unit of work whatever the interface count: it
+      // counts as sent when every socket took it, and as failed otherwise.
+      bool delivered = true;
       for (const std::shared_ptr<udp_sender> &sender : senders) {
         for (int attempt = 0;; attempt++) {
           boost::system::error_code send_ec;
           result.attempts++;
-          sender->send_data(datagram, send_ec);
-          if (!send_ec) {
-            result.sent++;
-            break;
-          }
+          sender->send_data(*payload, send_ec);
+          if (!send_ec) break;
           if (attempt >= config.retries || expired()) {
-            result.failed++;
+            delivered = false;
             report("Failed to send metrics to collectd target " + target_name + ": " + send_ec.message());
             break;
           }
           std::this_thread::sleep_for(std::chrono::milliseconds(retry_backoff_ms));
         }
       }
+      processed++;
+      if (delivered) {
+        result.sent++;
+      } else {
+        result.failed++;
+      }
     }
   } catch (const std::exception &e) {
-    result.failed = datagrams.size() - result.sent;
+    result.failed += total - processed;
     report("Failed to send metrics to collectd target " + target_name + ": " + e.what());
   }
   return result;

--- a/include/net/collectd/collectd_sender.hpp
+++ b/include/net/collectd/collectd_sender.hpp
@@ -9,6 +9,12 @@
 
 namespace collectd {
 
+// Milliseconds waited between two attempts at the same datagram. A send that
+// failed locally usually failed because a buffer was momentarily full, so an
+// immediate retry would fail the same way; the wait is short enough that the
+// whole retry budget stays well inside one metrics interval.
+static const unsigned int retry_backoff_ms = 20;
+
 // Where one target's datagrams go. Deliberately free of the plugin API so the
 // send path can be driven against a real loopback socket from a unit test; the
 // caller turns the reported problems into log lines.
@@ -18,19 +24,34 @@ struct sender_config {
   std::string address;
   std::string port;
 
-  sender_config() {}
-  sender_config(std::string address, std::string port) : address(std::move(address)), port(std::move(port)) {}
+  // Extra attempts after a failed send (the target's `retries` setting). A UDP
+  // send that fails locally never left the machine, so re-attempting it cannot
+  // duplicate a datagram the receiver already has - which is why this counts
+  // failed sends only and never re-sends a delivered one.
+  int retries;
+
+  // Wall-clock budget for the whole send, in seconds (the target's `timeout`
+  // setting); 0 means no limit. It bounds the retry loop, so an unreachable
+  // target cannot hold the metrics thread for retries x datagrams.
+  unsigned int timeout_seconds;
+
+  sender_config() : retries(0), timeout_seconds(0) {}
+  sender_config(std::string address, std::string port, int retries = 0, unsigned int timeout_seconds = 0)
+      : address(std::move(address)), port(std::move(port)), retries(retries), timeout_seconds(timeout_seconds) {}
 };
 
 struct sender_result {
   // Datagrams that reached the socket, and datagrams that did not.
   std::size_t sent;
   std::size_t failed;
+  // Send calls made, including retries: `attempts` above `sent` means the
+  // retry budget was being spent.
+  std::size_t attempts;
   // One line per problem, ready to log. Repeated identical failures are
   // collapsed so a broken target cannot flood the log every interval.
   std::list<std::string> errors;
 
-  sender_result() : sent(0), failed(0) {}
+  sender_result() : sent(0), failed(0), attempts(0) {}
 };
 
 // Send every datagram to the configured target.

--- a/include/net/collectd/collectd_sender.hpp
+++ b/include/net/collectd/collectd_sender.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <cstddef>
+#include <list>
+#include <string>
+
+namespace collectd {
+
+// Where one target's datagrams go. Deliberately free of the plugin API so the
+// send path can be driven against a real loopback socket from a unit test; the
+// caller turns the reported problems into log lines.
+struct sender_config {
+  // Host name or IP literal, and the port as a string - both straight from the
+  // target's settings.
+  std::string address;
+  std::string port;
+
+  sender_config() {}
+  sender_config(std::string address, std::string port) : address(std::move(address)), port(std::move(port)) {}
+};
+
+struct sender_result {
+  // Datagrams that reached the socket, and datagrams that did not.
+  std::size_t sent;
+  std::size_t failed;
+  // One line per problem, ready to log. Repeated identical failures are
+  // collapsed so a broken target cannot flood the log every interval.
+  std::list<std::string> errors;
+
+  sender_result() : sent(0), failed(0) {}
+};
+
+// Send every datagram to the configured target.
+//
+// The address is resolved, so a target may name a host rather than an IP
+// literal. A multicast target is sent through every local interface of the
+// matching address family, as collectd's own network plugin does.
+sender_result send_datagrams(const sender_config &config, const std::list<std::string> &datagrams);
+
+}  // namespace collectd

--- a/include/net/collectd/collectd_sender.hpp
+++ b/include/net/collectd/collectd_sender.hpp
@@ -35,9 +35,20 @@ struct sender_config {
   // target cannot hold the metrics thread for retries x datagrams.
   unsigned int timeout_seconds;
 
+  // Which local interfaces a multicast target's datagrams leave through (the
+  // target's `multicast interface` setting): "auto" or empty for the one the
+  // routing table picks, "all" for every local interface of the target's
+  // address family, or a comma-separated list of local IP addresses. Ignored
+  // for a unicast target, which the routing table has always decided.
+  std::string multicast_interfaces;
+
   sender_config() : retries(0), timeout_seconds(0) {}
-  sender_config(std::string address, std::string port, int retries = 0, unsigned int timeout_seconds = 0)
-      : address(std::move(address)), port(std::move(port)), retries(retries), timeout_seconds(timeout_seconds) {}
+  sender_config(std::string address, std::string port, int retries = 0, unsigned int timeout_seconds = 0, std::string multicast_interfaces = "")
+      : address(std::move(address)),
+        port(std::move(port)),
+        retries(retries),
+        timeout_seconds(timeout_seconds),
+        multicast_interfaces(std::move(multicast_interfaces)) {}
 };
 
 struct sender_result {
@@ -57,8 +68,8 @@ struct sender_result {
 // Send every datagram to the configured target.
 //
 // The address is resolved, so a target may name a host rather than an IP
-// literal. A multicast target is sent through every local interface of the
-// matching address family, as collectd's own network plugin does.
+// literal. A multicast target goes out through the interface(s) named by
+// `multicast_interfaces`.
 sender_result send_datagrams(const sender_config &config, const std::list<std::string> &datagrams);
 
 }  // namespace collectd

--- a/include/net/collectd/collectd_sender.hpp
+++ b/include/net/collectd/collectd_sender.hpp
@@ -31,8 +31,9 @@ struct sender_config {
   int retries;
 
   // Wall-clock budget for the whole send, in seconds (the target's `timeout`
-  // setting); 0 means no limit. It bounds the retry loop, so an unreachable
-  // target cannot hold the metrics thread for retries x datagrams.
+  // setting); 0 means no limit. It covers name resolution as well as the retry
+  // loop, so neither an unreachable target nor an unresponsive DNS server can
+  // hold the metrics thread past it.
   unsigned int timeout_seconds;
 
   // Which local interfaces a multicast target's datagrams leave through (the
@@ -52,11 +53,15 @@ struct sender_config {
 };
 
 struct sender_result {
-  // Datagrams that reached the socket, and datagrams that did not.
+  // Datagrams delivered to every socket the target uses, and datagrams that
+  // were not - including the ones a spent timeout left unsent. Both count
+  // payloads, so together they account for every non-empty datagram passed in,
+  // whatever the number of interfaces behind a multicast target.
   std::size_t sent;
   std::size_t failed;
-  // Send calls made, including retries: `attempts` above `sent` means the
-  // retry budget was being spent.
+  // Send calls made, including retries and one per interface: `attempts` above
+  // `sent` means the retry budget was being spent, or the target fans out over
+  // several interfaces.
   std::size_t attempts;
   // One line per problem, ready to log. Repeated identical failures are
   // collapsed so a broken target cannot flood the log every interval.

--- a/include/net/collectd/collectd_sender.hpp
+++ b/include/net/collectd/collectd_sender.hpp
@@ -68,7 +68,12 @@ struct sender_result {
 // Send every datagram to the configured target.
 //
 // The address is resolved, so a target may name a host rather than an IP
-// literal. A multicast target goes out through the interface(s) named by
+// literal; the datagrams go to the first address the resolver returns - the
+// one any other client would use for that name - so a name with both an A and
+// an AAAA record follows the host's own address preference. Name a literal on
+// the target when the collectd daemon listens on one family only.
+//
+// A multicast target goes out through the interface(s) named by
 // `multicast_interfaces`.
 sender_result send_datagrams(const sender_config &config, const std::list<std::string> &datagrams);
 

--- a/modules/CollectdClient/CMakeLists.txt
+++ b/modules/CollectdClient/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRCS
     ${SRCS}
     "${TARGET}.cpp"
     ${NSCP_INCLUDEDIR}/net/collectd/collectd_packet.cpp
+    ${NSCP_INCLUDEDIR}/net/collectd/collectd_sender.cpp
     ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
     ${NSCP_DEF_PLUGIN_CPP}
     ${NSCP_CLIENT_CPP}
@@ -24,6 +25,7 @@ if(WIN32)
         collectd_client.hpp
         collectd_handler.hpp
         ${NSCP_INCLUDEDIR}/net/collectd/collectd_packet.hpp
+        ${NSCP_INCLUDEDIR}/net/collectd/collectd_sender.hpp
         ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.hpp
         ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.hpp
         ${NSCP_DEF_PLUGIN_HPP}
@@ -63,6 +65,23 @@ NSCP_CREATE_TEST(
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
+# Unit tests for the UDP delivery half: resolution, the sockets a target opens
+# and what is reported when a datagram cannot be sent. Drives a real loopback
+# socket, so it needs no plugin API.
+NSCP_CREATE_TEST(
+    collectd_sender_test
+    SOURCES
+        collectd_sender_test.cpp
+        ${NSCP_INCLUDEDIR}/net/collectd/collectd_sender.cpp
+    LIBRARIES
+        GTest::gtest_main
+        ${Boost_THREAD_LIBRARY}
+        ${EXTRA_LIBS}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
 # Unit tests for the module class itself: the settings it registers/reads and
 # the target/handler sections it turns into client targets and commands. The
 # stub core (include/nscapi/test_helpers.hpp) stands in for the daemon.
@@ -72,6 +91,7 @@ NSCP_CREATE_TEST(
         collectd_module_test.cpp
         "${TARGET}.cpp"
         ${NSCP_INCLUDEDIR}/net/collectd/collectd_packet.cpp
+        ${NSCP_INCLUDEDIR}/net/collectd/collectd_sender.cpp
         ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
         ${NSCP_DEF_PLUGIN_CPP}
         ${NSCP_CLIENT_CPP}

--- a/modules/CollectdClient/collectd_client.hpp
+++ b/modules/CollectdClient/collectd_client.hpp
@@ -24,8 +24,14 @@ struct connection_data : public socket_helpers::connection_info {
     if (address.empty()) address = "239.192.74.66";
     port_ = arguments.address.get_port_string("25826");
     ssl.enabled = false;
-    timeout = arguments.get_int_data("timeout", 30);
-    retry = arguments.get_int_data("retries", 3);
+    // destination_container routes the well-known "timeout" key into a typed
+    // field (see set_string_data), never into the free-form data map, so
+    // get_int_data("timeout") could not see a configured value and the fallback
+    // always won. "retries" is not one of those keys and does land in the map.
+    // The settings layer notifies the documented defaults (30 / 3) for targets
+    // that set neither.
+    if (arguments.timeout > 0) timeout = arguments.timeout;
+    retry = arguments.get_int_data("retries", arguments.retry);
     sender_hostname = sender.address.host;
     if (sender.has_data("host")) sender_hostname = sender.get_string_data("host");
   }
@@ -216,7 +222,8 @@ struct collectd_client_handler : public client::handler_interface {
       if (p.get_size() == 0) continue;  // never put an empty datagram on the wire
       datagrams.push_back(p.get_buffer());
     }
-    const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config(target.get_address(), target.get_port()), datagrams);
+    const collectd::sender_config config(target.get_address(), target.get_port(), target.retry, target.timeout);
+    const collectd::sender_result result = collectd::send_datagrams(config, datagrams);
     for (const std::string &error : result.errors) {
       NSC_LOG_ERROR(error);
     }

--- a/modules/CollectdClient/collectd_client.hpp
+++ b/modules/CollectdClient/collectd_client.hpp
@@ -16,6 +16,9 @@ namespace collectd_client {
 
 struct connection_data : public socket_helpers::connection_info {
   std::string sender_hostname;
+  // Which local interface(s) a multicast target's datagrams leave through; see
+  // collectd::sender_config.
+  std::string multicast_interfaces;
 
   connection_data() {}
 
@@ -32,6 +35,7 @@ struct connection_data : public socket_helpers::connection_info {
     // that set neither.
     if (arguments.timeout > 0) timeout = arguments.timeout;
     retry = arguments.get_int_data("retries", arguments.retry);
+    multicast_interfaces = arguments.get_string_data("multicast interface", "auto");
     sender_hostname = sender.address.host;
     if (sender.has_data("host")) sender_hostname = sender.get_string_data("host");
   }
@@ -222,7 +226,7 @@ struct collectd_client_handler : public client::handler_interface {
       if (p.get_size() == 0) continue;  // never put an empty datagram on the wire
       datagrams.push_back(p.get_buffer());
     }
-    const collectd::sender_config config(target.get_address(), target.get_port(), target.retry, target.timeout);
+    const collectd::sender_config config(target.get_address(), target.get_port(), target.retry, target.timeout, target.multicast_interfaces);
     const collectd::sender_result result = collectd::send_datagrams(config, datagrams);
     for (const std::string &error : result.errors) {
       NSC_LOG_ERROR(error);

--- a/modules/CollectdClient/collectd_client.hpp
+++ b/modules/CollectdClient/collectd_client.hpp
@@ -6,39 +6,13 @@
 #include <boost/date_time/gregorian/gregorian.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <net/collectd/collectd_packet.hpp>
+#include <net/collectd/collectd_sender.hpp>
 #include <nscapi/macros.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <nscapi/protobuf/functions_convert.hpp>
 #include <nscapi/protobuf/metrics.hpp>
 
 namespace collectd_client {
-
-class udp_sender {
- public:
-  // Multicast: bind the socket to a specific local interface (source_endpoint)
-  // so the datagram leaves through it.
-  udp_sender(boost::asio::io_context &io_service, boost::asio::ip::udp::endpoint source_endpoint, const boost::asio::ip::address &target_address,
-             unsigned short target_port)
-      : endpoint_(target_address, target_port), socket_(io_service, source_endpoint) {}
-
-  // Unicast (or default-interface multicast): open a socket for the target's
-  // protocol family and let the OS pick the source.
-  udp_sender(boost::asio::io_context &io_service, const boost::asio::ip::address &target_address, unsigned short target_port)
-      : endpoint_(target_address, target_port), socket_(io_service, endpoint_.protocol()) {}
-
-  // Queue one datagram. The payload is owned by a shared_ptr captured in the
-  // completion handler so it stays alive until the async send finishes — this
-  // lets us queue several packets before a single io_context.run() drains them
-  // (the previous single-member buffer was overwritten by the next send).
-  void send_data(const std::string &data) {
-    auto payload = std::make_shared<std::string>(data);
-    socket_.async_send_to(boost::asio::buffer(*payload), endpoint_, [payload](const boost::system::error_code &, std::size_t) {});
-  }
-
- private:
-  boost::asio::ip::udp::endpoint endpoint_;
-  boost::asio::ip::udp::socket socket_;
-};
 
 struct connection_data : public socket_helpers::connection_info {
   std::string sender_hostname;
@@ -237,42 +211,14 @@ struct collectd_client_handler : public client::handler_interface {
 
   void send(const connection_data &target, const collectd::collectd_builder::packet_list &packets) {
     NSC_TRACE_ENABLED() { NSC_TRACE_MSG("Sending " + str::xtos(packets.size()) + " packets to: " + target.to_string()); }
-    try {
-      boost::asio::io_context io_service;
-      const boost::asio::ip::address target_address = boost::asio::ip::make_address(target.get_address());
-      const unsigned short target_port = target.get_int_port();
-
-      const bool is_multicast = (target_address.is_v4() && target_address.to_v4().is_multicast()) ||
-                                (target_address.is_v6() && target_address.to_v6().is_multicast());
-
-      // Build the set of sockets to send through. For unicast that is a single
-      // OS-routed socket; for multicast we send out every local interface of
-      // the matching address family.
-      std::list<std::shared_ptr<udp_sender> > senders;
-      if (is_multicast) {
-        boost::asio::ip::udp::resolver resolver(io_service);
-        for (const auto &entry : resolver.resolve(boost::asio::ip::host_name(), "")) {
-          const boost::asio::ip::address &local = entry.endpoint().address();
-          if (local.is_v4() == target_address.is_v4()) {
-            senders.push_back(std::make_shared<udp_sender>(io_service, entry.endpoint(), target_address, target_port));
-          }
-        }
-      }
-      if (senders.empty()) {
-        // Unicast, or multicast with no enumerable matching interface: fall
-        // back to a default-bound socket for the target's address family.
-        senders.push_back(std::make_shared<udp_sender>(io_service, target_address, target_port));
-      }
-
-      for (const collectd::packet &p : packets) {
-        if (p.get_size() == 0) continue;  // never put an empty datagram on the wire
-        for (const std::shared_ptr<udp_sender> &s : senders) {
-          s->send_data(p.get_buffer());
-        }
-      }
-      io_service.run();
-    } catch (std::exception &e) {
-      NSC_LOG_ERROR_STD(utf8::utf8_from_native(e.what()));
+    std::list<std::string> datagrams;
+    for (const collectd::packet &p : packets) {
+      if (p.get_size() == 0) continue;  // never put an empty datagram on the wire
+      datagrams.push_back(p.get_buffer());
+    }
+    const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config(target.get_address(), target.get_port()), datagrams);
+    for (const std::string &error : result.errors) {
+      NSC_LOG_ERROR(error);
     }
   }
 

--- a/modules/CollectdClient/collectd_client.hpp
+++ b/modules/CollectdClient/collectd_client.hpp
@@ -218,6 +218,18 @@ struct collectd_client_handler : public client::handler_interface {
 
     collectd::collectd_builder::packet_list packets;
     builder.render(packets);
+
+    // A value-list longer than a datagram can carry is truncated by the
+    // encoder rather than emitted malformed; say so, or the missing values
+    // look like a receiver-side problem.
+    std::size_t clamped = 0;
+    for (const collectd::packet &p : packets) clamped += p.clamped_values();
+    if (clamped > 0) {
+      NSC_LOG_ERROR("Dropped " + str::xtos(clamped) +
+                    " collectd value(s): a single value list does not fit one datagram (max " + str::xtos(collectd::max_packet_size) +
+                    " bytes). Split the metric across several entries.");
+    }
+
     connection_data con(target, sender);
     send(con, packets);
     return true;

--- a/modules/CollectdClient/collectd_client.hpp
+++ b/modules/CollectdClient/collectd_client.hpp
@@ -32,8 +32,10 @@ struct connection_data : public socket_helpers::connection_info {
     // get_int_data("timeout") could not see a configured value and the fallback
     // always won. "retries" is not one of those keys and does land in the map.
     // The settings layer notifies the documented defaults (30 / 3) for targets
-    // that set neither.
-    if (arguments.timeout > 0) timeout = arguments.timeout;
+    // that set neither. A configured 0 means "no time limit" to the sender, so
+    // it has to survive: only a negative value - impossible from settings, but
+    // reachable from a hand-written --timeout - keeps the inherited default.
+    if (arguments.timeout >= 0) timeout = static_cast<unsigned int>(arguments.timeout);
     retry = arguments.get_int_data("retries", arguments.retry);
     multicast_interfaces = arguments.get_string_data("multicast interface", "auto");
     sender_hostname = sender.address.host;

--- a/modules/CollectdClient/collectd_handler.hpp
+++ b/modules/CollectdClient/collectd_handler.hpp
@@ -14,7 +14,11 @@ struct collectd_target_object : public nscapi::targets::target_object {
 
   collectd_target_object(std::string alias, std::string path) : parent(alias, path) {
     set_property_string("port", "25826");
+    // collectd's default multicast group, so a target with no address still
+    // matches a stock collectd server. See `multicast interface` for which
+    // interface those datagrams leave through.
     set_property_string("host", "239.192.74.66");
+    set_property_string("multicast interface", "auto");
   }
   collectd_target_object(const nscapi::settings_objects::object_instance other, std::string alias, std::string path) : parent(other, alias, path) {}
 
@@ -26,10 +30,18 @@ struct collectd_target_object : public nscapi::targets::target_object {
     nscapi::settings_helper::path_extension root_path = settings.path(get_path());
     if (is_sample) root_path.set_sample();
 
-    root_path.add_key().add_int(
-        "interval", sh::int_fun_key([this](auto value) { this->set_property_int("interval", value); }), "METRICS INTERVAL",
-        "The interval (in seconds) reported to collectd for metrics sent to this target. Overrides the client-level interval; should match the core 'metrics "
-        "interval'.");
+    root_path.add_key()
+        .add_int("interval", sh::int_fun_key([this](auto value) { this->set_property_int("interval", value); }), "METRICS INTERVAL",
+                 "The interval (in seconds) reported to collectd for metrics sent to this target. Overrides the client-level interval; should match the core "
+                 "'metrics interval'.")
+
+        .add_string("multicast interface", sh::string_fun_key([this](auto value) { this->set_property_string("multicast interface", value); }, "auto"),
+                    "MULTICAST INTERFACE",
+                    "Which local interface a multicast target's metrics leave through. A target with no address is sent to collectd's default multicast group "
+                    "(239.192.74.66), so this decides how far those metrics travel. 'auto' (the default) sends one copy through the interface the routing "
+                    "table picks; 'all' sends a copy through every local interface of the target's address family, which puts the metrics on every attached "
+                    "segment; a comma-separated list of local IP addresses sends one copy through each of them and nothing else. Ignored for unicast "
+                    "targets.");
 
     settings.register_all();
     settings.notify();
@@ -49,6 +61,10 @@ struct options_reader_impl : public client::options_reader_interface {
     desc.add_options()
       ("interval", po::value<unsigned int>()->notifier([&data] (auto value) { data.set_int_data("interval", value); }),
       "The interval (in seconds) reported to collectd for these metrics.")
+
+      ("multicast-interface", po::value<std::string>()->notifier([&data] (auto value) { data.set_string_data("multicast interface", value); }),
+      "Which local interface a multicast target's metrics leave through: auto (the routed interface), all (every local interface of the target's address "
+      "family) or a comma-separated list of local IP addresses.")
     ;
     // clang-format on
   }

--- a/modules/CollectdClient/collectd_packet_test.cpp
+++ b/modules/CollectdClient/collectd_packet_test.cpp
@@ -152,6 +152,9 @@ TEST(CollectdPacket, ClampsOverlongStringPart) {
   EXPECT_GT(len, 0u);
   EXPECT_LE(len, collectd::max_packet_size);
   EXPECT_EQ(buf.size(), len);
+  // Clamped to the receiver's identifier limit, leaving room for the rest of
+  // the value-list rather than consuming the whole datagram.
+  EXPECT_EQ(len, collectd::max_string_length + 5);
 
   // Still decodes cleanly to a (clamped, non-empty) host without overrunning.
   p.add_gauge_value({1.0});
@@ -159,6 +162,67 @@ TEST(CollectdPacket, ClampsOverlongStringPart) {
   ASSERT_EQ(lists.size(), 1u);
   EXPECT_FALSE(lists[0].host.empty());
   EXPECT_LE(lists[0].host.size(), collectd::max_string_length);
+}
+
+TEST(CollectdPacket, ClampsOversizedValueList) {
+  collectd::packet p;
+  p.add_host("h");
+  // Far more values than a 1452-byte datagram can carry (9 bytes each): the
+  // part must be truncated to what fits rather than overflowing the datagram.
+  std::list<double> values(500, 1.5);
+  p.add_gauge_value(values);
+
+  const std::string buf = p.get_buffer();
+  EXPECT_LE(buf.size(), collectd::max_packet_size);
+  EXPECT_GT(p.clamped_values(), 0u);
+
+  const auto lists = decode_packet(buf);
+  ASSERT_EQ(lists.size(), 1u);
+  // Everything the part claims to carry is really there, and nothing was lost
+  // silently: emitted + clamped accounts for every configured value.
+  EXPECT_GT(lists[0].gauges.size(), 0u);
+  EXPECT_EQ(lists[0].gauges.size() + p.clamped_values(), values.size());
+  EXPECT_TRUE(std::all_of(lists[0].gauges.begin(), lists[0].gauges.end(), [](double d) { return d == 1.5; }));
+}
+
+TEST(CollectdPacket, ValuesPartLengthNeverWraps) {
+  collectd::packet p;
+  // Above ~3600 values the 16-bit length field wraps; the cap must make that
+  // unreachable, so the encoded length stays positive and inside the datagram.
+  p.add_derive_value(std::list<long long>(20000, 7));
+  const std::string buf = p.get_buffer();
+  ASSERT_GE(buf.size(), 6u);
+  const uint16_t len = read_be<uint16_t>(reinterpret_cast<const unsigned char *>(buf.data()) + 2);
+  const uint16_t count = read_be<uint16_t>(reinterpret_cast<const unsigned char *>(buf.data()) + 4);
+  EXPECT_GT(len, 0u);
+  EXPECT_EQ(len, buf.size());
+  EXPECT_LE(buf.size(), collectd::max_packet_size);
+  EXPECT_EQ(len, 6u + count * 9u);
+}
+
+TEST(CollectdPacket, DropsValuesWhenNoRoomIsLeft) {
+  collectd::packet p;
+  // Fill the datagram with identifier parts, then ask for values that cannot
+  // fit at all: no malformed zero-value part may be emitted.
+  while (p.remaining() >= collectd::max_string_length + 5) {
+    p.add_plugin_instance(std::string(collectd::max_string_length, 'x'));
+  }
+  const std::size_t size_before = p.get_size();
+  p.add_gauge_value({1.0, 2.0});
+  EXPECT_EQ(p.get_size(), size_before);
+  EXPECT_EQ(p.clamped_values(), 2u);
+  EXPECT_LE(p.get_size(), collectd::max_packet_size);
+}
+
+TEST(CollectdPacket, StringPartsNeverExceedTheDatagram) {
+  collectd::packet p;
+  // Every identifier part is clamped, so no sequence of them can push the
+  // packet past the receiver's read size.
+  for (int i = 0; i < 100; ++i) {
+    p.add_plugin(std::string(4000, 'p'));
+    p.add_type(std::string(4000, 't'));
+  }
+  EXPECT_LE(p.get_size(), collectd::max_packet_size);
 }
 
 TEST(CollectdPacket, TimeAndIntervalPartsAreBigEndian) {

--- a/modules/CollectdClient/collectd_packet_test.cpp
+++ b/modules/CollectdClient/collectd_packet_test.cpp
@@ -380,6 +380,38 @@ TEST(CollectdBuilder, UnmatchedVariableProducesNoMetrics) {
 // which stays within the collectd network buffer size.
 // ============================================================================
 
+TEST(CollectdBuilder, DoesNotClampAValueListThatFitsADatagramOfItsOwn) {
+  collectd::collectd_builder b;
+  b.set_time(1ULL << 30, 1ULL << 30);
+  b.set_host("a-reasonably-long-hostname-for-padding");
+  // Partly fill the first packet with small metrics...
+  for (int i = 0; i < 40; ++i) {
+    b.set_metric("small_" + std::to_string(i), "1");
+    b.add_metric("plugin" + std::to_string(i) + "-/gauge-value", "gauge:small_" + std::to_string(i));
+  }
+  // ...then a value list that fits a datagram of its own (120 * 9 + 6 bytes)
+  // but not what is left of a partly filled one. It has to be flushed into a
+  // fresh packet, not truncated to what happens to remain.
+  std::string values = "gauge:1";
+  for (int i = 1; i < 120; ++i) values += ",1";
+  b.add_metric("bigplugin-/gauge-value", values);
+
+  collectd::collectd_builder::packet_list packets;
+  b.render(packets);
+
+  std::size_t clamped = 0;
+  std::size_t big_values = 0;
+  for (const auto &pk : packets) {
+    EXPECT_LE(pk.get_size(), collectd::max_packet_size);
+    clamped += pk.clamped_values();
+    for (const auto &vl : decode_packet(pk.get_buffer())) {
+      if (vl.plugin == "bigplugin") big_values = vl.gauges.size();
+    }
+  }
+  EXPECT_EQ(clamped, 0u) << "a value list that fits a datagram was clamped into a partly filled one";
+  EXPECT_EQ(big_values, 120u);
+}
+
 TEST(CollectdBuilder, FragmentsLargeMetricSetWithinMtu) {
   collectd::collectd_builder b;
   b.set_time(1ULL << 30, 1ULL << 30);

--- a/modules/CollectdClient/collectd_sender_test.cpp
+++ b/modules/CollectdClient/collectd_sender_test.cpp
@@ -14,6 +14,9 @@
 
 #include <boost/asio.hpp>
 
+#include <algorithm>
+
+#include <chrono>
 #include <list>
 #include <string>
 #include <vector>
@@ -59,6 +62,8 @@ TEST(CollectdSender, SendsEveryDatagramToAnIpLiteralTarget) {
 
   EXPECT_EQ(result.sent, 3u);
   EXPECT_EQ(result.failed, 0u);
+  // One send call per datagram: a successful send never spends retry budget.
+  EXPECT_EQ(result.attempts, 3u);
   EXPECT_TRUE(result.errors.empty());
   const std::vector<std::string> received = sink.drain();
   ASSERT_EQ(received.size(), 3u);
@@ -108,4 +113,69 @@ TEST(CollectdSender, NothingToSendIsNotAnError) {
   EXPECT_EQ(result.sent, 0u);
   EXPECT_EQ(result.failed, 0u);
   EXPECT_TRUE(result.errors.empty());
+}
+
+// A datagram larger than the 65507-byte UDP maximum always fails to send, which
+// makes the failure path deterministic without an unreachable network.
+namespace {
+std::string oversized_datagram() { return std::string(70000, 'x'); }
+}  // namespace
+
+TEST(CollectdSender, RetriesAFailingSend) {
+  udp_sink sink;
+  const int retries = 2;
+
+  const collectd::sender_result result =
+      collectd::send_datagrams(collectd::sender_config("127.0.0.1", sink.port_string(), retries), {oversized_datagram()});
+
+  EXPECT_EQ(result.sent, 0u);
+  EXPECT_EQ(result.failed, 1u);
+  // The configured retries are actually spent: one initial attempt plus two.
+  EXPECT_EQ(result.attempts, static_cast<std::size_t>(retries + 1));
+  ASSERT_EQ(result.errors.size(), 1u);
+  EXPECT_NE(result.errors.front().find(sink.port_string()), std::string::npos);
+}
+
+TEST(CollectdSender, ReportsEachDistinctFailureOnce) {
+  udp_sink sink;
+
+  const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config("127.0.0.1", sink.port_string()),
+                                                                  {oversized_datagram(), oversized_datagram(), oversized_datagram()});
+
+  EXPECT_EQ(result.failed, 3u);
+  // Three identical failures, one log line: a broken target must not flood the
+  // log every metrics interval.
+  EXPECT_EQ(result.errors.size(), 1u);
+}
+
+TEST(CollectdSender, StopsRetryingWhenTheTimeoutExpires) {
+  udp_sink sink;
+  // A retry budget large enough to run for minutes, bounded by a one second
+  // timeout: the metrics thread must come back on time regardless.
+  const collectd::sender_config config("127.0.0.1", sink.port_string(), 100000, 1);
+
+  const auto started = std::chrono::steady_clock::now();
+  const collectd::sender_result result = collectd::send_datagrams(config, {oversized_datagram()});
+  const auto elapsed = std::chrono::steady_clock::now() - started;
+
+  EXPECT_LT(std::chrono::duration_cast<std::chrono::seconds>(elapsed).count(), 10);
+  EXPECT_GT(result.attempts, 1u);
+  EXPECT_LT(result.attempts, 100000u);
+  EXPECT_EQ(result.failed, 1u);
+}
+
+TEST(CollectdSender, AbandonsRemainingDatagramsWhenTheTimeoutExpires) {
+  udp_sink sink;
+  // The first datagram burns the whole budget; the rest must be reported as
+  // not sent rather than attempted anyway.
+  const collectd::sender_config config("127.0.0.1", sink.port_string(), 100000, 1);
+
+  const collectd::sender_result result = collectd::send_datagrams(config, {oversized_datagram(), "second", "third"});
+
+  EXPECT_EQ(result.sent, 0u);
+  EXPECT_EQ(result.failed, 3u);
+  EXPECT_EQ(sink.drain().size(), 0u);
+  const bool timed_out = std::any_of(result.errors.begin(), result.errors.end(),
+                                     [](const std::string &e) { return e.find("Timed out") != std::string::npos; });
+  EXPECT_TRUE(timed_out);
 }

--- a/modules/CollectdClient/collectd_sender_test.cpp
+++ b/modules/CollectdClient/collectd_sender_test.cpp
@@ -179,3 +179,71 @@ TEST(CollectdSender, AbandonsRemainingDatagramsWhenTheTimeoutExpires) {
                                      [](const std::string &e) { return e.find("Timed out") != std::string::npos; });
   EXPECT_TRUE(timed_out);
 }
+
+// ============================================================================
+// Multicast interface selection.
+//
+// A datagram aimed at a multicast group may or may not leave this machine
+// depending on the routes the test host has, so these assert on how many
+// sockets the send opens - visible as one attempt per socket per datagram -
+// rather than on delivery.
+// ============================================================================
+namespace {
+// collectd's default multicast group; the address a target falls back to when
+// none is configured.
+const char *kDefaultGroup = "239.192.74.66";
+}  // namespace
+
+TEST(CollectdSenderMulticast, AutoSendsOneCopyThroughTheRoutedInterface) {
+  // The default. Fanning a copy out of every local interface put the machine's
+  // metrics on every attached segment, including ones the operator never meant
+  // to reach - a DMZ or guest NIC.
+  const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config(kDefaultGroup, "25826", 0, 0, "auto"), {"payload"});
+
+  EXPECT_EQ(result.attempts, 1u);
+}
+
+TEST(CollectdSenderMulticast, AnUnsetSettingBehavesLikeAuto) {
+  const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config(kDefaultGroup, "25826"), {"payload"});
+
+  EXPECT_EQ(result.attempts, 1u);
+}
+
+TEST(CollectdSenderMulticast, AnExplicitListSendsOneCopyPerInterface) {
+  const collectd::sender_result result =
+      collectd::send_datagrams(collectd::sender_config(kDefaultGroup, "25826", 0, 0, "127.0.0.1, 127.0.0.1"), {"payload"});
+
+  // Two configured local addresses, two sockets, two sends of the datagram.
+  EXPECT_EQ(result.attempts, 2u);
+}
+
+TEST(CollectdSenderMulticast, ReportsAndSkipsUnusableInterfaceEntries) {
+  const collectd::sender_result result =
+      collectd::send_datagrams(collectd::sender_config(kDefaultGroup, "25826", 0, 0, "not-an-ip, ::1, 127.0.0.1"), {"payload"});
+
+  // The host name and the wrong-family entry are each reported and skipped;
+  // the usable one still carries the datagram.
+  EXPECT_EQ(result.attempts, 1u);
+  EXPECT_EQ(result.errors.size(), 2u);
+}
+
+TEST(CollectdSenderMulticast, SendsNothingWhenNoConfiguredInterfaceIsUsable) {
+  // Fail closed: a misconfigured allowlist must not silently fall back to
+  // sending through whatever interface the routing table picks.
+  const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config(kDefaultGroup, "25826", 0, 0, "not-an-ip"), {"a", "b"});
+
+  EXPECT_EQ(result.attempts, 0u);
+  EXPECT_EQ(result.sent, 0u);
+  EXPECT_EQ(result.failed, 2u);
+}
+
+TEST(CollectdSenderMulticast, TheSettingIsIgnoredForUnicastTargets) {
+  udp_sink sink;
+
+  const collectd::sender_result result =
+      collectd::send_datagrams(collectd::sender_config("127.0.0.1", sink.port_string(), 0, 0, "203.0.113.9"), {"payload"});
+
+  EXPECT_EQ(result.sent, 1u);
+  EXPECT_TRUE(result.errors.empty());
+  ASSERT_EQ(sink.drain().size(), 1u);
+}

--- a/modules/CollectdClient/collectd_sender_test.cpp
+++ b/modules/CollectdClient/collectd_sender_test.cpp
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// Unit tests for the UDP delivery half of CollectdClient: what
+// collectd::send_datagrams() puts on the wire, and what it reports back when
+// it cannot. The datagrams are read back from a real loopback UDP socket
+// rather than a mock, so the test covers the socket setup (address family,
+// resolution) and not only the bookkeeping - the same approach as
+// SyslogClient's sink test.
+
+#include <net/collectd/collectd_sender.hpp>
+
+#include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
+
+#include <list>
+#include <string>
+#include <vector>
+
+namespace {
+using boost::asio::ip::udp;
+
+// A UDP socket bound to an ephemeral loopback port, and the datagrams it saw.
+class udp_sink {
+ public:
+  udp_sink() : socket_(io_, udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0)) {}
+
+  unsigned short port() const { return socket_.local_endpoint().port(); }
+  std::string port_string() const { return std::to_string(port()); }
+
+  // Drain whatever has arrived. Non-blocking: everything under test sends
+  // before this is called, and a datagram that never arrives must fail the
+  // test rather than hang it.
+  std::vector<std::string> drain() {
+    std::vector<std::string> out;
+    socket_.non_blocking(true);
+    for (;;) {
+      char buffer[2048];
+      boost::system::error_code ec;
+      const std::size_t len = socket_.receive(boost::asio::buffer(buffer), 0, ec);
+      if (ec) break;
+      out.push_back(std::string(buffer, len));
+    }
+    return out;
+  }
+
+ private:
+  boost::asio::io_context io_;
+  udp::socket socket_;
+};
+}  // namespace
+
+TEST(CollectdSender, SendsEveryDatagramToAnIpLiteralTarget) {
+  udp_sink sink;
+  const std::list<std::string> datagrams = {"one", "two", "three"};
+
+  const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config("127.0.0.1", sink.port_string()), datagrams);
+
+  EXPECT_EQ(result.sent, 3u);
+  EXPECT_EQ(result.failed, 0u);
+  EXPECT_TRUE(result.errors.empty());
+  const std::vector<std::string> received = sink.drain();
+  ASSERT_EQ(received.size(), 3u);
+  EXPECT_EQ(received[0], "one");
+  EXPECT_EQ(received[2], "three");
+}
+
+TEST(CollectdSender, ResolvesAHostNameTarget) {
+  // The send path used to parse IP literals only, so a target configured with
+  // a host name threw on every metrics cycle and nothing was ever sent.
+  udp_sink sink;
+
+  const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config("localhost", sink.port_string()), {"payload"});
+
+  EXPECT_TRUE(result.errors.empty());
+  EXPECT_EQ(result.sent, 1u);
+  const std::vector<std::string> received = sink.drain();
+  ASSERT_EQ(received.size(), 1u);
+  EXPECT_EQ(received[0], "payload");
+}
+
+TEST(CollectdSender, ReportsAnUnresolvableTarget) {
+  const collectd::sender_result result =
+      collectd::send_datagrams(collectd::sender_config("no-such-host.invalid", "25826"), {"a", "b"});
+
+  EXPECT_EQ(result.sent, 0u);
+  EXPECT_EQ(result.failed, 2u);
+  ASSERT_EQ(result.errors.size(), 1u);
+  // The message must name the target: a bare resolver error is unactionable.
+  EXPECT_NE(result.errors.front().find("no-such-host.invalid"), std::string::npos);
+}
+
+TEST(CollectdSender, SkipsEmptyDatagrams) {
+  udp_sink sink;
+
+  const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config("127.0.0.1", sink.port_string()), {"", "kept", ""});
+
+  EXPECT_EQ(result.sent, 1u);
+  const std::vector<std::string> received = sink.drain();
+  ASSERT_EQ(received.size(), 1u);
+  EXPECT_EQ(received[0], "kept");
+}
+
+TEST(CollectdSender, NothingToSendIsNotAnError) {
+  const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config("127.0.0.1", "25826"), {});
+
+  EXPECT_EQ(result.sent, 0u);
+  EXPECT_EQ(result.failed, 0u);
+  EXPECT_TRUE(result.errors.empty());
+}

--- a/modules/CollectdClient/collectd_sender_test.cpp
+++ b/modules/CollectdClient/collectd_sender_test.cpp
@@ -24,10 +24,21 @@
 namespace {
 using boost::asio::ip::udp;
 
+// The address a name resolves to first - the endpoint send_datagrams() aims
+// at. "localhost" is ::1 on some hosts and 127.0.0.1 on others, so a test that
+// binds a literal and sends to the name would be asserting on the resolver
+// rather than on the code.
+boost::asio::ip::address first_resolved_address(const std::string &name) {
+  boost::asio::io_context io;
+  udp::resolver resolver(io);
+  return resolver.resolve(name, "25826").begin()->endpoint().address();
+}
+
 // A UDP socket bound to an ephemeral loopback port, and the datagrams it saw.
 class udp_sink {
  public:
-  udp_sink() : socket_(io_, udp::endpoint(boost::asio::ip::make_address("127.0.0.1"), 0)) {}
+  explicit udp_sink(const boost::asio::ip::address &bind_address = boost::asio::ip::make_address("127.0.0.1"))
+      : socket_(io_, udp::endpoint(bind_address, 0)) {}
 
   unsigned short port() const { return socket_.local_endpoint().port(); }
   std::string port_string() const { return std::to_string(port()); }
@@ -74,7 +85,7 @@ TEST(CollectdSender, SendsEveryDatagramToAnIpLiteralTarget) {
 TEST(CollectdSender, ResolvesAHostNameTarget) {
   // The send path used to parse IP literals only, so a target configured with
   // a host name threw on every metrics cycle and nothing was ever sent.
-  udp_sink sink;
+  udp_sink sink(first_resolved_address("localhost"));
 
   const collectd::sender_result result = collectd::send_datagrams(collectd::sender_config("localhost", sink.port_string()), {"payload"});
 
@@ -192,6 +203,12 @@ namespace {
 // collectd's default multicast group; the address a target falls back to when
 // none is configured.
 const char *kDefaultGroup = "239.192.74.66";
+
+// How many reported problems name `needle`.
+std::size_t errors_naming(const collectd::sender_result &result, const std::string &needle) {
+  return static_cast<std::size_t>(
+      std::count_if(result.errors.begin(), result.errors.end(), [&needle](const std::string &e) { return e.find(needle) != std::string::npos; }));
+}
 }  // namespace
 
 TEST(CollectdSenderMulticast, AutoSendsOneCopyThroughTheRoutedInterface) {
@@ -221,10 +238,14 @@ TEST(CollectdSenderMulticast, ReportsAndSkipsUnusableInterfaceEntries) {
   const collectd::sender_result result =
       collectd::send_datagrams(collectd::sender_config(kDefaultGroup, "25826", 0, 0, "not-an-ip, ::1, 127.0.0.1"), {"payload"});
 
-  // The host name and the wrong-family entry are each reported and skipped;
-  // the usable one still carries the datagram.
+  // The name and the wrong-family entry are each reported and skipped; the one
+  // usable entry still gets a socket and one send. Whether that send reaches
+  // the group from a loopback-bound socket depends on the host's routing (it
+  // fails on Windows), so the outcome of the send itself is not asserted -
+  // only that exactly one socket was opened and each bad entry named once.
   EXPECT_EQ(result.attempts, 1u);
-  EXPECT_EQ(result.errors.size(), 2u);
+  EXPECT_EQ(errors_naming(result, "not-an-ip"), 1u);
+  EXPECT_EQ(errors_naming(result, "::1"), 1u);
 }
 
 TEST(CollectdSenderMulticast, SendsNothingWhenNoConfiguredInterfaceIsUsable) {

--- a/modules/CollectdClient/collectd_sender_test.cpp
+++ b/modules/CollectdClient/collectd_sender_test.cpp
@@ -159,6 +159,32 @@ TEST(CollectdSender, ReportsEachDistinctFailureOnce) {
   EXPECT_EQ(result.errors.size(), 1u);
 }
 
+TEST(CollectdSender, AccountsForEveryPayloadExactlyOnce) {
+  udp_sink sink;
+
+  const collectd::sender_result result =
+      collectd::send_datagrams(collectd::sender_config("127.0.0.1", sink.port_string()), {"one", "", oversized_datagram(), "two"});
+
+  // Three payloads - the empty entry is not one. Each is either sent or
+  // failed, never both and never neither, so a caller can trust the pair.
+  EXPECT_EQ(result.sent + result.failed, 3u);
+  EXPECT_EQ(result.sent, 2u);
+  EXPECT_EQ(result.failed, 1u);
+}
+
+TEST(CollectdSender, TheTimeoutReportCountsOnlyRealPayloads) {
+  udp_sink sink;
+  const collectd::sender_config config("127.0.0.1", sink.port_string(), 100000, 1);
+
+  const collectd::sender_result result = collectd::send_datagrams(config, {oversized_datagram(), "", "", "last"});
+
+  // Two payloads: the first burns the whole budget and the last is abandoned.
+  // The two empty entries were never going on the wire and must not inflate
+  // the "not sent" count.
+  EXPECT_EQ(result.sent + result.failed, 2u);
+  EXPECT_EQ(result.failed, 2u);
+}
+
 TEST(CollectdSender, StopsRetryingWhenTheTimeoutExpires) {
   udp_sink sink;
   // A retry budget large enough to run for minutes, bounded by a one second
@@ -267,4 +293,15 @@ TEST(CollectdSenderMulticast, TheSettingIsIgnoredForUnicastTargets) {
   EXPECT_EQ(result.sent, 1u);
   EXPECT_TRUE(result.errors.empty());
   ASSERT_EQ(sink.drain().size(), 1u);
+}
+
+TEST(CollectdSenderMulticast, CountsADatagramOnceHoweverManyInterfacesCarryIt) {
+  const collectd::sender_result result =
+      collectd::send_datagrams(collectd::sender_config(kDefaultGroup, "25826", 0, 0, "127.0.0.1, 127.0.0.1"), {"payload"});
+
+  // Two sockets and two send calls, but one datagram: the payload counters
+  // stay at one, so `failed` can never be computed by subtracting a
+  // socket-scaled `sent` and underflow.
+  EXPECT_EQ(result.attempts, 2u);
+  EXPECT_EQ(result.sent + result.failed, 1u);
 }

--- a/tests/collectd-submit.test.ts
+++ b/tests/collectd-submit.test.ts
@@ -367,6 +367,50 @@ describe("CollectD hostname target", () => {
   });
 });
 
+// `multicast interface` is a per-target setting that only applies to multicast
+// targets. Configuring it on a unicast target must be accepted and ignored -
+// this also proves the key is registered, which a typo in the settings
+// declaration would break.
+describe("CollectD multicast interface setting", () => {
+  let nscp: NscpInstance;
+  let receiver: CollectdReceiver;
+
+  beforeAll(async () => {
+    receiver = new CollectdReceiver();
+    const port = await receiver.start();
+
+    nscp = new NscpInstance();
+    await nscp.configure({
+      "/modules": {
+        CheckSystem: "enabled",
+        CollectdClient: "enabled",
+      },
+      "/settings/core": {
+        "metrics interval": "1s",
+      },
+      "/settings/collectd/client": {
+        hostname: HOSTNAME,
+      },
+      "/settings/collectd/client/targets/default": {
+        address: `127.0.0.1:${port}`,
+        "multicast interface": "all",
+      },
+    });
+
+    nscp.start();
+  });
+
+  afterAll(async () => {
+    await nscp?.stop();
+    await receiver?.stop();
+  });
+
+  it("is ignored for a unicast target", async () => {
+    const ok = await receiver.waitFor((r) => r.some((v) => v.host === HOSTNAME));
+    expect(ok).toBe(true);
+  });
+});
+
 // A per-target `interval` must override the client-level interval on the wire.
 describe("CollectD per-target interval override", () => {
   let nscp: NscpInstance;

--- a/tests/collectd-submit.test.ts
+++ b/tests/collectd-submit.test.ts
@@ -323,6 +323,50 @@ describe("CollectD configurable mapping", () => {
   });
 });
 
+// A target may name a host rather than an IP literal: the send path resolves
+// it. Before that it parsed literals only, so a hostname target threw on every
+// metrics cycle and the metrics silently never arrived.
+describe("CollectD hostname target", () => {
+  let nscp: NscpInstance;
+  let receiver: CollectdReceiver;
+
+  beforeAll(async () => {
+    receiver = new CollectdReceiver();
+    const port = await receiver.start();
+
+    nscp = new NscpInstance();
+    await nscp.configure({
+      "/modules": {
+        CheckSystem: "enabled",
+        CollectdClient: "enabled",
+      },
+      "/settings/core": {
+        "metrics interval": "1s",
+      },
+      "/settings/collectd/client": {
+        hostname: HOSTNAME,
+      },
+      "/settings/collectd/client/targets/default": {
+        // The receiver binds 127.0.0.1, which "localhost" resolves to.
+        address: `localhost:${port}`,
+      },
+    });
+
+    nscp.start();
+  });
+
+  afterAll(async () => {
+    await nscp?.stop();
+    await receiver?.stop();
+  });
+
+  it("resolves the host name and delivers metrics", async () => {
+    const ok = await receiver.waitFor((r) => r.some((v) => v.host === HOSTNAME));
+    expect(ok).toBe(true);
+    expect(receiver.packets.length).toBeGreaterThan(0);
+  });
+});
+
 // A per-target `interval` must override the client-level interval on the wire.
 describe("CollectD per-target interval override", () => {
   let nscp: NscpInstance;

--- a/tests/collectd-submit.test.ts
+++ b/tests/collectd-submit.test.ts
@@ -365,7 +365,8 @@ describe("CollectD hostname target", () => {
         hostname: HOSTNAME,
       },
       "/settings/collectd/client/targets/default": {
-        // The receiver binds 127.0.0.1, which "localhost" resolves to.
+        // The receiver binds whatever "localhost" resolves to on this host,
+        // which may be ::1 - see resolveLocalhost above.
         address: `localhost:${port}`,
       },
     });

--- a/tests/collectd-submit.test.ts
+++ b/tests/collectd-submit.test.ts
@@ -30,6 +30,7 @@
  * mirrors what collectd_packet.cpp on the sending side writes.
  */
 import * as dgram from "dgram";
+import * as dns from "dns";
 import { NscpInstance } from "@fixtures/index";
 
 jest.setTimeout(600_000);
@@ -136,17 +137,31 @@ function decodeCollectd(buf: Buffer): CollectdReading[] {
   return readings;
 }
 
+/**
+ * The address "localhost" resolves to for this host - the same one
+ * NSClient++'s resolver picks when a target names it. Debian-family hosts map
+ * localhost to both 127.0.0.1 and ::1 in /etc/hosts and getaddrinfo prefers
+ * ::1, so a receiver bound to a hard-coded literal would be asserting on the
+ * resolver rather than on the agent.
+ */
+async function resolveLocalhost(): Promise<string> {
+  const { address } = await dns.promises.lookup("localhost");
+  return address;
+}
+
 /** A loopback UDP collectd receiver that decodes every datagram it gets. */
 class CollectdReceiver {
-  private readonly socket = dgram.createSocket("udp4");
+  private socket!: dgram.Socket;
   readonly readings: CollectdReading[] = [];
   /** Raw datagrams, kept so a failing assertion can show the bytes. */
   readonly packets: Buffer[] = [];
 
-  async start(): Promise<number> {
+  /** Bind the receiver, by default on IPv4 loopback. */
+  async start(host = "127.0.0.1"): Promise<number> {
+    this.socket = dgram.createSocket(host.includes(":") ? "udp6" : "udp4");
     await new Promise<void>((resolve, reject) => {
       this.socket.once("error", reject);
-      this.socket.bind(0, "127.0.0.1", () => {
+      this.socket.bind(0, host, () => {
         this.socket.off("error", reject);
         resolve();
       });
@@ -159,6 +174,7 @@ class CollectdReceiver {
   }
 
   async stop(): Promise<void> {
+    if (!this.socket) return; // start() never ran (a failed beforeAll)
     await new Promise<void>((resolve) => this.socket.close(() => resolve()));
   }
 
@@ -332,7 +348,9 @@ describe("CollectD hostname target", () => {
 
   beforeAll(async () => {
     receiver = new CollectdReceiver();
-    const port = await receiver.start();
+    // Listen where "localhost" actually points on this host, so the test
+    // asserts that the name is resolved and not which family the host prefers.
+    const port = await receiver.start(await resolveLocalhost());
 
     nscp = new NscpInstance();
     await nscp.configure({


### PR DESCRIPTION
Fixes the three findings left open by the [CollectdClient security review](https://claude.ai/code/artifact/5333df87-cd1c-4314-8f3a-5096d8c42159), plus the hostname half of finding 6 which `main` still carries. One commit per finding, then a round of review fixes.

Note: the sign/encrypt work (`claude/collectd-security-review-lrgg9m`, `38ddce5`) is **not** in `main` and not in this PR — these fixes are written against `main` and stand on their own.

## `never emit a datagram larger than the receiver reads` (finding 5)

The encoder clamped string parts but nothing bounded a values part: a configured value-list of a few hundred comma-separated entries overflowed the 1452-byte datagram collectd reads, and past ~3600 entries the cast of the part length to `int16_t` wrapped into a malformed part.

- `append_values()` caps the value count at what is left in the datagram; dropped values are counted and the client logs how many.
- `append_string()` clamps identifiers to 127 bytes (`DATA_MAX_NAME_LEN - 1`, what the receiver stores) and to the remaining budget. The old limit was the datagram size, so one overlong hostname consumed the whole packet.
- `render()` sizes each metric against what the packet has left and flushes *before* appending, so a value list that fits a datagram of its own is never clamped into a partly filled one. The clamps stay as the hard guarantee but now only bite on a list too large for any datagram — the case the log message describes.

## `resolve host names in target addresses` (finding 6, first half)

`boost::asio::ip::make_address()` accepts IP literals only, so a target named by host name threw on every metrics cycle, was caught, and showed up as nothing but a repeated log line — the metrics silently never arrived.

Addresses are resolved now (asynchronously, under the target's `timeout`, so an unresponsive DNS server cannot stall the metrics thread), and an unresolvable target is reported by name. The UDP delivery half moves out of `collectd_client.hpp` into `net/collectd/collectd_sender.{hpp,cpp}`, which knows nothing of the plugin API and can be driven against a real loopback socket from a unit test.

## `honour the target timeout and retries` (finding 6, second half)

Both settings were read into the connection and never used, and the async send discarded its completion error code — an unreachable target, a full socket buffer or an oversized datagram was indistinguishable from a delivered packet.

- Synchronous send with the error code checked; a failed send is retried up to `retries` times, 20 ms apart. Only sends that failed locally are retried, so nothing the receiver already has is sent twice.
- The whole send — resolution included — runs under `timeout`; when the budget is spent the remaining datagrams are abandoned and reported. A configured `timeout = 0` means no limit.
- Failures are logged once per distinct message, so a target that is down does not flood the log every interval.
- `timeout` also had to be read from the right place: `destination_container` routes the well-known key into a typed field, so `get_int_data("timeout")` always returned the fallback — the defect characterised in `syslog_client_test.cpp`, fixed the same way as IcingaClient/GraphiteClient.
- `sent` and `failed` count payloads, so they account for every non-empty datagram whatever the interface count behind a multicast target.

## `stop multicast metrics fanning out over every interface` (finding 2)

A target with no address falls back to `239.192.74.66:25826`, and a multicast target sent a copy of every datagram through every local interface — putting host name, CPU, memory, uptime and process counts on every attached segment as unauthenticated cleartext.

New per-target `multicast interface` setting: `auto` (default) sends one copy through the routed interface, `all` restores the old fan-out, and a comma-separated list of local IP addresses restricts it to those (also setting `IP_MULTICAST_IF`, since binding the source alone does not steer egress on every platform). An unusable entry is reported and skipped — in every mode — and a target whose whole list is unusable sends nothing rather than falling back to the default route.

`auto` is also more reliable: the enumeration behind `all` resolves the host name, which on a host whose name maps to `127.0.1.1` (the Debian convention) yields loopback and nothing else — so those metrics never left the machine at all.

## Tests

- `collectd_packet_test`: 17 tests (5 new) — oversized value lists, length-field wrap, no room left, string parts never exceeding the datagram, and a value list that fits a datagram not being clamped into a partly filled one (it lost 27 of 120 values before that fix).
- `collectd_sender_test`: **new**, 18 tests — delivery to a real loopback sink, host-name resolution, unresolvable targets, retry accounting, the timeout bounding both the retry loop and the remaining datagrams, payload accounting (`sent + failed` covering every payload exactly once), error collapsing, and each multicast interface mode.
- `tests/collectd-submit.test.ts`: a `localhost:<port>` target (a case that could not have passed before) and a `multicast interface` target proving the key is registered and ignored for unicast.

Both unit binaries were built and run outside CMake against Boost 1.83 + GTest 1.14 (35/35 pass); the integration suite type-checks and is prettier-clean. CI covers the rest.

## Docs

`multicast interface` added to the reference (YAML + regenerated Markdown), an upgrade note for the timeout/retries behaviour and one for the multicast default, and a security notice for the fan-out. `python3 docs/hooks/notes.py --check` passes. The notes are filed under `0.18.2` — move them if the next release is numbered differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ujm8ZwQrrzZPMjpgebckCv