### PR TITLE
fix: stop waiting on stalled collectors when the service shuts down

### DIFF
--- a/include/threads/stop_signal.hpp
+++ b/include/threads/stop_signal.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <exception>
 #include <string>
 
 #ifdef WIN32
@@ -45,6 +46,17 @@ namespace threads {
 // threads, and a stop/start cycle reopened the still-signalled object so the
 // restarted thread exited immediately. A name would also let any co-resident
 // process signal it and disable monitoring from outside.
+// Thrown by a worker step that gave up because its stop signal fired (a
+// collector fetch that let go of a stalled provider, an aborted search).
+// Deliberately unrelated to any failure type: a collector's "this source is
+// broken, disable it / count a failure" handling must never mistake a
+// shutdown for an error, and catching this type is how a portable collector
+// loop tells the two apart without knowing which platform API was abandoned.
+class stop_requested : public std::exception {
+ public:
+  const char *what() const noexcept override { return "stop requested"; }
+};
+
 class stop_signal {
  public:
   stop_signal() = default;

--- a/include/win/wmi/wmi_query.cpp
+++ b/include/win/wmi/wmi_query.cpp
@@ -173,12 +173,36 @@ long long row::get_int(const std::string &col) const {
   return value.value();
 }
 
+namespace {
+// How long one Next() call on an abortable enumerator waits before the abort
+// event is re-checked. Bounds how long a stop request can go unnoticed while a
+// provider is stalled; it costs nothing on a responsive provider, which
+// returns the row before the timeout.
+const long abort_poll_ms = 250;
+
+bool is_signalled(HANDLE event) { return event != nullptr && WaitForSingleObject(event, 0) == WAIT_OBJECT_0; }
+}  // namespace
+
 bool row_enumerator::has_next() {
   ULONG retcnt;
   if (row_instance.row_obj) row_instance.row_obj.Release();
-  const HRESULT hr = enumerator_obj->Next(WBEM_INFINITE, 1L, &row_instance.row_obj, &retcnt);
-  if (FAILED(hr)) throw wmi_exception(hr, "Enumeration failed: " + ComError::getComError(hr));
-  return hr == WBEM_S_NO_ERROR;
+  if (abort_event == nullptr) {
+    const HRESULT hr = enumerator_obj->Next(WBEM_INFINITE, 1L, &row_instance.row_obj, &retcnt);
+    if (FAILED(hr)) throw wmi_exception(hr, "Enumeration failed: " + ComError::getComError(hr));
+    return hr == WBEM_S_NO_ERROR;
+  }
+  for (;;) {
+    const HRESULT hr = enumerator_obj->Next(abort_poll_ms, 1L, &row_instance.row_obj, &retcnt);
+    if (hr == WBEM_S_TIMEDOUT) {
+      if (!is_signalled(abort_event)) continue;
+      // Releasing the enumerator cancels the semisynchronous operation on the
+      // WMI side, so the provider stops working on a result nobody will read.
+      enumerator_obj.Release();
+      throw wmi_aborted();
+    }
+    if (FAILED(hr)) throw wmi_exception(hr, "Enumeration failed: " + ComError::getComError(hr));
+    return hr == WBEM_S_NO_ERROR;
+  }
 }
 
 row &row_enumerator::get_next() { return row_instance; }
@@ -206,12 +230,21 @@ std::list<std::string> header_enumerator::get() const {
   }
   return ret;
 }
-row_enumerator query::execute() {
-  row_enumerator ret(columns);
+row_enumerator query::execute() { return execute(nullptr); }
+
+row_enumerator query::execute(HANDLE abort_event) {
+  // A stop that is already pending: do not even connect to WMI.
+  if (is_signalled(abort_event)) throw wmi_aborted();
+  row_enumerator ret(columns, abort_event);
   const CComBSTR strQL(L"WQL");
   const CComBSTR strQuery(utf8::cvt<std::wstring>(wql_query).c_str());
 
-  const HRESULT hr = instance.get()->ExecQuery(strQL, strQuery, WBEM_FLAG_FORWARD_ONLY, nullptr, &ret.enumerator_obj);
+  // Semisynchronous (RETURN_IMMEDIATELY) only when abortable: ExecQuery then
+  // returns before the provider has produced anything and the rows arrive
+  // through the bounded Next() waits in has_next(). Without an abort event
+  // the plain synchronous query is kept for the request-handler callers.
+  const long flags = abort_event != nullptr ? (WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY) : WBEM_FLAG_FORWARD_ONLY;
+  const HRESULT hr = instance.get()->ExecQuery(strQL, strQuery, flags, nullptr, &ret.enumerator_obj);
   if (FAILED(hr))
     throw wmi_exception(hr, "ExecQuery of '" + wql_query + "' failed: " + utf8::cvt<std::string>(ComError::getWMIError(hr)) + ", " + ComError::getComError(hr));
   return ret;

--- a/include/win/wmi/wmi_query.hpp
+++ b/include/win/wmi/wmi_query.hpp
@@ -63,6 +63,16 @@ class wmi_exception : public std::exception {
   HRESULT get_code() const noexcept { return code_; }
 };
 
+// Thrown by query::execute(HANDLE) and row_enumerator::has_next() when the
+// abort event handed to execute() is signalled while the query is in flight.
+// Deliberately NOT a wmi_exception: callers treat those as provider failures
+// (log an error, disable the collector) and an abort is neither, so a
+// `catch (const wmi_exception&)` must not see it.
+class wmi_aborted : public std::exception {
+ public:
+  const char* what() const noexcept override { return "WMI query aborted"; }
+};
+
 struct row {
   CComPtr<IWbemClassObject> row_obj;
   const std::list<std::string>& columns;
@@ -81,7 +91,14 @@ struct row {
 struct row_enumerator {
   row row_instance;
   CComPtr<IEnumWbemClassObject> enumerator_obj;
-  explicit row_enumerator(const std::list<std::string>& columns) : row_instance(columns), enumerator_obj() {}
+  // Optional, not owned. When set the enumerator was opened semisynchronously
+  // and has_next() pulls rows with a bounded wait, checking this event between
+  // waits; once it is signalled the enumerator is released (which cancels the
+  // outstanding WMI operation) and wmi_aborted is thrown. Null means the
+  // classic blocking enumeration.
+  HANDLE abort_event;
+  explicit row_enumerator(const std::list<std::string>& columns, HANDLE abort_event = nullptr)
+      : row_instance(columns), enumerator_obj(), abort_event(abort_event) {}
   bool has_next();
   row& get_next();
 };
@@ -111,6 +128,14 @@ struct query {
 
   std::list<std::string> get_columns();
   row_enumerator execute();
+  // Abortable variant for background collectors: the query runs in WMI's
+  // semisynchronous mode and the returned enumerator watches abort_event (a
+  // manual-reset event, typically a threads::stop_signal handle) so a stop
+  // request interrupts a stalled provider within one poll interval instead of
+  // holding the calling thread until WMI answers. Throws wmi_aborted if the
+  // event is already signalled, or from has_next() once it becomes so. A null
+  // handle behaves exactly like execute().
+  row_enumerator execute(HANDLE abort_event);
 };
 
 struct instances {

--- a/include/win/wmi/wmi_query.hpp
+++ b/include/win/wmi/wmi_query.hpp
@@ -12,6 +12,7 @@
 #include <error/error.hpp>
 #include <list>
 #include <string>
+#include <threads/stop_signal.hpp>
 #include <utility>
 
 namespace wmi_impl {
@@ -67,8 +68,10 @@ class wmi_exception : public std::exception {
 // abort event handed to execute() is signalled while the query is in flight.
 // Deliberately NOT a wmi_exception: callers treat those as provider failures
 // (log an error, disable the collector) and an abort is neither, so a
-// `catch (const wmi_exception&)` must not see it.
-class wmi_aborted : public std::exception {
+// `catch (const wmi_exception&)` must not see it. It is a
+// threads::stop_requested so that a platform-neutral collector loop can
+// recognise the abort without naming WMI.
+class wmi_aborted : public threads::stop_requested {
  public:
   const char* what() const noexcept override { return "WMI query aborted"; }
 };

--- a/include/win/wmi/wmi_query_test.cpp
+++ b/include/win/wmi/wmi_query_test.cpp
@@ -5,6 +5,9 @@
 
 #ifdef WIN32
 
+#include <list>
+#include <string>
+#include <vector>
 #include <win/wmi/wmi_query.hpp>
 
 // Test fixture for WMI tests that require COM initialization
@@ -463,6 +466,128 @@ TEST_F(WmiQueryTest, WmiServiceInvalidNamespace) {
 
   wmi_impl::wmi_service svc("root\\nonexistent_namespace_xyz", "", "");
   EXPECT_THROW(svc.get(), wmi_impl::wmi_exception);
+}
+
+// ============================================================================
+// Abortable enumeration (query::execute(HANDLE) / row_enumerator::has_next)
+// ============================================================================
+//
+// The WMI side is stood in for by a fake IEnumWbemClassObject that answers
+// Next() from a scripted list of HRESULTs, so the poll/abort logic is exercised
+// deterministically without a stalled provider.
+
+namespace {
+
+class fake_enumerator final : public IEnumWbemClassObject {
+  LONG refs_;
+  std::vector<HRESULT> script_;
+  size_t index_;
+
+ public:
+  int next_calls;
+
+  explicit fake_enumerator(std::vector<HRESULT> script) : refs_(1), script_(std::move(script)), index_(0), next_calls(0) {}
+  LONG refs() const { return refs_; }
+
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** ppv) override {
+    if (ppv == nullptr) return E_POINTER;
+    if (riid == IID_IUnknown || riid == IID_IEnumWbemClassObject) {
+      *ppv = static_cast<IEnumWbemClassObject*>(this);
+      AddRef();
+      return S_OK;
+    }
+    *ppv = nullptr;
+    return E_NOINTERFACE;
+  }
+  ULONG STDMETHODCALLTYPE AddRef() override { return static_cast<ULONG>(InterlockedIncrement(&refs_)); }
+  // The test owns the object (it outlives the enumerator under test) so the
+  // count is only tracked, never used to delete.
+  ULONG STDMETHODCALLTYPE Release() override { return static_cast<ULONG>(InterlockedDecrement(&refs_)); }
+
+  HRESULT STDMETHODCALLTYPE Reset() override { return WBEM_S_NO_ERROR; }
+  HRESULT STDMETHODCALLTYPE Next(long, ULONG, IWbemClassObject** objects, ULONG* returned) override {
+    ++next_calls;
+    if (objects != nullptr) *objects = nullptr;
+    if (returned != nullptr) *returned = 0;
+    if (index_ >= script_.size()) return WBEM_S_FALSE;
+    return script_[index_++];
+  }
+  HRESULT STDMETHODCALLTYPE NextAsync(ULONG, IWbemObjectSink*) override { return WBEM_E_NOT_SUPPORTED; }
+  HRESULT STDMETHODCALLTYPE Clone(IEnumWbemClassObject**) override { return WBEM_E_NOT_SUPPORTED; }
+  HRESULT STDMETHODCALLTYPE Skip(long, ULONG) override { return WBEM_E_NOT_SUPPORTED; }
+};
+
+struct manual_event {
+  HANDLE h;
+  manual_event() : h(CreateEvent(nullptr, TRUE, FALSE, nullptr)) {}
+  ~manual_event() {
+    if (h != nullptr) CloseHandle(h);
+  }
+  manual_event(const manual_event&) = delete;
+  manual_event& operator=(const manual_event&) = delete;
+};
+
+const std::list<std::string> no_columns;
+
+}  // namespace
+
+TEST(WmiAbortTest, has_next_keeps_polling_while_abort_is_not_signalled) {
+  manual_event abort;
+  ASSERT_NE(abort.h, nullptr);
+  // Two provider timeouts, then "no more rows": the enumeration must ride out
+  // the timeouts and end normally.
+  fake_enumerator fake({WBEM_S_TIMEDOUT, WBEM_S_TIMEDOUT, WBEM_S_FALSE});
+
+  wmi_impl::row_enumerator rows(no_columns, abort.h);
+  rows.enumerator_obj = &fake;
+  EXPECT_FALSE(rows.has_next());
+  EXPECT_EQ(fake.next_calls, 3);
+}
+
+TEST(WmiAbortTest, has_next_throws_wmi_aborted_and_releases_enumerator_once_signalled) {
+  manual_event abort;
+  ASSERT_NE(abort.h, nullptr);
+  // A provider that never answers: the only way out is the abort event.
+  fake_enumerator fake({WBEM_S_TIMEDOUT, WBEM_S_TIMEDOUT, WBEM_S_TIMEDOUT, WBEM_S_TIMEDOUT});
+
+  wmi_impl::row_enumerator rows(no_columns, abort.h);
+  rows.enumerator_obj = &fake;
+  const LONG refs_while_held = fake.refs();
+  SetEvent(abort.h);
+  EXPECT_THROW(rows.has_next(), wmi_impl::wmi_aborted);
+  // Exactly one poll: the abort is noticed on the first timeout.
+  EXPECT_EQ(fake.next_calls, 1);
+  // Released: that is what cancels the outstanding semisynchronous operation.
+  EXPECT_EQ(rows.enumerator_obj.p, nullptr);
+  EXPECT_EQ(fake.refs(), refs_while_held - 1);
+}
+
+TEST(WmiAbortTest, wmi_aborted_is_not_a_wmi_exception) {
+  // Collectors catch wmi_exception to decide "provider broken, disable"; an
+  // abort must fly past those handlers.
+  wmi_impl::wmi_aborted aborted;
+  EXPECT_EQ(dynamic_cast<wmi_impl::wmi_exception*>(&aborted), nullptr);
+  EXPECT_NE(dynamic_cast<std::exception*>(&aborted), nullptr);
+  EXPECT_STREQ(aborted.what(), "WMI query aborted");
+}
+
+TEST(WmiAbortTest, has_next_without_abort_event_is_unchanged) {
+  fake_enumerator fake({WBEM_S_FALSE});
+  wmi_impl::row_enumerator rows(no_columns);
+  rows.enumerator_obj = &fake;
+  EXPECT_FALSE(rows.has_next());
+  EXPECT_EQ(fake.next_calls, 1);
+}
+
+TEST(WmiAbortTest, execute_with_signalled_abort_throws_before_connecting) {
+  manual_event abort;
+  ASSERT_NE(abort.h, nullptr);
+  SetEvent(abort.h);
+  // No COM initialisation in this test: if execute() reached ConnectServer it
+  // would fail with a wmi_exception, not wmi_aborted.
+  wmi_impl::query q("select Name from Win32_Processor", "root\\cimv2", "", "");
+  EXPECT_THROW(q.execute(abort.h), wmi_impl::wmi_aborted);
+  EXPECT_FALSE(q.instance.is_initialized);
 }
 
 #endif  // WIN32

--- a/include/win/wmi/wmi_query_test.cpp
+++ b/include/win/wmi/wmi_query_test.cpp
@@ -568,6 +568,9 @@ TEST(WmiAbortTest, wmi_aborted_is_not_a_wmi_exception) {
   wmi_impl::wmi_aborted aborted;
   EXPECT_EQ(dynamic_cast<wmi_impl::wmi_exception*>(&aborted), nullptr);
   EXPECT_NE(dynamic_cast<std::exception*>(&aborted), nullptr);
+  // ... but it is the portable stop marker, which is what a cross-platform
+  // collector loop catches.
+  EXPECT_NE(dynamic_cast<threads::stop_requested*>(&aborted), nullptr);
   EXPECT_STREQ(aborted.what(), "WMI query aborted");
 }
 
@@ -588,6 +591,31 @@ TEST(WmiAbortTest, execute_with_signalled_abort_throws_before_connecting) {
   wmi_impl::query q("select Name from Win32_Processor", "root\\cimv2", "", "");
   EXPECT_THROW(q.execute(abort.h), wmi_impl::wmi_aborted);
   EXPECT_FALSE(q.instance.is_initialized);
+}
+
+// Live check that the semisynchronous path actually delivers rows for the
+// class family the collectors care about: the cooked PerfFormattedData
+// classes need the provider to take two samples, which is where a
+// semisynchronous enumeration differs most from a blocking one.
+TEST_F(WmiQueryTest, abortable_execute_delivers_perf_formatted_rows) {
+  if (!com_initialized_) GTEST_SKIP() << "COM not initialized";
+  manual_event abort;
+  ASSERT_NE(abort.h, nullptr);
+  wmi_impl::query q("select Name, DiskReadBytesPersec from Win32_PerfFormattedData_PerfDisk_PhysicalDisk", "root\\cimv2", "", "");
+  try {
+    const DWORD started = GetTickCount();
+    wmi_impl::row_enumerator rows = q.execute(abort.h);
+    int count = 0;
+    while (rows.has_next()) {
+      EXPECT_FALSE(rows.get_next().get_string("Name").empty());
+      ++count;
+    }
+    const DWORD elapsed = GetTickCount() - started;
+    EXPECT_GT(count, 0) << "no rows from the semisynchronous enumeration";
+    EXPECT_LT(elapsed, 30000u) << "semisynchronous enumeration took " << elapsed << " ms";
+  } catch (const wmi_impl::wmi_exception& ex) {
+    GTEST_SKIP() << "WMI access failed: " << ex.what();
+  }
 }
 
 #endif  // WIN32

--- a/modules/CheckDisk/check_disk_io.hpp
+++ b/modules/CheckDisk/check_disk_io.hpp
@@ -10,6 +10,7 @@
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/protobuf/metrics.hpp>
 #include <string>
+#include <threads/stop_signal.hpp>
 #include <vector>
 #ifdef WIN32
 #include <win/wmi/wmi_query.hpp>
@@ -101,7 +102,13 @@ class disk_io_data {
   // False when nothing at all was collected: the source could not be read, or
   // querying it has been permanently disabled (see fetch_disk_io_). The
   // collector counts that as a failed fetch; throwing does the same.
-  bool fetch();
+  //
+  // `stop` is the collector's stop signal. On Windows the PerfDisk WMI
+  // queries watch it and, once it fires, abandon the query, store nothing
+  // and throw threads::stop_requested (which the collector treats as a
+  // shutdown, not a failure). Null runs the classic blocking queries. The
+  // Unix source is a /proc read that cannot stall, so it ignores the signal.
+  bool fetch(const threads::stop_signal *stop = nullptr);
   // True when the last fetch() stored a set of disks, even if it then failed.
   // A latency failure is deliberately partial - the rates are stored before
   // the error is raised - so the collector must not count it against the
@@ -125,12 +132,12 @@ class disk_io_data {
   // unavailable the check keeps reporting rates and only the latency fields
   // stay at 0 (fetch() logs and clears this on a permanent query failure).
   bool fetch_latency_ = true;
-  disks_type query_perf();
-  void apply_latency(disks_type &disks);
+  disks_type query_perf(HANDLE abort_event);
+  void apply_latency(disks_type &disks, HANDLE abort_event);
 #else
   // Previous raw /proc/diskstats counters (per device) + timestamp, used to
   // compute per-second rates from the cumulative counters (Unix).
-  std::map<std::string, std::vector<unsigned long long>> prev_raw_;
+  std::map<std::string, std::vector<unsigned long long> > prev_raw_;
   long long prev_time_ms_ = 0;
 #endif
 };

--- a/modules/CheckDisk/check_disk_io_test.cpp
+++ b/modules/CheckDisk/check_disk_io_test.cpp
@@ -22,6 +22,42 @@
 nscapi::helper_singleton *nscapi::plugin_singleton = new nscapi::helper_singleton();
 
 // ============================================================================
+// Shutdown contract: a stop that is already pending makes fetch() bail out
+// before touching WMI, storing nothing and surfacing the portable stop marker
+// rather than an error (#1504).
+// ============================================================================
+
+TEST(DiskIo, FetchWithSignalledStopThrowsStopRequestedAndStoresNothing) {
+  threads::stop_signal stop;
+  std::string error;
+  ASSERT_TRUE(stop.create(error)) << error;
+  stop.signal();
+
+  disk_io_check::disk_io_data data;
+  EXPECT_THROW(data.fetch(&stop), threads::stop_requested);
+  EXPECT_FALSE(data.stored_data());
+  EXPECT_TRUE(data.get().empty());
+}
+
+TEST(DiskIo, FetchWithUnsignalledStopIsNotAnAbort) {
+  threads::stop_signal stop;
+  std::string error;
+  ASSERT_TRUE(stop.create(error)) << error;
+
+  disk_io_check::disk_io_data data;
+  // Live WMI: on a host where the PerfDisk classes exist this collects, and
+  // where they do not it reports the failure the usual way. Either way the
+  // one thing it must not do is claim a stop was requested.
+  try {
+    data.fetch(&stop);
+  } catch (const threads::stop_requested &) {
+    FAIL() << "fetch reported an abort with the stop signal unsignalled";
+  } catch (const std::exception &) {
+    // provider failure: acceptable here
+  }
+}
+
+// ============================================================================
 // disk_io struct tests
 // ============================================================================
 

--- a/modules/CheckDisk/check_disk_io_unix.cpp
+++ b/modules/CheckDisk/check_disk_io_unix.cpp
@@ -6,8 +6,6 @@
 // space is read with statvfs over the real mounts. The metric builders / check
 // logic are shared in check_disk_io.cpp.
 
-#include "check_disk_io.hpp"
-
 #include <dirent.h>
 #include <mntent.h>
 #include <sys/statvfs.h>
@@ -24,6 +22,8 @@
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include "check_disk_io.hpp"
 
 namespace {
 
@@ -125,10 +125,9 @@ std::string mount_source_to_disk(const std::string &fsname, const std::function<
 std::string device_to_disk(const std::string &fsname) { return mount_source_to_disk(fsname, canonicalize_dev, sysfs_slaves); }
 
 bool is_pseudo_fs(const std::string &fstype) {
-  static const std::set<std::string> pseudo = {"proc",     "sysfs",      "cgroup",   "cgroup2",  "devtmpfs",  "devpts",   "mqueue",
-                                               "hugetlbfs", "debugfs",    "tracefs",  "securityfs", "pstore",  "bpf",      "configfs",
-                                               "fusectl",   "autofs",     "binfmt_misc", "rpc_pipefs", "nsfs",  "efivarfs", "ramfs",
-                                               "selinuxfs", "overlay",    "tmpfs",    "squashfs", "fuse.snapfuse"};
+  static const std::set<std::string> pseudo = {"proc",    "sysfs",      "cgroup", "cgroup2",   "devtmpfs", "devpts",  "mqueue",   "hugetlbfs",    "debugfs",
+                                               "tracefs", "securityfs", "pstore", "bpf",       "configfs", "fusectl", "autofs",   "binfmt_misc",  "rpc_pipefs",
+                                               "nsfs",    "efivarfs",   "ramfs",  "selinuxfs", "overlay",  "tmpfs",   "squashfs", "fuse.snapfuse"};
   return pseudo.count(fstype) > 0;
 }
 
@@ -136,7 +135,7 @@ bool is_pseudo_fs(const std::string &fstype) {
 
 namespace disk_io_check {
 
-bool disk_io_data::fetch() {
+bool disk_io_data::fetch(const threads::stop_signal *) {
   stored_data_ = false;
   std::ifstream f("/proc/diskstats");
   if (!f) return false;
@@ -208,7 +207,8 @@ bool disk_io_data::fetch() {
   total.percent_idle_time = 100 - total.percent_disk_time;
   if (total_reads > 0) total.read_latency = static_cast<double>(total_read_ms) / static_cast<double>(total_reads);
   if (total_writes > 0) total.write_latency = static_cast<double>(total_write_ms) / static_cast<double>(total_writes);
-  if (total_reads + total_writes > 0) total.total_latency = static_cast<double>(total_read_ms + total_write_ms) / static_cast<double>(total_reads + total_writes);
+  if (total_reads + total_writes > 0)
+    total.total_latency = static_cast<double>(total_read_ms + total_write_ms) / static_cast<double>(total_reads + total_writes);
   disks.push_back(total);
 
   prev_raw_.swap(current);

--- a/modules/CheckDisk/check_disk_io_win.cpp
+++ b/modules/CheckDisk/check_disk_io_win.cpp
@@ -5,12 +5,12 @@
 // + GetDiskFreeSpaceEx). The metric builders / check logic are shared in
 // check_disk_io.cpp.
 
-#include "check_disk_io.hpp"
-
 #include <boost/thread/locks.hpp>
 #include <map>
 #include <nsclient/nsclient_exception.hpp>
 #include <utility>
+
+#include "check_disk_io.hpp"
 
 namespace disk_io_check {
 
@@ -55,9 +55,9 @@ void disk_io::read_wmi(const wmi_impl::row &r) {
   split_io_per_sec = r.get_int("SplitIOPerSec");
 }
 
-disks_type disk_io_data::query_perf() {
+disks_type disk_io_data::query_perf(HANDLE abort_event) {
   wmi_impl::query wmi_q(helper::perf_query, helper::perf_namespace, "", "");
-  wmi_impl::row_enumerator row = wmi_q.execute();
+  wmi_impl::row_enumerator row = wmi_q.execute(abort_event);
   disks_type disks;
   while (row.has_next()) {
     const wmi_impl::row r = row.get_next();
@@ -70,12 +70,12 @@ disks_type disk_io_data::query_perf() {
 
 // Latency from the raw counters: average time per I/O since the previous
 // sample. The first sample only seeds prev_raw_, leaving latencies at 0.
-void disk_io_data::apply_latency(disks_type &disks) {
+void disk_io_data::apply_latency(disks_type &disks, HANDLE abort_event) {
   std::map<std::string, disk_io *> by_name;
   for (disk_io &d : disks) by_name[d.name] = &d;
 
   wmi_impl::query raw_q(helper::raw_latency_query, helper::perf_namespace, "", "");
-  wmi_impl::row_enumerator raw_row = raw_q.execute();
+  wmi_impl::row_enumerator raw_row = raw_q.execute(abort_event);
   std::map<std::string, raw_latency_sample> current;
   while (raw_row.has_next()) {
     const wmi_impl::row r = raw_row.get_next();
@@ -101,13 +101,17 @@ void disk_io_data::apply_latency(disks_type &disks) {
   prev_raw_.swap(current);
 }
 
-bool disk_io_data::fetch() {
+bool disk_io_data::fetch(const threads::stop_signal *stop) {
   stored_data_ = false;
   if (!fetch_disk_io_) return false;
+  // A stop mid-query surfaces as wmi_impl::wmi_aborted, which is not a
+  // wmi_exception: it passes the handlers below untouched, so nothing is
+  // stored and the collector sees a threads::stop_requested.
+  const HANDLE abort_event = stop != nullptr ? stop->native_handle() : nullptr;
 
   disks_type disks;
   try {
-    disks = query_perf();
+    disks = query_perf(abort_event);
   } catch (const wmi_impl::wmi_exception &e) {
     if (e.get_code() == WBEM_E_INVALID_QUERY || e.get_code() == WBEM_E_NOT_FOUND) {
       fetch_disk_io_ = false;
@@ -120,7 +124,7 @@ bool disk_io_data::fetch() {
   // and report the problem; on a permanent error stop querying the raw class.
   if (fetch_latency_) {
     try {
-      apply_latency(disks);
+      apply_latency(disks, abort_event);
     } catch (const wmi_impl::wmi_exception &e) {
       if (e.get_code() == WBEM_E_INVALID_QUERY || e.get_code() == WBEM_E_NOT_FOUND) {
         fetch_latency_ = false;

--- a/modules/CheckDisk/collector_thread.cpp
+++ b/modules/CheckDisk/collector_thread.cpp
@@ -34,6 +34,13 @@ bool collector_thread::start() {
     const boost::lock_guard<boost::mutex> lock(stop_mutex_);
     stop_requested_ = false;
   }
+  // Without the abort primitive the collector still works, its fetches are
+  // just not interruptible (fetch() gets a null signal), so this is a
+  // warning rather than a refusal to start.
+  std::string error;
+  if (!abort_signal_.create(error)) {
+    NSC_LOG_ERROR("Failed to create the disk collector abort signal, a stalled fetch will delay shutdown: " + error);
+  }
   thread_ = std::make_shared<boost::thread>([this]() { this->thread_proc(); });
   return true;
 }
@@ -43,12 +50,22 @@ bool collector_thread::stop() {
     const boost::lock_guard<boost::mutex> lock(stop_mutex_);
     stop_requested_ = true;
   }
+  // Order matters: the fetch in flight watches abort_signal_, the wait
+  // between ticks watches the CV. Signal both before joining.
+  abort_signal_.signal();
   stop_cv_.notify_all();
   if (thread_) {
     thread_->join();
     thread_.reset();
   }
+  // After the join so a stop/start cycle gets a fresh, unsignalled primitive.
+  abort_signal_.close();
   return true;
+}
+
+bool collector_thread::stop_pending() {
+  const boost::lock_guard<boost::mutex> lock(stop_mutex_);
+  return stop_requested_;
 }
 
 void collector_thread::update_trends(const long long now) {
@@ -170,6 +187,12 @@ void collector_thread::thread_proc() {
     try {
       fetched = fetch();
       if (!fetched) NSC_LOG_ERROR(std::string("Failed to get ") + what + ": no data returned");
+    } catch (const threads::stop_requested &) {
+      // The collector is stopping and the fetch let go of its source. The
+      // previous sample stays published and the failure tracker is left
+      // alone: a shutdown is not evidence that the source is broken.
+      NSC_DEBUG_MSG(std::string("Aborted collecting ") + what + ": collector is stopping");
+      return false;
     } catch (const nsclient::nsclient_exception &e) {
       NSC_LOG_ERROR(std::string("Failed to get ") + what + ": " + e.reason());
       fetched = collected_anyway && collected_anyway();
@@ -189,27 +212,36 @@ void collector_thread::thread_proc() {
     return fetched;
   };
 
-  const std::function<bool()> fetch_disk_io = [this]() { return disk_io_.fetch(); };
+  const std::function<bool()> fetch_disk_io = [this]() { return disk_io_.fetch(abort_signal_.valid() ? &abort_signal_ : nullptr); };
   // The Windows fetch stores the rates before raising a latency error, so the
   // rates keep flowing and only latency degrades; that must not accumulate
   // towards giving up on disk I/O altogether.
   const std::function<bool()> disk_io_stored_data = [this]() { return disk_io_.stored_data(); };
   const std::function<bool()> fetch_disk_free = [this]() { return disk_free_.fetch(); };
 
-  // Initial fetch to populate data immediately.
+  // Initial fetch to populate data immediately. A stop that lands in the
+  // first fetch must not start the second (#1504).
   if (!disable_disk_io) {
     run_fetch(io_failures, "disk I/O metrics", fetch_disk_io, disk_io_stored_data);
   }
-  if (!disable_disk_free) {
+  if (!disable_disk_free && !stop_pending()) {
     run_fetch(free_failures, "disk free metrics", fetch_disk_free, nullptr);
   }
 
   const long long started = static_cast<long long>(std::time(nullptr));
   long long last_save = started;
   for (;;) {
+    // A stop that landed in the initial fetches above arrives here without
+    // passing the wait at the bottom of the loop, so check before starting
+    // another fetch that would only be aborted straight away.
+    if (stop_pending()) break;
     if (!disable_disk_io && !io_failures.given_up()) {
       run_fetch(io_failures, "disk I/O metrics", fetch_disk_io, disk_io_stored_data);
     }
+    // Re-check between the fetches: the disk free probe cannot be
+    // interrupted once started, so do not start it for a stop that arrived
+    // during the disk I/O fetch.
+    if (stop_pending()) break;
     if (!disable_disk_free && !free_failures.given_up()) {
       // A failed fetch leaves the previous snapshot in place. Timestamping it
       // as a fresh sample would feed the regression a fabricated flat segment,

--- a/modules/CheckDisk/collector_thread.hpp
+++ b/modules/CheckDisk/collector_thread.hpp
@@ -11,6 +11,7 @@
 #include <nscapi/nscapi_core_wrapper.hpp>
 #include <set>
 #include <string>
+#include <threads/stop_signal.hpp>
 #include <trend/trend_buffer.hpp>
 
 #include "check_disk_io.hpp"
@@ -62,6 +63,12 @@ class collector_thread {
   boost::mutex stop_mutex_;
   boost::condition_variable stop_cv_;
   bool stop_requested_;
+  // The same stop request as a kernel primitive, for the fetches themselves:
+  // the CV only wakes the wait between ticks, while a fetch that is blocked
+  // inside a provider (the PerfDisk WMI classes stall for tens of seconds
+  // while WmiApSrv restarts) needs something it can poll or wait on to let go
+  // (#1504). Signalled in stop() before the CV, closed after the join.
+  threads::stop_signal abort_signal_;
   int plugin_id_;
   nscapi::core_wrapper *core_;
 
@@ -117,6 +124,10 @@ class collector_thread {
 
  private:
   void thread_proc();
+  // Whether stop() has been called; checked between the fetches of one tick
+  // so a stop that lands in the disk I/O fetch does not start the disk free
+  // one.
+  bool stop_pending();
   void update_trends(long long now);
   // Rebuild snapshot_ from trends_; must be called with trends_mutex_ held.
   void publish_trends();

--- a/modules/CheckSystem/check_battery.cpp
+++ b/modules/CheckSystem/check_battery.cpp
@@ -110,7 +110,7 @@ void battery_data::query_power_status(batteries_type &batteries) {
   batteries.push_back(info);
 }
 
-void battery_data::query_wmi_battery(batteries_type &batteries) {
+void battery_data::query_wmi_battery(batteries_type &batteries, HANDLE abort_event) {
   if (batteries.empty()) return;
 
   // Try to get additional battery info from WMI BatteryStatus and BatteryStaticData
@@ -119,7 +119,7 @@ void battery_data::query_wmi_battery(batteries_type &batteries) {
   try {
     // BatteryStatus provides dynamic battery information
     wmi_impl::query wmi_status("select Tag, ChargeRate, DischargeRate, RemainingCapacity from BatteryStatus where Active = True", "root\\WMI", "", "");
-    wmi_impl::row_enumerator row = wmi_status.execute();
+    wmi_impl::row_enumerator row = wmi_status.execute(abort_event);
     while (row.has_next()) {
       wmi_impl::row r = row.get_next();
       // Apply to the first battery (we only track one from GetSystemPowerStatus)
@@ -138,7 +138,7 @@ void battery_data::query_wmi_battery(batteries_type &batteries) {
   try {
     // BatteryStaticData provides design capacity information for health calculation
     wmi_impl::query wmi_static("select Tag, DesignedCapacity from BatteryStaticData", "root\\WMI", "", "");
-    wmi_impl::row_enumerator row = wmi_static.execute();
+    wmi_impl::row_enumerator row = wmi_static.execute(abort_event);
     while (row.has_next()) {
       wmi_impl::row r = row.get_next();
       if (!batteries.empty()) {
@@ -154,7 +154,7 @@ void battery_data::query_wmi_battery(batteries_type &batteries) {
   try {
     // BatteryFullChargedCapacity provides current full charge capacity
     wmi_impl::query wmi_full("select Tag, FullChargedCapacity from BatteryFullChargedCapacity", "root\\WMI", "", "");
-    wmi_impl::row_enumerator row = wmi_full.execute();
+    wmi_impl::row_enumerator row = wmi_full.execute(abort_event);
     while (row.has_next()) {
       wmi_impl::row r = row.get_next();
       if (!batteries.empty()) {
@@ -175,13 +175,17 @@ void battery_data::query_wmi_battery(batteries_type &batteries) {
   }
 }
 
-void battery_data::fetch() {
+void battery_data::fetch(const threads::stop_signal *stop) {
   if (!fetch_battery_) return;
 
   batteries_type tmp;
   try {
     query_power_status(tmp);
-    query_wmi_battery(tmp);
+    query_wmi_battery(tmp, stop != nullptr ? stop->native_handle() : nullptr);
+  } catch (const wmi_impl::wmi_aborted &) {
+    // A stop request is not a broken battery driver: keep the collector
+    // enabled and let the caller see the abort.
+    throw;
   } catch (const std::exception &e) {
     fetch_battery_ = false;
     throw nsclient::nsclient_exception("Failed to fetch battery status, disabling: " + std::string(e.what()));

--- a/modules/CheckSystem/check_battery.hpp
+++ b/modules/CheckSystem/check_battery.hpp
@@ -8,6 +8,7 @@
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/protobuf/metrics.hpp>
 #include <string>
+#include <threads/stop_signal.hpp>
 
 namespace battery_check {
 
@@ -86,12 +87,14 @@ class battery_data final {
  public:
   battery_data() : fetch_battery_(true) {}
 
-  void fetch();
+  // `stop`: see network_data::fetch(); a stop mid-query abandons the WMI
+  // operation, publishes nothing and lets wmi_impl::wmi_aborted propagate.
+  void fetch(const threads::stop_signal *stop = nullptr);
   batteries_type get();
 
  private:
   static void query_power_status(batteries_type &batteries);
-  static void query_wmi_battery(batteries_type &batteries);
+  static void query_wmi_battery(batteries_type &batteries, HANDLE abort_event = nullptr);
 };
 
 namespace check {

--- a/modules/CheckSystem/check_cpu_frequency.cpp
+++ b/modules/CheckSystem/check_cpu_frequency.cpp
@@ -85,9 +85,9 @@ void cpu_frequency::build_metrics(PB::Metrics::MetricsBundle *section) const {
   add_metric(section, name + ".l3_cache", l3_cache);
 }
 
-cpus_type cpu_frequency_data::query_wmi() {
+cpus_type cpu_frequency_data::query_wmi(HANDLE abort_event) {
   wmi_impl::query wmi_q(helper::query, helper::ns, "", "");
-  wmi_impl::row_enumerator row = wmi_q.execute();
+  wmi_impl::row_enumerator row = wmi_q.execute(abort_event);
   cpus_type cpus;
   while (row.has_next()) {
     const wmi_impl::row r = row.get_next();
@@ -98,11 +98,11 @@ cpus_type cpu_frequency_data::query_wmi() {
   return cpus;
 }
 
-void cpu_frequency_data::fetch() {
+void cpu_frequency_data::fetch(const threads::stop_signal *stop) {
   if (!fetch_cpu_frequency_) return;
 
   try {
-    const cpus_type tmp = query_wmi();
+    const cpus_type tmp = query_wmi(stop != nullptr ? stop->native_handle() : nullptr);
     const boost::unique_lock<boost::shared_mutex> write_lock(mutex_, boost::get_system_time() + boost::posix_time::seconds(5));
     if (!write_lock.owns_lock()) throw nsclient::nsclient_exception("Failed to get mutex for writing CPU frequency data");
     cpus_ = tmp;

--- a/modules/CheckSystem/check_cpu_frequency.hpp
+++ b/modules/CheckSystem/check_cpu_frequency.hpp
@@ -10,6 +10,7 @@
 #include <nscapi/protobuf/metrics.hpp>
 #include <parsers/where/node.hpp>
 #include <string>
+#include <threads/stop_signal.hpp>
 #include <win/wmi/wmi_query.hpp>
 
 namespace cpu_frequency_check {
@@ -80,11 +81,13 @@ class cpu_frequency_data {
  public:
   cpu_frequency_data() : fetch_cpu_frequency_(true) {}
 
-  void fetch();
+  // `stop`: see network_data::fetch(); a stop mid-query abandons the WMI
+  // operation, publishes nothing and lets wmi_impl::wmi_aborted propagate.
+  void fetch(const threads::stop_signal *stop = nullptr);
   cpus_type get();
 
  private:
-  static cpus_type query_wmi();
+  static cpus_type query_wmi(HANDLE abort_event = nullptr);
 };
 
 namespace check {

--- a/modules/CheckSystem/check_network.cpp
+++ b/modules/CheckSystem/check_network.cpp
@@ -7,7 +7,6 @@
 #include <boost/program_options.hpp>
 #include <boost/thread/locks.hpp>
 #include <map>
-#include <utility>
 #include <nscapi/nscapi_metrics_helper.hpp>
 #include <nsclient/nsclient_exception.hpp>
 #include <parsers/filter/cli_helper.hpp>
@@ -17,6 +16,7 @@
 #include <parsers/where/node.hpp>
 #include <str/format.hpp>
 #include <str/xtos.hpp>
+#include <utility>
 
 namespace po = boost::program_options;
 
@@ -163,9 +163,9 @@ void network_interface::build_metrics(PB::Metrics::MetricsBundle *section) const
   }
 }
 
-void network_data::query_nif(netmap_type &netmap) {
+void network_data::query_nif(netmap_type &netmap, HANDLE abort_event) {
   wmi_impl::query wmiQuery1(helper::nif_query, "root\\cimv2", "", "");
-  wmi_impl::row_enumerator row = wmiQuery1.execute();
+  wmi_impl::row_enumerator row = wmiQuery1.execute(abort_event);
   while (row.has_next()) {
     wmi_impl::row r = row.get_next();
     std::string name = helper::parse_nif_name(r.get_string("Name"));
@@ -184,9 +184,9 @@ void network_data::query_nif(netmap_type &netmap) {
   }
 }
 
-void network_data::query_prd(netmap_type &netmap, long long delta, const std::string &query, bool allow_insert) {
+void network_data::query_prd(netmap_type &netmap, long long delta, const std::string &query, bool allow_insert, HANDLE abort_event) {
   wmi_impl::query wmiQuery(query, "root\\cimv2", "", "");
-  wmi_impl::row_enumerator row = wmiQuery.execute();
+  wmi_impl::row_enumerator row = wmiQuery.execute(abort_event);
   while (row.has_next()) {
     wmi_impl::row r = row.get_next();
     std::string name = helper::parse_prd_name(r.get_string("Name"));
@@ -205,13 +205,13 @@ void network_data::query_prd(netmap_type &netmap, long long delta, const std::st
   }
 }
 
-void network_data::query_team(netmap_type &if_netmap, netmap_type &ad_netmap) {
+void network_data::query_team(netmap_type &if_netmap, netmap_type &ad_netmap, HANDLE abort_event) {
   if (!fetch_team_) return;
   // member interface name -> (team name, raw operational status)
   std::map<std::string, std::pair<std::string, std::string> > members;
   try {
     wmi_impl::query q("select Name, Team, OperationalStatus from MSFT_NetLbfoTeamMember", "root\\StandardCimv2", "", "");
-    wmi_impl::row_enumerator row = q.execute();
+    wmi_impl::row_enumerator row = q.execute(abort_event);
     while (row.has_next()) {
       wmi_impl::row r = row.get_next();
       members[r.get_string("Name")] = std::make_pair(r.get_string("Team"), str::xtos(r.get_int("OperationalStatus")));
@@ -240,8 +240,9 @@ void network_data::query_team(netmap_type &if_netmap, netmap_type &ad_netmap) {
   annotate(ad_netmap);
 }
 
-void network_data::fetch() {
+void network_data::fetch(const threads::stop_signal *stop) {
   if (!fetch_network_) return;
+  const HANDLE abort_event = stop != nullptr ? stop->native_handle() : nullptr;
 
   nics_type tmp;
   // Two separate maps keyed by name: NetworkInterface and NetworkAdapter use
@@ -270,7 +271,7 @@ void network_data::fetch() {
 
     // Win32_NetworkAdapter metadata applies to both perfraw sources, so we run
     // it once and merge into whichever map(s) end up holding a matching entry.
-    query_nif(if_netmap);
+    query_nif(if_netmap, abort_event);
     for (const netmap_type::value_type &v : if_netmap) {
       netmap_type::iterator it = ad_netmap.find(v.first);
       if (it == ad_netmap.end()) {
@@ -301,13 +302,13 @@ void network_data::fetch() {
       }
     }
 
-    query_prd(if_netmap, delta, helper::prd_query, false);
+    query_prd(if_netmap, delta, helper::prd_query, false, abort_event);
     // allow_insert=true so the team aggregate (no nif match) surfaces.
-    query_prd(ad_netmap, delta, helper::prd_adapter_query, true);
+    query_prd(ad_netmap, delta, helper::prd_adapter_query, true, abort_event);
 
     // Best-effort NIC-team membership annotation (no-op / self-disabling when
     // the LBFO provider is unavailable).
-    query_team(if_netmap, ad_netmap);
+    query_team(if_netmap, ad_netmap, abort_event);
 
     for (netmap_type::value_type &v : if_netmap) {
       if (!v.second.is_compleate()) continue;

--- a/modules/CheckSystem/check_network.hpp
+++ b/modules/CheckSystem/check_network.hpp
@@ -9,6 +9,7 @@
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/protobuf/metrics.hpp>
 #include <string>
+#include <threads/stop_signal.hpp>
 #include <win/wmi/wmi_query.hpp>
 
 namespace network_check {
@@ -179,15 +180,18 @@ class network_data {
  public:
   network_data() : fetch_network_(true), last_(boost::posix_time::second_clock::local_time()) {}
 
-  void fetch();
+  // `stop` is the collector's stop signal: when it fires mid-query the WMI
+  // operation is abandoned, nothing is published and wmi_impl::wmi_aborted
+  // propagates to the caller. Null runs the classic blocking queries.
+  void fetch(const threads::stop_signal *stop = nullptr);
   nics_type get();
 
  private:
-  void query_nif(netmap_type &netmap);
-  void query_prd(netmap_type &netmap, long long delta, const std::string &query, bool allow_insert);
+  void query_nif(netmap_type &netmap, HANDLE abort_event);
+  void query_prd(netmap_type &netmap, long long delta, const std::string &query, bool allow_insert, HANDLE abort_event);
   // Best-effort: annotate entries in both maps with NIC-team membership. Never
   // throws — the LBFO provider is absent on many systems and that is not an error.
-  void query_team(netmap_type &if_netmap, netmap_type &ad_netmap);
+  void query_team(netmap_type &if_netmap, netmap_type &ad_netmap, HANDLE abort_event);
   bool fetch_team_ = true;
 };
 

--- a/modules/CheckSystem/check_os_updates.cpp
+++ b/modules/CheckSystem/check_os_updates.cpp
@@ -246,11 +246,32 @@ class search_completed_callback final : public ISearchCompletedCallback {
 
 // How long to wait for WUA to acknowledge RequestAbort() before giving up on
 // the job. WUA normally completes an aborted search within a second; the cap
-// only matters if it does not, in which case the job is released without
-// EndSearch() rather than holding shutdown hostage.
+// only matters if it does not, in which case the job is abandoned without
+// EndSearch() (see pin_this_module) rather than holding shutdown hostage.
 const DWORD abort_grace_ms = 5000;
 
 bool abort_requested(HANDLE abort_event) { return abort_event != nullptr && WaitForSingleObject(abort_event, 0) == WAIT_OBJECT_0; }
+
+// Keep this DLL mapped for the remaining life of the process.
+//
+// BeginSearch() hands WUA its own reference to the completion callback, and
+// WUA keeps it until the job is torn down. On the abandoned-job path below we
+// return without EndSearch(), so that reference outlives the call -- and both
+// the callback's Invoke() and its Release()/destructor dispatch through a
+// vtable that lives in this module. stop_plugins() unloads it moments later,
+// so a late call from a WUA worker would land in unmapped memory: an access
+// violation during exactly the stalled shutdown this code exists to fix
+// (#1504). Pinning costs one abandoned module mapping (the module can no
+// longer be unloaded and reloaded without restarting the service) in the rare
+// case where WUA does not acknowledge RequestAbort() in time, which is the
+// better trade.
+void pin_this_module() {
+  // Any address inside the module image identifies it; PIN makes the reference
+  // permanent, so the handle is deliberately never released.
+  static const char anchor = 0;
+  HMODULE self = nullptr;
+  GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN, reinterpret_cast<LPCWSTR>(&anchor), &self);
+}
 
 // Run the WUA search. Returns false when the search was abandoned because
 // abort_event was signalled (out is then left as "pending" and must not be
@@ -314,11 +335,16 @@ bool perform_wua_search(os_updates_obj &out, HANDLE abort_event) {
       // Stop requested (or the wait itself failed, which we treat the same
       // way: there is no point sitting on a search nobody will read).
       job->RequestAbort();
-      // Let WUA wind the job down so EndSearch() releases it cleanly; if it
-      // does not acknowledge in time, just drop our reference and go.
+      // Let WUA wind the job down so EndSearch() releases it cleanly.
       if (WaitForSingleObject(callback->done_event(), abort_grace_ms) == WAIT_OBJECT_0) {
         com_ptr<ISearchResult> discarded;
         searcher->EndSearch(job.get(), discarded.out());
+      } else {
+        // WUA did not acknowledge in time and we will not hold the unload
+        // hostage any longer: drop our references and abandon the job. WUA
+        // still holds one on the callback, so the module has to stay mapped
+        // for whatever it does with it next.
+        pin_this_module();
       }
       return false;
     }
@@ -382,6 +408,8 @@ bool os_updates_data::force_fetch(const threads::stop_signal *stop) {
   }
   return true;
 }
+
+void os_updates_data::set_last_fetch_age_for_test(long long age_seconds) { last_fetch_ = now_seconds() - age_seconds; }
 
 bool os_updates_data::fetch(const threads::stop_signal *stop) {
   if (!fetch_supported_) return true;

--- a/modules/CheckSystem/check_os_updates.cpp
+++ b/modules/CheckSystem/check_os_updates.cpp
@@ -15,9 +15,9 @@
 #include <parsers/filter/modern_filter.hpp>
 #include <parsers/where/filter_handler_impl.hpp>
 #include <str/utf8.hpp>
-#include <win/com_helpers.hpp>
 #include <str/xtos.hpp>
 #include <utility>
+#include <win/com_helpers.hpp>
 
 namespace os_updates_check {
 
@@ -201,10 +201,74 @@ void read_update(IUpdate *update, update_info &info) {
   }
 }
 
-void perform_wua_search(os_updates_obj &out) {
+// Minimal ISearchCompletedCallback: WUA invokes it (on one of its own threads)
+// when an asynchronous search finishes, whether it completed, failed or was
+// aborted. It owns the completion event so the handle stays valid for as long
+// as WUA holds a reference, even if the searching thread has already given up
+// on the job.
+class search_completed_callback final : public ISearchCompletedCallback {
+  LONG refs_;
+  HANDLE done_;
+
+ public:
+  search_completed_callback() : refs_(1), done_(CreateEvent(nullptr, TRUE, FALSE, nullptr)) {}
+  search_completed_callback(const search_completed_callback &) = delete;
+  search_completed_callback &operator=(const search_completed_callback &) = delete;
+
+  HANDLE done_event() const { return done_; }
+
+  HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void **ppv) override {
+    if (ppv == nullptr) return E_POINTER;
+    if (riid == IID_IUnknown || riid == __uuidof(ISearchCompletedCallback)) {
+      *ppv = static_cast<ISearchCompletedCallback *>(this);
+      AddRef();
+      return S_OK;
+    }
+    *ppv = nullptr;
+    return E_NOINTERFACE;
+  }
+  ULONG STDMETHODCALLTYPE AddRef() override { return static_cast<ULONG>(InterlockedIncrement(&refs_)); }
+  ULONG STDMETHODCALLTYPE Release() override {
+    const LONG refs = InterlockedDecrement(&refs_);
+    if (refs == 0) delete this;
+    return static_cast<ULONG>(refs);
+  }
+  HRESULT STDMETHODCALLTYPE Invoke(ISearchJob *, ISearchCompletedCallbackArgs *) override {
+    if (done_ != nullptr) SetEvent(done_);
+    return S_OK;
+  }
+
+ private:
+  ~search_completed_callback() {
+    if (done_ != nullptr) CloseHandle(done_);
+  }
+};
+
+// How long to wait for WUA to acknowledge RequestAbort() before giving up on
+// the job. WUA normally completes an aborted search within a second; the cap
+// only matters if it does not, in which case the job is released without
+// EndSearch() rather than holding shutdown hostage.
+const DWORD abort_grace_ms = 5000;
+
+bool abort_requested(HANDLE abort_event) { return abort_event != nullptr && WaitForSingleObject(abort_event, 0) == WAIT_OBJECT_0; }
+
+// Run the WUA search. Returns false when the search was abandoned because
+// abort_event was signalled (out is then left as "pending" and must not be
+// published); throws on any WUA failure.
+//
+// The search runs asynchronously (BeginSearch) rather than through the
+// blocking Search() so that a stop request can interrupt it: the synchronous
+// call goes online to Windows Update / WSUS and routinely takes minutes on a
+// server, and the collector thread that issued it cannot be joined until it
+// returns. That is what made the service take minutes to stop when the first
+// search of a fresh start was still running (#1504).
+bool perform_wua_search(os_updates_obj &out, HANDLE abort_event) {
   out.updates.clear();
   out.fetch_succeeded = false;
   out.error.clear();
+
+  // A stop that arrived before we got here: do not even touch WUA.
+  if (abort_requested(abort_event)) return false;
 
   // Scoped COM init (tolerates RPC_E_CHANGED_MODE): balanced on every exit
   // path, including the exceptions thrown below.
@@ -225,11 +289,49 @@ void perform_wua_search(os_updates_obj &out) {
       throw nsclient::nsclient_exception(out.error);
     }
 
+    com_ptr<search_completed_callback> callback;
+    *callback.out() = new search_completed_callback();
+    if (callback->done_event() == nullptr) {
+      out.error = "Failed to create the WUA search completion event";
+      throw nsclient::nsclient_exception(out.error);
+    }
+
     bstr_holder criteria(L"IsInstalled=0 and Type='Software' and IsHidden=0");
+    VARIANT state;
+    VariantInit(&state);
+    com_ptr<ISearchJob> job;
+    hr = searcher->BeginSearch(criteria.b, static_cast<IUnknown *>(callback.get()), state, job.out());
+    if (FAILED(hr) || !job.get()) {
+      out.error = "WUA BeginSearch() failed (HRESULT=0x" + str::xtos(static_cast<long>(hr)) + ")";
+      throw nsclient::nsclient_exception(out.error);
+    }
+
+    // Block until WUA reports the job complete or a stop is requested.
+    HANDLE handles[2] = {callback->done_event(), abort_event};
+    const DWORD handle_count = abort_event != nullptr ? 2 : 1;
+    const DWORD wait = WaitForMultipleObjects(handle_count, handles, FALSE, INFINITE);
+    if (wait != WAIT_OBJECT_0) {
+      // Stop requested (or the wait itself failed, which we treat the same
+      // way: there is no point sitting on a search nobody will read).
+      job->RequestAbort();
+      // Let WUA wind the job down so EndSearch() releases it cleanly; if it
+      // does not acknowledge in time, just drop our reference and go.
+      if (WaitForSingleObject(callback->done_event(), abort_grace_ms) == WAIT_OBJECT_0) {
+        com_ptr<ISearchResult> discarded;
+        searcher->EndSearch(job.get(), discarded.out());
+      }
+      return false;
+    }
+
     com_ptr<ISearchResult> results;
-    hr = searcher->Search(criteria.b, results.out());
+    hr = searcher->EndSearch(job.get(), results.out());
     if (FAILED(hr) || !results.get()) {
-      out.error = "WUA Search() failed (HRESULT=0x" + str::xtos(static_cast<long>(hr)) + ")";
+      out.error = "WUA EndSearch() failed (HRESULT=0x" + str::xtos(static_cast<long>(hr)) + ")";
+      throw nsclient::nsclient_exception(out.error);
+    }
+    OperationResultCode result_code = orcNotStarted;
+    if (SUCCEEDED(results->get_ResultCode(&result_code)) && result_code != orcSucceeded && result_code != orcSucceededWithErrors) {
+      out.error = "WUA search did not succeed (result code " + str::xtos(static_cast<long>(result_code)) + ")";
       throw nsclient::nsclient_exception(out.error);
     }
 
@@ -252,15 +354,19 @@ void perform_wua_search(os_updates_obj &out) {
     out.recompute();
     out.fetch_succeeded = true;
   }
+  return true;
 }
 
 }  // namespace
 
-void os_updates_data::force_fetch() {
-  if (!fetch_supported_) return;
+bool os_updates_data::force_fetch(const threads::stop_signal *stop) {
+  if (!fetch_supported_) return true;
   os_updates_obj tmp;
   try {
-    perform_wua_search(tmp);
+    // An aborted search publishes nothing: the collector is shutting down and
+    // a half-finished result would only replace good cached data with
+    // "pending".
+    if (!perform_wua_search(tmp, stop != nullptr ? stop->native_handle() : nullptr)) return false;
   } catch (const std::exception &e) {
     tmp.fetch_succeeded = false;
     if (tmp.error.empty()) tmp.error = e.what();
@@ -274,12 +380,13 @@ void os_updates_data::force_fetch() {
     data_ = tmp;
     last_fetch_ = now_seconds();
   }
+  return true;
 }
 
-void os_updates_data::fetch() {
-  if (!fetch_supported_) return;
-  if (last_fetch_ >= 0 && (now_seconds() - last_fetch_) < ttl_seconds_) return;
-  force_fetch();
+bool os_updates_data::fetch(const threads::stop_signal *stop) {
+  if (!fetch_supported_) return true;
+  if (last_fetch_ >= 0 && (now_seconds() - last_fetch_) < ttl_seconds_) return true;
+  return force_fetch(stop);
 }
 
 os_updates_obj os_updates_data::get() {

--- a/modules/CheckSystem/check_os_updates.hpp
+++ b/modules/CheckSystem/check_os_updates.hpp
@@ -114,6 +114,11 @@ class os_updates_data final {
 
   // Return a snapshot of the current data.
   os_updates_obj get();
+
+  // Test seam: pretend a successful search completed `age_seconds` ago, so the
+  // TTL short-circuit in fetch() can be exercised without running a real (slow,
+  // admin- and network-dependent) WUA search.
+  void set_last_fetch_age_for_test(long long age_seconds);
 };
 
 namespace check {

--- a/modules/CheckSystem/check_os_updates.hpp
+++ b/modules/CheckSystem/check_os_updates.hpp
@@ -8,6 +8,7 @@
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/protobuf/metrics.hpp>
 #include <string>
+#include <threads/stop_signal.hpp>
 #include <vector>
 
 namespace os_updates_check {
@@ -99,11 +100,17 @@ class os_updates_data final {
 
   // Issue a WUA search if the cache is older than the configured TTL.
   // Safe to call from the collector loop; no-op until TTL has elapsed.
-  void fetch();
+  //
+  // `stop` is the collector's stop signal: when it fires mid-search the
+  // in-flight WUA job is aborted, nothing is published and false is returned,
+  // so a shutdown never has to wait out a multi-minute search (#1504). Pass
+  // nullptr to run uninterruptibly. Returns true otherwise, including when the
+  // search failed (the failure is recorded in the published data's error).
+  bool fetch(const threads::stop_signal *stop = nullptr);
 
   // Force a search regardless of TTL. Used on the first collector tick and
-  // exposed for tests.
-  void force_fetch();
+  // exposed for tests. Same `stop` semantics and return value as fetch().
+  bool force_fetch(const threads::stop_signal *stop = nullptr);
 
   // Return a snapshot of the current data.
   os_updates_obj get();

--- a/modules/CheckSystem/check_os_updates_test.cpp
+++ b/modules/CheckSystem/check_os_updates_test.cpp
@@ -5,6 +5,8 @@
 
 #include <gtest/gtest.h>
 
+#include <threads/stop_signal.hpp>
+
 using os_updates_check::classify_update;
 using os_updates_check::os_updates_data;
 using os_updates_check::os_updates_obj;
@@ -257,7 +259,51 @@ TEST(CheckOsUpdates, data_get_returns_default_before_fetch) {
 
 // fetch() will exercise the WUA COM API; we don't run it here because it
 // requires admin / network access and may take 30+ seconds. The data class is
-// otherwise covered by the snapshot/TTL tests above.
+// otherwise covered by the snapshot/TTL tests above and the abort tests below.
+
+// A stop that is already signalled must make the fetch bail out before it
+// touches WUA at all: nothing published, "pending" retained, false returned.
+// This is the shutdown contract that keeps unloadModule from waiting out a
+// multi-minute search (#1504).
+TEST(CheckOsUpdates, force_fetch_aborts_immediately_when_stop_is_signalled) {
+  threads::stop_signal stop;
+  std::string error;
+  ASSERT_TRUE(stop.create(error)) << error;
+  stop.signal();
+
+  os_updates_data d;
+  EXPECT_FALSE(d.force_fetch(&stop));
+
+  os_updates_obj snapshot = d.get();
+  EXPECT_FALSE(snapshot.fetch_succeeded);
+  EXPECT_TRUE(snapshot.error.empty());
+  EXPECT_EQ(snapshot.get_update_status(), "pending");
+  EXPECT_EQ(snapshot.count, 0);
+}
+
+// The TTL short-circuit must not be bypassed by the stop signal: a cache that
+// is still fresh reports success without starting (and then aborting) a job.
+TEST(CheckOsUpdates, fetch_within_ttl_is_a_noop_even_with_stop_signalled) {
+  threads::stop_signal stop;
+  std::string error;
+  ASSERT_TRUE(stop.create(error)) << error;
+  stop.signal();
+
+  os_updates_data d;
+  // First call: aborted, so last_fetch_ stays unset and the TTL does not apply.
+  EXPECT_FALSE(d.force_fetch(&stop));
+  EXPECT_FALSE(d.fetch(&stop));
+}
+
+// A stop signal that was never created (no kernel object) must behave like no
+// stop signal at all: the fetch must not report an abort because of it. We
+// cannot run the real search here, so only the "not aborted before WUA"
+// decision is observable: an uncreated signal is not "signalled".
+TEST(CheckOsUpdates, uncreated_stop_signal_is_not_a_stop_request) {
+  threads::stop_signal stop;
+  EXPECT_FALSE(stop.valid());
+  EXPECT_EQ(stop.native_handle(), nullptr);
+}
 
 // ============================================================================
 // filter keyword tests (the `updates` keyword and its deprecated `count` alias)

--- a/modules/CheckSystem/check_os_updates_test.cpp
+++ b/modules/CheckSystem/check_os_updates_test.cpp
@@ -283,6 +283,11 @@ TEST(CheckOsUpdates, force_fetch_aborts_immediately_when_stop_is_signalled) {
 
 // The TTL short-circuit must not be bypassed by the stop signal: a cache that
 // is still fresh reports success without starting (and then aborting) a job.
+//
+// The return value is what separates the two paths: the short-circuit reports
+// success, while a search that is started and then aborted reports false. The
+// cache age is seeded rather than produced by a real search, which needs admin
+// rights, network access and 30+ seconds.
 TEST(CheckOsUpdates, fetch_within_ttl_is_a_noop_even_with_stop_signalled) {
   threads::stop_signal stop;
   std::string error;
@@ -290,8 +295,31 @@ TEST(CheckOsUpdates, fetch_within_ttl_is_a_noop_even_with_stop_signalled) {
   stop.signal();
 
   os_updates_data d;
-  // First call: aborted, so last_fetch_ stays unset and the TTL does not apply.
-  EXPECT_FALSE(d.force_fetch(&stop));
+  d.set_ttl_seconds(3600);
+  d.set_last_fetch_age_for_test(60);  // well inside the TTL
+
+  EXPECT_TRUE(d.fetch(&stop));
+
+  // Nothing was published: the cached snapshot is whatever it already was.
+  os_updates_obj snapshot = d.get();
+  EXPECT_FALSE(snapshot.fetch_succeeded);
+  EXPECT_TRUE(snapshot.error.empty());
+}
+
+// The other half of the same guard: once the cache is older than the TTL,
+// fetch() does start a search, and the already-signalled stop aborts it before
+// WUA is touched. Without this case an inverted TTL comparison would still
+// pass the test above.
+TEST(CheckOsUpdates, fetch_past_ttl_starts_a_search_and_honours_the_stop) {
+  threads::stop_signal stop;
+  std::string error;
+  ASSERT_TRUE(stop.create(error)) << error;
+  stop.signal();
+
+  os_updates_data d;
+  d.set_ttl_seconds(60);
+  d.set_last_fetch_age_for_test(3600);  // stale
+
   EXPECT_FALSE(d.fetch(&stop));
 }
 

--- a/modules/CheckSystem/check_temperature.cpp
+++ b/modules/CheckSystem/check_temperature.cpp
@@ -88,9 +88,9 @@ void thermal_zone::build_metrics(PB::Metrics::MetricsBundle *section) const {
   add_metric(section, name + ".throttle_reasons", throttle_reasons);
 }
 
-void temperature_data::query_acpi(zones_type &zones) {
+void temperature_data::query_acpi(zones_type &zones, HANDLE abort_event) {
   wmi_impl::query wmi_q(helper::acpi_query, helper::acpi_namespace, "", "");
-  wmi_impl::row_enumerator row = wmi_q.execute();
+  wmi_impl::row_enumerator row = wmi_q.execute(abort_event);
   while (row.has_next()) {
     wmi_impl::row r = row.get_next();
     thermal_zone zone;
@@ -99,9 +99,9 @@ void temperature_data::query_acpi(zones_type &zones) {
   }
 }
 
-void temperature_data::query_perf(zones_type &zones) {
+void temperature_data::query_perf(zones_type &zones, HANDLE abort_event) {
   wmi_impl::query wmi_q(helper::perf_query, helper::perf_namespace, "", "");
-  wmi_impl::row_enumerator row = wmi_q.execute();
+  wmi_impl::row_enumerator row = wmi_q.execute(abort_event);
   while (row.has_next()) {
     wmi_impl::row r = row.get_next();
     thermal_zone zone;
@@ -110,13 +110,14 @@ void temperature_data::query_perf(zones_type &zones) {
   }
 }
 
-void temperature_data::fetch() {
+void temperature_data::fetch(const threads::stop_signal *stop) {
   if (!fetch_temperature_) return;
+  const HANDLE abort_event = stop != nullptr ? stop->native_handle() : nullptr;
 
   zones_type tmp;
   if (!use_fallback_) {
     try {
-      query_acpi(tmp);
+      query_acpi(tmp, abort_event);
       if (tmp.empty()) {
         // The ACPI class can exist yet expose no zones (common on consumer
         // hardware) — treat that like "not available" and use the fallback.
@@ -133,7 +134,7 @@ void temperature_data::fetch() {
   }
   if (use_fallback_) {
     try {
-      query_perf(tmp);
+      query_perf(tmp, abort_event);
     } catch (const wmi_impl::wmi_exception &e) {
       if (e.get_code() == WBEM_E_INVALID_QUERY || e.get_code() == WBEM_E_NOT_FOUND) {
         fetch_temperature_ = false;

--- a/modules/CheckSystem/check_temperature.hpp
+++ b/modules/CheckSystem/check_temperature.hpp
@@ -8,6 +8,7 @@
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/protobuf/metrics.hpp>
 #include <string>
+#include <threads/stop_signal.hpp>
 #include <win/wmi/wmi_query.hpp>
 
 namespace temperature_check {
@@ -62,12 +63,14 @@ class temperature_data {
  public:
   temperature_data() : fetch_temperature_(true), use_fallback_(false) {}
 
-  void fetch();
+  // `stop`: see network_data::fetch(); a stop mid-query abandons the WMI
+  // operation, publishes nothing and lets wmi_impl::wmi_aborted propagate.
+  void fetch(const threads::stop_signal *stop = nullptr);
   zones_type get();
 
  private:
-  void query_acpi(zones_type &zones);
-  void query_perf(zones_type &zones);
+  void query_acpi(zones_type &zones, HANDLE abort_event);
+  void query_perf(zones_type &zones, HANDLE abort_event);
 };
 
 namespace check {

--- a/modules/CheckSystem/pdh_thread.cpp
+++ b/modules/CheckSystem/pdh_thread.cpp
@@ -12,6 +12,7 @@
 #include <str/utils_no_boost.hpp>
 #include <win/com_helpers.hpp>
 #include <win/processes.hpp>
+#include <win/wmi/wmi_query.hpp>
 
 #include "check_memory.hpp"
 #include "check_process.hpp"
@@ -568,6 +569,10 @@ template <class Fetcher>
 void run_fetch(const std::string &what, Fetcher fetch) {
   try {
     fetch();
+  } catch (const wmi_impl::wmi_aborted &) {
+    // The collector is stopping and the fetch let go of its WMI query; the
+    // previous sample stays published, so this is not an error.
+    NSC_DEBUG_MSG("Aborted collecting " + what + ": collector is stopping");
   } catch (const nsclient::nsclient_exception &e) {
     NSC_LOG_ERROR("Failed to get " + what + ": " + e.reason());
   } catch (const std::exception &e) {
@@ -626,13 +631,15 @@ void pdh_thread::aux_thread_proc() {
       // provider, and stop() joins this thread, so a stop that lands during
       // one fetch must not start the next (#1504).
       const auto stop_requested = [this] { return WaitForSingleObject(stop_signal_.native_handle(), 0) == WAIT_OBJECT_0; };
-      if (!disable_network && !stop_requested()) run_fetch("network metrics", [this] { network.fetch(); });
-      if (!disable_temperature && !stop_requested()) run_fetch("temperature metrics", [this] { temperature.fetch(); });
-      if (!disable_cpu_frequency && !stop_requested()) run_fetch("CPU frequency metrics", [this] { cpu_frequency.fetch(); });
-      if (!disable_battery && !stop_requested()) run_fetch("battery metrics", [this] { battery.fetch(); });
+      // Every fetch is handed the stop signal so that a WMI provider stall
+      // (or the WUA search below) is abandoned as soon as stop() fires.
+      if (!disable_network && !stop_requested()) run_fetch("network metrics", [this] { network.fetch(&stop_signal_); });
+      if (!disable_temperature && !stop_requested()) run_fetch("temperature metrics", [this] { temperature.fetch(&stop_signal_); });
+      if (!disable_cpu_frequency && !stop_requested()) run_fetch("CPU frequency metrics", [this] { cpu_frequency.fetch(&stop_signal_); });
+      if (!disable_battery && !stop_requested()) run_fetch("battery metrics", [this] { battery.fetch(&stop_signal_); });
       // os_updates.fetch() is a no-op until its internal TTL has elapsed
-      // (default 1h). The search itself can take minutes, so it is handed the
-      // stop signal and aborts the in-flight WUA job when stop() fires.
+      // (default 1h). The search itself can take minutes; it aborts the
+      // in-flight WUA job when stop() fires.
       if (!disable_os_updates && !stop_requested()) {
         run_fetch("OS updates metrics", [this] {
           if (!os_updates.fetch(&stop_signal_)) NSC_DEBUG_MSG("OS updates search aborted: collector is stopping");

--- a/modules/CheckSystem/pdh_thread.cpp
+++ b/modules/CheckSystem/pdh_thread.cpp
@@ -622,12 +622,22 @@ void pdh_thread::aux_thread_proc() {
       }
     }
     if (com->is_ready()) {
-      if (!disable_network) run_fetch("network metrics", [this] { network.fetch(); });
-      if (!disable_temperature) run_fetch("temperature metrics", [this] { temperature.fetch(); });
-      if (!disable_cpu_frequency) run_fetch("CPU frequency metrics", [this] { cpu_frequency.fetch(); });
-      if (!disable_battery) run_fetch("battery metrics", [this] { battery.fetch(); });
-      // os_updates.fetch() is a no-op until its internal TTL has elapsed (default 1h).
-      if (!disable_os_updates) run_fetch("OS updates metrics", [this] { os_updates.fetch(); });
+      // Re-check the stop signal between fetches: each one can block on its
+      // provider, and stop() joins this thread, so a stop that lands during
+      // one fetch must not start the next (#1504).
+      const auto stop_requested = [this] { return WaitForSingleObject(stop_signal_.native_handle(), 0) == WAIT_OBJECT_0; };
+      if (!disable_network && !stop_requested()) run_fetch("network metrics", [this] { network.fetch(); });
+      if (!disable_temperature && !stop_requested()) run_fetch("temperature metrics", [this] { temperature.fetch(); });
+      if (!disable_cpu_frequency && !stop_requested()) run_fetch("CPU frequency metrics", [this] { cpu_frequency.fetch(); });
+      if (!disable_battery && !stop_requested()) run_fetch("battery metrics", [this] { battery.fetch(); });
+      // os_updates.fetch() is a no-op until its internal TTL has elapsed
+      // (default 1h). The search itself can take minutes, so it is handed the
+      // stop signal and aborts the in-flight WUA job when stop() fires.
+      if (!disable_os_updates && !stop_requested()) {
+        run_fetch("OS updates metrics", [this] {
+          if (!os_updates.fetch(&stop_signal_)) NSC_DEBUG_MSG("OS updates search aborted: collector is stopping");
+        });
+      }
     }
   } while ((wait_status = WaitForSingleObject(stop_signal_.native_handle(), interval_ms)) == WAIT_TIMEOUT);
   if (wait_status != WAIT_OBJECT_0) {
@@ -852,6 +862,12 @@ bool pdh_thread::start() {
   aux_thread_ = std::make_shared<boost::thread>([this]() { this->aux_thread_proc(); });
   return true;
 }
+namespace {
+// How long stop() waits quietly for the auxiliary collector before logging
+// that a fetch is holding up the unload.
+const long aux_join_warn_seconds = 5;
+}  // namespace
+
 bool pdh_thread::stop() {
   stop_signal_.signal();
   // Reset after joining so a second call (the destructor always calls stop())
@@ -860,10 +876,17 @@ bool pdh_thread::stop() {
     thread_->join();
     thread_.reset();
   }
-  // aux_thread_ may be mid-fetch (up to a WMI stall) before it sees the event;
-  // join still returns once that fetch completes, same worst case as before.
+  // aux_thread_ may be mid-fetch before it sees the event. The WUA search
+  // aborts on the signal, but a WMI provider stall still has to run its
+  // course, so say so in the log rather than sit silently: an operator
+  // watching a slow shutdown then knows which collector to look at (#1504).
+  // The thread is never detached: it runs against this object and this
+  // module's code, both of which are torn down right after stop() returns.
   if (aux_thread_) {
-    aux_thread_->join();
+    if (!aux_thread_->timed_join(boost::posix_time::seconds(aux_join_warn_seconds))) {
+      NSC_LOG_MESSAGE("CheckSystem auxiliary collector is still busy in a WMI/WUA fetch; waiting for it to finish before unloading");
+      aux_thread_->join();
+    }
     aux_thread_.reset();
   }
   // Release after both joins so a stop/start cycle gets a fresh, unsignalled


### PR DESCRIPTION
Fixes #1504.

## Problem

Stopping the service could take minutes when it happened shortly after start. The whole delay sat inside the CheckSystem unload: `pdh_thread::stop()` joins the auxiliary collector thread, and that thread was blocked in the synchronous `IUpdateSearcher::Search()` the OS updates collector issues on its very first cycle. The search goes online to Windows Update / WSUS and routinely takes minutes on a server, and nothing could interrupt it. The remaining WMI collectors (CheckSystem's network/temperature/CPU frequency/battery and CheckDisk's disk I/O) had the same shape on a smaller scale: a blocking query against the perf-data classes WmiApSrv serves, which stall for tens of seconds while that service restarts.

## Changes

- **CheckSystem, Windows Update search** — run it through `BeginSearch`/`EndSearch` with a completion callback and wait on that together with the collector's stop signal. A stop mid-search calls `RequestAbort()`, gives WUA a short grace period, publishes nothing and returns. A stop that is already pending returns before WUA is touched.
- **WMI helper** — new `query::execute(HANDLE abort_event)` runs the query semisynchronously and pulls rows with a 250 ms bounded wait, re-checking the event between waits. Once signalled it releases the enumerator (which cancels the operation on the WMI side) and throws `wmi_aborted`. The plain `execute()` is untouched for the request-handler callers in the other modules.
- **CheckSystem collectors** — network, temperature, CPU frequency and battery take the stop signal through `fetch()` and hand it to every query; the loop re-checks the stop between fetches; `stop()` logs which collector is holding up an unload if the join takes more than a few seconds.
- **CheckDisk collector** — gains a `threads::stop_signal` next to its portable condition-variable stop. The disk I/O fetch hands it to both PerfDisk queries; the loop re-checks the stop between the disk I/O and free-space fetches (the free-space probe cannot be interrupted) and at the top of each tick. A new portable `threads::stop_requested` marker (which `wmi_aborted` derives from) lets the platform-neutral loop treat an abort as a shutdown rather than a failure, so it does not count towards the give-up threshold.

An abort never publishes: the previous sample stays in place. Aborts are logged at debug level only.

## Testing

- New unit tests: the WUA abort contract (3), the WMI helper's poll/abort logic through a scripted fake enumerator (5) plus a live check that the semisynchronous path delivers rows for the cooked `PerfFormattedData` classes, and the CheckDisk stop contract (2). `check_system_test`, `wmi_query_test` and `check_disk_test` pass in full on Windows.
- `nscp test` with CheckSystem: on a host where the search takes ~8 s, stopping 3 s after start exited 0.6 s after the exit request with "OS updates search aborted" in the log. Stopping at 1 s / 3 s with every collector on abandoned the in-flight network / CPU frequency query the same way. Queries allowed to complete still feed `check_os_updates`, `check_network`, `check_cpu_frequency` and `check_temperature`.
- `nscp test` with CheckDisk: stopping inside the first disk I/O fetch exits within a second with one debug line and no error; left to run, `check_disk_io` reports live data from the first tick.
- The Linux CheckDisk module builds from the branch.

## Still not interruptible

Connecting to the WMI service and creating the WUA session both happen before the abortable operation exists, so a stop landing in a cold service start still waits for that connect (seconds, once). The disk free-space probe on a dead mapped network drive and synchronous realtime-filter submissions on CheckSystem's 1 Hz thread are separate changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UeS9smSxBbSwE4GbUH6v1d
