### PR TITLE
fix: drop the duplicated plugin_instance_data default constructor

### DIFF
--- a/include/nscapi/nscapi_plugin_wrapper.hpp
+++ b/include/nscapi/nscapi_plugin_wrapper.hpp
@@ -41,7 +41,6 @@ struct plugin_instance_data {
   // there. Every critical section here is a lookup in a map with one entry
   // per loaded module, so a reader/writer lock would buy nothing.
   mutable std::mutex mutex;
-  plugin_instance_data() = default;
   // The instance for id, or null when none exists. Only NSLoadModuleEx may
   // create one (see create()): an unloaded module used to be resurrected as a
   // fresh instance that never saw loadModuleEx by the next log line.


### PR DESCRIPTION
Unbreaks `main`, which currently fails to build on every platform.

## Summary
The merge of #1481 (`f6bce69`) took both sides of a conflicting hunk in `include/nscapi/nscapi_plugin_wrapper.hpp`. `main` had added `plugin_instance_data() = default;` at the top of the struct in `2bc63cc`, next to the deleted copy constructor; the .NET plugin branch added the identical declaration further down, after the `mutable std::mutex mutex;` member. The merged header declares the constructor twice, which every compiler rejects:

```
error: 'nscapi::plugin_instance_data<impl_type>::plugin_instance_data()'
cannot be overloaded with ...                                    (gcc)
error C2535: 'nscapi::plugin_instance_data<impl_type>::plugin_instance_data(void)':
member function already defined or declared                      (MSVC)
```

Because the header reaches nearly everything through `nscapi_core_helper.hpp`, this took out the whole matrix at once in [run #334](https://github.com/mickem/nscp/actions/runs/34488743341): Windows x64 and x86-static, Debian amd64/arm64, all four RedHat variants, plus the sanitizer and coverage jobs. The integration-test and release jobs then skipped.

## Changes
- Removed the later, duplicate declaration in `include/nscapi/nscapi_plugin_wrapper.hpp`, keeping the documented one at the top of the struct.

## Details
The surviving declaration is *not* redundant boilerplate: the deleted copy constructor immediately below it is user-declared, which suppresses the implicit default constructor, and under C++20 the struct is not an aggregate either. Removing that one instead would break every `plugin_instance_data` definition, so the duplicate after the mutex member is the one that had to go.

Verified by reproducing the exact gcc error against `origin/main` with a one-line translation unit that includes the header, then confirming a clean `-fsyntax-only` compile with the fix applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M33qnrqJCUuW1ZBqpH8CQr