### PR TITLE
test: cover the empty filter result of every enumerating check

### DIFF
--- a/tests/checkdisk-commands.test.ts
+++ b/tests/checkdisk-commands.test.ts
@@ -590,6 +590,65 @@ describe("CheckDisk commands", () => {
     expect(m).toMatch(/inodes \d+\/\d+ \(\d+% used, \d+ free\)/);
   });
 
+  // --- empty result sets ------------------------------------------------------
+
+  // A filter that matches nothing must land on each check's documented empty
+  // contract rather than an error (#1499 was check_service dying on exactly
+  // this path). The disk checks disagree on what an empty set means, so each
+  // case pins its own default.
+
+  it("check_drivesize with a filter that matches nothing returns UNKNOWN", async () => {
+    const q = await executeQuery(key, "check_drivesize", {
+      filter: "name = 'nosuchdrive-1499'",
+    });
+    expect(q.result).toBe(UNKNOWN);
+    expect(messageOf(q)).toMatch(/No drives found/i);
+  });
+
+  it("check_disk_io with a filter that matches nothing takes the empty state", async () => {
+    // The default empty-state is critical: a device list that comes back empty
+    // is an alert, not a quiet OK. The option still relaxes it.
+    const args = { filter: "name = 'nosuchdevice-1499'" };
+    const q = await executeQuery(key, "check_disk_io", args);
+    expect(q.result).toBe(CRITICAL);
+    const relaxed = await executeQuery(key, "check_disk_io", { ...args, "empty-state": "ok" });
+    expect(relaxed.result).toBe(OK);
+  });
+
+  it("check_disk_health with a filter that matches nothing takes the empty state", async () => {
+    const args = { filter: "name = 'nosuchdevice-1499'" };
+    const q = await executeQuery(key, "check_disk_health", args);
+    expect(q.result).toBe(CRITICAL);
+    const relaxed = await executeQuery(key, "check_disk_health", { ...args, "empty-state": "ok" });
+    expect(relaxed.result).toBe(OK);
+  });
+
+  it("check_files with a filter that matches nothing returns UNKNOWN", async () => {
+    // The directory exists and has a file, so this is the filter (not a bad
+    // path) producing the empty set.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nscp-empty-"));
+    fs.writeFileSync(path.join(dir, "present.txt"), "x");
+    try {
+      const q = await executeQuery(key, "check_files", {
+        path: dir,
+        filter: "filename = 'nosuchfile-1499'",
+      });
+      expect(q.result).toBe(UNKNOWN);
+      expect(messageOf(q)).toMatch(/No files found/i);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("check_share with a filter that matches nothing is OK (Windows)", async () => {
+    if (!onWindows) return; // SMB shares are a Windows feature.
+    // The default crit is `not exists`, an object-bound keyword: with no share
+    // in the context it must not fire.
+    const q = await executeQuery(key, "check_share", { filter: "name = 'nosuchshare-1499'" });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toMatch(/No shares found/i);
+  });
+
   // --- checksums (check_files, both platforms) ------------------------------
 
   it("check_files computes file content checksums", async () => {

--- a/tests/checkdocker-commands.test.ts
+++ b/tests/checkdocker-commands.test.ts
@@ -63,6 +63,28 @@ maybeDescribe("CheckDocker commands", () => {
     expect(out).toMatch(/nscp-no-such-container=missing/);
   });
 
+  it("check_docker with a filter that matches nothing takes the empty state", async () => {
+    // The #1499 shape: the default crit (`container_state != 'running'`) is
+    // force-evaluated with no container bound once nothing matched. The
+    // documented empty state is WARNING; the option still relaxes it. The
+    // empty syntax carries no status word, so the exit code is the verdict.
+    const args = ["client", "--module", "CheckDocker", "--boot", "--query", "check_docker", "filter=names = 'nscp-no-such-container-1499'"];
+    const r = await nscp.run(args, { allowFailure: true });
+    expect(r.all ?? `${r.stdout}\n${r.stderr}`).toMatch(/No containers found/);
+    expect(r.exitCode).toBe(1);
+    const relaxed = await nscp.run([...args, "empty-state=ok"], { allowFailure: true });
+    expect(relaxed.exitCode).toBe(0);
+  });
+
+  it("check_docker_restarts with a filter that matches nothing is OK", async () => {
+    const r = await nscp.run(
+      ["client", "--module", "CheckDocker", "--boot", "--query", "check_docker_restarts", "filter=names = 'nscp-no-such-container-1499'"],
+      { allowFailure: true },
+    );
+    expect(r.all ?? `${r.stdout}\n${r.stderr}`).toMatch(/No containers found/);
+    expect(r.exitCode).toBe(0);
+  });
+
   it("check_docker accepts all=true as a valued boolean (REST k=v token path)", async () => {
     const out = await query("check_docker", ["all=true", `filter=names = '${probeName}'`]);
     expect(out).not.toMatch(/does not take any arguments/i);

--- a/tests/checklogfile-commands.test.ts
+++ b/tests/checklogfile-commands.test.ts
@@ -81,6 +81,22 @@ describe("CheckLogFile check_logfile", () => {
     expect(messageOf(second)).toMatch(/2\/3/);
   });
 
+  it("reports the empty contract when the filter matches nothing", async () => {
+    // Part of #1499: with no line matched the warn/crit expressions are
+    // force-evaluated with no row bound, and column() used to read the row
+    // anyway. It must resolve to nothing so the check lands on its empty-state
+    // result, not an error.
+    const file = newLog("INFO one\nINFO two\n");
+    const q = await executeQuery(key, "check_logfile", {
+      file,
+      filter: "column1 = 'nosuchcolumn-1499'",
+      critical: "column(1) = 'ERROR' or count > 5",
+      "empty-state": "ok",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toMatch(/Nothing found/i);
+  });
+
   it("compares columns against decimal thresholds numerically", async () => {
     // Tab-separated columns (the default column-split). column2 is a dual
     // string/number keyword: the decimal literal re-types it to float and

--- a/tests/checkmssql-commands.test.ts
+++ b/tests/checkmssql-commands.test.ts
@@ -289,6 +289,22 @@ dockerDescribe("CheckMSSQL live (SQL Server 2022 container)", () => {
     expect(included).not.toMatch(/_full_age'?=-1s/);
   });
 
+  it("check_mssql_databases with a filter that matches nothing returns UNKNOWN", async () => {
+    // The #1499 shape: the default warn/crit on `state` are force-evaluated
+    // with no database bound once nothing matched.
+    const out = await query("check_mssql_databases", ["filter=name = 'nosuchdb-1499'"]);
+    if (!live) return expect(out).toMatch(CONNECT_FAILED);
+    expect(out).toMatch(/^UNKNOWN/m);
+    expect(out).toMatch(/No databases found/);
+  });
+
+  it("check_mssql_backup with a filter that matches nothing returns UNKNOWN", async () => {
+    const out = await query("check_mssql_backup", ["filter=name = 'nosuchdb-1499'"]);
+    if (!live) return expect(out).toMatch(CONNECT_FAILED);
+    expect(out).toMatch(/^UNKNOWN/m);
+    expect(out).toMatch(/No databases found/);
+  });
+
   it("check_mssql_jobs exposes is_running and keeps last_run_status for completed runs", async () => {
     const out = await query("check_mssql_jobs", [
       "warning=none",

--- a/tests/checknet-commands.test.ts
+++ b/tests/checknet-commands.test.ts
@@ -847,6 +847,19 @@ describe("CheckNet commands", () => {
     expect(m?.[4]).toBe(m?.[1]);
   });
 
+  it("check_connections with a filter that matches nothing reports no data", async () => {
+    // The empty state is 'ignored' here, so the verdict comes from the default
+    // thresholds being force-evaluated with no bucket bound (#1499 shape):
+    // they cannot resolve, which surfaces as UNKNOWN rather than a silent OK.
+    // Pinning the empty state gives the caller the quiet result.
+    const args = { filter: "protocol = 'nosuchprotocol-1499'" };
+    const q = await executeQuery(key, "check_connections", args);
+    expect(q.result).toBe(UNKNOWN);
+    expect(messageOf(q)).toMatch(/No connection data/i);
+    const relaxed = await executeQuery(key, "check_connections", { ...args, "empty-state": "ok" });
+    expect(relaxed.result).toBe(OK);
+  });
+
   // --- check_ntp_offset -----------------------------------------------------
 
   it("check_ntp_offset reports the server's advertised root delay and dispersion", async () => {

--- a/tests/checksecurity.test.ts
+++ b/tests/checksecurity.test.ts
@@ -495,4 +495,48 @@ onWindows("CheckSecurity (Windows posture)", () => {
     expect(out).toMatch(/^CRITICAL/m);
     expect(out).toMatch(/unexpected owner/);
   });
+
+  // --- empty result sets -----------------------------------------------------
+
+  // A filter that matches nothing must land on each check's documented empty
+  // contract, never an error (#1499 was check_service dying on this path).
+  // Client-query output carries no status word when the empty syntax has
+  // none, so the UNKNOWN cases assert the message alone.
+
+  it("check_firewall with a filter that matches nothing reports no profiles", async () => {
+    const out = await query("check_firewall", ["filter=profile = 'nosuchprofile-1499'"]);
+    expect(out).toMatch(/No firewall profiles found/);
+    expect(out).not.toMatch(/^(OK|WARNING|CRITICAL)/m);
+  });
+
+  it("check_firewall_rules with a filter that matches nothing is OK", async () => {
+    // The default crit is `present = 0`, an object-bound keyword.
+    const out = await query("check_firewall_rules", ["filter=name = 'nosuchrule-1499'"]);
+    expect(out).toMatch(/^OK/m);
+    expect(out).toMatch(/No firewall rules matched/);
+  });
+
+  it("check_local_accounts with a filter that matches nothing is OK", async () => {
+    const out = await query("check_local_accounts", ["filter=name = 'nosuchaccount-1499'"]);
+    expect(out).toMatch(/^OK/m);
+    expect(out).toMatch(/No local accounts found/);
+  });
+
+  it("check_nla with a filter that matches nothing reports no networks", async () => {
+    const out = await query("check_nla", ["filter=network = 'nosuchnetwork-1499'"]);
+    expect(out).toMatch(/No networks found/);
+    expect(out).not.toMatch(/^(WARNING|CRITICAL)/m);
+  });
+
+  it("check_certificate with a store filter that matches nothing reports no certificates", async () => {
+    const out = await query("check_certificate", ["store=MY", "filter=subject = 'nosuchsubject-1499'"]);
+    expect(out).toMatch(/No certificates found/);
+    expect(out).not.toMatch(/^(OK|WARNING|CRITICAL)/m);
+  });
+
+  it("check_file_security with a filter that matches nothing returns UNKNOWN", async () => {
+    const out = await query("check_file_security", ["path=C:\\Windows", "filter=path = 'nosuchpath-1499'"]);
+    expect(out).toMatch(/^UNKNOWN/m);
+    expect(out).toMatch(/No paths checked/);
+  });
 });

--- a/tests/checksystem-commands.test.ts
+++ b/tests/checksystem-commands.test.ts
@@ -616,6 +616,71 @@ describe("CheckSystem commands", () => {
     expect(alive.result).not.toBeUndefined();
   });
 
+  // --- empty result sets ------------------------------------------------------
+
+  // The same shape as #1499 for the other enumerating checks: a filter that
+  // matches nothing must land on the check's documented empty contract, never
+  // an error - and the agent must still be there afterwards.
+
+  it("check_process with a filter that matches nothing returns UNKNOWN", async () => {
+    // The default warn/crit (`state not in ('started')` / `state = 'stopped'`)
+    // are object-bound and get force-evaluated with no process in the context.
+    const q = await executeQuery(key, "check_process", {
+      filter: "exe = 'nosuchprocess-1499.exe'",
+    });
+    expect(q.result).toBe(UNKNOWN);
+    expect(messageOf(q)).toMatch(/No processes found/i);
+  });
+
+  it("check_network with a filter that matches nothing takes the empty state", async () => {
+    // check_network defaults to empty-state=critical: an interface list that
+    // comes back empty is worth an alert. The option still relaxes it.
+    const args = { filter: "name = 'nosuchinterface-1499'" };
+    const q = await executeQuery(key, "check_network", args);
+    expect(q.result).toBe(CRITICAL);
+    const relaxed = await executeQuery(key, "check_network", { ...args, "empty-state": "ok" });
+    expect(relaxed.result).toBe(OK);
+  });
+
+  it("check_registry_key with a filter that matches nothing returns UNKNOWN (Windows)", async () => {
+    if (!onWindows) return; // the registry checks are Windows-only (CheckSystem).
+    // The default crit is `not exists`, an object-bound keyword.
+    const q = await executeQuery(key, "check_registry_key", {
+      key: "HKLM\\SOFTWARE",
+      filter: "name = 'nosuchkey-1499'",
+    });
+    expect(q.result).toBe(UNKNOWN);
+    expect(messageOf(q)).toMatch(/No registry keys found/i);
+  });
+
+  it("check_registry_value with a filter that matches nothing returns UNKNOWN (Windows)", async () => {
+    if (!onWindows) return;
+    const q = await executeQuery(key, "check_registry_value", {
+      key: "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion",
+      filter: "name = 'nosuchvalue-1499'",
+    });
+    expect(q.result).toBe(UNKNOWN);
+    expect(messageOf(q)).toMatch(/No registry values found/i);
+  });
+
+  it("check_printqueue with a filter that matches nothing is OK (Windows)", async () => {
+    if (!onWindows) return; // print queues are a Windows feature.
+    const q = await executeQuery(key, "check_printqueue", {
+      filter: "printer = 'nosuchprinter-1499'",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toMatch(/No printers found/i);
+  });
+
+  it("check_printjobs with a filter that matches nothing is OK (Windows)", async () => {
+    if (!onWindows) return;
+    const q = await executeQuery(key, "check_printjobs", {
+      filter: "printer = 'nosuchprinter-1499'",
+    });
+    expect(q.result).toBe(OK);
+    expect(messageOf(q)).toMatch(/No print jobs queued/i);
+  });
+
   // --- check_pending_reboot (Windows) ----------------------------------------
 
   it("check_pending_reboot returns one aggregate row with perf (Windows)", async () => {

--- a/tests/checktasksched-commands.test.ts
+++ b/tests/checktasksched-commands.test.ts
@@ -16,6 +16,7 @@ import { join } from "node:path";
 import {
   NscpInstance,
   OK,
+  WARNING,
   executeQuery,
   messageOf,
   setupQueryNscp,
@@ -97,5 +98,18 @@ const HIDDEN_TASK_XML = `<?xml version="1.0" encoding="UTF-16"?>
     const msg = messageOf(q);
     expect(msg).toMatch(/No tasks found/i);
     expect(msg).not.toContain(TASK);
+  });
+
+  it("a filter that matches nothing takes the empty state (WARNING by default)", async () => {
+    // The #1499 shape: the default warn/crit on exit_code are re-evaluated
+    // with no task bound once nothing matched. check_tasksched defaults to
+    // empty-state=warning (a task list that comes back empty deserves a look);
+    // the option still relaxes it.
+    const args = { filter: "title = 'nosuchtask-1499'" };
+    const q = await executeQuery(key, "check_tasksched", args);
+    expect(q.result).toBe(WARNING);
+    expect(messageOf(q)).toMatch(/No tasks found/i);
+    const relaxed = await executeQuery(key, "check_tasksched", { ...args, "empty-state": "ok" });
+    expect(relaxed.result).toBe(OK);
   });
 });

--- a/tests/checkwindowsapps-iis-commands.test.ts
+++ b/tests/checkwindowsapps-iis-commands.test.ts
@@ -80,6 +80,24 @@ const expectIis = process.env.NSCP_EXPECT_IIS === "1";
     if (expectIis) expect(out).toMatch(/Default Web Site: \w+, \d+ connections/);
   });
 
+  // --- empty result sets ----------------------------------------------------
+
+  // The #1499 shape: the default crit (`state != 'running' and auto_start != 0`)
+  // is force-evaluated with no pool/site bound once a filter matched nothing.
+  // Both host shapes must end on a documented message, never WARNING/CRITICAL.
+
+  it("check_iis_app_pools with a filter that matches nothing takes the empty state", async () => {
+    const out = await query("check_iis_app_pools", ["filter=pool = 'nosuchpool-1499'", "empty-state=ok"]);
+    expect(out).toMatch(/not available|No application pools found/);
+    expect(out).not.toMatch(/(^|\s)(WARNING|CRITICAL)\b/);
+  });
+
+  it("check_iis_sites with a filter that matches nothing takes the empty state", async () => {
+    const out = await query("check_iis_sites", ["filter=site = 'nosuchsite-1499'", "empty-state=ok"]);
+    expect(out).toMatch(/not available|No web sites found/);
+    expect(out).not.toMatch(/(^|\s)(WARNING|CRITICAL)\b/);
+  });
+
   // --- check_iis_worker_processes -------------------------------------------
 
   it("check_iis_worker_processes reports workers or the documented contracts", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #1500 / #1499. check_service used to kill the agent when its filter matched nothing, because the default warn/crit expressions are force-evaluated with no object bound once the result set is empty. Every filter check shares that path, so this adds one integration case per enumerating check that passes a filter matching nothing and asserts the documented empty contract. A regression now shows up as a failed test instead of a dead process.

### Covered

| Suite | Checks |
|---|---|
| checksystem-commands | check_process, check_network, check_registry_key, check_registry_value, check_printqueue, check_printjobs |
| checkdisk-commands | check_drivesize, check_disk_io, check_disk_health, check_files, check_share |
| checktasksched-commands | check_tasksched |
| checknet-commands | check_connections |
| checklogfile-commands | check_logfile with a `column()` threshold (the second keyword guarded in #1500) |
| checkwindowsapps-iis-commands | check_iis_app_pools, check_iis_sites |
| checksecurity | check_firewall, check_firewall_rules, check_local_accounts, check_nla, check_certificate (store), check_file_security |
| checkdocker-commands | check_docker, check_docker_restarts |
| checkmssql-commands | check_mssql_databases, check_mssql_backup |

Where the default empty-state is `critical` or `warning` (network, disk io, disk health, tasksched, docker) the case pins that default and shows `empty-state=ok` relaxing it. Where the empty state is `ignored` (check_connections) the unresolved default thresholds surface as UNKNOWN, which is pinned with a comment explaining why.

Skipped on purpose: single-row checks (uptime, memory, cpu, …) where an empty filter is contrived, and checks that already had an empty-result case (check_eventlog, check_installed_software, check_battery, check_shadowcopy, check_mssql_jobs).

## Test plan

- [x] Windows: the seven touched suites pass (264 passed). The only failures are the pre-existing check_group_members cases, which look for `Administrators` on a Swedish-locale host.
- [x] Linux (WSL) + Docker: checksystem, checkdisk, checknet, checklogfile and checkdocker suites pass (231 passed).
- [ ] The two CheckMSSQL cases live in the SQL Server container block and were not executed locally (Docker Desktop on Windows was unavailable). They fall back to the connect-failure contract when the container is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLMGnkVT1FS2D2fveor889
