### PR TITLE
fix: build the vendored simpleini header under C++17

### DIFF
--- a/include/simpleini/simpleini.h
+++ b/include/simpleini/simpleini.h
@@ -332,7 +332,7 @@ class CSimpleIniTempl {
 #endif
 
     /** Strict less ordering by name of key only */
-    struct KeyOrder : std::binary_function<Entry, Entry, bool> {
+    struct KeyOrder {
       bool operator()(const Entry &lhs, const Entry &rhs) const {
         const static SI_STRLESS isLess = SI_STRLESS();
         return isLess(lhs.pItem, rhs.pItem);
@@ -340,7 +340,7 @@ class CSimpleIniTempl {
     };
 
     /** Strict less ordering by order, and then name of key */
-    struct LoadOrder : std::binary_function<Entry, Entry, bool> {
+    struct LoadOrder {
       bool operator()(const Entry &lhs, const Entry &rhs) const {
         if (lhs.nOrder != rhs.nOrder) {
           return lhs.nOrder < rhs.nOrder;


### PR DESCRIPTION
The two comparators in the vendored SimpleIni 4.14 header derive from
std::binary_function, which C++17 removed. libstdc++ still ships it as a
deprecated declaration, so the Linux builds never noticed; the MSVC STL
does not, so raising the project to C++17 (#1483) fails every Windows job
with 15 copies of

  simpleini.h(335): error C2039: 'binary_function': is not a member of 'std'

in the four targets that reach the header - check_nrpe, check_nscp,
settings_manager and settings_test.

std::binary_function only ever supplied the first_argument_type,
second_argument_type and result_type typedefs, for the sake of the
pre-C++11 function adaptors. Nothing here reads them: KeyOrder and
LoadOrder are used only as the comparator of a std::map/std::multimap and
as the predicate of std::list::sort, all of which need operator() and
nothing else. Dropping the base leaves both structs equivalent, and the
header then compiles at C++14, C++17 and C++20 alike.

Verified against the header's ordering paths - section and key load order,
multi-key sections, case-insensitive key collation, Save() output after
inserts and a delete - which render byte-identical before and after.

Assisted-by: Claude Code:claude-opus-5
Claude-Session: https://claude.ai/code/session_01NyC1sPUEH1WVAgBtnhsftq
Signed-off-by: Michael Medin <michael@medin.name>