### PR TITLE
build: cancel superseded CI runs and move sanitizers to main only

### DIFF
--- a/.github/workflows/build-feature.yml
+++ b/.github/workflows/build-feature.yml
@@ -12,18 +12,19 @@ on:
       - "main"
       - "feature/**"
 
+# A PR head that gets a new push makes the run already in flight pointless:
+# it is testing a commit nobody will merge. Cancel it and start over on the
+# new head instead of paying for both. The group is per-PR (github.ref is
+# refs/pull/<n>/merge here), so PRs never cancel each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   get-version:
     uses: ./.github/workflows/get-version.yml
   create-test-bundle:
     uses: ./.github/workflows/create-test-bundle.yml
-  # Non-blocking initially: surfaces real issues without gating PRs while the
-  # team triages what falls out. Drop continue-on-error to make it required.
-  sanitizer-tests:
-    needs: get-version
-    uses: ./.github/workflows/tests-sanitizers.yml
-    with:
-      version: ${{ needs.get-version.outputs.version }}
   build-server-x64:
     needs: [get-version, create-test-bundle]
     uses: ./.github/workflows/build-windows.yml

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -8,11 +8,30 @@ on:
   push:
     branches: [main]
 
+# Merging three PRs in a row used to start three full release builds when only
+# the newest one can become the release: the drafts from the older two are
+# superseded before they are even finished. Cancel them and let the newest
+# merge produce the artifacts.
+#
+# Trade-off: a merge whose run is cancelled never gets its own draft release.
+# That is deliberate — the draft is cut from the newest state of main, and the
+# run that follows produces one for its own version a few minutes later. If a
+# per-merge draft ever becomes load-bearing, set cancel-in-progress to false
+# and the runs will queue instead.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   get-version:
     uses: ./.github/workflows/get-version.yml
   create-test-bundle:
     uses: ./.github/workflows/create-test-bundle.yml
+  # Sanitizers (and coverage) run on main only, not per PR: together they are
+  # close to half of a PR run's machine time and they almost never fail on a
+  # single change. A regression is caught on the merge instead, and a branch
+  # that needs them checked first can run tests-sanitizers.yml on demand from
+  # the Actions tab ("Run workflow" -> pick the branch).
   sanitizer-tests:
     needs: get-version
     uses: ./.github/workflows/tests-sanitizers.yml

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,6 +1,11 @@
 name: Codespell
 on: [pull_request]
 
+# A new push to the PR supersedes this run; do not let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     name: Check

--- a/.github/workflows/docs-notes.yml
+++ b/.github/workflows/docs-notes.yml
@@ -13,7 +13,7 @@ on:
       - 'docs/hooks/**'
       - 'docs/docs/setup/upgrading.md'
       - 'docs/docs/security/notices.md'
-      - '.github/workflows/docs-upgrade-notes.yml'
+      - '.github/workflows/docs-notes.yml'
   pull_request:
     paths:
       - 'docs/upgrades/**'
@@ -21,10 +21,15 @@ on:
       - 'docs/hooks/**'
       - 'docs/docs/setup/upgrading.md'
       - 'docs/docs/security/notices.md'
-      - '.github/workflows/docs-upgrade-notes.yml'
+      - '.github/workflows/docs-notes.yml'
 
 permissions:
   contents: read
+
+# A new push supersedes this run; do not let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   check:

--- a/.github/workflows/test-packaging.yml
+++ b/.github/workflows/test-packaging.yml
@@ -14,6 +14,11 @@ on:
       - 'packaging/**'
       - '.github/workflows/test-packaging.yml'
 
+# A new push supersedes this run; do not let it finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-render-templates:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-sanitizers.yml
+++ b/.github/workflows/tests-sanitizers.yml
@@ -27,6 +27,15 @@ on:
         description: 'Version to build'
         required: true
         default: '0.0.0'
+  # Runnable on its own so a branch can be checked under the sanitizers
+  # before merging — they are not part of the PR build (see build-main.yml).
+  workflow_dispatch:
+    inputs:
+      version:
+        type: string
+        description: 'Version to build'
+        required: false
+        default: '0.0.0'
 
 jobs:
   sanitizer-tests:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,25 @@
   `feature: give \`nscp test\` a real prompt` — or the release it lands in is
   numbered as a patch. Conventional-commit prefixes (`fix:`, `docs:`, `test:`,
   `build:`, `refactor:`) are used for everything else and all read as a patch.
+- A **documentation-only** change does not need the full build matrix (Windows
+  x64/x86/XP, Debian, RedHat, web, integration tests — roughly 300 machine-
+  minutes). GitHub honours `[skip ci]` in the commit message for `push` and
+  `pull_request` events; the other accepted spellings are `[ci skip]`,
+  `[no ci]`, `[skip actions]`, `[actions skip]`, and a `skip-checks: true`
+  trailer. Put it in the **subject**, e.g.
+  `docs: document check_battery keywords [skip ci]`.
+  The catch: a skipped workflow leaves its check `Pending`, not `Passed`, so a
+  **required** check never resolves and the pull request cannot be merged.
+  Therefore:
+  - Use it on a commit pushed straight to `main`, or on a merge commit, where
+    nothing is gating it.
+  - Do **not** use it on a pull request head branch while any check is
+    required. Let CI run there — a docs-only PR is one of the cheap ones and
+    it stays mergeable.
+  Reach for it only when the diff genuinely cannot affect a build: `.md` under
+  `docs/`, release notes, prose in comments. Anything touching `docs/hooks/`,
+  `mkdocs.yml`, the `docs/samples/` wiring or a `CMakeLists.txt` is not
+  docs-only.
 
 ## C++ conventions
 

--- a/build.md
+++ b/build.md
@@ -942,6 +942,13 @@ export UBSAN_OPTIONS=suppressions=$PWD/../tools/sanitizers/ubsan-suppressions.tx
 See the header of `tools/sanitizers/run.sh` and
 `.github/workflows/tests-sanitizers.yml` for more variations.
 
+In CI the sanitizers run on **`main` only**, not on every pull request: the job
+is close to half of a PR run's machine time and it very rarely fails on a single
+change. If a branch touches memory handling and you want it checked before it
+merges, run `tools/sanitizers/run.sh` locally, or start
+`.github/workflows/tests-sanitizers.yml` from the Actions tab ("Run workflow",
+then pick the branch).
+
 #### Coverage reports
 
 `-DNSCP_COVERAGE=ON` instruments every target with gcov counters. Because the


### PR DESCRIPTION
Addresses points 1, 2 and 4 of #1495, plus written-down guidance for the `[skip ci]` part.

## Cancel superseded runs

There was no `concurrency:` anywhere in `.github/workflows/`. Pushing a fix to a PR left the run for the previous head going to completion, and merging three PRs in a row started three full release builds when only the newest one can become the release.

Added a per-ref concurrency group with `cancel-in-progress: true` to the five workflows that have their own trigger:

| workflow | trigger | why |
|---|---|---|
| `build-feature.yml` | `pull_request` | the big one — a superseded PR head is testing a commit nobody will merge |
| `build-main.yml` | `push: main` | three merges in a row → three full release builds |
| `codespell.yml` | `pull_request` | cheap, but consistent |
| `docs-notes.yml` | `push: main`, `pull_request` | cheap, but consistent |
| `test-packaging.yml` | `push: main`, `pull_request` | cheap, but consistent |

Deliberately **not** touched:

- the reusable (`workflow_call`) workflows — they run inside the caller's run and are cancelled with it, so a group of their own would only fight the caller;
- `release.yml`, `publish-scoop.yml`, `publish-winget.yml`, `publish-chocolatey.yml` — a publish must never be cancelled halfway.

On `main`, `github.ref` is `refs/heads/main`, so this is one group for the branch. On a PR, `github.ref` is `refs/pull/<n>/merge`, so PRs never cancel each other.

### The `main` trade-off

A merge whose run gets cancelled never produces its own draft release. That is intended, and the rationale is written into `build-main.yml` rather than left implicit: the draft is cut from the newest state of `main` anyway, and the run that follows produces one for its own version a few minutes later. If a per-merge draft ever turns out to be load-bearing, flipping `cancel-in-progress` to `false` makes the runs queue instead.

## Sanitizers on `main` only

`sanitizer-tests` was ~70 min of a ~294 machine-minute PR run — the single most expensive job — and in practice it almost never fails on an individual change. Removed from `build-feature.yml`; it stays in `build-main.yml` (alongside `coverage`, which was already main-only), so a regression is caught on the merge.

To keep the escape hatch, `tests-sanitizers.yml` gains a `workflow_dispatch` trigger, mirroring what `tests-coverage.yml` already does. A branch that touches memory handling can be checked before merging from the Actions tab ("Run workflow" → pick the branch), or locally with `tools/sanitizers/run.sh`. Both are documented in `build.md` next to the local runner.

Expected saving on a PR run: ~70 machine-minutes up front, plus whatever the cancellations reclaim.

## `[skip ci]` for docs-only commits

Written into `CLAUDE.md` (Git commits section): GitHub honours `[skip ci]` — and `[ci skip]`, `[no ci]`, `[skip actions]`, `[actions skip]`, a `skip-checks: true` trailer — for `push` and `pull_request` events, so a docs-only commit need not spend the full matrix.

The note leads with the caveat that makes it a footgun, because it is the part that bites: a skipped workflow leaves its check **`Pending`**, not `Passed`, so a required check never resolves and the PR cannot be merged. It is therefore documented as safe on a commit pushed straight to `main` or a merge commit, and explicitly *not* on a PR head branch while any check is required. It also draws the line on what counts as docs-only — `.md` under `docs/` yes, `docs/hooks/`, `mkdocs.yml` or a `CMakeLists.txt` no.

## Drive-by

`docs-notes.yml`'s path filter listed `.github/workflows/docs-upgrade-notes.yml`, which is not the file's name (`docs-notes.yml`). Editing the workflow therefore did not re-trigger it. One-line fix, in both the `push` and `pull_request` filters.

## Not done here

Point 3 of the issue — a `changes` job that the heavy builds gate on with `if:` — is a bigger change and interacts with which checks are marked required on the branch protection rule, so it is left for a follow-up.

## Verification

- All 22 workflow files parse as YAML; confirmed `concurrency` lands on exactly the five entry workflows and none of the reusable or publish ones.
- `python3 docs/hooks/notes.py --check` → `95 upgrade notes across 15 versions, 21 security notices: OK`.
- No upgrade or security note added: nothing here changes NSClient++'s behaviour for anyone running it.

Refs #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CBXDbQu4UbjeNXEPCyLtE


---
_Generated by [Claude Code](https://claude.ai/code/session_011CBXDbQu4UbjeNXEPCyLtE)_