### PR TITLE
feature: add access control gates for data-reading checks

### DIFF
--- a/docs/docs/concepts/check-access.md
+++ b/docs/docs/concepts/check-access.md
@@ -16,7 +16,8 @@ the first place*:
 
 That is what those checks are for, and on a host where only the configuration
 decides what runs, it is not a problem. It becomes one where the *caller*
-chooses the argument — NRPE with `allow arguments = true`, or the REST API —
+chooses the argument — NRPE with `allow arguments = true`, or a REST user who
+is not on the no-arguments [`restricted` role](../setup/securing.md#adding-a-dedicated-user) —
 because the agent runs as `SYSTEM` (Windows) or `root`/`nsclient` (Linux) and
 the argument then decides how much of the machine a single check can read back.
 
@@ -335,28 +336,38 @@ configuration.
 
 | Approach | Where you set it | The monitoring server can still | What it costs you | Where it falls short |
 |---|---|---|---|---|
-| **Refuse arguments entirely** | `allow arguments = false` in `[/settings/NRPE/server]` (the default) | Run the commands and aliases you defined, with the thresholds you baked into them | Every variation becomes a configuration entry — thresholds and output syntax included, not just the file or key | **NRPE only.** The REST API has no equivalent switch, so a REST caller is unaffected. It is also all-or-nothing across every check at once |
+| **Refuse arguments entirely** | `allow arguments = false` in `[/settings/NRPE/server]` (the default) for NRPE; the [`restricted` web role](../setup/securing.md#adding-a-dedicated-user) (`queries.execute.noargs`) for REST | Run the commands and aliases you defined, with the thresholds you baked into them | Every variation becomes a configuration entry — thresholds and output syntax included, not just the file or key | **Set per transport.** Each door has its own switch, so one you forget — or one added later — is not covered. It is also all-or-nothing across every check at once |
 | **Allow a folder or subtree** | `access mode = allowed` with a directory, key or channel-family entry | Pick anything at or below what you allowed, and set its own thresholds and syntax | One setting per module, plus knowing what else lives under that area | Whatever lands there **later** is readable too. A folder shared with other applications is broader than it looks |
 | **Allow specific items** | `access mode = allowed` with exact entries | Set thresholds, syntax and bookmarks — everything except choosing a different target | An agent configuration edit for each new file, key or channel | The paths live in the monitoring server's command line, so they are visible there and have to be kept in step with the agent |
 | **Only predefined names** | `access mode = predefined` plus the module's names section | Run any name you defined, with its own thresholds and syntax | The most configuration up front, and the monitoring server's commands have to be rewritten to use names | No ad-hoc troubleshooting through the agent: a new target needs a configuration change and a reload |
 
 ### How they combine
 
-They are not alternatives so much as layers, and the important asymmetry is in
-the last column above: **refusing arguments is a property of one transport,
-while an access mode is a property of the check.** Turning off NRPE arguments
-does nothing about a REST caller; setting an access mode covers both, and every
-transport added later.
+They are not alternatives so much as layers, and the asymmetry is in the last
+column above: **refusing arguments is set per transport, while an access mode is
+set per check.**
 
-So on a host that only answers NRPE with arguments off, the access modes add
-nothing you do not already have — leave them at `any`. On a host that exposes
-REST at all, or NRPE with `allow arguments = true`, the access mode is the only
-one of the four that applies.
+Both doors can refuse arguments. NRPE has `allow arguments = false`, and the
+web server has the built-in
+[`restricted` role](../setup/securing.md#adding-a-dedicated-user), whose
+`queries.execute.noargs` privilege runs checks and aliases but rejects any
+request carrying a parameter. What you have to remember is that they are two
+separate settings: closing one says nothing about the other, a user given
+`monitoring` rather than `restricted` is unaffected by the NRPE switch, and a
+transport added later starts open again. An access mode is written once on the
+check and holds for every caller that reaches it.
 
-The two are worth having together where it matters: arguments off stops the
-caller choosing anything, and the access mode means that if someone later turns
-arguments on — or enables the web server for an afternoon of troubleshooting —
-the agent does not quietly become readable.
+So on a host where every door already refuses arguments — NRPE with
+`allow arguments = false` and every web user on `restricted` — the access modes
+add little you do not already have, and leaving them at `any` is a defensible
+choice. On a host where any caller can pass arguments (a `monitoring` web user,
+or NRPE with `allow arguments = true`), the access mode is the only one of the
+four that applies.
+
+They are worth having together where it matters: arguments off stops the caller
+choosing anything, and the access mode means that if someone later turns
+arguments on — or adds a `monitoring` user for an afternoon of troubleshooting
+— the agent does not quietly become readable.
 
 ### Rolling it out
 

--- a/docs/docs/concepts/check-access.md
+++ b/docs/docs/concepts/check-access.md
@@ -11,6 +11,8 @@ the first place*:
 | `check_pdh` (`check_counter`) | `counter=` | any performance object on the machine |
 | `check_files`, `check_single_file` | `path=`, `file=` | any directory tree the agent can read: every name, size and timestamp, plus a checksum of any file |
 | `check_disk_write` | `file=` | creates and deletes a test file at any path the agent can write |
+| `check_registry_key`, `check_registry_value` | `key=` | any registry key, and the value data itself, with binary rendered as hex |
+| `check_eventlog` | `file=`, `log=` | any event log channel, and the event text itself |
 
 That is what those checks are for, and on a host where only the configuration
 decides what runs, it is not a problem. It becomes one where the *caller*
@@ -38,6 +40,8 @@ Each module has one mode setting and, where it applies, one allow list:
 | `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
 | `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
 | `check_files`, `check_single_file`, `check_disk_write` | `[/settings/disk]` | `file access` | `allowed files` |
+| `check_registry_key`, `check_registry_value` | `[/settings/system/windows]` | `registry access` | `allowed registry keys` |
+| `check_eventlog` | `[/settings/eventlog]` | `log access` | `allowed logs` |
 
 === "any"
 
@@ -240,6 +244,87 @@ Two things to know about the allow list:
   English spellings.
 * The `counter:<alias>=<path>` form is gated exactly like `counter=`.
 
+## check_registry_key and check_registry_value
+
+```ini
+[/settings/system/windows]
+registry access = allowed
+allowed registry keys = HKLM\SOFTWARE\MyApp, HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion
+
+; or, tighter:
+registry access = predefined
+
+[/settings/system/windows/registry]
+myapp = HKLM\SOFTWARE\MyApp
+winver = HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion
+```
+
+!!! warning "This is the widest read of the lot"
+
+    `check_registry_value` returns the value data itself — `string_value`
+    renders `REG_SZ` expanded and `REG_BINARY` as hex — and `string_value` is
+    part of the **default** detail syntax, so a caller needs no syntax argument
+    to get it. With `value=*` and `recursive=true` at unlimited depth, one call
+    walks an entire subtree. The registry is where Windows and third-party
+    software keep autologon passwords, product keys, community strings and
+    stored connection settings, so on a host where callers pass arguments this
+    is the setting to reach for first.
+
+Entries are **hierarchical, not glob**: an entry allows that key and everything
+below it. The match is on whole key names, so `HKLM\SOFTWARE\MyApp` covers
+`HKLM\SOFTWARE\MyApp\Settings` but not `HKLM\SOFTWARE\MyAppOther`. An entry
+containing `*` or `?` is matched as a wildcard against the whole key instead,
+for the cases where that is what you want.
+
+Both hive spellings mean the same hive on either side of the comparison, so an
+allow list written with `HKLM` still matches a caller who sent
+`HKEY_LOCAL_MACHINE`. Matching ignores case, as the registry does.
+
+Only the **starting** key is checked. Enumeration below it stays inside the
+subtree by construction, so a key that passed cannot walk out of the allowed
+part of the hive.
+
+While `registry access` is not `any`, the `computer=` argument is refused
+outright and only the local registry is reachable. A remote computer is a
+destination the allow list says nothing about, and connecting to one
+authenticates outbound as the machine account.
+
+## check_eventlog
+
+```ini
+[/settings/eventlog]
+log access = allowed
+allowed logs = Application, System, Microsoft-Windows-Sysmon
+
+; or, tighter:
+log access = predefined
+
+[/settings/eventlog/logs]
+app = Application
+sysmon = Microsoft-Windows-Sysmon/Operational
+```
+
+The event text comes back through the `message`, `strings` and `xml` keywords,
+and `message` is part of the default detail syntax — so, as with the registry, a
+caller gets content without asking for it. What that reaches is every channel
+the agent can read: `Security`, the PowerShell and Sysmon operational channels,
+and the task scheduler's, among others.
+
+Entries are hierarchical on `/`, so `Microsoft-Windows-Sysmon` covers
+`Microsoft-Windows-Sysmon/Operational` without naming each channel — and, by the
+same whole-segment rule as the registry, does not cover
+`Microsoft-Windows-SysmonOther`. A `*` or `?` in an entry switches it to
+wildcard matching.
+
+!!! note "The default channels are not exempt"
+
+    With no `file=` argument `check_eventlog` reads `Application` and `System`.
+    Those go through the gate too: leaving the argument off is not a way to opt
+    them in, so list them if you want them.
+
+Only channel names can be named — `check_eventlog` cannot be pointed at an
+`.evtx` file on disk, because the query is always opened against a channel path.
+
 ## Choosing a mode
 
 * **Leave it at `any`** where the agent only answers a monitoring server you
@@ -251,6 +336,9 @@ Two things to know about the allow list:
 * **Use `predefined`** where the monitoring server should run your checks and
   nothing else. This is the one to aim for on a host exposed to NRPE with
   `allow arguments = true` or to the REST API.
+
+If you are only going to set one of these, set `registry access`: it is the one
+whose default reaches furthest.
 
 A typo in a mode setting is refused rather than ignored: the check fails with
 `expected any, allowed or predefined` and the module logs the error at startup.

--- a/docs/docs/concepts/check-access.md
+++ b/docs/docs/concepts/check-access.md
@@ -1,0 +1,229 @@
+# Restricting what a check may read
+
+Most checks judge something the agent already knows: how full a disk is, whether
+a service is running. A few take an argument which decides *what data is read in
+the first place*:
+
+| Check | Argument | What it reaches |
+|-------|----------|-----------------|
+| `check_logfile` | `file=` | any file the agent can open, returned through the `line` and `columnN` keywords |
+| `check_wmi` | `query=` | any WMI class, including the filesystem via `CIM_DataFile` and `Win32_Directory` |
+| `check_pdh` (`check_counter`) | `counter=` | any performance object on the machine |
+
+That is what those checks are for, and on a host where only the configuration
+decides what runs, it is not a problem. It becomes one where the *caller*
+chooses the argument — NRPE with `allow arguments = true`, or the REST API —
+because the agent runs as `SYSTEM` (Windows) or `root`/`nsclient` (Linux) and
+the argument then decides how much of the machine a single check can read back.
+
+An operator who only wants two log files watched has no reason to leave the
+other several hundred thousand reachable. The `access mode` settings are how you
+say so.
+
+!!! note "Nothing changes unless you change it"
+
+    All three default to `any`, which is what every release before 0.21.0 did.
+    Restricting access is opt-in; upgrading does not break a working setup.
+
+## The three modes
+
+Each of the three checks has one mode setting and, where it applies, one allow
+list:
+
+| Check | Section | Mode setting | Allow list |
+|-------|---------|--------------|------------|
+| `check_logfile` | `[/settings/logfile]` | `file access` | `allowed files` |
+| `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
+| `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
+
+=== "any"
+
+    Anything the caller names is read. The default, and the behaviour of every
+    earlier release.
+
+=== "allowed"
+
+    Only values matching the allow list are read. Everything else is refused
+    with a message naming what was rejected — never what the list contains.
+
+=== "predefined"
+
+    Only names *you* defined in configuration are accepted. A raw path, query or
+    counter path from the caller is refused outright. This is the tightest
+    setting, and the one to reach for when the monitoring server should be able
+    to run your checks and nothing else.
+
+### Predefined names work in every mode
+
+A name you configured always resolves, whatever the mode is set to — `any`
+included. That ordering is deliberate: it lets you name your checks first,
+confirm the monitoring server still works, and tighten the mode afterwards,
+instead of having to do both in one step.
+
+It also means a predefined value is trusted as written. A predefined WMI query
+is not parsed and is not held against `allowed classes`; you configured it, so
+you have vouched for it.
+
+## check_logfile
+
+```ini
+[/settings/logfile]
+file access = allowed
+allowed files = C:/logs, C:/inetpub/logs/LogFiles/*.log
+
+; or, tighter:
+file access = predefined
+
+[/settings/logfile/files]
+app = C:/logs/app.log
+iis = C:/inetpub/logs/LogFiles/W3SVC1/u_ex.log
+```
+
+With the section above and `file access = predefined`, the monitoring server
+runs `check_logfile file=app` and nothing else.
+
+Allow-list entries come in three shapes:
+
+| Entry | Matches |
+|-------|---------|
+| `C:/logs` | a directory: every file beneath it, at any depth |
+| `C:/logs/*.log` | a wildcard (`*` and `?`), matched against the whole path |
+| `C:/logs/app.log` | that one file |
+
+**Paths are resolved before they are matched.** `..` is flattened and symbolic
+links and junctions are followed, so neither
+`C:/logs/../../Windows/System32/config/SAM` nor a link planted inside an allowed
+directory widens it. The resolved path is also the one the check opens, so what
+was matched is what gets read — which means `${file}` in your syntax may spell
+the name differently than the caller did.
+
+!!! tip "Bookmarks and the first restricted check"
+
+    A [bookmark](checks.md) is keyed on the file name, so the first check after
+    you switch a bookmarked `check_logfile` to `allowed` may see a new key — if
+    the resolved path spells the name differently — and read the file from the
+    start once. It settles after that run. Switching to `predefined` avoids it
+    if you point the configured name at the same spelling the caller used.
+
+On Windows, matching ignores case; on Linux it does not, because
+`/var/log/App.log` and `/var/log/app.log` are two different files there.
+
+## check_wmi
+
+```ini
+[/settings/wmi]
+query access = allowed
+allowed classes = Win32_Service, Win32_OperatingSystem, Win32_PerfFormattedData_*
+allowed namespaces = root\cimv2
+```
+
+In `allowed` mode the query is parsed to find the class it reads, and that class
+is held against `allowed classes`.
+
+!!! warning "Only a plain SELECT can be checked by class"
+
+    The gate refuses anything whose class it cannot determine with certainty,
+    rather than guessing: `ASSOCIATORS OF`, `REFERENCES OF`, a class path
+    carrying a namespace or a machine name (`root\cimv2:Win32_Process`), or more
+    than one statement. Approving the wrong class would be worse than refusing,
+    because the query would then read something the allow list never permitted.
+
+    Queries like that are still perfectly usable — configure them as predefined
+    queries, where you have already vouched for them:
+
+    ```ini
+    [/settings/wmi]
+    query access = predefined
+
+    [/settings/wmi/queries]
+    disk-partitions = ASSOCIATORS OF {Win32_LogicalDisk.DeviceID='C:'} WHERE AssocClass = Win32_LogicalDiskToPartition
+    services = SELECT Name, State FROM Win32_Service
+    ```
+
+Two further restrictions apply whenever `query access` is not `any`:
+
+* **Namespaces.** `allowed namespaces` lists the namespaces a caller may bind
+  to. Leaving it empty means the namespace cannot be moved off the default
+  `root\cimv2` at all — restricting the class while leaving the namespace open
+  would let the same class name be read from a different provider.
+* **Targets.** `target=` must name a target defined in
+  `[/settings/wmi/targets]`. An unknown target is otherwise taken as a bare host
+  name, which would let a caller point the check at a machine of its own
+  choosing and hand it the configured credentials.
+
+The `nscp wmi` command line is not affected. It is a local administrative tool,
+and reaching it over REST already requires the `legacy` or `console.exec`
+permission, which is administrator-equivalent in its own right.
+
+## check_pdh
+
+```ini
+[/settings/system/windows]
+counter access = allowed
+allowed counters = \Processor(*)\*, \Memory\*, \System\*
+```
+
+`check_pdh` needs no new predefined list: the counters you already configured in
+`[/settings/system/windows/counters]` *are* the predefined set, so
+`counter access = predefined` means "only the counters I configured".
+
+```ini
+[/settings/system/windows]
+counter access = predefined
+
+[/settings/system/windows/counters]
+threads = \System\Threads
+disk_queue_length = \PhysicalDisk($INSTANCE$)\% Disk Time
+```
+
+The monitoring server then runs `check_pdh counter=threads`.
+
+Wildcard entries are matched literally apart from `*` and `?`, so the
+backslashes and parentheses a counter path is full of mean exactly what they
+look like — `\Processor(_Total)\*` matches the `_Total` instance and not
+`\Processor_Total\…`.
+
+Two things to know about the allow list:
+
+* The pattern is matched against the counter path **as the caller wrote it**,
+  before any index expansion. On a mixed estate, list both the localized and the
+  English spellings.
+* The `counter:<alias>=<path>` form is gated exactly like `counter=`.
+
+## Choosing a mode
+
+* **Leave it at `any`** where the agent only answers a monitoring server you
+  control and `allow arguments` is off. The configuration decides everything,
+  and nothing here adds to that.
+* **Use `allowed`** where you want a family of checks — every log under one
+  directory, every counter of one object — without enumerating each one.
+* **Use `predefined`** where the monitoring server should run your checks and
+  nothing else. This is the one to aim for on a host exposed to NRPE with
+  `allow arguments = true` or to the REST API.
+
+A typo in a mode setting is refused rather than ignored: the check fails with
+`expected any, allowed or predefined` and the module logs the error at startup.
+A setting that decides what may be read must not fail open because it was
+misspelled.
+
+## What a refusal looks like
+
+The check returns `UNKNOWN` with a message naming what was rejected and the
+section that governs it:
+
+```
+Refusing file 'C:\Windows\System32\config\SAM': it is not in 'allowed files'
+(see [/settings/logfile] in the configuration)
+```
+
+The contents of the allow list are deliberately left out — the caller has no
+business enumerating it. When a check you expected to work is refused, the
+agent log is where to look.
+
+## See also
+
+* [Securing NSClient++](../setup/securing.md) — where this fits among the other
+  controls, and what to do first.
+* [Checks In Depth](checks.md) — how filters, keywords and thresholds work.
+* [Permissions](permissions.md) — restricting *which* checks a caller may run at
+  all, which is the other half of the same question.

--- a/docs/docs/concepts/check-access.md
+++ b/docs/docs/concepts/check-access.md
@@ -98,6 +98,11 @@ Allow-list entries come in three shapes:
 | `C:/logs/*.log` | a wildcard (`*` and `?`), matched against the whole path |
 | `C:/logs/app.log` | that one file |
 
+Paths are compared after both sides are resolved, and separators are folded
+only where the platform treats them as separators: on Windows `\` and `/` are
+the same thing, on Linux `\` is an ordinary character in a file name. An entry
+may also be a filesystem root (`/`, or `C:\`), which allows everything on it.
+
 A bare entry is a directory unless it names a file which exists when the
 settings are read; a path which does not exist yet (a volume mounted later, a
 log directory the application creates on first run) is taken as a directory,
@@ -160,6 +165,11 @@ else is a single file.
     So the exposure is narrower than `check_logfile`'s but reaches much wider —
     whole trees rather than one named file — which is why it is worth setting
     even where you left `check_logfile` open.
+
+While the disk checks are restricted, `check_files` also requires `pattern` to
+be a plain file mask: it may not contain a path separator or `..`. The pattern
+is appended to the directory being walked, so one carrying a path would
+enumerate a tree the allow list never approved, no matter which root passed.
 
 For `check_files` only the **scan root** is checked, not each file the walk
 finds. That is sound rather than a shortcut: the recursion refuses to follow

--- a/docs/docs/concepts/check-access.md
+++ b/docs/docs/concepts/check-access.md
@@ -325,25 +325,76 @@ wildcard matching.
 Only channel names can be named — `check_eventlog` cannot be pointed at an
 `.evtx` file on disk, because the query is always opened against a channel path.
 
-## Choosing a mode
+## Choosing an approach
 
-* **Leave it at `any`** where the agent only answers a monitoring server you
-  control and `allow arguments` is off. The configuration decides everything,
-  and nothing here adds to that.
-* **Use `allowed`** where you want a family of checks — every log under one
-  directory, every file under one tree, every counter of one object — without
-  enumerating each one.
-* **Use `predefined`** where the monitoring server should run your checks and
-  nothing else. This is the one to aim for on a host exposed to NRPE with
-  `allow arguments = true` or to the REST API.
+An access mode is not the only way to stop a caller reading more than you meant
+it to, and it is not always the right one. There are four practical approaches,
+and they trade the same thing against each other: how much the monitoring server
+may decide for itself, versus how much you have to write down in the agent's
+configuration.
 
-If you are only going to set one of these, set `registry access`: it is the one
-whose default reaches furthest.
+| Approach | Where you set it | The monitoring server can still | What it costs you | Where it falls short |
+|---|---|---|---|---|
+| **Refuse arguments entirely** | `allow arguments = false` in `[/settings/NRPE/server]` (the default) | Run the commands and aliases you defined, with the thresholds you baked into them | Every variation becomes a configuration entry — thresholds and output syntax included, not just the file or key | **NRPE only.** The REST API has no equivalent switch, so a REST caller is unaffected. It is also all-or-nothing across every check at once |
+| **Allow a folder or subtree** | `access mode = allowed` with a directory, key or channel-family entry | Pick anything at or below what you allowed, and set its own thresholds and syntax | One setting per module, plus knowing what else lives under that area | Whatever lands there **later** is readable too. A folder shared with other applications is broader than it looks |
+| **Allow specific items** | `access mode = allowed` with exact entries | Set thresholds, syntax and bookmarks — everything except choosing a different target | An agent configuration edit for each new file, key or channel | The paths live in the monitoring server's command line, so they are visible there and have to be kept in step with the agent |
+| **Only predefined names** | `access mode = predefined` plus the module's names section | Run any name you defined, with its own thresholds and syntax | The most configuration up front, and the monitoring server's commands have to be rewritten to use names | No ad-hoc troubleshooting through the agent: a new target needs a configuration change and a reload |
 
-A typo in a mode setting is refused rather than ignored: the check fails with
+### How they combine
+
+They are not alternatives so much as layers, and the important asymmetry is in
+the last column above: **refusing arguments is a property of one transport,
+while an access mode is a property of the check.** Turning off NRPE arguments
+does nothing about a REST caller; setting an access mode covers both, and every
+transport added later.
+
+So on a host that only answers NRPE with arguments off, the access modes add
+nothing you do not already have — leave them at `any`. On a host that exposes
+REST at all, or NRPE with `allow arguments = true`, the access mode is the only
+one of the four that applies.
+
+The two are worth having together where it matters: arguments off stops the
+caller choosing anything, and the access mode means that if someone later turns
+arguments on — or enables the web server for an afternoon of troubleshooting —
+the agent does not quietly become readable.
+
+### Rolling it out
+
+Because a configured name resolves in **every** mode, you do not have to pick
+between the last two rows in one step:
+
+1. Add the names first, under `[/settings/logfile/files]`,
+   `[/settings/system/windows/registry]` and so on, and leave the mode at `any`.
+2. Move the monitoring server onto those names. Nothing has been restricted yet,
+   so a mistake shows up as a normal check failure rather than an outage.
+3. Once the checks are green, set the mode to `predefined`.
+
+If you would rather not rewrite the monitoring server's commands at all, stop at
+the second row instead and allow the folders you already use.
+
+### If you only change one thing
+
+Set `registry access`. Of all the defaults it is the one that reaches furthest —
+value data, rendered as hex for binary values, in the default syntax, over a
+whole subtree at once.
+
+### A typo will not open the gate
+
+A mode that does not parse is refused rather than ignored: the check fails with
 `expected any, allowed or predefined` and the module logs the error at startup.
 A setting that decides what may be read must not fail open because it was
 misspelled.
+
+### Restricting which checks run at all
+
+All of the above restricts what a check may *read*. It is worth saying that the
+other half of the question — which commands a caller may run in the first place
+— is a separate control, and often the cheaper win: see
+[Permissions](permissions.md) for the policy engine, and the
+[securing guide](../setup/securing.md#locking-down-which-commands-the-web-user-can-run)
+for restricting a web user to a fixed list of commands. An access mode and a
+permission policy answer different questions, and a tight deployment usually
+wants both.
 
 ## What a refusal looks like
 

--- a/docs/docs/concepts/check-access.md
+++ b/docs/docs/concepts/check-access.md
@@ -77,7 +77,7 @@ you have vouched for it.
 ```ini
 [/settings/logfile]
 file access = allowed
-allowed files = C:/logs, C:/inetpub/logs/LogFiles/*.log
+allowed files = C:/logs, C:/inetpub/logs/LogFiles/**.log
 
 ; or, tighter:
 file access = predefined
@@ -97,6 +97,14 @@ Allow-list entries come in three shapes:
 | `C:/logs` | a directory: every file beneath it, at any depth |
 | `C:/logs/*.log` | a wildcard (`*` and `?`), matched against the whole path |
 | `C:/logs/app.log` | that one file |
+
+A bare entry is a directory unless it names a file which exists when the
+settings are read; a path which does not exist yet (a volume mounted later, a
+log directory the application creates on first run) is taken as a directory,
+so the files that appear beneath it are covered without a reload. In a
+wildcard, `*` and `?` stop at a directory separator: `C:/logs/*.log` names the
+`.log` files in `C:/logs` itself and not those in `C:/logs/private/`. Write
+`**` where the whole subtree is meant, as in `C:/logs/**.log`.
 
 **Paths are resolved before they are matched.** `..` is flattened and symbolic
 links and junctions are followed, so neither
@@ -154,10 +162,11 @@ else is a single file.
     even where you left `check_logfile` open.
 
 For `check_files` only the **scan root** is checked, not each file the walk
-finds. That is sound rather than a shortcut: the recursion already refuses to
-follow symbolic links and reparse points, so everything it yields is genuinely
-beneath a root which passed. It also keeps the inner loop free of policy work on
-a check that may visit many thousands of files.
+finds. That is sound rather than a shortcut: the recursion refuses to follow
+symbolic links — directory links and junctions, and file links too — so
+everything it yields is genuinely beneath a root which passed. It also keeps
+the inner loop free of policy work on a check that may visit many thousands of
+files.
 
 `check_disk_write` cannot overwrite anything — the test file is created
 exclusively, capped at 1 MB and deleted afterwards — but where you have narrowed

--- a/docs/docs/concepts/check-access.md
+++ b/docs/docs/concepts/check-access.md
@@ -9,6 +9,8 @@ the first place*:
 | `check_logfile` | `file=` | any file the agent can open, returned through the `line` and `columnN` keywords |
 | `check_wmi` | `query=` | any WMI class, including the filesystem via `CIM_DataFile` and `Win32_Directory` |
 | `check_pdh` (`check_counter`) | `counter=` | any performance object on the machine |
+| `check_files`, `check_single_file` | `path=`, `file=` | any directory tree the agent can read: every name, size and timestamp, plus a checksum of any file |
+| `check_disk_write` | `file=` | creates and deletes a test file at any path the agent can write |
 
 That is what those checks are for, and on a host where only the configuration
 decides what runs, it is not a problem. It becomes one where the *caller*
@@ -17,24 +19,25 @@ because the agent runs as `SYSTEM` (Windows) or `root`/`nsclient` (Linux) and
 the argument then decides how much of the machine a single check can read back.
 
 An operator who only wants two log files watched has no reason to leave the
-other several hundred thousand reachable. The `access mode` settings are how you
+other several hundred thousand reachable. The access-mode settings are how you
 say so.
 
 !!! note "Nothing changes unless you change it"
 
-    All three default to `any`, which is what every release before 0.21.0 did.
-    Restricting access is opt-in; upgrading does not break a working setup.
+    Every one of these defaults to `any`, which is what each release before
+    0.21.0 did. Restricting access is opt-in; upgrading does not break a
+    working setup.
 
 ## The three modes
 
-Each of the three checks has one mode setting and, where it applies, one allow
-list:
+Each module has one mode setting and, where it applies, one allow list:
 
 | Check | Section | Mode setting | Allow list |
 |-------|---------|--------------|------------|
 | `check_logfile` | `[/settings/logfile]` | `file access` | `allowed files` |
 | `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
 | `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
+| `check_files`, `check_single_file`, `check_disk_write` | `[/settings/disk]` | `file access` | `allowed files` |
 
 === "any"
 
@@ -107,6 +110,53 @@ the name differently than the caller did.
 
 On Windows, matching ignores case; on Linux it does not, because
 `/var/log/App.log` and `/var/log/app.log` are two different files there.
+
+## check_files, check_single_file and check_disk_write
+
+```ini
+[/settings/disk]
+file access = allowed
+allowed files = C:/logs, D:/data/incoming/*.csv
+
+; or, tighter:
+file access = predefined
+
+[/settings/disk/files]
+logs = C:/logs
+spool = D:/data/incoming
+```
+
+`[/settings/disk]` covers all three at once: `check_files` and
+`check_single_file` read, `check_disk_write` writes. Entry shapes and path
+resolution are exactly as for `check_logfile` above — a directory covers its
+whole subtree, a wildcard is matched against the resolved path, and anything
+else is a single file.
+
+!!! info "These checks do not return file contents"
+
+    There is no `line` or `content` keyword here. What they expose is the
+    filesystem's *shape* — `path`, `filename`, `size`, `type`, `version` and the
+    timestamps — for every file under the tree you point them at. Two keyword
+    families go further without returning contents:
+
+    * the checksum keywords (`md5_checksum`, `sha1_checksum`, `sha256_checksum`,
+      `sha384_checksum`, `sha512_checksum`) hash the file, which confirms known
+      content and, for a short or predictable file, effectively recovers it;
+    * `line_count` and `version` are weaker oracles of the same kind.
+
+    So the exposure is narrower than `check_logfile`'s but reaches much wider —
+    whole trees rather than one named file — which is why it is worth setting
+    even where you left `check_logfile` open.
+
+For `check_files` only the **scan root** is checked, not each file the walk
+finds. That is sound rather than a shortcut: the recursion already refuses to
+follow symbolic links and reparse points, so everything it yields is genuinely
+beneath a root which passed. It also keeps the inner loop free of policy work on
+a check that may visit many thousands of files.
+
+`check_disk_write` cannot overwrite anything — the test file is created
+exclusively, capped at 1 MB and deleted afterwards — but where you have narrowed
+which paths a caller may name, that applies to writing them too.
 
 ## check_wmi
 
@@ -196,7 +246,8 @@ Two things to know about the allow list:
   control and `allow arguments` is off. The configuration decides everything,
   and nothing here adds to that.
 * **Use `allowed`** where you want a family of checks — every log under one
-  directory, every counter of one object — without enumerating each one.
+  directory, every file under one tree, every counter of one object — without
+  enumerating each one.
 * **Use `predefined`** where the monitoring server should run your checks and
   nothing else. This is the one to aim for on a host exposed to NRPE with
   `allow arguments = true` or to the REST API.

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -484,6 +484,59 @@ WEBServer : monitor = CheckSystem.check_cpu, CheckSystem.check_drivesize, CheckD
 See [Permissions](../concepts/permissions.md) for the full reference: identity model, which modules stamp what,
 pattern syntax, the worked `CheckHelpers` example, and the detailed step-by-step setup guide.
 
+## Data disclosure: restricting what a check may read
+
+Code execution is the risk people look for first, but a handful of checks take an argument which decides **what data is
+read**, and the agent reads it with its own privileges - `SYSTEM` on Windows, `root` or `nsclient` on Linux:
+
+| Check | Argument | What an unrestricted argument reaches |
+|-------|----------|---------------------------------------|
+| `check_logfile` | `file=` | any file the agent can open; `${line}` returns its contents |
+| `check_wmi` | `query=` | any WMI class, the filesystem included (`CIM_DataFile`, `Win32_Directory`) |
+| `check_pdh` / `check_counter` | `counter=` | any performance object on the machine |
+
+That is what those checks are *for*, so it is not a defect, and where only your configuration decides what runs it does
+not matter. It matters where the **caller** picks the argument: NRPE with `allow arguments = true`, or the REST API. A
+caller who can reach `check_logfile` with an arbitrary `file=` can read `/etc/shadow`, a private key or a registry hive
+backup, and gets the contents back in the check output.
+
+Each of the three checks has an access mode which narrows this. All three default to `any` - the behaviour of every
+release before 0.21.0 - so this is opt-in and an upgrade changes nothing:
+
+| Check | Section | Mode setting | Allow list |
+|-------|---------|--------------|------------|
+| `check_logfile` | `[/settings/logfile]` | `file access` | `allowed files` |
+| `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
+| `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
+
+The modes are `any` (anything the caller names), `allowed` (only what matches the list) and `predefined` (only names you
+configured). Names you configure resolve in **every** mode, so you can name your checks first, confirm the monitoring
+server still works, and tighten the mode afterwards:
+
+```ini
+[/settings/logfile]
+file access = predefined
+
+[/settings/logfile/files]
+app = C:/logs/app.log
+iis = C:/inetpub/logs/LogFiles/W3SVC1/u_ex.log
+```
+
+The monitoring server then runs `check_logfile file=app`, and a caller asking for anything else is refused.
+
+**Recommended posture.** If `allow arguments` is off for NRPE and the REST API is not exposed, `any` costs you nothing -
+your configuration already decides everything. Otherwise set `predefined` on whichever of the three modules you have
+enabled; `allowed` is the middle ground when you want a whole directory or performance object without enumerating each
+entry.
+
+File paths are resolved before they are matched, so `..` and symbolic links or junctions cannot widen an allowed
+directory, and a misspelled mode is refused rather than ignored. The full reference - entry syntax, the WMI query forms
+which can and cannot be checked by class, and what a refusal looks like - is in
+[Restricting what a check may read](../concepts/check-access.md).
+
+This is the companion to the [permission policy](#permission-policy) above: that one restricts *which* checks a caller
+may run, this one restricts *what* those checks may reach.
+
 ## Remote code execution: understanding the attack surface
 
 NSClient++ is, by design, a remote-administration agent. Several modules can ultimately cause arbitrary code to run on
@@ -733,3 +786,6 @@ If two-way TLS is not yet in place, the compensating controls are:
 | check_nt (`NSClientServer`) protocol            | optional      | avoid; leave disabled. If required, firewall to the monitor, treat the password as public, and set `allow = metrics, info` |
 | Service account                                 | `LocalSystem` | dedicated low-privilege account with only the access your checks require |
 | Permission policy (`/settings/permissions`)     | disabled      | enable in observe mode, lock down to per-subject allow-list              |
+| `check_logfile` `file access`                   | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
+| `check_wmi` `query access`                      | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
+| `check_pdh` `counter access`                    | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -496,6 +496,8 @@ read**, and the agent reads it with its own privileges - `SYSTEM` on Windows, `r
 | `check_pdh` / `check_counter` | `counter=` | any performance object on the machine |
 | `check_files`, `check_single_file` | `path=` / `file=` | any directory tree: every name, size and timestamp, plus a checksum of any file |
 | `check_disk_write` | `file=` | creates and deletes a test file at any writable path |
+| `check_registry_key`, `check_registry_value` | `key=` | any registry key, and the value data itself (binary as hex) |
+| `check_eventlog` | `file=` / `log=` | any event log channel, and the event text itself |
 
 That is what those checks are *for*, so it is not a defect, and where only your configuration decides what runs it does
 not matter. It matters where the **caller** picks the argument: NRPE with `allow arguments = true`, or the REST API. A
@@ -511,6 +513,13 @@ release before 0.21.0 - so this is opt-in and an upgrade changes nothing:
 | `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
 | `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
 | `check_files`, `check_single_file`, `check_disk_write` | `[/settings/disk]` | `file access` | `allowed files` |
+| `check_registry_key`, `check_registry_value` | `[/settings/system/windows]` | `registry access` | `allowed registry keys` |
+| `check_eventlog` | `[/settings/eventlog]` | `log access` | `allowed logs` |
+
+If you set only one of these, set `registry access`. `check_registry_value` returns value data with binary rendered as hex,
+in its *default* syntax, and `recursive=true` walks a whole subtree — the registry is where autologon passwords, product keys
+and stored connection settings live. `check_eventlog` is the next widest: event text comes back in its default syntax too, from
+any channel the agent can read, `Security` included.
 
 The disk checks never return file contents, but they enumerate whole trees and can report a checksum of any readable
 file, which confirms known content and for a short file effectively recovers it. Narrower than `check_logfile`, but much
@@ -797,3 +806,5 @@ If two-way TLS is not yet in place, the compensating controls are:
 | `check_wmi` `query access`                      | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
 | `check_pdh` `counter access`                    | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
 | CheckDisk `file access`                         | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
+| `check_registry_*` `registry access`            | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
+| `check_eventlog` `log access`                   | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -504,7 +504,7 @@ not matter. It matters where the **caller** picks the argument: NRPE with `allow
 caller who can reach `check_logfile` with an arbitrary `file=` can read `/etc/shadow`, a private key or a registry hive
 backup, and gets the contents back in the check output.
 
-Each of the three checks has an access mode which narrows this. All three default to `any` - the behaviour of every
+Each of these modules has an access mode which narrows this. They all default to `any` - the behaviour of every
 release before 0.21.0 - so this is opt-in and an upgrade changes nothing:
 
 | Check | Section | Mode setting | Allow list |
@@ -540,14 +540,17 @@ iis = C:/inetpub/logs/LogFiles/W3SVC1/u_ex.log
 
 The monitoring server then runs `check_logfile file=app`, and a caller asking for anything else is refused.
 
-**Recommended posture.** If `allow arguments` is off for NRPE and the REST API is not exposed, `any` costs you nothing -
-your configuration already decides everything. Otherwise set `predefined` on whichever of the modules you have enabled;
+**Recommended posture.** If no caller can pass arguments at all - `allow arguments` off for NRPE, and every web user on
+the `restricted` role or the REST API not exposed - `any` costs you nothing; your configuration already decides
+everything. Otherwise set `predefined` on whichever of the modules you have enabled;
 `allowed` is the middle ground when you want a whole directory, key subtree or performance object without enumerating
 each entry.
 
-Note the asymmetry that decides which control you actually need: **`allow arguments` is a property of one transport, an
-access mode is a property of the check.** Turning off NRPE arguments does nothing about a REST caller; setting an access
-mode covers both, and any transport added later. The concepts page has a
+Refusing arguments is the other way to close this, and it is now available on both doors: `allow arguments = false` for
+NRPE, and the [`restricted` web role](#adding-a-dedicated-user) (`queries.execute.noargs`) for REST. Note what still
+differs, because it decides whether you need an access mode as well: **refusing arguments is set per transport, an access
+mode is set per check.** You have to remember both doors, and a third added later; an access mode covers every transport
+at once. The concepts page has a
 [table comparing the four approaches](../concepts/check-access.md#choosing-an-approach) - refusing arguments, allowing a
 folder, allowing specific items, and predefined names only - with what each costs and where each falls short.
 

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -494,6 +494,8 @@ read**, and the agent reads it with its own privileges - `SYSTEM` on Windows, `r
 | `check_logfile` | `file=` | any file the agent can open; `${line}` returns its contents |
 | `check_wmi` | `query=` | any WMI class, the filesystem included (`CIM_DataFile`, `Win32_Directory`) |
 | `check_pdh` / `check_counter` | `counter=` | any performance object on the machine |
+| `check_files`, `check_single_file` | `path=` / `file=` | any directory tree: every name, size and timestamp, plus a checksum of any file |
+| `check_disk_write` | `file=` | creates and deletes a test file at any writable path |
 
 That is what those checks are *for*, so it is not a defect, and where only your configuration decides what runs it does
 not matter. It matters where the **caller** picks the argument: NRPE with `allow arguments = true`, or the REST API. A
@@ -508,6 +510,11 @@ release before 0.21.0 - so this is opt-in and an upgrade changes nothing:
 | `check_logfile` | `[/settings/logfile]` | `file access` | `allowed files` |
 | `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
 | `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
+| `check_files`, `check_single_file`, `check_disk_write` | `[/settings/disk]` | `file access` | `allowed files` |
+
+The disk checks never return file contents, but they enumerate whole trees and can report a checksum of any readable
+file, which confirms known content and for a short file effectively recovers it. Narrower than `check_logfile`, but much
+wider reach.
 
 The modes are `any` (anything the caller names), `allowed` (only what matches the list) and `predefined` (only names you
 configured). Names you configure resolve in **every** mode, so you can name your checks first, confirm the monitoring
@@ -789,3 +796,4 @@ If two-way TLS is not yet in place, the compensating controls are:
 | `check_logfile` `file access`                   | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
 | `check_wmi` `query access`                      | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
 | `check_pdh` `counter access`                    | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |
+| CheckDisk `file access`                         | `any`         | `predefined` (or `allowed`) wherever callers may pass arguments          |

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -541,9 +541,15 @@ iis = C:/inetpub/logs/LogFiles/W3SVC1/u_ex.log
 The monitoring server then runs `check_logfile file=app`, and a caller asking for anything else is refused.
 
 **Recommended posture.** If `allow arguments` is off for NRPE and the REST API is not exposed, `any` costs you nothing -
-your configuration already decides everything. Otherwise set `predefined` on whichever of the three modules you have
-enabled; `allowed` is the middle ground when you want a whole directory or performance object without enumerating each
-entry.
+your configuration already decides everything. Otherwise set `predefined` on whichever of the modules you have enabled;
+`allowed` is the middle ground when you want a whole directory, key subtree or performance object without enumerating
+each entry.
+
+Note the asymmetry that decides which control you actually need: **`allow arguments` is a property of one transport, an
+access mode is a property of the check.** Turning off NRPE arguments does nothing about a REST caller; setting an access
+mode covers both, and any transport added later. The concepts page has a
+[table comparing the four approaches](../concepts/check-access.md#choosing-an-approach) - refusing arguments, allowing a
+folder, allowing specific items, and predefined names only - with what each costs and where each falls short.
 
 File paths are resolved before they are matched, so `..` and symbolic links or junctions cannot widen an allowed
 directory, and a misspelled mode is refused rather than ignored. The full reference - entry syntax, the WMI query forms

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
   - Concepts:
       - How NSClient++ Works: concepts/index.md
       - Checks In Depth: concepts/checks.md
+      - Restricting What A Check May Read: concepts/check-access.md
       - Settings: concepts/settings.md
       - Test Mode: concepts/test-mode.md
       - File Layout: concepts/file-layout.md

--- a/docs/security/250-check-access-modes.md
+++ b/docs/security/250-check-access-modes.md
@@ -82,9 +82,11 @@ reach rather than depth: they never return file contents, but they enumerate
 whole directory trees (name, size, timestamps, executable version) and their
 checksum keywords hash any readable file, which confirms known content and for a
 short or predictable file effectively recovers it. For `check_files` only the
-scan root is held against the policy - the recursion already refuses to follow
-symbolic links and reparse points, so every file it yields is genuinely beneath
-a root which passed.
+scan root is held against the policy - the recursion refuses to follow symbolic
+links, directory and file links alike (the Windows scanner previously skipped
+only directory reparse points, so a file symlink planted in an allowed tree
+could be hashed through), so every file it yields is genuinely beneath a root
+which passed.
 
 Refusals name what was rejected and the section that governs it, but never the
 contents of the allow list.

--- a/docs/security/250-check-access-modes.md
+++ b/docs/security/250-check-access-modes.md
@@ -1,11 +1,11 @@
 ---
-title: "Check access modes for check_logfile, check_wmi and check_pdh"
+title: "Access modes for the checks whose argument decides what is read"
 fixed_in: next
 severity: "Low (hardening; no vulnerability — the previous behaviour is the documented purpose of these checks)"
 modules: [CheckLogFile, CheckWMI, CheckSystem, CheckDisk, CheckEventLog]
 action: conditional
 ---
-Three checks take an argument which decides *what data is read* rather than how
+Several checks take an argument which decides *what data is read* rather than how
 it is judged, and the agent reads it with its own privileges (`SYSTEM` on
 Windows, `root` or the service account on Linux):
 
@@ -22,13 +22,15 @@ Windows, `root` or the service account on Linux):
 This is the documented purpose of those checks and is not a vulnerability: on a
 host where only the configuration decides what runs, nothing here is reachable
 by a caller. It becomes a disclosure surface where the **caller** chooses the
-argument — NRPE with `allow arguments = true`, or the REST API — because a
-single check can then return the contents of any file the agent can read. Until
+argument — NRPE with `allow arguments = true`, or a REST user not on the
+no-arguments [`restricted` role](../setup/securing.md#adding-a-dedicated-user)
+— because a single check can then return the contents of any file the agent can
+read. Until
 now an operator had no way to narrow that short of disabling the module.
 
 #### What changed
 
-Each of the three modules gained an access mode and an allow list, defaulting to
+Each of these modules gained an access mode and an allow list, defaulting to
 `any` — the behaviour of every earlier release, so no installation changes on
 upgrade.
 
@@ -99,7 +101,7 @@ reaching it over REST already requires the `legacy` or `console.exec`
 permission, which is administrator-equivalent.
 
 **What to do:** nothing on upgrade. If callers can pass arguments to these
-checks — NRPE with `allow arguments = true`, or an exposed REST API — set the
-mode to `predefined` (or `allowed`) on the modules you have enabled. See
+checks — NRPE with `allow arguments = true`, or a REST user not on the
+no-arguments `restricted` role — set the mode to `predefined` (or `allowed`) on the modules you have enabled. See
 [Restricting what a check may read](../concepts/check-access.md) and the
 [securing guide](../setup/securing.md#data-disclosure-restricting-what-a-check-may-read).

--- a/docs/security/250-check-access-modes.md
+++ b/docs/security/250-check-access-modes.md
@@ -2,7 +2,7 @@
 title: "Check access modes for check_logfile, check_wmi and check_pdh"
 fixed_in: next
 severity: "Low (hardening; no vulnerability — the previous behaviour is the documented purpose of these checks)"
-modules: [CheckLogFile, CheckWMI, CheckSystem]
+modules: [CheckLogFile, CheckWMI, CheckSystem, CheckDisk]
 action: conditional
 ---
 Three checks take an argument which decides *what data is read* rather than how
@@ -14,6 +14,8 @@ Windows, `root` or the service account on Linux):
 | `check_logfile` | `file=` | any file the agent can open; the `line` and `columnN` keywords return its contents |
 | `check_wmi` | `query=` | any WMI class, including the filesystem via `CIM_DataFile` and `Win32_Directory` |
 | `check_pdh` (`check_counter`) | `counter=` | any performance object on the machine |
+| `check_files`, `check_single_file` | `path=`, `file=` | any directory tree the agent can read: every name, size and timestamp, and a checksum of any file |
+| `check_disk_write` | `file=` | creates and deletes a test file at any path the agent can write |
 
 This is the documented purpose of those checks and is not a vulnerability: on a
 host where only the configuration decides what runs, nothing here is reachable
@@ -33,6 +35,7 @@ upgrade.
 | `check_logfile` | `[/settings/logfile]` | `file access` | `allowed files` |
 | `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
 | `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
+| `check_files`, `check_single_file`, `check_disk_write` | `[/settings/disk]` | `file access` | `allowed files` |
 
 `allowed` accepts only values matching the list; `predefined` accepts only names
 the operator configured and refuses a raw value outright. Configured names
@@ -54,6 +57,15 @@ Three details matter for the strength of the control:
   queries remain usable as predefined queries.
 * **A misspelled mode fails closed.** An unrecognised value refuses every
   request and is logged at startup, rather than reading as "no restriction".
+
+The disk checks are a weaker case than `check_logfile` and were included for
+reach rather than depth: they never return file contents, but they enumerate
+whole directory trees (name, size, timestamps, executable version) and their
+checksum keywords hash any readable file, which confirms known content and for a
+short or predictable file effectively recovers it. For `check_files` only the
+scan root is held against the policy - the recursion already refuses to follow
+symbolic links and reparse points, so every file it yields is genuinely beneath
+a root which passed.
 
 Refusals name what was rejected and the section that governs it, but never the
 contents of the allow list.

--- a/docs/security/250-check-access-modes.md
+++ b/docs/security/250-check-access-modes.md
@@ -54,7 +54,13 @@ Three details matter for the strength of the control:
   symbolic links and junctions are followed, so neither a traversal out of an
   allowed directory nor a link planted inside one widens it. The resolved path
   is also the one the check opens, so nothing re-resolves the name between the
-  check and the read.
+  check and the read. Separators are folded before that resolution, and only
+  where the platform separates on them - folding afterwards would hand back a
+  path still carrying a `..` for the kernel to walk after the match had passed.
+* **An argument which is not the path still cannot leave it.** `check_files`
+  takes a `pattern`, which the scanner appends to each directory it walks; while
+  access is restricted it must be a file mask, not a path, or the scan would
+  step outside the root that passed the gate.
 * **A WMI query whose class cannot be determined with certainty is refused, not
   guessed at.** `ASSOCIATORS OF`, `REFERENCES OF`, a class path carrying a
   namespace or machine name, and multiple statements are all rejected in

--- a/docs/security/250-check-access-modes.md
+++ b/docs/security/250-check-access-modes.md
@@ -1,0 +1,76 @@
+---
+title: "Check access modes for check_logfile, check_wmi and check_pdh"
+fixed_in: next
+severity: "Low (hardening; no vulnerability — the previous behaviour is the documented purpose of these checks)"
+modules: [CheckLogFile, CheckWMI, CheckSystem]
+action: conditional
+---
+Three checks take an argument which decides *what data is read* rather than how
+it is judged, and the agent reads it with its own privileges (`SYSTEM` on
+Windows, `root` or the service account on Linux):
+
+| Check | Argument | Reach |
+|-------|----------|-------|
+| `check_logfile` | `file=` | any file the agent can open; the `line` and `columnN` keywords return its contents |
+| `check_wmi` | `query=` | any WMI class, including the filesystem via `CIM_DataFile` and `Win32_Directory` |
+| `check_pdh` (`check_counter`) | `counter=` | any performance object on the machine |
+
+This is the documented purpose of those checks and is not a vulnerability: on a
+host where only the configuration decides what runs, nothing here is reachable
+by a caller. It becomes a disclosure surface where the **caller** chooses the
+argument — NRPE with `allow arguments = true`, or the REST API — because a
+single check can then return the contents of any file the agent can read. Until
+now an operator had no way to narrow that short of disabling the module.
+
+#### What changed
+
+Each of the three modules gained an access mode and an allow list, defaulting to
+`any` — the behaviour of every earlier release, so no installation changes on
+upgrade.
+
+| Check | Section | Mode setting | Allow list |
+|-------|---------|--------------|------------|
+| `check_logfile` | `[/settings/logfile]` | `file access` | `allowed files` |
+| `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
+| `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
+
+`allowed` accepts only values matching the list; `predefined` accepts only names
+the operator configured and refuses a raw value outright. Configured names
+resolve in every mode, so a site can name its checks first and tighten the mode
+afterwards without rewriting the monitoring server's commands.
+
+Three details matter for the strength of the control:
+
+* **File paths are resolved before they are matched.** `..` is flattened and
+  symbolic links and junctions are followed, so neither a traversal out of an
+  allowed directory nor a link planted inside one widens it. The resolved path
+  is also the one the check opens, so nothing re-resolves the name between the
+  check and the read.
+* **A WMI query whose class cannot be determined with certainty is refused, not
+  guessed at.** `ASSOCIATORS OF`, `REFERENCES OF`, a class path carrying a
+  namespace or machine name, and multiple statements are all rejected in
+  `allowed` mode; approving the trailing identifier of a qualified path would
+  let the query read from a provider the allow list never permitted. Such
+  queries remain usable as predefined queries.
+* **A misspelled mode fails closed.** An unrecognised value refuses every
+  request and is logged at startup, rather than reading as "no restriction".
+
+Refusals name what was rejected and the section that governs it, but never the
+contents of the allow list.
+
+While `query access` is not `any`, `check_wmi` additionally requires
+`namespace=` to match `allowed namespaces` (an empty list meaning the default
+`root\cimv2` only), and requires `target=` to name a target defined in
+`[/settings/wmi/targets]` — an unknown target was otherwise taken as a bare host
+name, which would let a caller point a restricted check at a machine of its own
+choosing.
+
+The `nscp wmi` command line is unchanged: it is a local administrative tool, and
+reaching it over REST already requires the `legacy` or `console.exec`
+permission, which is administrator-equivalent.
+
+**What to do:** nothing on upgrade. If callers can pass arguments to these
+checks — NRPE with `allow arguments = true`, or an exposed REST API — set the
+mode to `predefined` (or `allowed`) on the modules you have enabled. See
+[Restricting what a check may read](../concepts/check-access.md) and the
+[securing guide](../setup/securing.md#data-disclosure-restricting-what-a-check-may-read).

--- a/docs/security/250-check-access-modes.md
+++ b/docs/security/250-check-access-modes.md
@@ -2,7 +2,7 @@
 title: "Check access modes for check_logfile, check_wmi and check_pdh"
 fixed_in: next
 severity: "Low (hardening; no vulnerability — the previous behaviour is the documented purpose of these checks)"
-modules: [CheckLogFile, CheckWMI, CheckSystem, CheckDisk]
+modules: [CheckLogFile, CheckWMI, CheckSystem, CheckDisk, CheckEventLog]
 action: conditional
 ---
 Three checks take an argument which decides *what data is read* rather than how
@@ -16,6 +16,8 @@ Windows, `root` or the service account on Linux):
 | `check_pdh` (`check_counter`) | `counter=` | any performance object on the machine |
 | `check_files`, `check_single_file` | `path=`, `file=` | any directory tree the agent can read: every name, size and timestamp, and a checksum of any file |
 | `check_disk_write` | `file=` | creates and deletes a test file at any path the agent can write |
+| `check_registry_key`, `check_registry_value` | `key=` | any registry key, and the value data itself, with binary rendered as hex |
+| `check_eventlog` | `file=`, `log=` | any event log channel, and the event text itself |
 
 This is the documented purpose of those checks and is not a vulnerability: on a
 host where only the configuration decides what runs, nothing here is reachable
@@ -36,6 +38,8 @@ upgrade.
 | `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
 | `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
 | `check_files`, `check_single_file`, `check_disk_write` | `[/settings/disk]` | `file access` | `allowed files` |
+| `check_registry_key`, `check_registry_value` | `[/settings/system/windows]` | `registry access` | `allowed registry keys` |
+| `check_eventlog` | `[/settings/eventlog]` | `log access` | `allowed logs` |
 
 `allowed` accepts only values matching the list; `predefined` accepts only names
 the operator configured and refuses a raw value outright. Configured names
@@ -57,6 +61,19 @@ Three details matter for the strength of the control:
   queries remain usable as predefined queries.
 * **A misspelled mode fails closed.** An unrecognised value refuses every
   request and is logged at startup, rather than reading as "no restriction".
+
+The registry and event-log gates cover the two widest reads of the set, and both
+return content in their *default* rendering, so a caller needs no syntax argument
+to receive it. `check_registry_value` renders `REG_BINARY` as hex and will walk a
+whole subtree with `recursive=true`; `check_eventlog` returns event text through
+`message`, `strings` and `xml` from any channel the agent can read. Their
+allow-list entries are hierarchical rather than glob - an entry covers that key or
+channel and everything below it, matched on whole name segments, so
+`HKLM\SOFTWARE\MyApp` cannot be widened into `HKLM\SOFTWARE\MyAppOther` - and
+both registry hive spellings compare equal. Only the starting key or channel is
+checked, because enumeration below it cannot leave the subtree. While registry
+access is restricted the `computer=` argument is refused, so the local registry is
+the only one reachable.
 
 The disk checks are a weaker case than `check_logfile` and were included for
 reach rather than depth: they never return file contents, but they enumerate

--- a/docs/upgrades/next/check-access-modes.md
+++ b/docs/upgrades/next/check-access-modes.md
@@ -1,6 +1,6 @@
 ---
 icon: "🔒 🔧"
-modules: [CheckLogFile, CheckWMI, CheckSystem, CheckDisk]
+modules: [CheckLogFile, CheckWMI, CheckSystem, CheckDisk, CheckEventLog]
 action: none
 ---
 **The checks whose argument decides *what data is read* can now be told which
@@ -17,15 +17,23 @@ file-read primitive. Each module gained a mode setting and an allow list:
 | `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
 | `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
 | `check_files`, `check_single_file`, `check_disk_write` | `[/settings/disk]` | `file access` | `allowed files` |
+| `check_registry_key`, `check_registry_value` | `[/settings/system/windows]` | `registry access` | `allowed registry keys` |
+| `check_eventlog` | `[/settings/eventlog]` | `log access` | `allowed logs` |
 
 The modes are `any`, `allowed` (only what matches the list) and `predefined`
 (only names you configured — `[/settings/logfile/files]`,
-`[/settings/wmi/queries]`, `[/settings/disk/files]`, and for `check_pdh` the
-counters already in `[/settings/system/windows/counters]`). Configured names resolve in every mode,
-so you can name your checks first and tighten the mode afterwards. Two things
-only take effect once a mode is set: a `check_wmi` `namespace=` may then no
-longer be moved off `root\cimv2` unless `allowed namespaces` says so, and
-`target=` must name a target defined in `[/settings/wmi/targets]`. See
+`[/settings/wmi/queries]`, `[/settings/disk/files]`,
+`[/settings/system/windows/registry]`, `[/settings/eventlog/logs]`, and for
+`check_pdh` the counters already in `[/settings/system/windows/counters]`).
+Registry and event-log entries are hierarchical: an entry covers that key or
+channel and everything below it, matched on whole name segments. Configured names resolve in every mode,
+so you can name your checks first and tighten the mode afterwards. Some arguments
+only tighten once a mode is set: a `check_wmi` `namespace=` may then no longer be
+moved off `root\cimv2` unless `allowed namespaces` says so, `check_wmi`
+`target=` must name a target defined in `[/settings/wmi/targets]`,
+`check_registry_*` refuses `computer=` so only the local registry is read, and
+`check_eventlog`'s default `Application`/`System` channels go through the gate
+like any other. See
 [Restricting what a check may read](../concepts/check-access.md), the
 [securing guide](securing.md#data-disclosure-restricting-what-a-check-may-read)
 and the

--- a/docs/upgrades/next/check-access-modes.md
+++ b/docs/upgrades/next/check-access-modes.md
@@ -1,10 +1,10 @@
 ---
 icon: "🔒 🔧"
-modules: [CheckLogFile, CheckWMI, CheckSystem]
+modules: [CheckLogFile, CheckWMI, CheckSystem, CheckDisk]
 action: none
 ---
-**`check_logfile`, `check_wmi` and `check_pdh` can now be told which files,
-queries and counters a caller may ask for.** Nothing to do on upgrade: all
+**The checks whose argument decides *what data is read* can now be told which
+files, queries and counters a caller may ask for.** Nothing to do on upgrade: all
 three default to `any`, which is exactly what earlier releases did. Those
 checks take an argument that decides *what data is read*, and the agent reads
 it with its own privileges — so where callers choose the argument (NRPE with
@@ -16,11 +16,12 @@ file-read primitive. Each module gained a mode setting and an allow list:
 | `check_logfile` | `[/settings/logfile]` | `file access` | `allowed files` |
 | `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
 | `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
+| `check_files`, `check_single_file`, `check_disk_write` | `[/settings/disk]` | `file access` | `allowed files` |
 
 The modes are `any`, `allowed` (only what matches the list) and `predefined`
 (only names you configured — `[/settings/logfile/files]`,
-`[/settings/wmi/queries]`, and for `check_pdh` the counters already in
-`[/settings/system/windows/counters]`). Configured names resolve in every mode,
+`[/settings/wmi/queries]`, `[/settings/disk/files]`, and for `check_pdh` the
+counters already in `[/settings/system/windows/counters]`). Configured names resolve in every mode,
 so you can name your checks first and tighten the mode afterwards. Two things
 only take effect once a mode is set: a `check_wmi` `namespace=` may then no
 longer be moved off `root\cimv2` unless `allowed namespaces` says so, and

--- a/docs/upgrades/next/check-access-modes.md
+++ b/docs/upgrades/next/check-access-modes.md
@@ -4,12 +4,13 @@ modules: [CheckLogFile, CheckWMI, CheckSystem, CheckDisk, CheckEventLog]
 action: none
 ---
 **The checks whose argument decides *what data is read* can now be told which
-files, queries and counters a caller may ask for.** Nothing to do on upgrade: all
-three default to `any`, which is exactly what earlier releases did. Those
+files, queries and counters a caller may ask for.** Nothing to do on upgrade: they
+all default to `any`, which is exactly what earlier releases did. Those
 checks take an argument that decides *what data is read*, and the agent reads
 it with its own privileges — so where callers choose the argument (NRPE with
-`allow arguments = true`, or the REST API) an unrestricted `file=` is a general
-file-read primitive. Each module gained a mode setting and an allow list:
+`allow arguments = true`, or a REST user not on the no-arguments
+[`restricted` role](securing.md#adding-a-dedicated-user)) an
+unrestricted `file=` is a general file-read primitive. Each module gained a mode setting and an allow list:
 
 | Check | Section | Mode setting | Allow list |
 |-------|---------|--------------|------------|
@@ -37,4 +38,4 @@ like any other. See
 [Restricting what a check may read](../concepts/check-access.md), the
 [securing guide](securing.md#data-disclosure-restricting-what-a-check-may-read)
 and the
-[security notice](../security/notices.md#check-access-modes-for-check_logfile-check_wmi-and-check_pdh).
+[security notice](../security/notices.md#access-modes-for-the-checks-whose-argument-decides-what-is-read).

--- a/docs/upgrades/next/check-access-modes.md
+++ b/docs/upgrades/next/check-access-modes.md
@@ -1,0 +1,31 @@
+---
+icon: "🔒 🔧"
+modules: [CheckLogFile, CheckWMI, CheckSystem]
+action: none
+---
+**`check_logfile`, `check_wmi` and `check_pdh` can now be told which files,
+queries and counters a caller may ask for.** Nothing to do on upgrade: all
+three default to `any`, which is exactly what earlier releases did. Those
+checks take an argument that decides *what data is read*, and the agent reads
+it with its own privileges — so where callers choose the argument (NRPE with
+`allow arguments = true`, or the REST API) an unrestricted `file=` is a general
+file-read primitive. Each module gained a mode setting and an allow list:
+
+| Check | Section | Mode setting | Allow list |
+|-------|---------|--------------|------------|
+| `check_logfile` | `[/settings/logfile]` | `file access` | `allowed files` |
+| `check_wmi` | `[/settings/wmi]` | `query access` | `allowed classes`, `allowed namespaces` |
+| `check_pdh` | `[/settings/system/windows]` | `counter access` | `allowed counters` |
+
+The modes are `any`, `allowed` (only what matches the list) and `predefined`
+(only names you configured — `[/settings/logfile/files]`,
+`[/settings/wmi/queries]`, and for `check_pdh` the counters already in
+`[/settings/system/windows/counters]`). Configured names resolve in every mode,
+so you can name your checks first and tighten the mode afterwards. Two things
+only take effect once a mode is set: a `check_wmi` `namespace=` may then no
+longer be moved off `root\cimv2` unless `allowed namespaces` says so, and
+`target=` must name a target defined in `[/settings/wmi/targets]`. See
+[Restricting what a check may read](../concepts/check-access.md), the
+[securing guide](securing.md#data-disclosure-restricting-what-a-check-may-read)
+and the
+[security notice](../security/notices.md#check-access-modes-for-check_logfile-check_wmi-and-check_pdh).

--- a/docs/upgrades/next/check-files-skips-file-symlinks.md
+++ b/docs/upgrades/next/check-files-skips-file-symlinks.md
@@ -1,0 +1,16 @@
+---
+icon: "🔒"
+modules: [CheckDisk]
+action: conditional
+---
+**`check_files` no longer follows file symbolic links on Windows.** The scan
+already skipped directory reparse points (junctions, mount points, directory
+links); it now skips file symlinks too, as the Linux scanner always has, so a
+link planted inside a scanned tree can no longer make the checksum, `line_count`
+or `version` keywords read a file outside it. Deduplicated and cloud-backed files
+are still counted. If you relied on `check_files` counting file symlinks, point
+it at the link targets instead. Path allow-list wildcards also changed: `*` and
+`?` in an `allowed files` entry no longer cross a directory separator, so
+`C:/logs/*.log` covers the files in `C:/logs` only; write `C:/logs/**.log` for
+the subtree. See
+[Restricting what a check may read](../concepts/check-access.md#check_files-check_single_file-and-check_disk_write).

--- a/docs/upgrades/next/checklogfile-files-argument-works.md
+++ b/docs/upgrades/next/checklogfile-files-argument-works.md
@@ -1,0 +1,14 @@
+---
+icon: "🔧"
+modules: [CheckLogFile]
+action: conditional
+---
+**`check_logfile files=` now does what it says.** The comma-separated form of
+`file=` was parsed before the check read its arguments, so it has been ignored
+for as long as anyone is likely to have tried it: a check passing only `files=`
+failed with *Need to specify at least one file*, and one passing both `file=`
+and `files=` silently read only the `file=` entries. Both now work, and the two are one list rather than one
+overriding the other. If a check of yours passes both, it will read the union
+from this release on - and every name goes through `file access` in
+`[/settings/logfile]` exactly like a `file=` one. Nothing to do unless you were
+relying on the entries being dropped.

--- a/include/check/access_policy.hpp
+++ b/include/check/access_policy.hpp
@@ -7,7 +7,6 @@
 #include <boost/regex.hpp>
 #include <map>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -39,12 +38,19 @@
 //
 // A policy is read by the check threads and rewritten by a settings reload,
 // which calls loadModuleEx again on the live module while those threads run.
-// Every accessor therefore takes a shared lock and every mutator an exclusive
-// one, and a mutator replaces its part of the state in one step: the gate is
-// never observed half-rebuilt, and a reload never opens it - `reset()` drops
-// only the predefined entries, which the settings callbacks re-add, while the
-// mode and the allow list keep their previous values until notify() writes
-// the new ones over them.
+// Every accessor and every mutator therefore takes the lock, and a mutator
+// replaces its part of the state in one step: the gate is never observed
+// half-rebuilt, and a reload never opens it - `reset()` drops only the
+// predefined entries, which the settings callbacks re-add, while the mode and
+// the allow list keep their previous values until notify() writes the new ones
+// over them.
+//
+// A plain mutex, not a shared_mutex: the XP build defines _WIN32_WINNT=0x0501
+// and MSVC's <shared_mutex> is empty below Vista, because it is built on
+// SRWLOCK (net/socket/allowed_hosts.hpp makes the same choice for the same
+// reason). Nothing is lost by it - the critical sections are a mode read, a
+// map lookup and a walk of a handful of patterns, so there was never a
+// reader/writer win to have.
 
 namespace check {
 namespace access {
@@ -170,7 +176,7 @@ class policy {
   // own.
   policy(const policy &other)
       : noun_(other.noun_), nouns_(other.nouns_), settings_path_(other.settings_path_), case_sensitive_(other.case_sensitive_), mode_(mode::any) {
-    std::shared_lock<std::shared_mutex> lock(other.mutex_);
+    std::lock_guard<std::mutex> lock(other.mutex_);
     mode_ = other.mode_;
     config_error_ = other.config_error_;
     patterns_ = other.patterns_;
@@ -180,7 +186,7 @@ class policy {
   policy &operator=(const policy &other) {
     if (this == &other) return *this;
     policy copy(other);
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     noun_ = copy.noun_;
     nouns_ = copy.nouns_;
     settings_path_ = copy.settings_path_;
@@ -205,7 +211,7 @@ class policy {
       error = "invalid '" + noun_ + " access' in [" + settings_path_ + "]: '" + value + "' (expected any, allowed or predefined)";
       m = mode::predefined;
     }
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     config_error_.swap(error);
     mode_ = m;
   }
@@ -232,17 +238,17 @@ class policy {
         // list by throwing out of settings notification.
       }
     }
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     patterns_.swap(patterns);
     raw_patterns_.swap(raw_patterns);
   }
 
   void add_predefined(const std::string &name, const std::string &value) {
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     predefined_[name] = value;
   }
   void clear_predefined() {
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     predefined_.clear();
   }
 
@@ -257,38 +263,38 @@ class policy {
   // --- state ---------------------------------------------------------------
 
   mode get_mode() const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return mode_;
   }
   const std::string &get_settings_path() const { return settings_path_; }
   const std::string &get_noun() const { return noun_; }
   const std::string &get_nouns() const { return nouns_; }
   bool is_restricted() const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return mode_ != mode::any || !config_error_.empty();
   }
   std::string get_config_error() const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return config_error_;
   }
   bool has_predefined(const std::string &name) const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return predefined_.find(name) != predefined_.end();
   }
   bool lookup_predefined(const std::string &name, std::string &out) const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     const std::map<std::string, std::string>::const_iterator it = predefined_.find(name);
     if (it == predefined_.end()) return false;
     out = it->second;
     return true;
   }
   std::size_t allow_list_size() const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return patterns_.size();
   }
 
   bool matches_allow_list(const std::string &value) const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return matches_allow_list_unlocked(value);
   }
 
@@ -296,7 +302,7 @@ class policy {
 
   // Resolve one caller-supplied token into the value the check should use.
   decision resolve(const std::string &token) const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     const std::map<std::string, std::string>::const_iterator it = predefined_.find(token);
     if (it != predefined_.end()) return decision::accept(it->second);
 
@@ -337,7 +343,7 @@ class policy {
   std::string nouns_;
   std::string settings_path_;
   bool case_sensitive_;
-  mutable std::shared_mutex mutex_;
+  mutable std::mutex mutex_;
   mode mode_;
   std::string config_error_;
   std::vector<boost::regex> patterns_;

--- a/include/check/access_policy.hpp
+++ b/include/check/access_policy.hpp
@@ -209,6 +209,8 @@ class policy {
 
   mode get_mode() const { return mode_; }
   const std::string &get_settings_path() const { return settings_path_; }
+  const std::string &get_noun() const { return noun_; }
+  const std::string &get_nouns() const { return nouns_; }
   bool is_restricted() const { return mode_ != mode::any || !config_error_.empty(); }
   const std::string &get_config_error() const { return config_error_; }
   bool has_predefined(const std::string &name) const { return predefined_.find(name) != predefined_.end(); }

--- a/include/check/access_policy.hpp
+++ b/include/check/access_policy.hpp
@@ -1,0 +1,275 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <boost/algorithm/string.hpp>
+#include <boost/regex.hpp>
+#include <map>
+#include <string>
+#include <vector>
+
+// A shared gate for the checks whose argument names *what data is read* rather
+// than how it is judged: `check_logfile file=`, `check_wmi query=`,
+// `check_pdh counter=`.
+//
+// Those arguments are open by design - the whole point of check_logfile is to
+// read the log file you name - but where the caller is a remote monitoring
+// server (NRPE with `allow arguments`, or REST) the agent runs as SYSTEM/root
+// and the argument decides which of the machine's data comes back. An operator
+// who only wants two log files watched has, until now, had no way to say so.
+//
+// This is that knob. Three modes, per check:
+//
+//   any         Anything the caller names is read. The default, and what every
+//               release before this one did, so an upgrade changes nothing.
+//   allowed     Only values matching `allowed <nouns>` are read.
+//   predefined  Only names the operator defined in configuration are read; a
+//               raw value from the caller is refused.
+//
+// Predefined entries are operator-authored, so they resolve in *every* mode,
+// including `any`. That ordering is what lets a site name its checks first and
+// tighten the mode afterwards without rewriting the monitoring server's
+// commands.
+//
+// The path-shaped variant (file names, which need `..` and symlinks resolved
+// before they can be matched) lives in check/path_access_policy.hpp.
+
+namespace check {
+namespace access {
+
+enum class mode { any, allowed, predefined };
+
+inline std::string to_string(const mode m) {
+  switch (m) {
+    case mode::allowed:
+      return "allowed";
+    case mode::predefined:
+      return "predefined";
+    case mode::any:
+    default:
+      return "any";
+  }
+}
+
+// Parse a configured mode. Returns false on an unrecognised value, which the
+// caller turns into a refusal rather than a silent fall back to `any`: a typo
+// in a security setting must not read as "no restriction".
+inline bool parse_mode(const std::string &value, mode &out) {
+  const std::string v = boost::algorithm::to_lower_copy(boost::algorithm::trim_copy(value));
+  if (v.empty() || v == "any" || v == "all" || v == "unrestricted") {
+    out = mode::any;
+    return true;
+  }
+  if (v == "allowed" || v == "allow" || v == "list") {
+    out = mode::allowed;
+    return true;
+  }
+  if (v == "predefined" || v == "defined" || v == "named") {
+    out = mode::predefined;
+    return true;
+  }
+  return false;
+}
+
+// Translate a shell-style glob into a regular expression which matches it
+// literally apart from `*` and `?`.
+//
+// file_helpers::patterns::glob_to_regexp escapes only `.`, which is fine for
+// the file masks it was written for but not here: a PDH counter is
+// `\Processor(_Total)\% Processor Time` and a WMI class can be `Win32_*`, so
+// `\`, `(`, `)` and `+` all have to survive as literals. An unescaped `(`
+// would silently turn an allow-list entry into a capture group and change what
+// it matches.
+inline std::string glob_to_regex(const std::string &glob) {
+  std::string re;
+  re.reserve(glob.size() * 2);
+  for (const char c : glob) {
+    switch (c) {
+      case '*':
+        re += ".*";
+        break;
+      case '?':
+        re += '.';
+        break;
+      case '.':
+      case '\\':
+      case '+':
+      case '^':
+      case '$':
+      case '(':
+      case ')':
+      case '[':
+      case ']':
+      case '{':
+      case '}':
+      case '|':
+        re += '\\';
+        re += c;
+        break;
+      default:
+        re += c;
+        break;
+    }
+  }
+  return re;
+}
+
+// The outcome of resolving one caller-supplied token.
+//
+// `value` is what the check should actually use: the token itself when it was
+// accepted verbatim, or the operator-configured expansion when the token named
+// a predefined entry. `error` is operator-facing and names the rejected token
+// and the setting which would permit it - never the contents of the allow
+// list, which the caller has no business enumerating.
+struct decision {
+  bool allowed;
+  std::string value;
+  std::string error;
+
+  decision() : allowed(false) {}
+
+  static decision accept(std::string value) {
+    decision d;
+    d.allowed = true;
+    d.value = std::move(value);
+    return d;
+  }
+  static decision refuse(std::string error) {
+    decision d;
+    d.allowed = false;
+    d.error = std::move(error);
+    return d;
+  }
+};
+
+// One check's policy: the mode, the allow list, and the predefined entries.
+//
+// `noun` is what a single value is ("file", "query", "counter") and `nouns`
+// its plural, used to build both the error messages and the names of the
+// settings quoted in them. `settings_path` is the section the keys live in, so
+// an operator reading the error knows where to go.
+class policy {
+ public:
+  policy(std::string noun, std::string nouns, std::string settings_path, const bool case_sensitive = false)
+      : noun_(std::move(noun)), nouns_(std::move(nouns)), settings_path_(std::move(settings_path)), case_sensitive_(case_sensitive), mode_(mode::any) {}
+
+  // --- configuration -------------------------------------------------------
+
+  // A mode which does not parse is remembered as a configuration error and
+  // refuses every value, so a typo fails closed and says so once per check
+  // rather than quietly opening the gate.
+  void set_mode(const std::string &value) {
+    mode m = mode::any;
+    if (!parse_mode(value, m)) {
+      config_error_ = "invalid '" + noun_ + " access' in [" + settings_path_ + "]: '" + value + "' (expected any, allowed or predefined)";
+      mode_ = mode::predefined;
+      return;
+    }
+    config_error_.clear();
+    mode_ = m;
+  }
+
+  void set_allow_list(const std::string &value) {
+    patterns_.clear();
+    raw_patterns_.clear();
+    std::vector<std::string> entries;
+    boost::algorithm::split(entries, value, boost::algorithm::is_any_of(","));
+    for (std::string &entry : entries) {
+      boost::algorithm::trim(entry);
+      if (entry.empty()) continue;
+      raw_patterns_.push_back(entry);
+      boost::regex::flag_type flags = boost::regex::perl;
+      if (!case_sensitive_) flags |= boost::regex::icase;
+      try {
+        patterns_.emplace_back(glob_to_regex(entry), flags);
+      } catch (const boost::regex_error &) {
+        // glob_to_regex escapes every metacharacter, so this should not be
+        // reachable; drop the entry rather than let a malformed one widen the
+        // list by throwing out of settings notification.
+        raw_patterns_.pop_back();
+      }
+    }
+  }
+
+  void add_predefined(const std::string &name, const std::string &value) { predefined_[name] = value; }
+  void clear_predefined() { predefined_.clear(); }
+
+  // Settings callbacks append, so a reload has to start from nothing or every
+  // reload doubles the list (see the reload rule in CLAUDE.md).
+  void reset() {
+    patterns_.clear();
+    raw_patterns_.clear();
+    predefined_.clear();
+    config_error_.clear();
+    mode_ = mode::any;
+  }
+
+  // --- state ---------------------------------------------------------------
+
+  mode get_mode() const { return mode_; }
+  const std::string &get_settings_path() const { return settings_path_; }
+  bool is_restricted() const { return mode_ != mode::any || !config_error_.empty(); }
+  const std::string &get_config_error() const { return config_error_; }
+  bool has_predefined(const std::string &name) const { return predefined_.find(name) != predefined_.end(); }
+  bool lookup_predefined(const std::string &name, std::string &out) const {
+    const std::map<std::string, std::string>::const_iterator it = predefined_.find(name);
+    if (it == predefined_.end()) return false;
+    out = it->second;
+    return true;
+  }
+  std::size_t allow_list_size() const { return patterns_.size(); }
+
+  bool matches_allow_list(const std::string &value) const {
+    for (const boost::regex &re : patterns_) {
+      if (boost::regex_match(value, re)) return true;
+    }
+    return false;
+  }
+
+  // --- resolution ----------------------------------------------------------
+
+  // Resolve one caller-supplied token into the value the check should use.
+  decision resolve(const std::string &token) const {
+    const std::map<std::string, std::string>::const_iterator it = predefined_.find(token);
+    if (it != predefined_.end()) return decision::accept(it->second);
+
+    if (!config_error_.empty()) return decision::refuse(config_error_);
+
+    switch (mode_) {
+      case mode::any:
+        return decision::accept(token);
+      case mode::allowed:
+        if (matches_allow_list(token)) return decision::accept(token);
+        return decision::refuse(refusal(token, "it is not in 'allowed " + nouns_ + "'"));
+      case mode::predefined:
+      default:
+        return decision::refuse(refusal(token, "'" + noun_ + " access' is set to predefined, so only a configured " + noun_ + " name may be used"));
+    }
+  }
+
+  // Check a value which is not itself the token - a WMI class extracted from a
+  // query, a namespace - against a second allow list held by another policy.
+  decision check_value(const std::string &value, const std::string &what) const {
+    if (matches_allow_list(value)) return decision::accept(value);
+    return decision::refuse("Refusing " + what + " '" + value + "': it is not in 'allowed " + nouns_ + "' in [" + settings_path_ + "]");
+  }
+
+ private:
+  std::string refusal(const std::string &token, const std::string &why) const {
+    return "Refusing " + noun_ + " '" + token + "': " + why + " (see [" + settings_path_ + "] in the configuration)";
+  }
+
+  std::string noun_;
+  std::string nouns_;
+  std::string settings_path_;
+  bool case_sensitive_;
+  mode mode_;
+  std::string config_error_;
+  std::vector<boost::regex> patterns_;
+  std::vector<std::string> raw_patterns_;
+  std::map<std::string, std::string> predefined_;
+};
+
+}  // namespace access
+}  // namespace check

--- a/include/check/access_policy.hpp
+++ b/include/check/access_policy.hpp
@@ -6,6 +6,8 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/regex.hpp>
 #include <map>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -34,6 +36,15 @@
 //
 // The path-shaped variant (file names, which need `..` and symlinks resolved
 // before they can be matched) lives in check/path_access_policy.hpp.
+//
+// A policy is read by the check threads and rewritten by a settings reload,
+// which calls loadModuleEx again on the live module while those threads run.
+// Every accessor therefore takes a shared lock and every mutator an exclusive
+// one, and a mutator replaces its part of the state in one step: the gate is
+// never observed half-rebuilt, and a reload never opens it - `reset()` drops
+// only the predefined entries, which the settings callbacks re-add, while the
+// mode and the allow list keep their previous values until notify() writes
+// the new ones over them.
 
 namespace check {
 namespace access {
@@ -154,6 +165,34 @@ class policy {
   policy(std::string noun, std::string nouns, std::string settings_path, const bool case_sensitive = false)
       : noun_(std::move(noun)), nouns_(std::move(nouns)), settings_path_(std::move(settings_path)), case_sensitive_(case_sensitive), mode_(mode::any) {}
 
+  // A mutex is neither copyable nor movable, so copying a policy copies its
+  // configuration under the source's lock and gives the copy a lock of its
+  // own.
+  policy(const policy &other)
+      : noun_(other.noun_), nouns_(other.nouns_), settings_path_(other.settings_path_), case_sensitive_(other.case_sensitive_), mode_(mode::any) {
+    std::shared_lock<std::shared_mutex> lock(other.mutex_);
+    mode_ = other.mode_;
+    config_error_ = other.config_error_;
+    patterns_ = other.patterns_;
+    raw_patterns_ = other.raw_patterns_;
+    predefined_ = other.predefined_;
+  }
+  policy &operator=(const policy &other) {
+    if (this == &other) return *this;
+    policy copy(other);
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    noun_ = copy.noun_;
+    nouns_ = copy.nouns_;
+    settings_path_ = copy.settings_path_;
+    case_sensitive_ = copy.case_sensitive_;
+    mode_ = copy.mode_;
+    config_error_ = copy.config_error_;
+    patterns_.swap(copy.patterns_);
+    raw_patterns_.swap(copy.raw_patterns_);
+    predefined_.swap(copy.predefined_);
+    return *this;
+  }
+
   // --- configuration -------------------------------------------------------
 
   // A mode which does not parse is remembered as a configuration error and
@@ -161,78 +200,103 @@ class policy {
   // rather than quietly opening the gate.
   void set_mode(const std::string &value) {
     mode m = mode::any;
+    std::string error;
     if (!parse_mode(value, m)) {
-      config_error_ = "invalid '" + noun_ + " access' in [" + settings_path_ + "]: '" + value + "' (expected any, allowed or predefined)";
-      mode_ = mode::predefined;
-      return;
+      error = "invalid '" + noun_ + " access' in [" + settings_path_ + "]: '" + value + "' (expected any, allowed or predefined)";
+      m = mode::predefined;
     }
-    config_error_.clear();
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    config_error_.swap(error);
     mode_ = m;
   }
 
+  // The new list is built beside the old one and swapped in whole, so a check
+  // running through a reload sees either the previous list or the new one and
+  // never an empty or half-filled one.
   void set_allow_list(const std::string &value) {
-    patterns_.clear();
-    raw_patterns_.clear();
+    std::vector<boost::regex> patterns;
+    std::vector<std::string> raw_patterns;
     std::vector<std::string> entries;
     boost::algorithm::split(entries, value, boost::algorithm::is_any_of(","));
     for (std::string &entry : entries) {
       boost::algorithm::trim(entry);
       if (entry.empty()) continue;
-      raw_patterns_.push_back(entry);
       boost::regex::flag_type flags = boost::regex::perl;
       if (!case_sensitive_) flags |= boost::regex::icase;
       try {
-        patterns_.emplace_back(glob_to_regex(entry), flags);
+        patterns.emplace_back(glob_to_regex(entry), flags);
+        raw_patterns.push_back(entry);
       } catch (const boost::regex_error &) {
         // glob_to_regex escapes every metacharacter, so this should not be
         // reachable; drop the entry rather than let a malformed one widen the
         // list by throwing out of settings notification.
-        raw_patterns_.pop_back();
       }
     }
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    patterns_.swap(patterns);
+    raw_patterns_.swap(raw_patterns);
   }
 
-  void add_predefined(const std::string &name, const std::string &value) { predefined_[name] = value; }
-  void clear_predefined() { predefined_.clear(); }
-
-  // Settings callbacks append, so a reload has to start from nothing or every
-  // reload doubles the list (see the reload rule in CLAUDE.md).
-  void reset() {
-    patterns_.clear();
-    raw_patterns_.clear();
+  void add_predefined(const std::string &name, const std::string &value) {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    predefined_[name] = value;
+  }
+  void clear_predefined() {
+    std::unique_lock<std::shared_mutex> lock(mutex_);
     predefined_.clear();
-    config_error_.clear();
-    mode_ = mode::any;
   }
+
+  // Called at the top of loadModuleEx before the settings are re-read. The
+  // predefined entries are the one thing the callbacks *append* to, so they
+  // have to start from nothing or every reload doubles them (the reload rule
+  // in CLAUDE.md). The mode and the allow list are *replaced* by their
+  // callbacks and are left alone here: dropping them would open the gate for
+  // every check which arrives between this call and settings.notify().
+  void reset() { clear_predefined(); }
 
   // --- state ---------------------------------------------------------------
 
-  mode get_mode() const { return mode_; }
+  mode get_mode() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return mode_;
+  }
   const std::string &get_settings_path() const { return settings_path_; }
   const std::string &get_noun() const { return noun_; }
   const std::string &get_nouns() const { return nouns_; }
-  bool is_restricted() const { return mode_ != mode::any || !config_error_.empty(); }
-  const std::string &get_config_error() const { return config_error_; }
-  bool has_predefined(const std::string &name) const { return predefined_.find(name) != predefined_.end(); }
+  bool is_restricted() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return mode_ != mode::any || !config_error_.empty();
+  }
+  std::string get_config_error() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return config_error_;
+  }
+  bool has_predefined(const std::string &name) const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return predefined_.find(name) != predefined_.end();
+  }
   bool lookup_predefined(const std::string &name, std::string &out) const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
     const std::map<std::string, std::string>::const_iterator it = predefined_.find(name);
     if (it == predefined_.end()) return false;
     out = it->second;
     return true;
   }
-  std::size_t allow_list_size() const { return patterns_.size(); }
+  std::size_t allow_list_size() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return patterns_.size();
+  }
 
   bool matches_allow_list(const std::string &value) const {
-    for (const boost::regex &re : patterns_) {
-      if (boost::regex_match(value, re)) return true;
-    }
-    return false;
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return matches_allow_list_unlocked(value);
   }
 
   // --- resolution ----------------------------------------------------------
 
   // Resolve one caller-supplied token into the value the check should use.
   decision resolve(const std::string &token) const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
     const std::map<std::string, std::string>::const_iterator it = predefined_.find(token);
     if (it != predefined_.end()) return decision::accept(it->second);
 
@@ -242,7 +306,7 @@ class policy {
       case mode::any:
         return decision::accept(token);
       case mode::allowed:
-        if (matches_allow_list(token)) return decision::accept(token);
+        if (matches_allow_list_unlocked(token)) return decision::accept(token);
         return decision::refuse(refusal(token, "it is not in 'allowed " + nouns_ + "'"));
       case mode::predefined:
       default:
@@ -258,6 +322,13 @@ class policy {
   }
 
  private:
+  bool matches_allow_list_unlocked(const std::string &value) const {
+    for (const boost::regex &re : patterns_) {
+      if (boost::regex_match(value, re)) return true;
+    }
+    return false;
+  }
+
   std::string refusal(const std::string &token, const std::string &why) const {
     return "Refusing " + noun_ + " '" + token + "': " + why + " (see [" + settings_path_ + "] in the configuration)";
   }
@@ -266,6 +337,7 @@ class policy {
   std::string nouns_;
   std::string settings_path_;
   bool case_sensitive_;
+  mutable std::shared_mutex mutex_;
   mode mode_;
   std::string config_error_;
   std::vector<boost::regex> patterns_;

--- a/include/check/access_policy_test.cpp
+++ b/include/check/access_policy_test.cpp
@@ -1,0 +1,428 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include <check/access_policy.hpp>
+#include <check/path_access_policy.hpp>
+#include <check/wql_query.hpp>
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <gtest/gtest.h>
+
+namespace fs = boost::filesystem;
+using check::access::decision;
+using check::access::mode;
+
+namespace {
+
+check::access::policy make_policy() { return check::access::policy("counter", "counters", "/settings/system/windows"); }
+
+// ---------------------------------------------------------------------------
+// mode parsing
+// ---------------------------------------------------------------------------
+
+TEST(access_mode, parses_the_documented_spellings) {
+  mode m = mode::predefined;
+  EXPECT_TRUE(check::access::parse_mode("any", m));
+  EXPECT_EQ(mode::any, m);
+  EXPECT_TRUE(check::access::parse_mode("allowed", m));
+  EXPECT_EQ(mode::allowed, m);
+  EXPECT_TRUE(check::access::parse_mode("predefined", m));
+  EXPECT_EQ(mode::predefined, m);
+}
+
+TEST(access_mode, is_case_and_whitespace_insensitive) {
+  mode m = mode::any;
+  EXPECT_TRUE(check::access::parse_mode("  PreDefined \t", m));
+  EXPECT_EQ(mode::predefined, m);
+}
+
+TEST(access_mode, an_unset_value_is_any) {
+  mode m = mode::predefined;
+  EXPECT_TRUE(check::access::parse_mode("", m));
+  EXPECT_EQ(mode::any, m);
+}
+
+TEST(access_mode, rejects_an_unknown_value) {
+  mode m = mode::any;
+  EXPECT_FALSE(check::access::parse_mode("predefinedd", m));
+  EXPECT_FALSE(check::access::parse_mode("none", m));
+}
+
+// A typo in a security setting must not read as "no restriction": the policy
+// keeps the error and refuses everything until it is fixed.
+TEST(access_policy, an_invalid_mode_fails_closed) {
+  check::access::policy p = make_policy();
+  p.set_mode("allwed");
+  EXPECT_TRUE(p.is_restricted());
+  EXPECT_FALSE(p.get_config_error().empty());
+  const decision d = p.resolve("\\Memory\\Pages/sec");
+  EXPECT_FALSE(d.allowed);
+  EXPECT_NE(std::string::npos, d.error.find("expected any, allowed or predefined"));
+}
+
+// ---------------------------------------------------------------------------
+// mode: any
+// ---------------------------------------------------------------------------
+
+TEST(access_policy, any_is_the_default_and_accepts_everything) {
+  const check::access::policy p = make_policy();
+  EXPECT_EQ(mode::any, p.get_mode());
+  EXPECT_FALSE(p.is_restricted());
+  const decision d = p.resolve("\\Processor(_Total)\\% Processor Time");
+  EXPECT_TRUE(d.allowed);
+  EXPECT_EQ("\\Processor(_Total)\\% Processor Time", d.value);
+}
+
+// ---------------------------------------------------------------------------
+// mode: allowed
+// ---------------------------------------------------------------------------
+
+TEST(access_policy, allowed_accepts_a_value_matching_the_list) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("\\Processor(*)\\*, \\Memory\\*");
+  EXPECT_TRUE(p.resolve("\\Processor(_Total)\\% Processor Time").allowed);
+  EXPECT_TRUE(p.resolve("\\Memory\\Pages/sec").allowed);
+}
+
+TEST(access_policy, allowed_refuses_a_value_outside_the_list) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("\\Memory\\*");
+  const decision d = p.resolve("\\Process(lsass)\\ID Process");
+  EXPECT_FALSE(d.allowed);
+  EXPECT_NE(std::string::npos, d.error.find("\\Process(lsass)\\ID Process"));
+  EXPECT_NE(std::string::npos, d.error.find("allowed counters"));
+}
+
+// The refusal tells the operator what was rejected and which setting governs
+// it, but never what the list holds - the caller does not get to enumerate it.
+TEST(access_policy, a_refusal_does_not_disclose_the_list) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("\\SecretObject\\SecretCounter");
+  const decision d = p.resolve("\\Memory\\Pages/sec");
+  ASSERT_FALSE(d.allowed);
+  EXPECT_EQ(std::string::npos, d.error.find("SecretObject"));
+  EXPECT_EQ(std::string::npos, d.error.find("SecretCounter"));
+}
+
+TEST(access_policy, an_empty_allow_list_in_allowed_mode_refuses_everything) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("");
+  EXPECT_EQ(0u, p.allow_list_size());
+  EXPECT_FALSE(p.resolve("\\Memory\\Pages/sec").allowed);
+}
+
+// A glob entry is matched literally apart from `*` and `?`; the regex
+// metacharacters a counter name is full of must not change what it matches.
+TEST(access_policy, glob_metacharacters_are_literal) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("\\Processor(_Total)\\*");
+  EXPECT_TRUE(p.resolve("\\Processor(_Total)\\% Processor Time").allowed);
+  // Without escaping, "(_Total)" would be a capture group and this would match.
+  EXPECT_FALSE(p.resolve("\\Processor_Total\\% Processor Time").allowed);
+}
+
+TEST(access_policy, a_glob_is_anchored_at_both_ends) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("Win32_Service");
+  EXPECT_TRUE(p.resolve("Win32_Service").allowed);
+  EXPECT_FALSE(p.resolve("Win32_ServiceExtra").allowed);
+  EXPECT_FALSE(p.resolve("XWin32_Service").allowed);
+}
+
+TEST(access_policy, question_mark_matches_one_character) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("Win32_Disk?");
+  EXPECT_TRUE(p.resolve("Win32_Disk1").allowed);
+  EXPECT_FALSE(p.resolve("Win32_Disk12").allowed);
+}
+
+TEST(access_policy, matching_is_case_insensitive_by_default) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("win32_service");
+  EXPECT_TRUE(p.resolve("Win32_Service").allowed);
+}
+
+TEST(access_policy, a_case_sensitive_policy_does_not_fold_case) {
+  check::access::policy p("file", "files", "/settings/logfile", true);
+  p.set_mode("allowed");
+  p.set_allow_list("/var/log/app.log");
+  EXPECT_TRUE(p.resolve("/var/log/app.log").allowed);
+  EXPECT_FALSE(p.resolve("/var/log/App.log").allowed);
+}
+
+// ---------------------------------------------------------------------------
+// mode: predefined
+// ---------------------------------------------------------------------------
+
+TEST(access_policy, predefined_expands_a_configured_name) {
+  check::access::policy p = make_policy();
+  p.set_mode("predefined");
+  p.add_predefined("cpu", "\\Processor(_Total)\\% Processor Time");
+  const decision d = p.resolve("cpu");
+  EXPECT_TRUE(d.allowed);
+  EXPECT_EQ("\\Processor(_Total)\\% Processor Time", d.value);
+}
+
+TEST(access_policy, predefined_refuses_a_raw_value) {
+  check::access::policy p = make_policy();
+  p.set_mode("predefined");
+  p.add_predefined("cpu", "\\Processor(_Total)\\% Processor Time");
+  const decision d = p.resolve("\\Memory\\Pages/sec");
+  EXPECT_FALSE(d.allowed);
+  EXPECT_NE(std::string::npos, d.error.find("set to predefined"));
+}
+
+// Operator-authored names resolve in every mode. That is what lets a site name
+// its checks first and tighten the mode afterwards without touching the
+// monitoring server's commands.
+TEST(access_policy, a_predefined_name_resolves_in_any_mode) {
+  check::access::policy p = make_policy();
+  p.add_predefined("cpu", "\\Processor(_Total)\\% Processor Time");
+  EXPECT_EQ("\\Processor(_Total)\\% Processor Time", p.resolve("cpu").value);
+
+  p.set_mode("allowed");
+  p.set_allow_list("\\Memory\\*");
+  EXPECT_EQ("\\Processor(_Total)\\% Processor Time", p.resolve("cpu").value);
+}
+
+// A predefined value is operator-authored, so it is trusted even when it would
+// not have passed the allow list itself.
+TEST(access_policy, a_predefined_value_is_not_held_against_the_allow_list) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("\\Memory\\*");
+  p.add_predefined("cpu", "\\Processor(_Total)\\% Processor Time");
+  EXPECT_TRUE(p.resolve("cpu").allowed);
+}
+
+// Settings callbacks append, so a reload which does not clear first would
+// double every entry under the threads reading them.
+TEST(access_policy, reset_clears_everything_for_a_reload) {
+  check::access::policy p = make_policy();
+  p.set_mode("predefined");
+  p.set_allow_list("a,b,c");
+  p.add_predefined("cpu", "x");
+  p.reset();
+  EXPECT_EQ(mode::any, p.get_mode());
+  EXPECT_EQ(0u, p.allow_list_size());
+  EXPECT_FALSE(p.has_predefined("cpu"));
+  EXPECT_FALSE(p.is_restricted());
+}
+
+TEST(access_policy, check_value_reports_the_dimension_it_rejected) {
+  check::access::policy p("namespace", "namespaces", "/settings/wmi");
+  p.set_allow_list("root\\cimv2");
+  EXPECT_TRUE(p.check_value("root\\cimv2", "namespace").allowed);
+  const decision d = p.check_value("root\\securitycenter2", "namespace");
+  EXPECT_FALSE(d.allowed);
+  EXPECT_NE(std::string::npos, d.error.find("allowed namespaces"));
+}
+
+// ---------------------------------------------------------------------------
+// WQL class extraction
+// ---------------------------------------------------------------------------
+
+TEST(wql, extracts_the_class_from_a_plain_select) {
+  const check::wql::parse_result r = check::wql::extract_class("SELECT * FROM Win32_OperatingSystem");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ("Win32_OperatingSystem", r.class_name);
+}
+
+TEST(wql, handles_a_column_list_and_a_where_clause) {
+  const check::wql::parse_result r = check::wql::extract_class("select Name, State from Win32_Service where State = 'Running'");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ("Win32_Service", r.class_name);
+}
+
+TEST(wql, tolerates_newlines_and_padding) {
+  const check::wql::parse_result r = check::wql::extract_class("\n  SELECT *\n  FROM Win32_Process\n  WHERE Name = 'x'\n");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ("Win32_Process", r.class_name);
+}
+
+// "FROM" inside a string literal in the WHERE clause must not be mistaken for
+// the real FROM: the non-greedy column list stops at the first one.
+TEST(wql, a_where_clause_mentioning_from_does_not_move_the_class) {
+  const check::wql::parse_result r = check::wql::extract_class("SELECT * FROM Win32_Process WHERE Name = 'FROM Win32_Service'");
+  ASSERT_TRUE(r.ok) << r.error;
+  EXPECT_EQ("Win32_Process", r.class_name);
+}
+
+TEST(wql, refuses_a_second_statement) {
+  const check::wql::parse_result r = check::wql::extract_class("SELECT * FROM Win32_Service; SELECT * FROM Win32_Process");
+  EXPECT_FALSE(r.ok);
+  EXPECT_NE(std::string::npos, r.error.find("single statement"));
+}
+
+// A class path carrying a namespace or a machine would be approved on its
+// trailing identifier and read somewhere else entirely.
+TEST(wql, refuses_a_qualified_class_path) {
+  EXPECT_FALSE(check::wql::extract_class("SELECT * FROM root\\cimv2:Win32_Process").ok);
+  EXPECT_FALSE(check::wql::extract_class("SELECT * FROM \\\\host\\root\\cimv2:Win32_Process").ok);
+  EXPECT_FALSE(check::wql::extract_class("SELECT * FROM root/cimv2:Win32_Process").ok);
+}
+
+TEST(wql, refuses_the_association_forms) {
+  EXPECT_FALSE(check::wql::extract_class("ASSOCIATORS OF {Win32_LogicalDisk.DeviceID='C:'}").ok);
+  EXPECT_FALSE(check::wql::extract_class("REFERENCES OF {Win32_Service.Name='x'}").ok);
+}
+
+TEST(wql, refuses_a_column_list_which_is_not_plain) {
+  EXPECT_FALSE(check::wql::extract_class("SELECT (SELECT * FROM Win32_Process) FROM Win32_Service").ok);
+  EXPECT_FALSE(check::wql::extract_class("SELECT a.b FROM Win32_Service").ok);
+}
+
+TEST(wql, refuses_an_embedded_nul) {
+  std::string q("SELECT * FROM Win32_Service");
+  q.push_back('\0');
+  q += " extra";
+  EXPECT_FALSE(check::wql::extract_class(q).ok);
+}
+
+TEST(wql, refuses_nonsense) {
+  EXPECT_FALSE(check::wql::extract_class("").ok);
+  EXPECT_FALSE(check::wql::extract_class("DELETE FROM Win32_Service").ok);
+  EXPECT_FALSE(check::wql::extract_class("SELECT * FROM").ok);
+}
+
+// ---------------------------------------------------------------------------
+// path policy
+// ---------------------------------------------------------------------------
+
+class path_access_test : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    root_ = fs::temp_directory_path() / fs::unique_path("nscp-access-%%%%%%%%");
+    fs::create_directories(root_ / "logs" / "sub");
+    fs::create_directories(root_ / "secret");
+    write(root_ / "logs" / "app.log", "in\n");
+    write(root_ / "logs" / "sub" / "deep.log", "deep\n");
+    write(root_ / "logs" / "notes.txt", "txt\n");
+    write(root_ / "secret" / "shadow", "secret\n");
+  }
+  void TearDown() override {
+    boost::system::error_code ec;
+    fs::remove_all(root_, ec);
+  }
+  static void write(const fs::path &p, const std::string &body) {
+    std::ofstream f(p.string().c_str());
+    f << body;
+  }
+  std::string at(const std::string &rel) const { return (root_ / rel).string(); }
+
+  fs::path root_;
+};
+
+TEST_F(path_access_test, any_accepts_any_path_unchanged) {
+  const check::access::path_policy p("file", "files", "/settings/logfile");
+  const decision d = p.resolve(at("secret/shadow"));
+  EXPECT_TRUE(d.allowed);
+  EXPECT_EQ(at("secret/shadow"), d.value);
+}
+
+TEST_F(path_access_test, a_directory_entry_covers_the_whole_subtree) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs"));
+  EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
+  EXPECT_TRUE(p.resolve(at("logs/sub/deep.log")).allowed);
+  EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
+}
+
+TEST_F(path_access_test, a_glob_entry_matches_only_its_own_level) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs") + "/*.log");
+  EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
+  EXPECT_FALSE(p.resolve(at("logs/notes.txt")).allowed);
+  EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
+}
+
+// The whole reason a path needs its own policy: `..` has to be flattened
+// before the comparison, or the allow list is decoration.
+TEST_F(path_access_test, dot_dot_traversal_out_of_an_allowed_directory_is_refused) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs"));
+  EXPECT_FALSE(p.resolve(at("logs/../secret/shadow")).allowed);
+  EXPECT_FALSE(p.resolve(at("logs/sub/../../secret/shadow")).allowed);
+}
+
+TEST_F(path_access_test, a_sibling_directory_with_a_shared_prefix_is_not_inside) {
+  fs::create_directories(root_ / "logs-private");
+  write(root_ / "logs-private" / "x.log", "x\n");
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs"));
+  EXPECT_FALSE(p.resolve(at("logs-private/x.log")).allowed);
+}
+
+#ifndef WIN32
+// A symlink planted inside an allowed directory is the other way the string
+// comparison lies; weakly_canonical resolves it before the test.
+TEST_F(path_access_test, a_symlink_leading_out_of_an_allowed_directory_is_refused) {
+  boost::system::error_code ec;
+  fs::create_symlink(root_ / "secret" / "shadow", root_ / "logs" / "escape.log", ec);
+  if (ec) GTEST_SKIP() << "cannot create symlinks here: " << ec.message();
+
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs"));
+  EXPECT_FALSE(p.resolve(at("logs/escape.log")).allowed);
+}
+#endif
+
+// What is matched is what gets opened: resolve() hands back the path it
+// approved, so nothing re-resolves the name between the check and the read.
+TEST_F(path_access_test, an_accepted_path_comes_back_resolved) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs"));
+  const decision d = p.resolve(at("logs/sub/../app.log"));
+  ASSERT_TRUE(d.allowed) << d.error;
+  EXPECT_EQ(check::access::path_policy::canonical(at("logs/app.log")), d.value);
+}
+
+TEST_F(path_access_test, predefined_files_resolve_by_name) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("predefined");
+  p.add_predefined("app", at("logs/app.log"));
+  const decision d = p.resolve("app");
+  EXPECT_TRUE(d.allowed);
+  EXPECT_EQ(at("logs/app.log"), d.value);
+  EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
+}
+
+TEST_F(path_access_test, an_exact_file_entry_allows_only_that_file) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs/app.log"));
+  EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
+  EXPECT_FALSE(p.resolve(at("logs/notes.txt")).allowed);
+}
+
+TEST_F(path_access_test, a_trailing_separator_on_a_directory_entry_is_harmless) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs") + "/");
+  EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
+}
+
+TEST_F(path_access_test, several_entries_are_all_considered) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs/app.log") + " , " + at("logs/sub"));
+  EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
+  EXPECT_TRUE(p.resolve(at("logs/sub/deep.log")).allowed);
+  EXPECT_FALSE(p.resolve(at("logs/notes.txt")).allowed);
+}
+
+}  // namespace

--- a/include/check/access_policy_test.cpp
+++ b/include/check/access_policy_test.cpp
@@ -3,6 +3,7 @@
 
 #include <check/access_policy.hpp>
 #include <check/path_access_policy.hpp>
+#include <check/prefix_access_policy.hpp>
 #include <check/wql_query.hpp>
 #include <boost/filesystem.hpp>
 #include <fstream>
@@ -423,6 +424,173 @@ TEST_F(path_access_test, several_entries_are_all_considered) {
   EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
   EXPECT_TRUE(p.resolve(at("logs/sub/deep.log")).allowed);
   EXPECT_FALSE(p.resolve(at("logs/notes.txt")).allowed);
+}
+
+// ---------------------------------------------------------------------------
+// prefix policy (registry keys, event log channels)
+// ---------------------------------------------------------------------------
+
+namespace {
+// The registry accepts both spellings of every hive, so the gate compares them
+// in one spelling or an operator's list silently misses half the requests.
+std::string normalize_hive(const std::string &key) {
+  static const char *pairs[][2] = {{"HKEY_LOCAL_MACHINE", "HKLM"}, {"HKEY_CURRENT_USER", "HKCU"}, {"HKEY_CLASSES_ROOT", "HKCR"},
+                                   {"HKEY_USERS", "HKU"},          {"HKEY_CURRENT_CONFIG", "HKCC"}};
+  for (const auto &pair : pairs) {
+    const std::string full(pair[0]);
+    if (key.size() >= full.size() && boost::algorithm::iequals(key.substr(0, full.size()), full)) {
+      return std::string(pair[1]) + key.substr(full.size());
+    }
+  }
+  return key;
+}
+
+check::access::prefix_policy registry_policy() {
+  return check::access::prefix_policy("registry key", "registry keys", "/settings/system/windows", '\\', &normalize_hive);
+}
+check::access::prefix_policy channel_policy() { return check::access::prefix_policy("log", "logs", "/settings/eventlog", '/'); }
+}  // namespace
+
+TEST(prefix_policy, any_is_the_default) {
+  const check::access::prefix_policy p = registry_policy();
+  EXPECT_FALSE(p.is_restricted());
+  EXPECT_TRUE(p.resolve("HKLM\\SAM").allowed);
+}
+
+TEST(prefix_policy, a_literal_entry_covers_the_key_itself) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\MyApp");
+  EXPECT_TRUE(p.resolve("HKLM\\SOFTWARE\\MyApp").allowed);
+}
+
+TEST(prefix_policy, a_literal_entry_covers_the_subtree) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\MyApp");
+  EXPECT_TRUE(p.resolve("HKLM\\SOFTWARE\\MyApp\\Settings").allowed);
+  EXPECT_TRUE(p.resolve("HKLM\\SOFTWARE\\MyApp\\Deep\\Nested\\Key").allowed);
+}
+
+// The whole reason this is not a plain glob: a prefix only counts when the next
+// character ends the segment, or `MyApp` would cover `MyAppEvil`.
+TEST(prefix_policy, a_prefix_does_not_match_mid_segment) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\MyApp");
+  EXPECT_FALSE(p.resolve("HKLM\\SOFTWARE\\MyAppEvil").allowed);
+  EXPECT_FALSE(p.resolve("HKLM\\SOFTWARE\\MyAppEvil\\Sub").allowed);
+}
+
+TEST(prefix_policy, refuses_a_sibling_and_another_hive) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\MyApp");
+  EXPECT_FALSE(p.resolve("HKLM\\SOFTWARE\\Other").allowed);
+  EXPECT_FALSE(p.resolve("HKLM\\SAM").allowed);
+  EXPECT_FALSE(p.resolve("HKCU\\SOFTWARE\\MyApp").allowed);
+}
+
+TEST(prefix_policy, the_long_hive_spelling_resolves_to_the_same_entry) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\MyApp");
+  EXPECT_TRUE(p.resolve("HKEY_LOCAL_MACHINE\\SOFTWARE\\MyApp\\Sub").allowed);
+  EXPECT_FALSE(p.resolve("HKEY_LOCAL_MACHINE\\SAM").allowed);
+}
+
+TEST(prefix_policy, an_entry_written_with_the_long_spelling_works_too) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKEY_LOCAL_MACHINE\\SOFTWARE\\MyApp");
+  EXPECT_TRUE(p.resolve("HKLM\\SOFTWARE\\MyApp\\Sub").allowed);
+}
+
+TEST(prefix_policy, registry_matching_ignores_case) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\Software\\MyApp");
+  EXPECT_TRUE(p.resolve("hklm\\SOFTWARE\\myapp\\Sub").allowed);
+}
+
+TEST(prefix_policy, a_trailing_separator_on_an_entry_is_harmless) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\MyApp\\");
+  EXPECT_TRUE(p.resolve("HKLM\\SOFTWARE\\MyApp\\Sub").allowed);
+  EXPECT_FALSE(p.resolve("HKLM\\SOFTWARE\\MyAppEvil").allowed);
+}
+
+TEST(prefix_policy, a_wildcard_entry_is_matched_as_a_glob) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\*\\Version");
+  EXPECT_TRUE(p.resolve("HKLM\\SOFTWARE\\MyApp\\Version").allowed);
+  EXPECT_FALSE(p.resolve("HKLM\\SOFTWARE\\MyApp\\Secrets").allowed);
+}
+
+TEST(prefix_policy, predefined_names_resolve_in_every_mode) {
+  check::access::prefix_policy p = registry_policy();
+  p.add_predefined("myapp", "HKLM\\SOFTWARE\\MyApp");
+  EXPECT_EQ("HKLM\\SOFTWARE\\MyApp", p.resolve("myapp").value);
+
+  p.set_mode("predefined");
+  EXPECT_EQ("HKLM\\SOFTWARE\\MyApp", p.resolve("myapp").value);
+  const check::access::decision d = p.resolve("HKLM\\SAM");
+  EXPECT_FALSE(d.allowed);
+  EXPECT_NE(std::string::npos, d.error.find("set to predefined"));
+}
+
+TEST(prefix_policy, an_invalid_mode_fails_closed) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allwed");
+  const check::access::decision d = p.resolve("HKLM\\SOFTWARE\\MyApp");
+  EXPECT_FALSE(d.allowed);
+  EXPECT_NE(std::string::npos, d.error.find("expected any, allowed or predefined"));
+}
+
+TEST(prefix_policy, a_refusal_does_not_disclose_the_list) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\SecretVendor");
+  const check::access::decision d = p.resolve("HKLM\\SAM");
+  ASSERT_FALSE(d.allowed);
+  EXPECT_EQ(std::string::npos, d.error.find("SecretVendor"));
+}
+
+TEST(prefix_policy, reset_clears_everything_for_a_reload) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("predefined");
+  p.set_allow_list("HKLM\\a,HKLM\\b");
+  p.add_predefined("x", "HKLM\\x");
+  p.reset();
+  EXPECT_EQ(check::access::mode::any, p.get_mode());
+  EXPECT_EQ(0u, p.allow_list_size());
+  EXPECT_TRUE(p.resolve("HKLM\\SAM").allowed);
+}
+
+// The event log uses the same machinery with '/' as the separator, so a channel
+// family can be allowed without naming each channel.
+TEST(prefix_policy, an_event_log_channel_family_is_covered_by_its_prefix) {
+  check::access::prefix_policy p = channel_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("Application, Microsoft-Windows-Sysmon");
+  EXPECT_TRUE(p.resolve("Application").allowed);
+  EXPECT_TRUE(p.resolve("Microsoft-Windows-Sysmon/Operational").allowed);
+  EXPECT_FALSE(p.resolve("Security").allowed);
+  // The separator rule again: a sibling family sharing the prefix is not in.
+  EXPECT_FALSE(p.resolve("Microsoft-Windows-SysmonEvil/Operational").allowed);
+}
+
+TEST(prefix_policy, an_event_log_refusal_names_the_setting) {
+  check::access::prefix_policy p = channel_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("Application");
+  const check::access::decision d = p.resolve("Security");
+  EXPECT_FALSE(d.allowed);
+  EXPECT_NE(std::string::npos, d.error.find("Refusing log 'Security'"));
+  EXPECT_NE(std::string::npos, d.error.find("allowed logs"));
+  EXPECT_NE(std::string::npos, d.error.find("/settings/eventlog"));
 }
 
 }  // namespace

--- a/include/check/access_policy_test.cpp
+++ b/include/check/access_policy_test.cpp
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2004-2026 Michael Medin
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
 #include <check/access_policy.hpp>
 #include <check/path_access_policy.hpp>
 #include <check/prefix_access_policy.hpp>
 #include <check/wql_query.hpp>
-#include <boost/filesystem.hpp>
 #include <fstream>
-#include <gtest/gtest.h>
 
 namespace fs = boost::filesystem;
 using check::access::decision;
@@ -204,18 +205,56 @@ TEST(access_policy, a_predefined_value_is_not_held_against_the_allow_list) {
   EXPECT_TRUE(p.resolve("cpu").allowed);
 }
 
-// Settings callbacks append, so a reload which does not clear first would
-// double every entry under the threads reading them.
-TEST(access_policy, reset_clears_everything_for_a_reload) {
+// The predefined entries are appended by the settings callbacks, so a reload
+// which does not clear them first would double every entry under the threads
+// reading them...
+TEST(access_policy, reset_clears_the_predefined_entries_for_a_reload) {
   check::access::policy p = make_policy();
-  p.set_mode("predefined");
-  p.set_allow_list("a,b,c");
   p.add_predefined("cpu", "x");
   p.reset();
-  EXPECT_EQ(mode::any, p.get_mode());
-  EXPECT_EQ(0u, p.allow_list_size());
   EXPECT_FALSE(p.has_predefined("cpu"));
-  EXPECT_FALSE(p.is_restricted());
+}
+
+// ...but the mode and the allow list are replaced by theirs, and must stay in
+// force: a reload calls loadModuleEx on the live module, and a check arriving
+// between reset() and settings.notify() must not find the gate open.
+TEST(access_policy, reset_keeps_the_gate_closed_until_the_settings_are_reread) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("\\Memory\\*");
+  p.reset();
+  EXPECT_EQ(mode::allowed, p.get_mode());
+  EXPECT_TRUE(p.is_restricted());
+  EXPECT_EQ(1u, p.allow_list_size());
+  EXPECT_TRUE(p.resolve("\\Memory\\Available Bytes").allowed);
+  EXPECT_FALSE(p.resolve("\\Processor(_Total)\\% Processor Time").allowed);
+
+  p.set_mode("predefined");
+  p.reset();
+  EXPECT_FALSE(p.resolve("\\Memory\\Available Bytes").allowed);
+}
+
+TEST(access_policy, an_invalid_mode_survives_a_reset) {
+  check::access::policy p = make_policy();
+  p.set_mode("alowed");
+  p.reset();
+  EXPECT_TRUE(p.is_restricted());
+  EXPECT_FALSE(p.resolve("\\Memory\\Available Bytes").allowed);
+}
+
+TEST(access_policy, a_copy_carries_the_configuration) {
+  check::access::policy p = make_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("\\Memory\\*");
+  p.add_predefined("cpu", "x");
+  const check::access::policy copy(p);
+  EXPECT_EQ(mode::allowed, copy.get_mode());
+  EXPECT_TRUE(copy.resolve("\\Memory\\Available Bytes").allowed);
+  EXPECT_TRUE(copy.has_predefined("cpu"));
+  check::access::policy assigned = make_policy();
+  assigned = p;
+  EXPECT_TRUE(assigned.resolve("\\Memory\\Available Bytes").allowed);
+  EXPECT_TRUE(assigned.has_predefined("cpu"));
 }
 
 TEST(access_policy, check_value_reports_the_dimension_it_rejected) {
@@ -338,13 +377,86 @@ TEST_F(path_access_test, a_directory_entry_covers_the_whole_subtree) {
   EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
 }
 
+// `*` stops at a directory separator: an operator who wrote a one-level
+// pattern gets one level, not the subtree.
 TEST_F(path_access_test, a_glob_entry_matches_only_its_own_level) {
   check::access::path_policy p("file", "files", "/settings/logfile");
   p.set_mode("allowed");
   p.set_allow_list(at("logs") + "/*.log");
   EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
   EXPECT_FALSE(p.resolve(at("logs/notes.txt")).allowed);
+  EXPECT_FALSE(p.resolve(at("logs/sub/deep.log")).allowed);
   EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
+}
+
+TEST_F(path_access_test, a_question_mark_does_not_cross_a_separator) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs") + "/?u?/deep.log");
+  EXPECT_TRUE(p.resolve(at("logs/sub/deep.log")).allowed);
+  fs::create_directories(root_ / "logs" / "a" / "b");
+  write(root_ / "logs" / "a" / "b" / "deep.log", "x\n");
+  EXPECT_FALSE(p.resolve(at("logs/a/b/deep.log")).allowed);
+}
+
+// `**` is the spelling which crosses separators, for when the subtree is meant.
+TEST_F(path_access_test, a_double_star_glob_covers_the_subtree) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs") + "/**.log");
+  EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
+  EXPECT_TRUE(p.resolve(at("logs/sub/deep.log")).allowed);
+  EXPECT_FALSE(p.resolve(at("logs/notes.txt")).allowed);
+  EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
+}
+
+// A directory which is not there when the settings are read (a volume mounted
+// later, a log directory the application creates on first run) must still
+// cover what appears beneath it, without a reload.
+TEST_F(path_access_test, a_directory_entry_which_does_not_exist_yet_covers_what_appears_beneath_it) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("later"));
+  fs::create_directories(root_ / "later" / "sub");
+  write(root_ / "later" / "app.log", "x\n");
+  write(root_ / "later" / "sub" / "deep.log", "x\n");
+  EXPECT_TRUE(p.resolve(at("later/app.log")).allowed);
+  EXPECT_TRUE(p.resolve(at("later/sub/deep.log")).allowed);
+  EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
+}
+
+TEST_F(path_access_test, a_file_entry_which_does_not_exist_yet_covers_that_file) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs/later.log"));
+  write(root_ / "logs" / "later.log", "x\n");
+  EXPECT_TRUE(p.resolve(at("logs/later.log")).allowed);
+  EXPECT_FALSE(p.resolve(at("logs/app.log")).allowed);
+}
+
+#ifdef WIN32
+// Directory containment has to fold case like the glob entries do, or the
+// same tree is allowed under one drive-letter spelling and refused under
+// another.
+TEST_F(path_access_test, a_directory_entry_ignores_case_on_windows) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(boost::algorithm::to_upper_copy(at("logs")));
+  EXPECT_TRUE(p.resolve(boost::algorithm::to_lower_copy(at("logs/app.log"))).allowed);
+  EXPECT_TRUE(p.resolve(at("logs/sub/deep.log")).allowed);
+}
+#endif
+
+TEST_F(path_access_test, reset_keeps_the_allow_list_until_the_settings_are_reread) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(at("logs"));
+  p.add_predefined("app", at("logs/app.log"));
+  p.reset();
+  EXPECT_EQ(mode::allowed, p.get_mode());
+  EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
+  EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
+  EXPECT_FALSE(p.resolve("app").allowed);
 }
 
 // The whole reason a path needs its own policy: `..` has to be flattened
@@ -434,8 +546,8 @@ namespace {
 // The registry accepts both spellings of every hive, so the gate compares them
 // in one spelling or an operator's list silently misses half the requests.
 std::string normalize_hive(const std::string &key) {
-  static const char *pairs[][2] = {{"HKEY_LOCAL_MACHINE", "HKLM"}, {"HKEY_CURRENT_USER", "HKCU"}, {"HKEY_CLASSES_ROOT", "HKCR"},
-                                   {"HKEY_USERS", "HKU"},          {"HKEY_CURRENT_CONFIG", "HKCC"}};
+  static const char *pairs[][2] = {
+      {"HKEY_LOCAL_MACHINE", "HKLM"}, {"HKEY_CURRENT_USER", "HKCU"}, {"HKEY_CLASSES_ROOT", "HKCR"}, {"HKEY_USERS", "HKU"}, {"HKEY_CURRENT_CONFIG", "HKCC"}};
   for (const auto &pair : pairs) {
     const std::string full(pair[0]);
     if (key.size() >= full.size() && boost::algorithm::iequals(key.substr(0, full.size()), full)) {
@@ -558,15 +670,17 @@ TEST(prefix_policy, a_refusal_does_not_disclose_the_list) {
   EXPECT_EQ(std::string::npos, d.error.find("SecretVendor"));
 }
 
-TEST(prefix_policy, reset_clears_everything_for_a_reload) {
+TEST(prefix_policy, reset_drops_the_predefined_entries_and_keeps_the_gate) {
   check::access::prefix_policy p = registry_policy();
-  p.set_mode("predefined");
+  p.set_mode("allowed");
   p.set_allow_list("HKLM\\a,HKLM\\b");
   p.add_predefined("x", "HKLM\\x");
   p.reset();
-  EXPECT_EQ(check::access::mode::any, p.get_mode());
-  EXPECT_EQ(0u, p.allow_list_size());
-  EXPECT_TRUE(p.resolve("HKLM\\SAM").allowed);
+  EXPECT_EQ(check::access::mode::allowed, p.get_mode());
+  EXPECT_EQ(2u, p.allow_list_size());
+  EXPECT_FALSE(p.resolve("x").allowed);
+  EXPECT_TRUE(p.resolve("HKLM\\a\\sub").allowed);
+  EXPECT_FALSE(p.resolve("HKLM\\SAM").allowed);
 }
 
 // The event log uses the same machinery with '/' as the separator, so a channel

--- a/include/check/access_policy_test.cpp
+++ b/include/check/access_policy_test.cpp
@@ -3,12 +3,15 @@
 
 #include <gtest/gtest.h>
 
+#include <atomic>
 #include <boost/filesystem.hpp>
 #include <check/access_policy.hpp>
 #include <check/path_access_policy.hpp>
 #include <check/prefix_access_policy.hpp>
 #include <check/wql_query.hpp>
 #include <fstream>
+#include <thread>
+#include <vector>
 
 namespace fs = boost::filesystem;
 using check::access::decision;
@@ -705,6 +708,378 @@ TEST(prefix_policy, an_event_log_refusal_names_the_setting) {
   EXPECT_NE(std::string::npos, d.error.find("Refusing log 'Security'"));
   EXPECT_NE(std::string::npos, d.error.find("allowed logs"));
   EXPECT_NE(std::string::npos, d.error.find("/settings/eventlog"));
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests: the ways a path gate is fooled
+//
+// Every bug found in review of this gate had the same shape - resolve() said
+// yes and handed back a path which, read by the OS, was somewhere else. So
+// these tests do not assert "refused"; they assert the invariant that makes a
+// refusal unnecessary:
+//
+//   whatever the caller spelled, the value handed back must resolve - through
+//   boost, independently of anything in path_access_policy - to a path inside
+//   the allowed directory.
+//
+// A gate which accepts a hostile token but returns a path that stays inside is
+// just as correct as one which refuses it, and this says so without pinning
+// the test to today's behaviour.
+// ---------------------------------------------------------------------------
+
+class path_escape_test : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    root_ = fs::temp_directory_path() / fs::unique_path("nscp-escape-%%%%%%%%");
+    fs::create_directories(root_ / "logs" / "sub");
+    fs::create_directories(root_ / "secret");
+    write(root_ / "logs" / "app.log", "in\n");
+    write(root_ / "logs" / "sub" / "deep.log", "deep\n");
+    write(root_ / "secret" / "shadow", "SECRET\n");
+  }
+  void TearDown() override {
+    boost::system::error_code ec;
+    fs::remove_all(root_, ec);
+  }
+  static void write(const fs::path &p, const std::string &body) {
+    std::ofstream f(p.string().c_str());
+    f << body;
+  }
+  std::string at(const std::string &rel) const { return (root_ / rel).string(); }
+  std::string allowed_dir() const { return at("logs"); }
+
+  check::access::path_policy restricted() const {
+    check::access::path_policy p("file", "files", "/settings/logfile");
+    p.set_mode("allowed");
+    p.set_allow_list(allowed_dir());
+    return p;
+  }
+
+  // Resolve `token` against a policy allowing only <root>/logs, and check the
+  // invariant. Returns whether it was accepted, so a caller can additionally
+  // pin today's answer where that is worth pinning.
+  bool accepted_and_contained(const check::access::path_policy &p, const std::string &token) const {
+    const decision d = p.resolve(token);
+    if (!d.allowed) return false;
+    // Resolve the *returned* value the way the operating system will when the
+    // check opens it. Deliberately not path_policy::canonical: a bug in that
+    // function is exactly what this is meant to catch.
+    boost::system::error_code ec;
+    fs::path landed = fs::weakly_canonical(fs::path(d.value), ec);
+    if (ec) landed = fs::path(d.value).lexically_normal();
+    fs::path base = fs::weakly_canonical(fs::path(allowed_dir()), ec);
+    if (ec) base = fs::path(allowed_dir()).lexically_normal();
+
+    const std::string landed_s = landed.string();
+    const std::string base_s = base.string();
+    const bool inside = landed_s == base_s || (landed_s.size() > base_s.size() && landed_s.compare(0, base_s.size(), base_s) == 0 &&
+                                               (landed_s[base_s.size()] == '/' || landed_s[base_s.size()] == '\\'));
+    EXPECT_TRUE(inside) << "accepted '" << token << "' but it lands on '" << landed_s << "', outside '" << base_s << "'";
+    return true;
+  }
+
+  fs::path root_;
+};
+
+// The table this suite exists for. Each token is a way of writing "leave the
+// allowed directory"; none of them may come back as a path which does.
+TEST_F(path_escape_test, no_spelling_of_a_traversal_escapes_the_allowed_directory) {
+  const check::access::path_policy p = restricted();
+  const std::string logs = allowed_dir();
+  const std::vector<std::string> tokens = {
+      logs + "/../secret/shadow",
+      logs + "/../../etc/passwd",
+      // Written with a backslash. On Windows that is a separator and must be
+      // flattened; on Linux it is an ordinary character and must not become
+      // one after the match - which is what let this through (#1516 review).
+      logs + "/..\\..\\secret/shadow",
+      logs + "/..\\secret\\shadow",
+      logs + "\\..\\secret\\shadow",
+      logs + "/./../secret/shadow",
+      logs + "/.././secret/shadow",
+      logs + "//../secret/shadow",
+      logs + "/sub/../../secret/shadow",
+      logs + "/./sub/./../../secret/shadow",
+      logs + "/../logs/../secret/shadow",
+      logs + "/sub/../sub/../../secret/shadow",
+      logs + "/../../../../../../../../etc/passwd",
+      at("secret/shadow"),
+      "/etc/passwd",
+  };
+  for (const std::string &token : tokens) accepted_and_contained(p, token);
+}
+
+// The same table, but the allow list is a wildcard rather than a directory.
+TEST_F(path_escape_test, a_glob_entry_is_not_a_way_round_the_traversal_rule) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(allowed_dir() + "/*.log");
+  const std::string logs = allowed_dir();
+  for (const std::string &token : {logs + "/../secret/shadow.log", logs + "/..\\..\\secret/shadow.log", logs + "/sub/../../secret/shadow.log"}) {
+    accepted_and_contained(p, std::string(token));
+  }
+}
+
+#ifndef WIN32
+// Both link shapes, since only one of them was covered before: a file link and
+// a directory link, each planted inside the allowed directory.
+TEST_F(path_escape_test, neither_a_file_nor_a_directory_symlink_leads_out) {
+  boost::system::error_code ec;
+  fs::create_symlink(root_ / "secret" / "shadow", root_ / "logs" / "escape.log", ec);
+  if (ec) GTEST_SKIP() << "cannot create symlinks here: " << ec.message();
+  fs::create_directory_symlink(root_ / "secret", root_ / "logs" / "out", ec);
+  ASSERT_FALSE(ec) << ec.message();
+
+  const check::access::path_policy p = restricted();
+  EXPECT_FALSE(accepted_and_contained(p, at("logs/escape.log")));
+  EXPECT_FALSE(accepted_and_contained(p, at("logs/out/shadow")));
+  // Through the directory link and back out again.
+  accepted_and_contained(p, at("logs/out/../secret/shadow"));
+}
+
+// A symlink whose own name is a traversal written with a backslash: on Linux
+// that is a legal file name, so the resolver does see a link here.
+TEST_F(path_escape_test, a_link_named_like_a_traversal_is_resolved_not_pattern_matched) {
+  boost::system::error_code ec;
+  fs::create_symlink(root_ / "secret", root_ / "logs" / "..\\..", ec);
+  if (ec) GTEST_SKIP() << "cannot create that name here: " << ec.message();
+  const check::access::path_policy p = restricted();
+  accepted_and_contained(p, at("logs") + "/..\\../shadow");
+}
+
+// Linux file names are case sensitive, so folding case would hand one allow
+// list entry two different files.
+TEST_F(path_escape_test, case_is_significant_on_posix) {
+  fs::create_directories(root_ / "LOGS");
+  write(root_ / "LOGS" / "app.log", "other\n");
+  const check::access::path_policy p = restricted();
+  EXPECT_FALSE(p.resolve(at("LOGS/app.log")).allowed);
+  EXPECT_TRUE(p.resolve(at("logs/app.log")).allowed);
+}
+#endif
+
+// An allow list of "/" means the whole filesystem. It used to mean nothing at
+// all: the containment test looked for a separator after "/" and never found
+// one, so every path below it was refused.
+TEST_F(path_escape_test, the_filesystem_root_as_an_entry_allows_what_is_below_it) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+#ifdef WIN32
+  p.set_allow_list("C:\\");
+  EXPECT_TRUE(p.resolve("C:\\Windows\\win.ini").allowed);
+  // And the root keeps its separator, or Win32 reads "C:" as the current
+  // directory on that drive rather than its root.
+  EXPECT_EQ("C:/", check::access::path_policy::canonical("C:\\"));
+  EXPECT_EQ("C:/", check::access::path_policy::canonical("C:/"));
+#else
+  p.set_allow_list("/");
+  EXPECT_TRUE(p.resolve("/etc/passwd").allowed);
+  EXPECT_TRUE(p.resolve(at("secret/shadow")).allowed);
+  EXPECT_EQ("/", check::access::path_policy::canonical("/"));
+#endif
+}
+
+// A path handed back must never still carry a `..`: the check opens exactly
+// what resolve() returned, so an element the resolver left behind would be
+// walked after the match had already passed.
+TEST_F(path_escape_test, an_accepted_path_never_carries_a_parent_element) {
+  const check::access::path_policy p = restricted();
+  const std::string logs = allowed_dir();
+  for (const std::string &token : {logs + "/sub/../app.log", logs + "/./app.log", logs + "//app.log", logs + "/sub/../sub/deep.log"}) {
+    const decision d = p.resolve(std::string(token));
+    if (!d.allowed) continue;
+    EXPECT_EQ(std::string::npos, d.value.find("/../")) << d.value;
+    EXPECT_FALSE(d.value.size() > 3 && d.value.compare(d.value.size() - 3, 3, "/..") == 0) << d.value;
+  }
+}
+
+// Degenerate allow lists must fail closed rather than match everything.
+TEST_F(path_escape_test, a_degenerate_allow_list_allows_nothing) {
+  const std::vector<std::string> lists = {"", " ", ",", " , , ", "\t"};
+  for (const std::string &list : lists) {
+    check::access::path_policy p("file", "files", "/settings/logfile");
+    p.set_mode("allowed");
+    p.set_allow_list(list);
+    EXPECT_EQ(0u, p.allow_list_size()) << "list '" << list << "'";
+    EXPECT_FALSE(p.resolve(at("logs/app.log")).allowed) << "list '" << list << "'";
+    EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed) << "list '" << list << "'";
+  }
+}
+
+// A bare `*` is one element, not the whole filesystem: it cannot match a path
+// which still has separators in it.
+TEST_F(path_escape_test, a_bare_star_entry_does_not_match_an_absolute_path) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list("*");
+  EXPECT_FALSE(p.resolve(at("secret/shadow")).allowed);
+}
+
+// Reloads happen while checks are running. This hammers both sides: if the
+// gate were rebuilt in place - cleared and refilled, as it once was - a reader
+// would see an empty list (and accept nothing) or a torn one (and crash under
+// a sanitiser). Nothing here may ever be accepted from outside both lists.
+TEST_F(path_escape_test, a_reload_never_opens_the_gate_for_a_concurrent_check) {
+  check::access::path_policy p("file", "files", "/settings/logfile");
+  p.set_mode("allowed");
+  p.set_allow_list(allowed_dir());
+
+  std::atomic<bool> stop(false);
+  std::atomic<int> escaped(0);
+  std::atomic<int> accepted(0);
+
+  std::vector<std::thread> readers;
+  for (int i = 0; i < 4; ++i) {
+    readers.emplace_back([&] {
+      while (!stop.load()) {
+        if (p.resolve(at("secret/shadow")).allowed) escaped.fetch_add(1);
+        if (p.resolve(at("logs/app.log")).allowed) accepted.fetch_add(1);
+        p.allow_list_size();
+        p.is_restricted();
+      }
+    });
+  }
+  for (int i = 0; i < 300; ++i) {
+    p.reset();
+    p.set_allow_list(allowed_dir());
+    p.set_mode("allowed");
+    p.add_predefined("app", at("logs/app.log"));
+  }
+  stop.store(true);
+  for (std::thread &t : readers) t.join();
+
+  EXPECT_EQ(0, escaped.load()) << "a concurrent reload let a path outside the allow list through";
+  EXPECT_GT(accepted.load(), 0) << "the allow list was empty for the whole run, so the test proved nothing";
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests: WQL shapes which must not yield a class
+// ---------------------------------------------------------------------------
+
+TEST(wql_negative, refuses_every_query_whose_class_is_not_unambiguous) {
+  const std::vector<std::string> queries = {
+      // A second FROM: the column list used to swallow the first one and the
+      // gate then reported the last class while WMI reads the first (#1516).
+      "SELECT a FROM Win32_Foo FROM Win32_Allowed",
+      "SELECT a FROM Win32_Foo FROM Win32_Bar FROM Win32_Allowed",
+      "SELECT * FROM Win32_Foo FROM Win32_Allowed",
+      "SELECT FROM FROM Win32_Allowed",
+      // Keywords and punctuation in the column list.
+      "SELECT (SELECT * FROM Win32_Shadow) FROM Win32_Allowed",
+      "SELECT a.b FROM Win32_Allowed",
+      "SELECT a-b FROM Win32_Allowed",
+      "SELECT a b FROM Win32_Allowed",
+      "SELECT a,, FROM Win32_Allowed",
+      "SELECT ,a FROM Win32_Allowed",
+      "SELECT a, FROM Win32_Allowed",
+      // Qualified or non-identifier class names.
+      "SELECT * FROM root\\cimv2:Win32_Process",
+      "SELECT * FROM \\\\host\\root\\cimv2:Win32_Process",
+      "SELECT * FROM root/cimv2:Win32_Process",
+      "SELECT * FROM 9Win32_Process",
+      "SELECT * FROM Win32_Process, Win32_Service",
+      // Not a SELECT at all.
+      "ASSOCIATORS OF {Win32_Process.Handle='1'}",
+      "REFERENCES OF {Win32_Process.Handle='1'}",
+      "DELETE FROM Win32_Process",
+      "UPDATE Win32_Process SET a = 1",
+      // Trailing material the grammar does not account for.
+      "SELECT * FROM Win32_Process Win32_Other",
+      "SELECT * FROM Win32_Process HAVING x",
+      "SELECT * FROM Win32_Process GROUP BY a",
+      "SELECT * FROM Win32_Process WITHIN 10",
+      // Statement separators and embedded NUL.
+      "SELECT * FROM Win32_Service; SELECT * FROM Win32_Process",
+      std::string("SELECT * FROM Win32_Proc\0ess", 28),
+      // Empty and near-empty.
+      "",
+      "   ",
+      "SELECT",
+      "SELECT *",
+      "SELECT * FROM",
+      "SELECT * FROM ",
+  };
+  for (const std::string &query : queries) {
+    const check::wql::parse_result r = check::wql::extract_class(query);
+    EXPECT_FALSE(r.ok) << "accepted '" << query << "' as class '" << r.class_name << "'";
+    EXPECT_FALSE(r.error.empty()) << "refused '" << query << "' without saying why";
+  }
+}
+
+// The shapes which must keep working, so the grammar above is not simply
+// "refuse everything".
+TEST(wql_negative, still_accepts_the_plain_shapes) {
+  struct {
+    const char *query;
+    const char *expected;
+  } cases[] = {
+      {"SELECT * FROM Win32_Process", "Win32_Process"},
+      {"select * from win32_process", "win32_process"},
+      {"SELECT Name FROM Win32_Service", "Win32_Service"},
+      {"SELECT Name,State FROM Win32_Service", "Win32_Service"},
+      {"SELECT Name , State FROM Win32_Service", "Win32_Service"},
+      {"SELECT __CLASS, Name FROM Win32_Service", "Win32_Service"},
+      {"\n\tSELECT\n*\nFROM\tWin32_Process\n", "Win32_Process"},
+      {"SELECT * FROM Win32_Process WHERE Name = 'x'", "Win32_Process"},
+      // A WHERE clause is opaque on purpose: WMI evaluates it against the
+      // class already approved, so the words in it cannot move the class.
+      {"SELECT * FROM Win32_Process WHERE Name = 'FROM Win32_Service'", "Win32_Process"},
+      {"SELECT * FROM Win32_Process WHERE Name = 'a;b'", nullptr},
+  };
+  for (const auto &c : cases) {
+    const check::wql::parse_result r = check::wql::extract_class(c.query);
+    if (c.expected == nullptr) {
+      EXPECT_FALSE(r.ok) << c.query;  // the ';' rule wins, even inside a literal
+      continue;
+    }
+    ASSERT_TRUE(r.ok) << c.query << ": " << r.error;
+    EXPECT_EQ(c.expected, r.class_name) << c.query;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Negative tests: the hierarchical (registry / event log) gate
+// ---------------------------------------------------------------------------
+
+TEST(prefix_negative, nothing_outside_the_allowed_subtree_resolves) {
+  check::access::prefix_policy p = registry_policy();
+  p.set_mode("allowed");
+  p.set_allow_list("HKLM\\SOFTWARE\\MyApp");
+  const std::vector<std::string> refused = {
+      "HKLM\\SOFTWARE\\MyAppEvil",
+      "HKLM\\SOFTWARE\\MyAppEvil\\Sub",
+      "HKLM\\SOFTWARE\\MyApp2",
+      "HKLM\\SOFTWARE",
+      "HKLM\\SAM",
+      "HKEY_LOCAL_MACHINE\\SAM",
+      "HKCU\\SOFTWARE\\MyApp",
+      "HKLM\\SOFTWARE\\MyAppEvil\\..\\MyApp",
+      // The other separator is not a separator here, so it cannot end a
+      // segment on this gate's behalf.
+      "HKLM/SOFTWARE/MyApp/Sub",
+      "",
+  };
+  for (const std::string &key : refused) EXPECT_FALSE(p.resolve(key).allowed) << "accepted '" << key << "'";
+
+  const std::vector<std::string> allowed = {
+      "HKLM\\SOFTWARE\\MyApp",
+      "HKLM\\SOFTWARE\\MyApp\\",
+      "HKLM\\SOFTWARE\\MyApp\\Sub",
+      "HKLM\\SOFTWARE\\MyApp\\Sub\\Deeper",
+      "HKEY_LOCAL_MACHINE\\SOFTWARE\\MyApp\\Sub",
+  };
+  for (const std::string &key : allowed) EXPECT_TRUE(p.resolve(key).allowed) << "refused '" << key << "'";
+}
+
+TEST(prefix_negative, a_degenerate_allow_list_allows_nothing) {
+  for (const std::string list : {"", " ", ",", " , , "}) {
+    check::access::prefix_policy p("log", "logs", "/settings/eventlog", '/');
+    p.set_mode("allowed");
+    p.set_allow_list(list);
+    EXPECT_EQ(0u, p.allow_list_size());
+    EXPECT_FALSE(p.resolve("Application").allowed);
+    EXPECT_FALSE(p.resolve("Security").allowed);
+  }
 }
 
 }  // namespace

--- a/include/check/path_access_policy.hpp
+++ b/include/check/path_access_policy.hpp
@@ -36,6 +36,12 @@
 // next reload. Treating it as a directory costs nothing - a directory entry
 // covers the path itself too - and matches what the documentation promises.
 //
+// Separators are folded to `/` before anything is resolved, and only on the
+// platforms where `\` actually separates. Folding afterwards is what let
+// `/var/log/..\..\etc/passwd` through on Linux: the resolver saw one odd
+// file name, said it was under `/var/log`, and the fold then turned it into a
+// `..` the kernel walked after the match had already passed.
+//
 // In a path glob `*` and `?` do not cross a directory separator, so
 // `/var/log/*.log` names the files in that directory and not those in
 // `/var/log/private/`; `**` matches across separators for the cases where
@@ -57,7 +63,8 @@ class path_policy {
 #else
               true
 #endif
-        ) {}
+        ) {
+  }
 
   path_policy(const path_policy &other) : base_(other.base_) {
     std::lock_guard<std::mutex> lock(other.mutex_);
@@ -111,16 +118,36 @@ class path_policy {
   // Normalise a path the way resolve() does, so a caller can match a candidate
   // without going through the mode machinery (used by the tests).
   static std::string canonical(const std::string &path) {
+    // Fold the separators *first*. weakly_canonical only flattens a `..` it
+    // recognises as a path element, so on a platform where `\` separates, a
+    // `..\` has to reach it already spelled `../` - and on a platform where
+    // `\` does not separate, it must not be folded at all.
+    const std::string input = to_separators(path);
     boost::system::error_code ec;
-    const boost::filesystem::path resolved = boost::filesystem::weakly_canonical(boost::filesystem::path(path), ec);
+    const boost::filesystem::path resolved = boost::filesystem::weakly_canonical(boost::filesystem::path(input), ec);
     // weakly_canonical needs the filesystem to resolve symlinks; when it
     // cannot (a path on a volume which is gone, a permission error on a parent
     // directory) fall back to a purely lexical normalisation. That still
     // flattens `..`, so the traversal case stays closed; only symlink
     // resolution is lost, and an entry which is not reachable cannot be read
     // by the check either.
-    const boost::filesystem::path out = ec ? boost::filesystem::path(path).lexically_normal() : resolved;
-    return to_slashes(out.string());
+    const boost::filesystem::path out = ec ? boost::filesystem::path(input).lexically_normal() : resolved;
+    return trim_trailing_separator(to_separators(out.string()));
+  }
+
+  // True when the path still carries a parent-directory element. Nothing
+  // should reach the allow list in that state, so this is belt and braces: if
+  // the resolver ever leaves one behind, the check would open a path the
+  // match never saw, which is the whole failure this class exists to prevent.
+  static bool has_parent_element(const std::string &path) {
+    std::string::size_type start = 0;
+    for (;;) {
+      const std::string::size_type end = path.find('/', start);
+      const std::string element = end == std::string::npos ? path.substr(start) : path.substr(start, end - start);
+      if (element == "..") return true;
+      if (end == std::string::npos) return false;
+      start = end + 1;
+    }
   }
 
   // Translate a path glob into a regular expression. Unlike the generic
@@ -190,6 +217,10 @@ class path_policy {
         return decision::accept(token);
       case mode::allowed: {
         const std::string resolved = canonical(token);
+        if (has_parent_element(resolved)) {
+          return decision::refuse("Refusing file '" + token + "': it could not be resolved to a path without a '..' element (see [" +
+                                  base_.get_settings_path() + "] in the configuration)");
+        }
         if (matches_allow_list(resolved)) return decision::accept(resolved);
         return decision::refuse("Refusing file '" + token + "': it is not in 'allowed files' (see [" + base_.get_settings_path() + "] in the configuration)");
       }
@@ -219,11 +250,31 @@ class path_policy {
     return false;
   }
 
-  static std::string to_slashes(std::string s) {
+  // Windows spells a separator either way, so the two have to be folded into
+  // one before anything is compared. POSIX does not: there `\` is an ordinary
+  // character in a file name, and folding it would invent a separator the
+  // kernel will not honour - the match would then describe a different path
+  // than the one the check goes on to open.
+  static std::string to_separators(std::string s) {
+#ifdef WIN32
     std::replace(s.begin(), s.end(), '\\', '/');
+#endif
+    return s;
+  }
+
+  // A root keeps its trailing separator: it is part of the name. Dropping it
+  // turns `C:\` into `C:`, which Win32 reads as the current directory *on*
+  // drive C rather than its root, so the check would then scan a tree nobody
+  // matched.
+  static bool is_root(const std::string &s) {
+    if (s == "/") return true;
+    return s.size() == 3 && s[1] == ':' && s[2] == '/';
+  }
+
+  static std::string trim_trailing_separator(std::string s) {
     // A trailing separator would make the containment test compare an empty
     // final element; drop it so "/var/log/" and "/var/log" behave alike.
-    while (s.size() > 1 && s.back() == '/') s.pop_back();
+    while (s.size() > 1 && s.back() == '/' && !is_root(s)) s.pop_back();
     return s;
   }
 
@@ -258,7 +309,7 @@ class path_policy {
   }
 
   static std::string resolve_glob_prefix(const std::string &item) {
-    const std::string normalised = to_slashes(item);
+    const std::string normalised = trim_trailing_separator(to_separators(item));
     const std::string::size_type wild = normalised.find_first_of("*?");
     const std::string::size_type slash = normalised.rfind('/', wild);
     if (slash == std::string::npos || slash == 0) return normalised;
@@ -286,9 +337,16 @@ class path_policy {
   // resolved and slash-normalised, so this is a plain element-wise prefix
   // test: comparing the strings would let "/var/logger/x" pass for "/var/log".
   static bool is_under(const std::string &dir, const std::string &file) {
+    // An empty entry contains nothing; without this the separator test below
+    // would index off the front of the string.
+    if (dir.empty()) return false;
     if (same_text(file, dir)) return true;
     if (file.size() <= dir.size()) return false;
     if (!same_text(file.substr(0, dir.size()), dir)) return false;
+    // `/` and `C:/` already end in the separator, so what follows is the first
+    // element of the contained path. Requiring another one there refused
+    // everything beneath an allow list of `/`.
+    if (dir[dir.size() - 1] == '/') return true;
     return file[dir.size()] == '/';
   }
 

--- a/include/check/path_access_policy.hpp
+++ b/include/check/path_access_policy.hpp
@@ -6,7 +6,6 @@
 #include <boost/filesystem.hpp>
 #include <check/access_policy.hpp>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -61,14 +60,14 @@ class path_policy {
         ) {}
 
   path_policy(const path_policy &other) : base_(other.base_) {
-    std::shared_lock<std::shared_mutex> lock(other.mutex_);
+    std::lock_guard<std::mutex> lock(other.mutex_);
     entries_ = other.entries_;
   }
   path_policy &operator=(const path_policy &other) {
     if (this == &other) return *this;
     path_policy copy(other);
     base_ = copy.base_;
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     entries_.swap(copy.entries_);
     return *this;
   }
@@ -90,7 +89,7 @@ class path_policy {
       if (item.empty()) continue;
       entries.push_back(make_entry(item));
     }
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     entries_.swap(entries);
   }
 
@@ -105,7 +104,7 @@ class path_policy {
   bool is_restricted() const { return base_.is_restricted(); }
   std::string get_config_error() const { return base_.get_config_error(); }
   std::size_t allow_list_size() const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return entries_.size();
   }
 
@@ -169,7 +168,7 @@ class path_policy {
   }
 
   bool matches_allow_list(const std::string &resolved_path) const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return matches_allow_list_unlocked(resolved_path);
   }
 
@@ -294,7 +293,7 @@ class path_policy {
   }
 
   policy base_;
-  mutable std::shared_mutex mutex_;
+  mutable std::mutex mutex_;
   std::vector<entry> entries_;
 };
 

--- a/include/check/path_access_policy.hpp
+++ b/include/check/path_access_policy.hpp
@@ -5,6 +5,8 @@
 
 #include <boost/filesystem.hpp>
 #include <check/access_policy.hpp>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -27,7 +29,18 @@
 //   /var/log            a directory: everything beneath it, at any depth
 //   /var/log/*.log      a glob: matched against the whole resolved path
 //
-// A bare entry which is not a directory is an exact file name.
+// A bare entry which names an existing regular file is that one file. A bare
+// entry which names nothing yet is treated as a directory: the volume may be
+// mounted, or the application may create its log directory, after the
+// service has started, and an entry which is silently demoted to an exact
+// file name at load time would then refuse everything beneath it until the
+// next reload. Treating it as a directory costs nothing - a directory entry
+// covers the path itself too - and matches what the documentation promises.
+//
+// In a path glob `*` and `?` do not cross a directory separator, so
+// `/var/log/*.log` names the files in that directory and not those in
+// `/var/log/private/`; `**` matches across separators for the cases where
+// the whole subtree is meant (`/var/log/**.log`).
 
 namespace check {
 namespace access {
@@ -47,34 +60,54 @@ class path_policy {
 #endif
         ) {}
 
+  path_policy(const path_policy &other) : base_(other.base_) {
+    std::shared_lock<std::shared_mutex> lock(other.mutex_);
+    entries_ = other.entries_;
+  }
+  path_policy &operator=(const path_policy &other) {
+    if (this == &other) return *this;
+    path_policy copy(other);
+    base_ = copy.base_;
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    entries_.swap(copy.entries_);
+    return *this;
+  }
+
   // --- configuration -------------------------------------------------------
 
   void set_mode(const std::string &value) { base_.set_mode(value); }
   void add_predefined(const std::string &name, const std::string &value) { base_.add_predefined(name, value); }
   void clear_predefined() { base_.clear_predefined(); }
 
+  // Built beside the live list and swapped in whole, for the same reason as
+  // policy::set_allow_list.
   void set_allow_list(const std::string &value) {
-    entries_.clear();
+    std::vector<entry> entries;
     std::vector<std::string> raw;
     boost::algorithm::split(raw, value, boost::algorithm::is_any_of(","));
     for (std::string &item : raw) {
       boost::algorithm::trim(item);
       if (item.empty()) continue;
-      entries_.push_back(make_entry(item));
+      entries.push_back(make_entry(item));
     }
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    entries_.swap(entries);
   }
 
-  void reset() {
-    base_.reset();
-    entries_.clear();
-  }
+  // Only the predefined entries are appended to by the settings callbacks;
+  // the mode and the allow list are replaced by theirs, and clearing them
+  // here would open the gate until notify() has run (see policy::reset).
+  void reset() { base_.reset(); }
 
   // --- state ---------------------------------------------------------------
 
   mode get_mode() const { return base_.get_mode(); }
   bool is_restricted() const { return base_.is_restricted(); }
-  const std::string &get_config_error() const { return base_.get_config_error(); }
-  std::size_t allow_list_size() const { return entries_.size(); }
+  std::string get_config_error() const { return base_.get_config_error(); }
+  std::size_t allow_list_size() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return entries_.size();
+  }
 
   // Normalise a path the way resolve() does, so a caller can match a candidate
   // without going through the mode machinery (used by the tests).
@@ -91,15 +124,53 @@ class path_policy {
     return to_slashes(out.string());
   }
 
-  bool matches_allow_list(const std::string &resolved_path) const {
-    for (const entry &e : entries_) {
-      if (e.is_directory) {
-        if (is_under(e.text, resolved_path)) return true;
-      } else if (boost::regex_match(resolved_path, e.pattern)) {
-        return true;
+  // Translate a path glob into a regular expression. Unlike the generic
+  // glob_to_regex, `*` and `?` stop at a directory separator (the candidate
+  // is slash-normalised by canonical(), so `/` is the only one to consider)
+  // and `**` is the spelling which crosses them.
+  static std::string glob_to_regex(const std::string &glob) {
+    std::string re;
+    re.reserve(glob.size() * 2);
+    for (std::string::size_type i = 0; i < glob.size(); ++i) {
+      const char c = glob[i];
+      switch (c) {
+        case '*':
+          if (i + 1 < glob.size() && glob[i + 1] == '*') {
+            re += ".*";
+            ++i;
+          } else {
+            re += "[^/]*";
+          }
+          break;
+        case '?':
+          re += "[^/]";
+          break;
+        case '.':
+        case '\\':
+        case '+':
+        case '^':
+        case '$':
+        case '(':
+        case ')':
+        case '[':
+        case ']':
+        case '{':
+        case '}':
+        case '|':
+          re += '\\';
+          re += c;
+          break;
+        default:
+          re += c;
+          break;
       }
     }
-    return false;
+    return re;
+  }
+
+  bool matches_allow_list(const std::string &resolved_path) const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return matches_allow_list_unlocked(resolved_path);
   }
 
   // --- resolution ----------------------------------------------------------
@@ -112,7 +183,8 @@ class path_policy {
     std::string configured;
     if (base_.lookup_predefined(token, configured)) return decision::accept(configured);
 
-    if (!base_.get_config_error().empty()) return decision::refuse(base_.get_config_error());
+    const std::string config_error = base_.get_config_error();
+    if (!config_error.empty()) return decision::refuse(config_error);
 
     switch (base_.get_mode()) {
       case mode::any:
@@ -120,14 +192,12 @@ class path_policy {
       case mode::allowed: {
         const std::string resolved = canonical(token);
         if (matches_allow_list(resolved)) return decision::accept(resolved);
-        return decision::refuse("Refusing file '" + token + "': it is not in 'allowed files' (see [" + base_.get_settings_path() +
-                                "] in the configuration)");
+        return decision::refuse("Refusing file '" + token + "': it is not in 'allowed files' (see [" + base_.get_settings_path() + "] in the configuration)");
       }
       case mode::predefined:
       default:
-        return decision::refuse("Refusing file '" + token +
-                                "': 'file access' is set to predefined, so only a configured file name may be used (see [" + base_.get_settings_path() +
-                                "] in the configuration)");
+        return decision::refuse("Refusing file '" + token + "': 'file access' is set to predefined, so only a configured file name may be used (see [" +
+                                base_.get_settings_path() + "] in the configuration)");
     }
   }
 
@@ -138,6 +208,17 @@ class path_policy {
     boost::regex pattern;  // glob entries
     entry() : is_directory(false) {}
   };
+
+  bool matches_allow_list_unlocked(const std::string &resolved_path) const {
+    for (const entry &e : entries_) {
+      if (e.is_directory) {
+        if (is_under(e.text, resolved_path)) return true;
+      } else if (boost::regex_match(resolved_path, e.pattern)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   static std::string to_slashes(std::string s) {
     std::replace(s.begin(), s.end(), '\\', '/');
@@ -152,9 +233,14 @@ class path_policy {
   static entry make_entry(const std::string &item) {
     entry e;
     if (!has_wildcard(item)) {
+      // Everything which is not an existing regular file is a directory
+      // entry: an existing directory obviously, and a path which does not
+      // exist yet (see the header comment). Only a file which is there now is
+      // pinned to that one file.
       boost::system::error_code ec;
-      const bool dir = boost::filesystem::is_directory(boost::filesystem::path(item), ec);
-      e.is_directory = !ec && dir;
+      const boost::filesystem::file_status status = boost::filesystem::status(boost::filesystem::path(item), ec);
+      const bool is_file = !ec && boost::filesystem::exists(status) && !boost::filesystem::is_directory(status);
+      e.is_directory = !is_file;
       e.text = canonical(item);
       if (e.is_directory) return e;
     } else {
@@ -183,17 +269,32 @@ class path_policy {
     return canonical(prefix) + rest;
   }
 
+  // Compare two path fragments the way the platform's filesystem does: the
+  // glob entries are compiled case-insensitively on Windows, and a directory
+  // entry has to agree with them or the same tree is allowed under one
+  // spelling and refused under another. weakly_canonical keeps whatever
+  // case the caller wrote for the elements it resolves lexically, so this
+  // cannot be left to it.
+  static bool same_text(const std::string &a, const std::string &b) {
+#ifdef WIN32
+    return boost::algorithm::iequals(a, b);
+#else
+    return a == b;
+#endif
+  }
+
   // True when `file` sits inside `dir` (or is `dir` itself). Both are already
   // resolved and slash-normalised, so this is a plain element-wise prefix
   // test: comparing the strings would let "/var/logger/x" pass for "/var/log".
   static bool is_under(const std::string &dir, const std::string &file) {
-    if (file == dir) return true;
+    if (same_text(file, dir)) return true;
     if (file.size() <= dir.size()) return false;
-    if (file.compare(0, dir.size(), dir) != 0) return false;
+    if (!same_text(file.substr(0, dir.size()), dir)) return false;
     return file[dir.size()] == '/';
   }
 
   policy base_;
+  mutable std::shared_mutex mutex_;
   std::vector<entry> entries_;
 };
 

--- a/include/check/path_access_policy.hpp
+++ b/include/check/path_access_policy.hpp
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <boost/filesystem.hpp>
+#include <check/access_policy.hpp>
+#include <string>
+#include <utility>
+#include <vector>
+
+// The path-shaped variant of check::access::policy, for arguments which name a
+// file (`check_logfile file=`).
+//
+// A path cannot be matched as a plain string. `C:/logs/../../Windows/x.log`
+// and a symlink planted inside an allowed directory both read as "under
+// C:/logs" to a glob and are not, so every candidate is resolved with
+// weakly_canonical first - which flattens `..` and follows symlinks, including
+// Windows junctions - and the *resolved* path is what gets matched and what
+// the check then opens. Matching one path and opening another is the bug this
+// exists to prevent, so in a restricted mode the check reads the resolved path
+// even when that spells the name differently than the caller did.
+//
+// Allow-list entries come in two shapes, distinguished by whether they contain
+// a wildcard:
+//
+//   /var/log            a directory: everything beneath it, at any depth
+//   /var/log/*.log      a glob: matched against the whole resolved path
+//
+// A bare entry which is not a directory is an exact file name.
+
+namespace check {
+namespace access {
+
+class path_policy {
+ public:
+  path_policy(std::string noun, std::string nouns, std::string settings_path)
+      : base_(std::move(noun), std::move(nouns), std::move(settings_path),
+// Path comparison follows the platform: case-insensitive where the
+// filesystem is, case-sensitive where /var/log/App.log and
+// /var/log/app.log are two different files and an allow list must not
+// conflate them.
+#ifdef WIN32
+              false
+#else
+              true
+#endif
+        ) {}
+
+  // --- configuration -------------------------------------------------------
+
+  void set_mode(const std::string &value) { base_.set_mode(value); }
+  void add_predefined(const std::string &name, const std::string &value) { base_.add_predefined(name, value); }
+  void clear_predefined() { base_.clear_predefined(); }
+
+  void set_allow_list(const std::string &value) {
+    entries_.clear();
+    std::vector<std::string> raw;
+    boost::algorithm::split(raw, value, boost::algorithm::is_any_of(","));
+    for (std::string &item : raw) {
+      boost::algorithm::trim(item);
+      if (item.empty()) continue;
+      entries_.push_back(make_entry(item));
+    }
+  }
+
+  void reset() {
+    base_.reset();
+    entries_.clear();
+  }
+
+  // --- state ---------------------------------------------------------------
+
+  mode get_mode() const { return base_.get_mode(); }
+  bool is_restricted() const { return base_.is_restricted(); }
+  const std::string &get_config_error() const { return base_.get_config_error(); }
+  std::size_t allow_list_size() const { return entries_.size(); }
+
+  // Normalise a path the way resolve() does, so a caller can match a candidate
+  // without going through the mode machinery (used by the tests).
+  static std::string canonical(const std::string &path) {
+    boost::system::error_code ec;
+    const boost::filesystem::path resolved = boost::filesystem::weakly_canonical(boost::filesystem::path(path), ec);
+    // weakly_canonical needs the filesystem to resolve symlinks; when it
+    // cannot (a path on a volume which is gone, a permission error on a parent
+    // directory) fall back to a purely lexical normalisation. That still
+    // flattens `..`, so the traversal case stays closed; only symlink
+    // resolution is lost, and an entry which is not reachable cannot be read
+    // by the check either.
+    const boost::filesystem::path out = ec ? boost::filesystem::path(path).lexically_normal() : resolved;
+    return to_slashes(out.string());
+  }
+
+  bool matches_allow_list(const std::string &resolved_path) const {
+    for (const entry &e : entries_) {
+      if (e.is_directory) {
+        if (is_under(e.text, resolved_path)) return true;
+      } else if (boost::regex_match(resolved_path, e.pattern)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // --- resolution ----------------------------------------------------------
+
+  // Resolve one caller-supplied file argument. On success `value` holds the
+  // path the check should open: the token untouched when nothing is
+  // restricted, the configured path when the token named a predefined entry,
+  // and the resolved path when it had to pass the allow list.
+  decision resolve(const std::string &token) const {
+    std::string configured;
+    if (base_.lookup_predefined(token, configured)) return decision::accept(configured);
+
+    if (!base_.get_config_error().empty()) return decision::refuse(base_.get_config_error());
+
+    switch (base_.get_mode()) {
+      case mode::any:
+        return decision::accept(token);
+      case mode::allowed: {
+        const std::string resolved = canonical(token);
+        if (matches_allow_list(resolved)) return decision::accept(resolved);
+        return decision::refuse("Refusing file '" + token + "': it is not in 'allowed files' (see [" + base_.get_settings_path() +
+                                "] in the configuration)");
+      }
+      case mode::predefined:
+      default:
+        return decision::refuse("Refusing file '" + token +
+                                "': 'file access' is set to predefined, so only a configured file name may be used (see [" + base_.get_settings_path() +
+                                "] in the configuration)");
+    }
+  }
+
+ private:
+  struct entry {
+    bool is_directory;
+    std::string text;      // directory entries: the resolved directory
+    boost::regex pattern;  // glob entries
+    entry() : is_directory(false) {}
+  };
+
+  static std::string to_slashes(std::string s) {
+    std::replace(s.begin(), s.end(), '\\', '/');
+    // A trailing separator would make the containment test compare an empty
+    // final element; drop it so "/var/log/" and "/var/log" behave alike.
+    while (s.size() > 1 && s.back() == '/') s.pop_back();
+    return s;
+  }
+
+  static bool has_wildcard(const std::string &s) { return s.find('*') != std::string::npos || s.find('?') != std::string::npos; }
+
+  static entry make_entry(const std::string &item) {
+    entry e;
+    if (!has_wildcard(item)) {
+      boost::system::error_code ec;
+      const bool dir = boost::filesystem::is_directory(boost::filesystem::path(item), ec);
+      e.is_directory = !ec && dir;
+      e.text = canonical(item);
+      if (e.is_directory) return e;
+    } else {
+      // Resolve the literal directory prefix of the glob, so a pattern written
+      // through a symlinked or `..`-bearing path still matches the resolved
+      // candidates it is meant to cover. Everything from the first wildcard on
+      // is left alone - it is a pattern, not a path.
+      e.text = resolve_glob_prefix(item);
+    }
+    boost::regex::flag_type flags = boost::regex::perl;
+#ifdef WIN32
+    flags |= boost::regex::icase;
+#endif
+    e.pattern = boost::regex(glob_to_regex(e.text), flags);
+    return e;
+  }
+
+  static std::string resolve_glob_prefix(const std::string &item) {
+    const std::string normalised = to_slashes(item);
+    const std::string::size_type wild = normalised.find_first_of("*?");
+    const std::string::size_type slash = normalised.rfind('/', wild);
+    if (slash == std::string::npos || slash == 0) return normalised;
+    const std::string prefix = normalised.substr(0, slash);
+    const std::string rest = normalised.substr(slash);
+    if (has_wildcard(prefix)) return normalised;
+    return canonical(prefix) + rest;
+  }
+
+  // True when `file` sits inside `dir` (or is `dir` itself). Both are already
+  // resolved and slash-normalised, so this is a plain element-wise prefix
+  // test: comparing the strings would let "/var/logger/x" pass for "/var/log".
+  static bool is_under(const std::string &dir, const std::string &file) {
+    if (file == dir) return true;
+    if (file.size() <= dir.size()) return false;
+    if (file.compare(0, dir.size(), dir) != 0) return false;
+    return file[dir.size()] == '/';
+  }
+
+  policy base_;
+  std::vector<entry> entries_;
+};
+
+}  // namespace access
+}  // namespace check

--- a/include/check/prefix_access_policy.hpp
+++ b/include/check/prefix_access_policy.hpp
@@ -1,0 +1,149 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <boost/algorithm/string.hpp>
+#include <check/access_policy.hpp>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+// The hierarchical variant of check::access::policy, for arguments which name a
+// node in a separator-delimited namespace rather than a file: a registry key
+// (`HKLM\SOFTWARE\MyApp`, separator `\`) or an event log channel
+// (`Microsoft-Windows-Sysmon/Operational`, separator `/`).
+//
+// It exists because the plain policy matches a value against a glob and nothing
+// else, which is the wrong shape here. An operator allowing `HKLM\SOFTWARE\App`
+// means that key *and its subtree*; writing `HKLM\SOFTWARE\App*` to get it would
+// also match `HKLM\SOFTWARE\AppEvil`, and writing `HKLM\SOFTWARE\App\*` would
+// miss the key itself. So an entry with no wildcard matches the value exactly or
+// as a prefix ending on a separator - never mid-segment - and an entry with a
+// wildcard is matched as a glob, for the cases where that is what you want.
+//
+// Unlike the path variant there is nothing to resolve against a filesystem:
+// these namespaces have no `..` and no links. What they do have is alternate
+// spellings (`HKLM` and `HKEY_LOCAL_MACHINE` name the same hive), so a
+// normaliser can be supplied; it is applied to both the allow-list entries and
+// the value being tested, so the two are compared in the same spelling.
+
+namespace check {
+namespace access {
+
+class prefix_policy {
+ public:
+  typedef std::function<std::string(const std::string &)> normalizer;
+
+  prefix_policy(std::string noun, std::string nouns, std::string settings_path, const char separator, normalizer normalize = normalizer())
+      : base_(std::move(noun), std::move(nouns), std::move(settings_path)), separator_(separator), normalize_(std::move(normalize)) {}
+
+  // --- configuration -------------------------------------------------------
+
+  void set_mode(const std::string &value) { base_.set_mode(value); }
+  void add_predefined(const std::string &name, const std::string &value) { base_.add_predefined(name, value); }
+  void clear_predefined() { base_.clear_predefined(); }
+
+  void set_allow_list(const std::string &value) {
+    entries_.clear();
+    std::vector<std::string> raw;
+    boost::algorithm::split(raw, value, boost::algorithm::is_any_of(","));
+    for (std::string &item : raw) {
+      boost::algorithm::trim(item);
+      if (item.empty()) continue;
+      entries_.push_back(make_entry(normalize(item)));
+    }
+  }
+
+  void reset() {
+    base_.reset();
+    entries_.clear();
+  }
+
+  // --- state ---------------------------------------------------------------
+
+  mode get_mode() const { return base_.get_mode(); }
+  bool is_restricted() const { return base_.is_restricted(); }
+  const std::string &get_config_error() const { return base_.get_config_error(); }
+  std::size_t allow_list_size() const { return entries_.size(); }
+
+  bool matches_allow_list(const std::string &value) const {
+    const std::string subject = normalize(value);
+    for (const entry &e : entries_) {
+      if (e.is_glob) {
+        if (boost::regex_match(subject, e.pattern)) return true;
+      } else if (is_at_or_under(e.text, subject)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // --- resolution ----------------------------------------------------------
+
+  decision resolve(const std::string &token) const {
+    std::string configured;
+    if (base_.lookup_predefined(token, configured)) return decision::accept(configured);
+
+    if (!base_.get_config_error().empty()) return decision::refuse(base_.get_config_error());
+
+    switch (base_.get_mode()) {
+      case mode::any:
+        return decision::accept(token);
+      case mode::allowed:
+        if (matches_allow_list(token)) return decision::accept(token);
+        return decision::refuse(refusal(token, "it is not in 'allowed " + base_.get_nouns() + "'"));
+      case mode::predefined:
+      default:
+        return decision::refuse(
+            refusal(token, "'" + base_.get_noun() + " access' is set to predefined, so only a configured " + base_.get_noun() + " name may be used"));
+    }
+  }
+
+ private:
+  struct entry {
+    bool is_glob;
+    std::string text;      // literal entries, already normalised
+    boost::regex pattern;  // glob entries
+    entry() : is_glob(false) {}
+  };
+
+  std::string normalize(const std::string &value) const { return normalize_ ? normalize_(value) : value; }
+
+  entry make_entry(const std::string &item) const {
+    entry e;
+    e.is_glob = item.find('*') != std::string::npos || item.find('?') != std::string::npos;
+    e.text = trim_separators(item);
+    if (e.is_glob) e.pattern = boost::regex(glob_to_regex(e.text), boost::regex::perl | boost::regex::icase);
+    return e;
+  }
+
+  std::string trim_separators(std::string s) const {
+    while (s.size() > 1 && s.back() == separator_) s.pop_back();
+    return s;
+  }
+
+  // True when `value` is `prefix` itself or sits below it. The separator test
+  // is what keeps `HKLM\SOFTWARE\App` from covering `HKLM\SOFTWARE\AppEvil`:
+  // a prefix only counts when the next character ends the segment.
+  bool is_at_or_under(const std::string &prefix, const std::string &value) const {
+    const std::string subject = trim_separators(value);
+    if (boost::algorithm::iequals(subject, prefix)) return true;
+    if (subject.size() <= prefix.size()) return false;
+    if (!boost::algorithm::iequals(subject.substr(0, prefix.size()), prefix)) return false;
+    return subject[prefix.size()] == separator_;
+  }
+
+  std::string refusal(const std::string &token, const std::string &why) const {
+    return "Refusing " + base_.get_noun() + " '" + token + "': " + why + " (see [" + base_.get_settings_path() + "] in the configuration)";
+  }
+
+  policy base_;
+  char separator_;
+  normalizer normalize_;
+  std::vector<entry> entries_;
+};
+
+}  // namespace access
+}  // namespace check

--- a/include/check/prefix_access_policy.hpp
+++ b/include/check/prefix_access_policy.hpp
@@ -7,7 +7,6 @@
 #include <check/access_policy.hpp>
 #include <functional>
 #include <mutex>
-#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -42,14 +41,14 @@ class prefix_policy {
       : base_(std::move(noun), std::move(nouns), std::move(settings_path)), separator_(separator), normalize_(std::move(normalize)) {}
 
   prefix_policy(const prefix_policy &other) : base_(other.base_), separator_(other.separator_), normalize_(other.normalize_) {
-    std::shared_lock<std::shared_mutex> lock(other.mutex_);
+    std::lock_guard<std::mutex> lock(other.mutex_);
     entries_ = other.entries_;
   }
   prefix_policy &operator=(const prefix_policy &other) {
     if (this == &other) return *this;
     prefix_policy copy(other);
     base_ = copy.base_;
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     separator_ = copy.separator_;
     normalize_ = copy.normalize_;
     entries_.swap(copy.entries_);
@@ -73,7 +72,7 @@ class prefix_policy {
       if (item.empty()) continue;
       entries.push_back(make_entry(normalize(item)));
     }
-    std::unique_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     entries_.swap(entries);
   }
 
@@ -88,13 +87,13 @@ class prefix_policy {
   bool is_restricted() const { return base_.is_restricted(); }
   std::string get_config_error() const { return base_.get_config_error(); }
   std::size_t allow_list_size() const {
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return entries_.size();
   }
 
   bool matches_allow_list(const std::string &value) const {
     const std::string subject = normalize(value);
-    std::shared_lock<std::shared_mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     for (const entry &e : entries_) {
       if (e.is_glob) {
         if (boost::regex_match(subject, e.pattern)) return true;
@@ -168,7 +167,7 @@ class prefix_policy {
   policy base_;
   char separator_;
   normalizer normalize_;
-  mutable std::shared_mutex mutex_;
+  mutable std::mutex mutex_;
   std::vector<entry> entries_;
 };
 

--- a/include/check/prefix_access_policy.hpp
+++ b/include/check/prefix_access_policy.hpp
@@ -6,6 +6,8 @@
 #include <boost/algorithm/string.hpp>
 #include <check/access_policy.hpp>
 #include <functional>
+#include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <utility>
 #include <vector>
@@ -39,37 +41,60 @@ class prefix_policy {
   prefix_policy(std::string noun, std::string nouns, std::string settings_path, const char separator, normalizer normalize = normalizer())
       : base_(std::move(noun), std::move(nouns), std::move(settings_path)), separator_(separator), normalize_(std::move(normalize)) {}
 
+  prefix_policy(const prefix_policy &other) : base_(other.base_), separator_(other.separator_), normalize_(other.normalize_) {
+    std::shared_lock<std::shared_mutex> lock(other.mutex_);
+    entries_ = other.entries_;
+  }
+  prefix_policy &operator=(const prefix_policy &other) {
+    if (this == &other) return *this;
+    prefix_policy copy(other);
+    base_ = copy.base_;
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    separator_ = copy.separator_;
+    normalize_ = copy.normalize_;
+    entries_.swap(copy.entries_);
+    return *this;
+  }
+
   // --- configuration -------------------------------------------------------
 
   void set_mode(const std::string &value) { base_.set_mode(value); }
   void add_predefined(const std::string &name, const std::string &value) { base_.add_predefined(name, value); }
   void clear_predefined() { base_.clear_predefined(); }
 
+  // Built beside the live list and swapped in whole, for the same reason as
+  // policy::set_allow_list.
   void set_allow_list(const std::string &value) {
-    entries_.clear();
+    std::vector<entry> entries;
     std::vector<std::string> raw;
     boost::algorithm::split(raw, value, boost::algorithm::is_any_of(","));
     for (std::string &item : raw) {
       boost::algorithm::trim(item);
       if (item.empty()) continue;
-      entries_.push_back(make_entry(normalize(item)));
+      entries.push_back(make_entry(normalize(item)));
     }
+    std::unique_lock<std::shared_mutex> lock(mutex_);
+    entries_.swap(entries);
   }
 
-  void reset() {
-    base_.reset();
-    entries_.clear();
-  }
+  // Only the predefined entries are appended to by the settings callbacks;
+  // the mode and the allow list are replaced by theirs, and clearing them
+  // here would open the gate until notify() has run (see policy::reset).
+  void reset() { base_.reset(); }
 
   // --- state ---------------------------------------------------------------
 
   mode get_mode() const { return base_.get_mode(); }
   bool is_restricted() const { return base_.is_restricted(); }
-  const std::string &get_config_error() const { return base_.get_config_error(); }
-  std::size_t allow_list_size() const { return entries_.size(); }
+  std::string get_config_error() const { return base_.get_config_error(); }
+  std::size_t allow_list_size() const {
+    std::shared_lock<std::shared_mutex> lock(mutex_);
+    return entries_.size();
+  }
 
   bool matches_allow_list(const std::string &value) const {
     const std::string subject = normalize(value);
+    std::shared_lock<std::shared_mutex> lock(mutex_);
     for (const entry &e : entries_) {
       if (e.is_glob) {
         if (boost::regex_match(subject, e.pattern)) return true;
@@ -86,7 +111,8 @@ class prefix_policy {
     std::string configured;
     if (base_.lookup_predefined(token, configured)) return decision::accept(configured);
 
-    if (!base_.get_config_error().empty()) return decision::refuse(base_.get_config_error());
+    const std::string config_error = base_.get_config_error();
+    if (!config_error.empty()) return decision::refuse(config_error);
 
     switch (base_.get_mode()) {
       case mode::any:
@@ -142,6 +168,7 @@ class prefix_policy {
   policy base_;
   char separator_;
   normalizer normalize_;
+  mutable std::shared_mutex mutex_;
   std::vector<entry> entries_;
 };
 

--- a/include/check/wql_query.hpp
+++ b/include/check/wql_query.hpp
@@ -33,10 +33,17 @@ struct parse_result {
   parse_result() : ok(false) {}
 };
 
-// Accepts: optional whitespace, SELECT, a column list with no statement
-// punctuation in it, FROM, a bare class identifier, and optionally a WHERE
-// clause (whose contents are not our business - WMI evaluates it against the
-// class we just approved, it cannot reach another one).
+// Accepts: optional whitespace, SELECT, a column list which is `*` or a
+// comma-separated list of identifiers and nothing else, FROM, a bare class
+// identifier, and optionally a WHERE clause (whose contents are not our
+// business - WMI evaluates it against the class we just approved, it cannot
+// reach another one).
+//
+// The column list is spelled out in the grammar rather than checked afterwards
+// because a looser one lets the class move. With the column list written as
+// "anything without a semicolon", `SELECT a FROM Win32_Foo FROM Win32_Allowed`
+// matched with the columns swallowing the first FROM, and the gate reported
+// the *last* class in the query while WMI would read the first.
 inline parse_result extract_class(const std::string &query) {
   parse_result result;
 
@@ -55,8 +62,17 @@ inline parse_result extract_class(const std::string &query) {
   // what keeps a query from naming a class in another namespace or on another
   // machine (`\\\\host\\root\\cimv2:Win32_Process`) and slipping past a check
   // which only compared the trailing identifier.
+  // A column or class named after a keyword leaves the statement ambiguous -
+  // `SELECT FROM FROM Win32_Allowed` parses two ways and WMI picks one of them
+  // - so no identifier here may be one. `\\b` keeps `FROMAGE` an ordinary name.
+  static const std::string ident = "(?!(?:FROM|WHERE|SELECT)\\b)[A-Za-z_][A-Za-z0-9_]*";
   static const boost::regex re(
-      "\\A\\s*SELECT\\s+([^;]+?)\\s+FROM\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*(?:WHERE\\s+(.*))?\\z",
+      "\\A\\s*SELECT\\s+"
+      "(\\*|" +
+          ident + "(?:\\s*,\\s*" + ident +
+          ")*)"
+          "\\s+FROM\\s+(" +
+          ident + ")\\s*(?:WHERE\\s+(.*))?\\z",
       boost::regex::perl | boost::regex::icase | boost::regex::mod_s);
 
   boost::smatch what;
@@ -64,15 +80,6 @@ inline parse_result extract_class(const std::string &query) {
     result.error =
         "only a plain 'SELECT ... FROM <class> [WHERE ...]' query can be checked against 'allowed classes'; "
         "configure it as a predefined query instead";
-    return result;
-  }
-
-  // The column list is identifiers, commas, `*` and whitespace. Anything else
-  // (a nested keyword, a path, punctuation we have not reasoned about) means
-  // this is not the simple shape we claim to understand.
-  const std::string columns = what[1].str();
-  if (!boost::regex_match(columns, boost::regex("\\A[A-Za-z0-9_,\\s*]+\\z"))) {
-    result.error = "the column list is not a plain list of column names";
     return result;
   }
 

--- a/include/check/wql_query.hpp
+++ b/include/check/wql_query.hpp
@@ -1,0 +1,85 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <boost/algorithm/string.hpp>
+#include <boost/regex.hpp>
+#include <string>
+
+// Extract the class a WQL query reads from, so `check_wmi` can hold it against
+// an allow list.
+//
+// This is a gate, not a parser: its job is to answer "which class does WMI
+// read if I hand it this string" and to answer *nothing* rather than guess.
+// Every form it cannot account for exactly - ASSOCIATORS OF, REFERENCES OF, a
+// statement separator, a class path with a namespace or machine prefix - is
+// refused, because a wrong answer here is a bypass: the gate would approve one
+// class and WMI would read another.
+//
+// The cost is that a site restricting by class can only use plain
+// `SELECT ... FROM <class> [WHERE ...]`. Anything more elaborate has to be
+// configured as a predefined query, where the operator has already vouched for
+// it. That is the right side to err on, and it is what the documentation says.
+
+namespace check {
+namespace wql {
+
+struct parse_result {
+  bool ok;
+  std::string class_name;
+  std::string error;
+
+  parse_result() : ok(false) {}
+};
+
+// Accepts: optional whitespace, SELECT, a column list with no statement
+// punctuation in it, FROM, a bare class identifier, and optionally a WHERE
+// clause (whose contents are not our business - WMI evaluates it against the
+// class we just approved, it cannot reach another one).
+inline parse_result extract_class(const std::string &query) {
+  parse_result result;
+
+  // One query per call. A separator means there may be a second statement
+  // whose class we have not looked at.
+  if (query.find(';') != std::string::npos) {
+    result.error = "the query contains ';' and only a single statement can be checked";
+    return result;
+  }
+  if (query.find('\0') != std::string::npos) {
+    result.error = "the query contains a NUL character";
+    return result;
+  }
+
+  // A WQL class name is a bare identifier. Refusing `:`, `\` and `/` here is
+  // what keeps a query from naming a class in another namespace or on another
+  // machine (`\\\\host\\root\\cimv2:Win32_Process`) and slipping past a check
+  // which only compared the trailing identifier.
+  static const boost::regex re(
+      "\\A\\s*SELECT\\s+([^;]+?)\\s+FROM\\s+([A-Za-z_][A-Za-z0-9_]*)\\s*(?:WHERE\\s+(.*))?\\z",
+      boost::regex::perl | boost::regex::icase | boost::regex::mod_s);
+
+  boost::smatch what;
+  if (!boost::regex_match(query, what, re)) {
+    result.error =
+        "only a plain 'SELECT ... FROM <class> [WHERE ...]' query can be checked against 'allowed classes'; "
+        "configure it as a predefined query instead";
+    return result;
+  }
+
+  // The column list is identifiers, commas, `*` and whitespace. Anything else
+  // (a nested keyword, a path, punctuation we have not reasoned about) means
+  // this is not the simple shape we claim to understand.
+  const std::string columns = what[1].str();
+  if (!boost::regex_match(columns, boost::regex("\\A[A-Za-z0-9_,\\s*]+\\z"))) {
+    result.error = "the column list is not a plain list of column names";
+    return result;
+  }
+
+  result.ok = true;
+  result.class_name = what[2].str();
+  return result;
+}
+
+}  // namespace wql
+}  // namespace check

--- a/modules/CheckDisk/CMakeLists.txt
+++ b/modules/CheckDisk/CMakeLists.txt
@@ -120,6 +120,7 @@ if(WIN32)
             drive_trend_test.cpp
             check_files_test.cpp
             check_single_file_test.cpp
+            check_disk_access_test.cpp
             check_uncpath_test.cpp
             check_storagepool_test.cpp
             check_shadowcopy_test.cpp
@@ -198,6 +199,7 @@ else()
             drive_trend_test.cpp
             check_files.cpp
             check_files_checksum_test.cpp
+            check_disk_access_test.cpp
             check_mount.cpp
             check_mount_test.cpp
             check_single_file.cpp

--- a/modules/CheckDisk/CheckDisk.cpp
+++ b/modules/CheckDisk/CheckDisk.cpp
@@ -42,7 +42,7 @@
 namespace sh = nscapi::settings_helper;
 namespace po = boost::program_options;
 
-CheckDisk::CheckDisk() : show_errors_(false) {}
+CheckDisk::CheckDisk() : show_errors_(false), file_access_("file", "files", "/settings/disk") {}
 
 namespace {
 // The collector hands out an immutable, shared snapshot (null before it has
@@ -85,9 +85,37 @@ bool CheckDisk::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   sh::settings_registry settings(nscapi::settings_proxy::create(get_id(), get_core()));
   settings.set_alias("disk", alias);
 
+  // A reload calls loadModuleEx again on the live module and the settings
+  // callbacks below append, so start from nothing or every reload doubles the
+  // list.
+  file_access_.reset();
+
+  // clang-format off
+  settings.alias().add_path_to_settings()
+    ("files", sh::fun_values_path([this](const auto& key, const auto& value) { file_access_.add_predefined(key, value); }),
+      "PREDEFINED PATHS", "Files and folders the disk checks may use by name, as <name> = <path>.\n"
+      "A name defined here can be used as file=<name> (or path=<name>) in any access mode, and is the only thing accepted "
+      "when 'file access' is set to predefined.")
+    ;
+  // clang-format on
+
   std::string collection_interval, trend_interval, trend_retention;
   // clang-format off
   settings.alias().add_key_to_settings()
+    .add_string("file access", sh::string_fun_key([this](const auto& value) { file_access_.set_mode(value); }, "any"),
+        "FILE ACCESS MODE",
+        "Which paths a caller may ask check_files, check_single_file and check_disk_write to use: any (the default - any path the caller names, which is "
+        "how every earlier release behaved), allowed (only paths matching 'allowed files') or predefined (only names defined in the "
+        "[/settings/disk/files] section).\n"
+        "These checks do not return file contents, but they enumerate whole directory trees (name, size, timestamps) and can report a file's checksum, so "
+        "on a host where callers may pass arguments (NRPE with 'allow arguments', or the REST API) this decides how much of the filesystem a check can "
+        "describe. See the 'Restricting what a check may read' section of the documentation.")
+    .add_string("allowed files", sh::string_fun_key([this](const auto& value) { file_access_.set_allow_list(value); }, ""),
+        "ALLOWED PATHS",
+        "Comma separated list of paths the disk checks may use when 'file access' is set to allowed.\n"
+        "An entry naming a directory allows it and everything beneath it at any depth; an entry containing * or ? is a wildcard matched against the whole "
+        "path; any other entry is a single file. Paths are resolved (`..` is flattened and symbolic links and junctions are followed) before they are "
+        "matched, so a link planted inside an allowed directory does not widen it.")
     .add_string("disable", sh::string_key(&collector_->disable_, ""),
         "Disable automatic checks",
         "A comma separated list of checks to disable in the collector: disk_io, disk_free, trend. "
@@ -112,6 +140,8 @@ bool CheckDisk::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   // clang-format on
   settings.register_all();
   settings.notify();
+
+  if (!file_access_.get_config_error().empty()) NSC_LOG_ERROR_STD(file_access_.get_config_error());
 
   try {
     const long long interval = str::format::stox_as_time_sec<long long>(collection_interval, "s");
@@ -186,7 +216,7 @@ void CheckDisk::check_disk_health(const PB::Commands::QueryRequestMessage::Reque
 
 void CheckDisk::check_disk_write(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
   try {
-    check_disk_write_command::check(request, response);
+    check_disk_write_command::check(request, response, file_access_);
   } catch (const std::exception &e) {
     nscapi::protobuf::functions::set_response_bad(*response, "Failed to run disk write test: " + std::string(e.what()));
   }
@@ -409,11 +439,11 @@ void CheckDisk::checkFiles(PB::Commands::QueryRequestMessage::Request &request, 
 }
 
 void CheckDisk::check_files(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
-  check_files_command::check(request, response);
+  check_files_command::check(request, response, file_access_);
 }
 
 void CheckDisk::check_single_file(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
-  check_single_file_command::check(request, response);
+  check_single_file_command::check(request, response, file_access_);
 }
 
 void CheckDisk::check_mount(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {

--- a/modules/CheckDisk/CheckDisk.cpp
+++ b/modules/CheckDisk/CheckDisk.cpp
@@ -85,9 +85,11 @@ bool CheckDisk::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   sh::settings_registry settings(nscapi::settings_proxy::create(get_id(), get_core()));
   settings.set_alias("disk", alias);
 
-  // A reload calls loadModuleEx again on the live module and the settings
-  // callbacks below append, so start from nothing or every reload doubles the
-  // list.
+  // A reload calls loadModuleEx again on the live module and the predefined
+  // entries below are appended, so drop them or every reload doubles the
+  // list. The mode and the allow list are replaced by their callbacks and
+  // stay in force meanwhile, so a check arriving mid-reload is not let
+  // through an open gate.
   file_access_.reset();
 
   // clang-format off
@@ -113,9 +115,10 @@ bool CheckDisk::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
     .add_string("allowed files", sh::string_fun_key([this](const auto& value) { file_access_.set_allow_list(value); }, ""),
         "ALLOWED PATHS",
         "Comma separated list of paths the disk checks may use when 'file access' is set to allowed.\n"
-        "An entry naming a directory allows it and everything beneath it at any depth; an entry containing * or ? is a wildcard matched against the whole "
-        "path; any other entry is a single file. Paths are resolved (`..` is flattened and symbolic links and junctions are followed) before they are "
-        "matched, so a link planted inside an allowed directory does not widen it.")
+        "An entry naming a directory (or a path which does not exist yet) allows it and everything beneath it at any depth; an entry naming an existing "
+        "file is that single file; an entry containing * or ? is a wildcard matched against the whole path, where * and ? do not cross a directory "
+        "separator and ** does. Paths are resolved (`..` is flattened and symbolic links and junctions are followed) before they are matched, so a link "
+        "planted inside an allowed directory does not widen it.")
     .add_string("disable", sh::string_key(&collector_->disable_, ""),
         "Disable automatic checks",
         "A comma separated list of checks to disable in the collector: disk_io, disk_free, trend. "

--- a/modules/CheckDisk/CheckDisk.h
+++ b/modules/CheckDisk/CheckDisk.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <check/path_access_policy.hpp>
 #include <memory>
 #include <nscapi/nscapi_plugin_impl.hpp>
 #include <nscapi/protobuf/command.hpp>
@@ -13,6 +14,10 @@
 class CheckDisk : public nscapi::impl::simple_plugin {
   bool show_errors_;
   std::shared_ptr<collector_thread> collector_;
+  // Which paths a caller may name in check_files, check_single_file and
+  // check_disk_write. Open by default, so an upgrade changes nothing; see
+  // docs/docs/concepts/check-access.md.
+  check::access::path_policy file_access_;
 
  public:
   CheckDisk();

--- a/modules/CheckDisk/check_disk_access_test.cpp
+++ b/modules/CheckDisk/check_disk_access_test.cpp
@@ -1,0 +1,304 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+// The `file access` gate on the three disk checks which take a caller-supplied
+// path: check_files, check_single_file and check_disk_write.
+//
+// Unlike check_logfile these never return file contents, but check_files walks
+// whole directory trees and reports every name, size and timestamp, and the
+// checksum keywords turn any readable file into a hash oracle. Where the caller
+// chooses the argument - NRPE with `allow arguments`, or REST - that is a wide
+// enough reach to be worth narrowing.
+//
+// The policy itself is covered by include/check/access_policy_test.cpp; what is
+// tested here is that each command actually consults it, refuses before doing
+// any work, and reports through the normal UNKNOWN path.
+
+#include <check/path_access_policy.hpp>
+#include <gtest/gtest.h>
+
+#include <boost/filesystem.hpp>
+#include <fstream>
+#include <string>
+
+#include "check_disk_write.hpp"
+#include "check_files.hpp"
+#include "check_single_file.hpp"
+#include "test_support.hpp"
+
+namespace {
+
+namespace fs = boost::filesystem;
+using check_disk_test_support::join_lines;
+using ScratchDir = check_disk_test_support::ScratchDir;
+
+/** A policy restricted to `dir`, in the mode named. */
+check::access::path_policy restricted(const std::string &mode, const std::string &allowed) {
+  check::access::path_policy policy("file", "files", "/settings/disk");
+  policy.set_mode(mode);
+  policy.set_allow_list(allowed);
+  return policy;
+}
+
+PB::Commands::QueryRequestMessage::Request make_request(const std::string &command, const std::vector<std::string> &args) {
+  PB::Commands::QueryRequestMessage::Request request;
+  request.set_command(command);
+  for (const std::string &a : args) request.add_arguments(a);
+  return request;
+}
+
+class DiskAccessTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    allowed_dir_ = (scratch_.path() / "logs").string();
+    secret_dir_ = (scratch_.path() / "secret").string();
+    fs::create_directories(fs::path(allowed_dir_) / "sub");
+    fs::create_directories(secret_dir_);
+    write(fs::path(allowed_dir_) / "app.log", "one\ntwo\n");
+    write(fs::path(allowed_dir_) / "sub" / "deep.log", "deep\n");
+    write(fs::path(secret_dir_) / "credentials", "hunter2\n");
+  }
+  static void write(const fs::path &p, const std::string &body) {
+    std::ofstream f(p.string().c_str());
+    f << body;
+  }
+
+  ScratchDir scratch_{"nscp-disk-access"};
+  std::string allowed_dir_;
+  std::string secret_dir_;
+};
+
+// ---------------------------------------------------------------------------
+// check_files
+// ---------------------------------------------------------------------------
+
+TEST_F(DiskAccessTest, CheckFilesAnyModeScansAnyRoot) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_files", {"path=" + secret_dir_, "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
+
+  EXPECT_NE(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+}
+
+TEST_F(DiskAccessTest, CheckFilesAllowsARootInsideTheList) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_files", {"path=" + allowed_dir_, "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_files_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_NE(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+}
+
+TEST_F(DiskAccessTest, CheckFilesRefusesARootOutsideTheList) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_files", {"path=" + secret_dir_, "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_files_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  const std::string out = join_lines(response);
+  EXPECT_NE(out.find("Refusing file"), std::string::npos) << out;
+  // The refusal must not carry the thing the caller was trying to enumerate.
+  EXPECT_EQ(out.find("credentials"), std::string::npos) << out;
+}
+
+// The reason a path needs resolving before it is matched: as plain text this
+// root reads as "under the allowed directory" and is not.
+TEST_F(DiskAccessTest, CheckFilesRefusesATraversalOutOfTheAllowedRoot) {
+  PB::Commands::QueryRequestMessage::Request request =
+      make_request("check_files", {"path=" + (fs::path(allowed_dir_) / ".." / "secret").string(), "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_files_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Refusing file"), std::string::npos) << join_lines(response);
+}
+
+// `paths=` is a comma separated alias for repeated `path=`; it is split before
+// the gate runs, so its entries are held to the same list.
+TEST_F(DiskAccessTest, CheckFilesGatesThePathsAlias) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_files", {"paths=" + allowed_dir_ + "," + secret_dir_, "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_files_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Refusing file"), std::string::npos) << join_lines(response);
+}
+
+TEST_F(DiskAccessTest, CheckFilesRefusesEveryRootWhenOneIsNotAllowed) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_files", {"path=" + allowed_dir_, "path=" + secret_dir_, "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_files_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Refusing file"), std::string::npos) << join_lines(response);
+}
+
+TEST_F(DiskAccessTest, CheckFilesPredefinedModeResolvesAName) {
+  check::access::path_policy policy = restricted("predefined", "");
+  policy.add_predefined("logs", allowed_dir_);
+
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_files", {"path=logs", "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_files_command::check(request, &response, policy);
+
+  EXPECT_NE(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+}
+
+TEST_F(DiskAccessTest, CheckFilesPredefinedModeRefusesARawPath) {
+  check::access::path_policy policy = restricted("predefined", "");
+  policy.add_predefined("logs", allowed_dir_);
+
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_files", {"path=" + allowed_dir_, "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_files_command::check(request, &response, policy);
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("set to predefined"), std::string::npos) << join_lines(response);
+}
+
+// ---------------------------------------------------------------------------
+// check_single_file
+// ---------------------------------------------------------------------------
+
+TEST_F(DiskAccessTest, CheckSingleFileAllowsAFileInsideTheList) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_single_file", {"file=" + (fs::path(allowed_dir_) / "app.log").string()});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_single_file_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_NE(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+}
+
+TEST_F(DiskAccessTest, CheckSingleFileRefusesAFileOutsideTheList) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_single_file", {"file=" + (fs::path(secret_dir_) / "credentials").string()});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_single_file_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  const std::string out = join_lines(response);
+  EXPECT_NE(out.find("Refusing file"), std::string::npos) << out;
+  // It must refuse rather than leak existence through the "File not found"
+  // message the ungated path would produce for an unreadable file.
+  EXPECT_EQ(out.find("File not found"), std::string::npos) << out;
+}
+
+// The `path=` alias reaches the same variable, so it is gated identically.
+TEST_F(DiskAccessTest, CheckSingleFileGatesThePathAlias) {
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_single_file", {"path=" + (fs::path(secret_dir_) / "credentials").string()});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_single_file_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Refusing file"), std::string::npos) << join_lines(response);
+}
+
+// `ignore-missing` returns OK for a file which is not there; it must not turn a
+// refusal into a silent OK, or the gate would be invisible.
+TEST_F(DiskAccessTest, CheckSingleFileRefusalBeatsIgnoreMissing) {
+  PB::Commands::QueryRequestMessage::Request request =
+      make_request("check_single_file", {"file=" + (fs::path(secret_dir_) / "credentials").string(), "ignore-missing=true"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_single_file_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Refusing file"), std::string::npos) << join_lines(response);
+}
+
+#ifndef WIN32
+// stat_single_file follows a symbolic link, so resolving the path before the
+// match is what stops a link inside an allowed directory reporting on its
+// target.
+TEST_F(DiskAccessTest, CheckSingleFileRefusesASymlinkLeadingOut) {
+  boost::system::error_code ec;
+  fs::create_symlink(fs::path(secret_dir_) / "credentials", fs::path(allowed_dir_) / "escape.log", ec);
+  if (ec) GTEST_SKIP() << "cannot create symlinks here: " << ec.message();
+
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_single_file", {"file=" + (fs::path(allowed_dir_) / "escape.log").string()});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_single_file_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Refusing file"), std::string::npos) << join_lines(response);
+}
+#endif
+
+// ---------------------------------------------------------------------------
+// check_disk_write
+// ---------------------------------------------------------------------------
+
+TEST_F(DiskAccessTest, CheckDiskWriteAllowsAPathInsideTheList) {
+  PB::Commands::QueryRequestMessage::Request request =
+      make_request("check_disk_write", {"file=" + (fs::path(allowed_dir_) / "probe.tmp").string(), "size=1k"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_disk_write_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_NE(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
+}
+
+TEST_F(DiskAccessTest, CheckDiskWriteRefusesAPathOutsideTheList) {
+  const fs::path target = fs::path(secret_dir_) / "probe.tmp";
+  PB::Commands::QueryRequestMessage::Request request = make_request("check_disk_write", {"file=" + target.string(), "size=1k"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_disk_write_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(response).find("Refusing file"), std::string::npos) << join_lines(response);
+  // Refused before anything was created.
+  EXPECT_FALSE(fs::exists(target));
+}
+
+// The gate runs before the size is parsed, so a refusal is not masked by an
+// argument error the caller could use to tell the two apart.
+TEST_F(DiskAccessTest, CheckDiskWriteRefusesBeforeValidatingSize) {
+  PB::Commands::QueryRequestMessage::Request request =
+      make_request("check_disk_write", {"file=" + (fs::path(secret_dir_) / "probe.tmp").string(), "size=not-a-size"});
+  PB::Commands::QueryResponseMessage::Response response;
+
+  check_disk_write_command::check(request, &response, restricted("allowed", allowed_dir_));
+
+  EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
+  const std::string out = join_lines(response);
+  EXPECT_NE(out.find("Refusing file"), std::string::npos) << out;
+  EXPECT_EQ(out.find("Invalid size"), std::string::npos) << out;
+}
+
+// ---------------------------------------------------------------------------
+// a typo in the mode must not read as "no restriction"
+// ---------------------------------------------------------------------------
+
+TEST_F(DiskAccessTest, AnInvalidModeFailsClosedOnEveryCommand) {
+  const check::access::path_policy policy = restricted("allwed", allowed_dir_);
+
+  PB::Commands::QueryRequestMessage::Request files = make_request("check_files", {"path=" + allowed_dir_, "pattern=*"});
+  PB::Commands::QueryResponseMessage::Response files_response;
+  check_files_command::check(files, &files_response, policy);
+  EXPECT_EQ(files_response.result(), PB::Common::ResultCode::UNKNOWN);
+  EXPECT_NE(join_lines(files_response).find("expected any, allowed or predefined"), std::string::npos) << join_lines(files_response);
+
+  PB::Commands::QueryRequestMessage::Request single =
+      make_request("check_single_file", {"file=" + (fs::path(allowed_dir_) / "app.log").string()});
+  PB::Commands::QueryResponseMessage::Response single_response;
+  check_single_file_command::check(single, &single_response, policy);
+  EXPECT_EQ(single_response.result(), PB::Common::ResultCode::UNKNOWN);
+
+  PB::Commands::QueryRequestMessage::Request write_req =
+      make_request("check_disk_write", {"file=" + (fs::path(allowed_dir_) / "probe.tmp").string(), "size=1k"});
+  PB::Commands::QueryResponseMessage::Response write_response;
+  check_disk_write_command::check(write_req, &write_response, policy);
+  EXPECT_EQ(write_response.result(), PB::Common::ResultCode::UNKNOWN);
+}
+
+}  // namespace

--- a/modules/CheckDisk/check_disk_write.cpp
+++ b/modules/CheckDisk/check_disk_write.cpp
@@ -205,7 +205,7 @@ write_result perform_write_test(const std::string &path, const long long size) {
 }
 
 void check_with(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
-                const write_tester &tester) {
+                const write_tester &tester, const check::access::path_policy &access) {
   modern_filter::data_container data;
   modern_filter::cli_helper<filter_type> filter_helper(request, response, data);
   std::string file_path;
@@ -229,6 +229,17 @@ void check_with(const PB::Commands::QueryRequestMessage::Request &request, PB::C
   if (file_path.empty()) {
     return nscapi::protobuf::functions::set_response_bad(*response, "No file specified (use file=<path>)");
   }
+
+  // Hold the path against [/settings/disk] 'file access' before anything is
+  // created. The test file cannot overwrite an existing one (it is created
+  // exclusively and removed afterwards), but where an operator has narrowed
+  // which paths a caller may name, that applies to writing them too.
+  {
+    const check::access::decision decision = access.resolve(file_path);
+    if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);
+    file_path = decision.value;
+  }
+
   long long size = 0;
   try {
     size = str::format::decode_byte_units(size_arg);
@@ -249,8 +260,9 @@ void check_with(const PB::Commands::QueryRequestMessage::Request &request, PB::C
   filter_helper.post_process(filter);
 }
 
-void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
-  check_with(request, response, &perform_write_test);
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+           const check::access::path_policy &access) {
+  check_with(request, response, &perform_write_test, access);
 }
 
 }  // namespace check_disk_write_command

--- a/modules/CheckDisk/check_disk_write.hpp
+++ b/modules/CheckDisk/check_disk_write.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <check/path_access_policy.hpp>
+
 #include <functional>
 #include <nscapi/protobuf/command.hpp>
 #include <string>
@@ -29,8 +31,12 @@ typedef std::function<write_result(const std::string &path, long long size)> wri
 // Evaluate a write test using the given tester. Exposed (with an injectable
 // tester) for unit testing the option parsing, filtering and rendering.
 void check_with(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
-                const write_tester &tester);
+                const write_tester &tester, const check::access::path_policy &access);
 
-void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+// `access` decides which paths the caller may name; see
+// docs/docs/concepts/check-access.md. It is passed in rather than looked up so
+// the gate can be unit tested without a live module.
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+           const check::access::path_policy &access);
 
 }  // namespace check_disk_write_command

--- a/modules/CheckDisk/check_disk_write_test.cpp
+++ b/modules/CheckDisk/check_disk_write_test.cpp
@@ -7,6 +7,8 @@
 #include <fstream>
 #include <gtest/gtest.h>
 
+#include "test_support.hpp"
+
 namespace fs = boost::filesystem;
 using check_disk_write_command::write_result;
 
@@ -24,7 +26,7 @@ PB::Common::ResultCode run(const std::vector<std::string> &args, PB::Commands::Q
   PB::Commands::QueryRequestMessage::Request request;
   request.set_command("check_disk_write");
   for (const std::string &a : args) request.add_arguments(a);
-  check_disk_write_command::check(request, &response);
+  check_disk_write_command::check(request, &response, check_disk_test_support::unrestricted());
   return response.result();
 }
 
@@ -33,7 +35,7 @@ PB::Common::ResultCode run_with(const check_disk_write_command::write_tester &te
   PB::Commands::QueryRequestMessage::Request request;
   request.set_command("check_disk_write");
   for (const std::string &a : args) request.add_arguments(a);
-  check_disk_write_command::check_with(request, &response, tester);
+  check_disk_write_command::check_with(request, &response, tester, check_disk_test_support::unrestricted());
   return response.result();
 }
 

--- a/modules/CheckDisk/check_files.cpp
+++ b/modules/CheckDisk/check_files.cpp
@@ -40,7 +40,9 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
         "In other words if one path contains an error the entire check will result in error.")
     ("file", po::value<std::vector<std::string> >(&file_list), "Alias for path.")
     ("paths", po::value<std::string>(&files_string), "A comma separated list of paths to scan")
-    ("pattern", po::value<std::string>(&context.pattern)->default_value("*.*"), "The pattern of files to search for (works like a filter but is faster and can be combined with a filter).")
+    ("pattern", po::value<std::string>(&context.pattern)->default_value("*.*"), "The pattern of files to search for (works like a filter but is faster and can be combined with a filter).\n"
+        "This is a file mask, not a path: while 'file access' in [/settings/disk] is restricted it may not contain a path separator or '..', since the "
+        "scan root is what was held against the allow list.")
     ("max-depth", po::value<int>(&context.max_depth), "Maximum depth to recurse")
     ("total", po::value(&total)->implicit_value("filter"), "Include the total of either (filter) all files matching the filter or (all) all files regardless of the filter")
     ("ignore-missing", po::value<bool>(&ignore_missing)->implicit_value(true)->default_value(false),
@@ -77,6 +79,18 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
     const check::access::decision decision = access.resolve(path);
     if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);
     path = decision.value;
+  }
+
+  // `pattern` is a file mask, and the Windows scanner builds its search string
+  // by concatenating it onto the directory it is walking. A pattern carrying
+  // separators or `..` therefore enumerates a tree the allow list never saw -
+  // the root passed the gate and the pattern then walked out of it. Only the
+  // root is held against the policy, so the pattern has to stay a mask.
+  if (access.is_restricted() &&
+      (context.pattern.find('/') != std::string::npos || context.pattern.find('\\') != std::string::npos || context.pattern.find("..") != std::string::npos)) {
+    return nscapi::protobuf::functions::set_response_bad(
+        *response, "Refusing pattern '" + context.pattern +
+                       "': it must be a file mask, not a path, while 'file access' is restricted (see [/settings/disk] in the configuration)");
   }
 
   if (!filter_helper.build_filter(filter)) return;

--- a/modules/CheckDisk/check_files.cpp
+++ b/modules/CheckDisk/check_files.cpp
@@ -70,8 +70,9 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
 
   // Hold every scan root against [/settings/disk] 'file access' before the
   // walk starts. Only the root needs checking: recursive_scan skips symbolic
-  // links and reparse points, so everything it yields is genuinely beneath a
-  // root which passed - and the inner loop stays free of policy work.
+  // links - directories and files alike, on both platforms - so everything it
+  // yields is genuinely beneath a root which passed, and the inner loop stays
+  // free of policy work.
   for (std::string &path : file_list) {
     const check::access::decision decision = access.resolve(path);
     if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);

--- a/modules/CheckDisk/check_files.cpp
+++ b/modules/CheckDisk/check_files.cpp
@@ -18,7 +18,8 @@ namespace po = boost::program_options;
 
 namespace check_files_command {
 
-void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+           const check::access::path_policy &access) {
   modern_filter::data_container data;
   modern_filter::cli_helper<file_filter::filter> filter_helper(request, response, data);
   std::vector<std::string> file_list;
@@ -66,6 +67,16 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
   if (!files_string.empty()) boost::split(file_list, files_string, boost::is_any_of(","));
 
   if (file_list.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No path specified");
+
+  // Hold every scan root against [/settings/disk] 'file access' before the
+  // walk starts. Only the root needs checking: recursive_scan skips symbolic
+  // links and reparse points, so everything it yields is genuinely beneath a
+  // root which passed - and the inner loop stays free of policy work.
+  for (std::string &path : file_list) {
+    const check::access::decision decision = access.resolve(path);
+    if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);
+    path = decision.value;
+  }
 
   if (!filter_helper.build_filter(filter)) return;
 

--- a/modules/CheckDisk/check_files.hpp
+++ b/modules/CheckDisk/check_files.hpp
@@ -3,8 +3,14 @@
 
 #pragma once
 
+#include <check/path_access_policy.hpp>
+
 #include <nscapi/protobuf/command.hpp>
 
 namespace check_files_command {
-void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+// `access` decides which paths the caller may name; see
+// docs/docs/concepts/check-access.md. It is passed in rather than looked up so
+// the gate can be unit tested without a live module.
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+           const check::access::path_policy &access);
 }

--- a/modules/CheckDisk/check_files_test.cpp
+++ b/modules/CheckDisk/check_files_test.cpp
@@ -28,7 +28,7 @@ TEST(CheckFilesCommand, NoPathSpecifiedReturnsUnknown) {
   PB::Commands::QueryResponseMessage::Response response;
   request.set_command("check_files");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
   EXPECT_NE(join_lines(response).find("No path specified"), std::string::npos) << join_lines(response);
@@ -42,7 +42,7 @@ TEST(CheckFilesCommand, MissingPathIsReportedAsUnknown) {
   request.set_command("check_files");
   request.add_arguments("path=Z:\\nscp_test_definitely_not_a_real_path_47b1f0e5");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
   EXPECT_NE(join_lines(response).find("Path was not found"), std::string::npos) << join_lines(response);
@@ -64,7 +64,7 @@ TEST(CheckFilesCommand, EmptyDirectoryUsesDefaultEmptyStateUnknown) {
   request.set_command("check_files");
   request.add_arguments("path=" + dir.string());
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
   EXPECT_NE(join_lines(response).find("No files found"), std::string::npos) << join_lines(response);
@@ -79,7 +79,7 @@ TEST(CheckFilesCommand, EmptyStateOverrideMakesEmptyDirectoryOk) {
   request.add_arguments("path=" + dir.string());
   request.add_arguments("empty-state=ok");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::OK);
 }
@@ -96,7 +96,7 @@ TEST(CheckFilesCommand, ScansFilesInDirectory) {
   request.add_arguments("path=" + dir.string());
   request.add_arguments("pattern=*.txt");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::OK);
   // Default detail-syntax includes "%(count) files"; with three matching
@@ -118,7 +118,7 @@ TEST(CheckFilesCommand, MaxDepthZeroSkipsSubdirectories) {
   request.add_arguments("pattern=*.txt");
   request.add_arguments("max-depth=0");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::OK);
   // Only top.txt is reachable at depth 0; deep.txt must not be scanned.
@@ -161,7 +161,7 @@ TEST(CheckFilesCommand, MixedCritDoesNotFireOnRunningCount) {
   request.add_arguments("pattern=*.txt");
   request.add_arguments("crit=count<3 or name='nonexistent.foo'");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
 }
@@ -181,7 +181,7 @@ TEST(CheckFilesCommand, MixedCritFiresWhenRowPredicateMatchesEvenIfSummaryFalse)
   request.add_arguments("pattern=*.txt");
   request.add_arguments("crit=count<1 or name='alert.txt'");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL) << join_lines(response);
 }
@@ -217,7 +217,7 @@ TEST(CheckFilesCommand, MixedCritFiresOnEmptyResultViaForceEvaluate) {
   request.add_arguments("empty-state=ignored");
   request.add_arguments("crit=count=0 or name='alert.txt'");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL) << join_lines(response);
 }
@@ -237,7 +237,7 @@ TEST(CheckFilesCommand, PureSummaryCritFiresOnEmptyResult) {
   request.add_arguments("empty-state=ignored");
   request.add_arguments("crit=count=0");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL) << join_lines(response);
 }
@@ -259,7 +259,7 @@ TEST(CheckFilesCommand, MixedCritDoesNotFireOnEmptyResultWhenSummarySideFalse) {
   request.add_arguments("empty-state=ignored");
   request.add_arguments("crit=count>0 and name='alert.txt'");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
 }
@@ -292,7 +292,7 @@ TEST(CheckFilesCommand, MixedCritUnsureSurfacesAsUnknown) {
   // summary side to definitively rescue the OR. Result: UNKNOWN.
   request.add_arguments("crit=name='alert.txt' or size>1000");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
 }
@@ -312,7 +312,7 @@ TEST(CheckFilesCommand, MixedCritInOnStringUnsureSurfacesAsUnknown) {
   request.add_arguments("empty-state=ignored");
   request.add_arguments("crit=name in ('alert.txt', 'urgent.txt') or count>0");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN) << join_lines(response);
 }
@@ -333,7 +333,7 @@ TEST(CheckFilesCommand, MixedCritInOnStringSureTrueSummaryStillFiresCrit) {
   request.add_arguments("empty-state=ignored");
   request.add_arguments("crit=name in ('alert.txt') or count=0");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL) << join_lines(response);
 }
@@ -367,7 +367,7 @@ TEST(CheckFilesCommand, MixedCritWithSummaryDoesNotEmitMutatingWarn) {
   // sure-false (none of these files match). OK verdict, no CRIT.
   request.add_arguments("crit=count<3 or name='alert.txt'");
 
-  check_files_command::check(request, &response);
+  check_files_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::OK) << join_lines(response);
   // The rendered message must not contain the legacy mutating marker.

--- a/modules/CheckDisk/check_single_file.cpp
+++ b/modules/CheckDisk/check_single_file.cpp
@@ -17,7 +17,8 @@ namespace po = boost::program_options;
 
 namespace check_single_file_command {
 
-void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+           const check::access::path_policy &access) {
   modern_filter::data_container data;
   modern_filter::cli_helper<file_filter::filter> filter_helper(request, response, data);
   std::string file_path;
@@ -57,6 +58,15 @@ void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Comman
 
   if (file_path.empty()) {
     return nscapi::protobuf::functions::set_response_bad(*response, "No file specified (use file=<path>)");
+  }
+
+  // Hold the path against [/settings/disk] 'file access' before it is stat'ed.
+  // stat_single_file follows a symbolic link, so resolving here is what stops
+  // a link inside an allowed directory from reporting on its target.
+  {
+    const check::access::decision decision = access.resolve(file_path);
+    if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);
+    file_path = decision.value;
   }
 
   if (!filter_helper.build_filter(filter)) return;

--- a/modules/CheckDisk/check_single_file.hpp
+++ b/modules/CheckDisk/check_single_file.hpp
@@ -3,8 +3,14 @@
 
 #pragma once
 
+#include <check/path_access_policy.hpp>
+
 #include <nscapi/protobuf/command.hpp>
 
 namespace check_single_file_command {
-void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+// `access` decides which paths the caller may name; see
+// docs/docs/concepts/check-access.md. It is passed in rather than looked up so
+// the gate can be unit tested without a live module.
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+           const check::access::path_policy &access);
 }

--- a/modules/CheckDisk/check_single_file_test.cpp
+++ b/modules/CheckDisk/check_single_file_test.cpp
@@ -23,7 +23,7 @@ TEST(CheckSingleFileCommand, NoFileSpecifiedReturnsUnknown) {
   PB::Commands::QueryResponseMessage::Response response;
   request.set_command("check_single_file");
 
-  check_single_file_command::check(request, &response);
+  check_single_file_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
   EXPECT_NE(join_lines(response).find("No file specified"), std::string::npos) << join_lines(response);
@@ -35,7 +35,7 @@ TEST(CheckSingleFileCommand, MissingFileReturnsUnknown) {
   request.set_command("check_single_file");
   request.add_arguments("file=Z:\\nscp_test_definitely_not_a_real_path_47b1f0e5\\foo.dat");
 
-  check_single_file_command::check(request, &response);
+  check_single_file_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::UNKNOWN);
   const std::string out = join_lines(response);
@@ -56,7 +56,7 @@ TEST(CheckSingleFileCommand, ExistingFileReturnsOk) {
   request.set_command("check_single_file");
   request.add_arguments("file=" + file_path);
 
-  check_single_file_command::check(request, &response);
+  check_single_file_command::check(request, &response, check_disk_test_support::unrestricted());
 
   // No thresholds and a single matching file → default-empty-state ("ok")
   // path; the file's name must appear in the rendered detail line.
@@ -73,7 +73,7 @@ TEST(CheckSingleFileCommand, PathAliasIsAcceptedForFile) {
   request.set_command("check_single_file");
   request.add_arguments("path=" + file_path);
 
-  check_single_file_command::check(request, &response);
+  check_single_file_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::OK);
   EXPECT_NE(join_lines(response).find("aliased.log"), std::string::npos) << join_lines(response);
@@ -90,7 +90,7 @@ TEST(CheckSingleFileCommand, SizeThresholdTriggersCritical) {
   request.add_arguments("file=" + file_path);
   request.add_arguments("crit=size > 8B");
 
-  check_single_file_command::check(request, &response);
+  check_single_file_command::check(request, &response, check_disk_test_support::unrestricted());
 
   EXPECT_EQ(response.result(), PB::Common::ResultCode::CRITICAL);
 }

--- a/modules/CheckDisk/file_finder_win.cpp
+++ b/modules/CheckDisk/file_finder_win.cpp
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: 2004-2026 Michael Medin
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 
-#include "file_finder.hpp"
-
 #include <file_helpers.hpp>
 #include <nscapi/macros.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <str/utf8.hpp>
 
+#include "file_finder.hpp"
 #include "filter.hpp"
 
 #ifndef INVALID_FILE_ATTRIBUTES
@@ -19,6 +18,17 @@
 #ifndef FILE_ATTRIBUTE_REPARSE_POINT
 #define FILE_ATTRIBUTE_REPARSE_POINT 0x00000400
 #endif
+#ifndef IO_REPARSE_TAG_SYMLINK
+#define IO_REPARSE_TAG_SYMLINK 0xA000000CL
+#endif
+
+// A file entry which is a symbolic link. When FILE_ATTRIBUTE_REPARSE_POINT is
+// set, FindFirstFile/FindNextFile put the reparse tag in dwReserved0. Only the
+// symlink tag counts: deduplicated and cloud-backed files are reparse points
+// too, and those are ordinary files which must keep being counted.
+static bool is_file_symlink(const WIN32_FIND_DATA &wfd) {
+  return (wfd.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 && wfd.dwReserved0 == IO_REPARSE_TAG_SYMLINK;
+}
 bool file_finder::is_directory(unsigned long dwAttr) {
   if (dwAttr == INVALID_FILE_ATTRIBUTES) {
     return false;
@@ -83,6 +93,15 @@ void file_finder::recursive_scan(file_filter::filter &filter, scanner_context &c
   if (hFind != INVALID_HANDLE_VALUE) {
     do {
       if (is_directory(wfd.dwFileAttributes) && (wcscmp(wfd.cFileName, L".") == 0 || wcscmp(wfd.cFileName, L"..") == 0)) continue;
+      // Skip file symlinks, as the unix scanner does (lstat/S_ISLNK): the
+      // keywords which open the file (the checksums, line_count, version)
+      // would otherwise read the link's target, which can sit anywhere - and
+      // when the scan root has been held against 'file access' that target
+      // is exactly what the allow list never approved.
+      if (!is_directory(wfd.dwFileAttributes) && is_file_symlink(wfd)) {
+        if (context.debug) context.report_debug(std::string("Skipping symbolic link: ") + utf8::cvt<std::string>(wfd.cFileName));
+        continue;
+      }
       std::shared_ptr<file_filter::filter_obj> info = file_filter::filter_obj::get(context.now, wfd, dir);
       modern_filter::match_result ret = filter.match(info);
       if (total_obj && (ret.matched_filter || total_all)) total_obj->add(info);

--- a/modules/CheckDisk/test_support.hpp
+++ b/modules/CheckDisk/test_support.hpp
@@ -12,11 +12,20 @@
 // any number of test files.
 
 #include <boost/filesystem.hpp>
+#include <check/path_access_policy.hpp>
 #include <fstream>
 #include <nscapi/protobuf/command.hpp>
 #include <string>
 
 namespace check_disk_test_support {
+
+// The path-taking checks are gated by an access policy the module owns. Tests
+// which are not about the gate pass this one: a freshly constructed policy is
+// in `any` mode, which is exactly the behaviour before the gate existed.
+inline const check::access::path_policy &unrestricted() {
+  static const check::access::path_policy policy("file", "files", "/settings/disk");
+  return policy;
+}
 
 // RAII helper that creates a unique scratch directory under the OS temp
 // folder and removes it (including all contents) on destruction. Tests use

--- a/modules/CheckEventLog/CheckEventLog.cpp
+++ b/modules/CheckEventLog/CheckEventLog.cpp
@@ -62,8 +62,9 @@ bool CheckEventLog::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode)
            "Real-time eventlog filters", "A set of filters to use in real-time mode", "FILTER DEFINITION",
            "For more configuration options add a dedicated section");
 
-  // A reload calls loadModuleEx again on the live module and the settings
-  // callbacks append, so start from nothing.
+  // A reload calls loadModuleEx again on the live module and the predefined
+  // logs are appended, so drop them; the mode and allow list are replaced by
+  // their callbacks and stay in force meanwhile.
   log_access_.reset();
 
   // clang-format off

--- a/modules/CheckEventLog/CheckEventLog.cpp
+++ b/modules/CheckEventLog/CheckEventLog.cpp
@@ -62,8 +62,36 @@ bool CheckEventLog::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode)
            "Real-time eventlog filters", "A set of filters to use in real-time mode", "FILTER DEFINITION",
            "For more configuration options add a dedicated section");
 
+  // A reload calls loadModuleEx again on the live module and the settings
+  // callbacks append, so start from nothing.
+  log_access_.reset();
+
+  // clang-format off
+  settings.alias().add_path_to_settings()
+    ("logs", sh::fun_values_path([this](const auto& key, const auto& value) { log_access_.add_predefined(key, value); }),
+      "PREDEFINED EVENT LOGS", "Event log channels check_eventlog may read by name, as <name> = <channel>.\n"
+      "A name defined here can be used as file=<name> in any access mode, and is the only thing accepted when "
+      "'log access' is set to predefined.")
+    ;
+  // clang-format on
+
   settings.alias()
       .add_key_to_settings()
+      .add_string("log access", sh::string_fun_key([this](const auto& value) { log_access_.set_mode(value); }, "any"), "EVENT LOG ACCESS MODE",
+                  "Which event log channels a caller may ask check_eventlog to read: any (the default - any channel the caller names, which is how every "
+                  "earlier release behaved), allowed (only channels at or below an entry in 'allowed logs') or predefined (only names defined in the "
+                  "[/settings/eventlog/logs] section).\n"
+                  "The event text itself comes back through the message, strings and xml keywords - and message is part of the default syntax - so on a "
+                  "host where callers may pass arguments (NRPE with 'allow arguments', or the REST API) this decides which of the machine's logs a check "
+                  "can read. The Security channel and the PowerShell and Sysmon operational channels are the ones usually worth withholding. See the "
+                  "'Restricting what a check may read' section of the documentation.")
+
+      .add_string("allowed logs", sh::string_fun_key([this](const auto& value) { log_access_.set_allow_list(value); }, ""), "ALLOWED EVENT LOGS",
+                  "Comma separated list of event log channels check_eventlog may read when 'log access' is set to allowed.\n"
+                  "An entry allows that channel and every channel below it, for example Microsoft-Windows-Sysmon covers "
+                  "Microsoft-Windows-Sysmon/Operational. The match is on whole channel-name segments, so that entry does not also allow "
+                  "Microsoft-Windows-SysmonOther. An entry containing * or ? is matched as a wildcard against the whole channel name instead.")
+
       .add_bool("debug", sh::bool_key(&debug_, false), "Enable debugging",
                 "Log more information when filtering (useful to detect issues with filters) not useful in production as it is a bit of a resource hog.")
 
@@ -93,6 +121,8 @@ bool CheckEventLog::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode)
 
   settings.register_all();
   settings.notify();
+
+  if (!log_access_.get_config_error().empty()) NSC_LOG_ERROR_STD(log_access_.get_config_error());
 
   thread_->filters_.add_samples(nscapi::settings_proxy::create(get_id(), get_core()));
   thread_->filters_.add_missing(nscapi::settings_proxy::create(get_id(), get_core()), "default", "");
@@ -511,7 +541,9 @@ void CheckEventLog::check_eventlog(const PB::Commands::QueryRequestMessage::Requ
   // clang-format off
   filter_helper.get_desc().add_options()
     ("file", po::value<std::vector<std::string> >(&file_list), "File to read (can be specified multiple times to check multiple files.\nNotice that specifying multiple files will create an aggregate set you will not check each file individually."
-	    "In other words if one file contains an error the entire check will result in error.")
+	    "In other words if one file contains an error the entire check will result in error.\n"
+	    "Which channels may be named here is governed by 'log access' in [/settings/eventlog]: by default any channel is read, but an operator can "
+	    "restrict this to a list of allowed channels or to names predefined in [/settings/eventlog/logs], in which case this takes such a name.")
     ("log", po::value<std::vector<std::string>>(&file_list), "Same as file")
     ("scan-range", po::value<std::string>(&scan_range),
 	    "Date range to scan.\n"
@@ -534,6 +566,16 @@ void CheckEventLog::check_eventlog(const PB::Commands::QueryRequestMessage::Requ
   if (file_list.empty()) {
     file_list.push_back("Application");
     file_list.push_back("System");
+  }
+
+  // Hold every channel against [/settings/eventlog] 'log access' before the
+  // log is opened. The defaults above go through the gate too: an operator who
+  // restricted access did not exempt Application and System by not naming them,
+  // and silently reading them would make the setting mean less than it says.
+  for (std::string &log_name : file_list) {
+    const check::access::decision decision = log_access_.resolve(log_name);
+    if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);
+    log_name = decision.value;
   }
   std::string bookmark_prefix = "auto,log[", bookmark_suffix;
   if (bookmark == "auto") {

--- a/modules/CheckEventLog/CheckEventLog.h
+++ b/modules/CheckEventLog/CheckEventLog.h
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2004-2026 Michael Medin
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 
+#include <check/prefix_access_policy.hpp>
 #include <memory>
 #include <nscapi/nscapi_plugin_impl.hpp>
 #include <nscapi/protobuf/command.hpp>
@@ -17,9 +18,12 @@ class CheckEventLog : public nscapi::impl::simple_plugin {
   int buffer_length_;
   bool lookup_names_;
   bookmarks bookmarks_;
+  // Which event log channels a caller may name in `file=`/`log=`. Open by
+  // default; see docs/docs/concepts/check-access.md.
+  check::access::prefix_policy log_access_;
 
  public:
-  CheckEventLog() {}
+  CheckEventLog() : log_access_("log", "logs", "/settings/eventlog", '/') {}
   virtual ~CheckEventLog() {}
   // Module calls
   bool loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode);

--- a/modules/CheckLogFile/CheckLogFile.cpp
+++ b/modules/CheckLogFile/CheckLogFile.cpp
@@ -53,8 +53,40 @@ bool CheckLogFile::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) 
       .add_bool("enabled", sh::bool_fun_key([this](auto value) { thread_->set_enabled(value); }, false), "Real time",
                 "Spawns a background thread which waits for file changes.");
 
+  // Which files a caller may name. A reload calls loadModuleEx again on the
+  // live module, and the settings callbacks below append, so start from
+  // nothing or every reload doubles the list.
+  file_access_.reset();
+
+  // clang-format off
+  settings.alias().add_path_to_settings()
+    ("files", sh::fun_values_path([this](const auto& key, const auto& value) { file_access_.add_predefined(key, value); }),
+      "PREDEFINED LOG FILES", "Log files which check_logfile may read by name, as <name> = <path>.\n"
+      "A name defined here can be used as file=<name> in any access mode, and is the only thing accepted when "
+      "'file access' is set to predefined.")
+    ;
+  // clang-format on
+
+  settings.alias()
+      .add_key_to_settings()
+
+      .add_string("file access", sh::string_fun_key([this](const auto& value) { file_access_.set_mode(value); }, "any"), "FILE ACCESS MODE",
+                  "Which files a caller may ask check_logfile to read: any (the default - any path the caller names, which is how every earlier release "
+                  "behaved), allowed (only paths matching 'allowed files') or predefined (only names defined in the [/settings/logfile/files] section).\n"
+                  "check_logfile reads the file it is given with the privileges of the agent, so on a host where callers may pass arguments (NRPE with "
+                  "'allow arguments', or the REST API) this decides how much of the machine a check can read. See the 'Restricting what a check may read' "
+                  "section of the documentation.")
+
+      .add_string("allowed files", sh::string_fun_key([this](const auto& value) { file_access_.set_allow_list(value); }, ""), "ALLOWED LOG FILES",
+                  "Comma separated list of files check_logfile may read when 'file access' is set to allowed.\n"
+                  "An entry naming a directory allows every file beneath it at any depth; an entry containing * or ? is a wildcard matched against the whole "
+                  "path; any other entry is a single file. Paths are resolved (`..` is flattened and symbolic links and junctions are followed) before they "
+                  "are matched, so a link planted inside an allowed directory does not widen it.");
+
   settings.register_all();
   settings.notify();
+
+  if (!file_access_.get_config_error().empty()) NSC_LOG_ERROR_STD(file_access_.get_config_error());
 
   thread_->ensure_default(nscapi::settings_proxy::create(get_id(), get_core()));
 
@@ -205,7 +237,9 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
 		("split", po::value<std::string>(&column_split), "Alias for split-column")
 		("file", po::value<std::vector<std::string> >(&file_list), "File to read (can be specified multiple times to check multiple files.\n"
 			"Notice that specifying multiple files will create an aggregate set it will not check each file individually.\n"
-			"In other words if one file contains an error the entire check will result in error or if you check the count it is the global count which is used.")
+			"In other words if one file contains an error the entire check will result in error or if you check the count it is the global count which is used.\n"
+			"Which files may be named here is governed by 'file access' in [/settings/logfile]: by default any path is read, but an operator can restrict "
+			"this to a list of allowed paths or to names predefined in [/settings/logfile/files], in which case this takes such a name.")
 		("files", po::value<std::string>(&files_string), "A comma separated list of files to scan (same as file except a list)")
 		// Present-but-empty (`bookmark=`, which is how several transports render a
 		// valueless argument) has to mean the same as the bare flag, or a check
@@ -250,6 +284,17 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
   if (line_split.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No line-split specified");
 
   if (file_list.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "Need to specify at least one file: file=foo.txt");
+
+  // Hold every name the caller gave against [/settings/logfile] 'file access'
+  // before anything is opened. In the default `any` mode this hands each token
+  // straight back; where the operator restricted it, what comes back is the
+  // resolved path which passed - so what was matched is what gets read, with
+  // no second resolution in between.
+  for (std::string &filename : file_list) {
+    const check::access::decision decision = file_access_.resolve(filename);
+    if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);
+    filename = decision.value;
+  }
 
   const bool newest_first = newest == "first";
   if (!newest_first && newest != "last") {

--- a/modules/CheckLogFile/CheckLogFile.cpp
+++ b/modules/CheckLogFile/CheckLogFile.cpp
@@ -54,8 +54,10 @@ bool CheckLogFile::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) 
                 "Spawns a background thread which waits for file changes.");
 
   // Which files a caller may name. A reload calls loadModuleEx again on the
-  // live module, and the settings callbacks below append, so start from
-  // nothing or every reload doubles the list.
+  // live module and the predefined entries below are appended, so drop them
+  // or every reload doubles the list. The mode and the allow list are
+  // replaced by their callbacks and stay in force meanwhile, so a check
+  // arriving mid-reload is not let through an open gate.
   file_access_.reset();
 
   // clang-format off
@@ -79,9 +81,10 @@ bool CheckLogFile::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) 
 
       .add_string("allowed files", sh::string_fun_key([this](const auto& value) { file_access_.set_allow_list(value); }, ""), "ALLOWED LOG FILES",
                   "Comma separated list of files check_logfile may read when 'file access' is set to allowed.\n"
-                  "An entry naming a directory allows every file beneath it at any depth; an entry containing * or ? is a wildcard matched against the whole "
-                  "path; any other entry is a single file. Paths are resolved (`..` is flattened and symbolic links and junctions are followed) before they "
-                  "are matched, so a link planted inside an allowed directory does not widen it.");
+                  "An entry naming a directory (or a path which does not exist yet) allows every file beneath it at any depth; an entry naming an existing "
+                  "file is that single file; an entry containing * or ? is a wildcard matched against the whole path, where * and ? do not cross a directory "
+                  "separator and ** does. Paths are resolved (`..` is flattened and symbolic links and junctions are followed) before they are matched, so "
+                  "a link planted inside an allowed directory does not widen it.");
 
   settings.register_all();
   settings.notify();

--- a/modules/CheckLogFile/CheckLogFile.cpp
+++ b/modules/CheckLogFile/CheckLogFile.cpp
@@ -279,9 +279,22 @@ void CheckLogFile::check_logfile(const PB::Commands::QueryRequestMessage::Reques
 		;
   // clang-format on
 
-  if (!files_string.empty()) boost::split(file_list, files_string, boost::is_any_of(","));
-
   if (!filter_helper.parse_options()) return;
+
+  // After parse_options, or files_string is still empty and `files=` reads as
+  // "not given at all" - it has been a dead argument for as far back as the
+  // history goes. The split has to land before the access gate below, so that
+  // every name it produces is held against 'file access' like a `file=` one.
+  // Append rather than assign: `file=` and `files=` are documented as the same
+  // list, so naming both must not silently drop one of them.
+  if (!files_string.empty()) {
+    std::vector<std::string> extra;
+    boost::split(extra, files_string, boost::is_any_of(","));
+    for (std::string &name : extra) {
+      boost::algorithm::trim(name);
+      if (!name.empty()) file_list.push_back(name);
+    }
+  }
 
   if (column_split.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No column-split specified");
   if (line_split.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No line-split specified");

--- a/modules/CheckLogFile/CheckLogFile.h
+++ b/modules/CheckLogFile/CheckLogFile.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <check/path_access_policy.hpp>
 #include <nscapi/nscapi_plugin_impl.hpp>
 #include <nscapi/protobuf/command.hpp>
 #include <set>
@@ -19,9 +20,12 @@ class CheckLogFile : public nscapi::impl::simple_plugin {
   // that has aged out (or whose filter was edited) does not keep its row in
   // nsclient.db forever.
   std::set<std::string> persisted_keys_;
+  // Which files a caller may name in `file=`/`files=`. Open by default, so an
+  // upgrade changes nothing; see docs/docs/concepts/check-access.md.
+  check::access::path_policy file_access_;
 
  public:
-  CheckLogFile() {}
+  CheckLogFile() : file_access_("file", "files", "/settings/logfile") {}
   virtual ~CheckLogFile() {}
 
   // Module calls

--- a/modules/CheckSystem/CheckSystem.cpp
+++ b/modules/CheckSystem/CheckSystem.cpp
@@ -192,6 +192,9 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   sh::settings_registry settings(nscapi::settings_proxy::create(get_id(), get_core()));
   settings.set_alias("system", alias, "windows");
   pdh_checker.counters_.set_path(settings.alias().get_settings_path("counters"));
+  // A reload calls loadModuleEx again on the live module and the settings
+  // callbacks append, so start the access policy from nothing.
+  pdh_checker.counter_access_.reset();
 
   collector->set_path(settings.alias().get_settings_path("real-time/memory"), settings.alias().get_settings_path("real-time/cpu"),
                       settings.alias().get_settings_path("real-time/process"), settings.alias().get_settings_path("real-time/checks"));
@@ -226,6 +229,22 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
     ;
 
   settings.alias().add_key_to_settings()
+  .add_string("counter access", sh::string_fun_key([this](const auto& value) { pdh_checker.counter_access_.set_mode(value); }, "any"),
+        "COUNTER ACCESS MODE",
+        "Which performance counters a caller may ask check_pdh (check_counter) to read: any (the default - any counter path the caller names, which is how "
+        "every earlier release behaved), allowed (only paths matching 'allowed counters') or predefined (only the counters configured in the "
+        "[/settings/system/windows/counters] section).\n"
+        "PDH exposes every performance object on the machine, so on a host where callers may pass arguments (NRPE with 'allow arguments', or the REST API) "
+        "this decides how much of it a check can read. Counters configured in the counters section are always available by name, whatever the mode. See the "
+        "'Restricting what a check may read' section of the documentation.")
+
+  .add_string("allowed counters", sh::string_fun_key([this](const auto& value) { pdh_checker.counter_access_.set_allow_list(value); }, ""),
+        "ALLOWED COUNTERS",
+        "Comma separated list of counter paths check_pdh may read when 'counter access' is set to allowed. Entries may contain * and ?, for example "
+        "\\Processor(*)\\*, \\Memory\\*.\n"
+        "The pattern is matched against the counter path exactly as the caller wrote it, so include both the localized and English spellings if your hosts "
+        "differ. It has no effect in the default any mode.")
+
   .add_string("default buffer length", sh::string_key(&collector->default_buffer_size, "1h"),
         "Default buffer time", "Used to define the default size of range buffer checks (ie. CPU).")
   .add_string("subsystem", sh::string_key(&collector->subsystem, "default"),
@@ -276,6 +295,8 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   // clang-format on
   settings.register_all();
   settings.notify();
+
+  if (!pdh_checker.counter_access_.get_config_error().empty()) NSC_LOG_ERROR_STD(pdh_checker.counter_access_.get_config_error());
 
   collector->ensure_default(nscapi::settings_proxy::create(get_id(), get_core()));
   collector->add_samples(nscapi::settings_proxy::create(get_id(), get_core()));

--- a/modules/CheckSystem/CheckSystem.cpp
+++ b/modules/CheckSystem/CheckSystem.cpp
@@ -195,6 +195,7 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   // A reload calls loadModuleEx again on the live module and the settings
   // callbacks append, so start the access policy from nothing.
   pdh_checker.counter_access_.reset();
+  registry_access_.reset();
 
   collector->set_path(settings.alias().get_settings_path("real-time/memory"), settings.alias().get_settings_path("real-time/cpu"),
                       settings.alias().get_settings_path("real-time/process"), settings.alias().get_settings_path("real-time/checks"));
@@ -206,6 +207,11 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
     ("counters", sh::fun_values_path([this] (auto key, auto value) { this->add_counter(key, value); }),
         "PDH Counters", "Add counters to check",
         "COUNTER", "For more configuration options add a dedicated section")
+
+    ("registry", sh::fun_values_path([this] (auto key, auto value) { registry_access_.add_predefined(key, value); }),
+        "PREDEFINED REGISTRY KEYS", "Registry keys the registry checks may use by name, as <name> = <key>.\n"
+        "A name defined here can be used as key=<name> in any access mode, and is the only thing accepted when "
+        "'registry access' is set to predefined.")
 
     ("real-time/memory", sh::fun_values_path([this] (auto key, auto value) { collector->add_realtime_mem_filter(nscapi::settings_proxy::create(get_id(), get_core()), key, value); }),
         "Realtime memory filters", "A set of filters to use in real-time mode",
@@ -244,6 +250,23 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
         "\\Processor(*)\\*, \\Memory\\*.\n"
         "The pattern is matched against the counter path exactly as the caller wrote it, so include both the localized and English spellings if your hosts "
         "differ. It has no effect in the default any mode.")
+
+  .add_string("registry access", sh::string_fun_key([this](const auto& value) { registry_access_.set_mode(value); }, "any"),
+        "REGISTRY ACCESS MODE",
+        "Which registry keys a caller may ask check_registry_key and check_registry_value to read: any (the default - any key the caller names, which is "
+        "how every earlier release behaved), allowed (only keys at or below an entry in 'allowed registry keys') or predefined (only names defined in the "
+        "[/settings/system/windows/registry] section).\n"
+        "check_registry_value returns the value data itself, with binary values rendered as hex, and will walk a whole subtree when 'recursive' is set, so "
+        "on a host where callers may pass arguments (NRPE with 'allow arguments', or the REST API) this decides how much of the registry a check can read. "
+        "While this is not 'any' the 'computer' argument is also refused, so only the local registry is reachable. See the 'Restricting what a check may "
+        "read' section of the documentation.")
+
+  .add_string("allowed registry keys", sh::string_fun_key([this](const auto& value) { registry_access_.set_allow_list(value); }, ""),
+        "ALLOWED REGISTRY KEYS",
+        "Comma separated list of registry keys check_registry_key and check_registry_value may read when 'registry access' is set to allowed.\n"
+        "An entry allows that key and everything below it, for example HKLM\\SOFTWARE\\MyApp. The match is on whole key names, so that entry does not "
+        "also allow HKLM\\SOFTWARE\\MyAppOther. An entry containing * or ? is matched as a wildcard against the whole key instead. Both hive spellings "
+        "(HKLM and HKEY_LOCAL_MACHINE) mean the same thing on either side of the comparison.")
 
   .add_string("default buffer length", sh::string_key(&collector->default_buffer_size, "1h"),
         "Default buffer time", "Used to define the default size of range buffer checks (ie. CPU).")
@@ -297,6 +320,7 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   settings.notify();
 
   if (!pdh_checker.counter_access_.get_config_error().empty()) NSC_LOG_ERROR_STD(pdh_checker.counter_access_.get_config_error());
+  if (!registry_access_.get_config_error().empty()) NSC_LOG_ERROR_STD(registry_access_.get_config_error());
 
   collector->ensure_default(nscapi::settings_proxy::create(get_id(), get_core()));
   collector->add_samples(nscapi::settings_proxy::create(get_id(), get_core()));
@@ -1171,11 +1195,11 @@ void CheckSystem::check_pdh(const PB::Commands::QueryRequestMessage::Request &re
 }
 
 void CheckSystem::check_registry_key(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
-  registry_key_checks::check(request, response);
+  registry_key_checks::check(request, response, registry_access_);
 }
 
 void CheckSystem::check_registry_value(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
-  registry_value_checks::check(request, response);
+  registry_value_checks::check(request, response, registry_access_);
 }
 
 void CheckSystem::check_pending_reboot(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {

--- a/modules/CheckSystem/CheckSystem.cpp
+++ b/modules/CheckSystem/CheckSystem.cpp
@@ -192,8 +192,9 @@ bool CheckSystem::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
   sh::settings_registry settings(nscapi::settings_proxy::create(get_id(), get_core()));
   settings.set_alias("system", alias, "windows");
   pdh_checker.counters_.set_path(settings.alias().get_settings_path("counters"));
-  // A reload calls loadModuleEx again on the live module and the settings
-  // callbacks append, so start the access policy from nothing.
+  // A reload calls loadModuleEx again on the live module and the predefined
+  // entries are appended, so drop them; the modes and allow lists are
+  // replaced by their callbacks and stay in force meanwhile.
   pdh_checker.counter_access_.reset();
   registry_access_.reset();
 

--- a/modules/CheckSystem/CheckSystem.h
+++ b/modules/CheckSystem/CheckSystem.h
@@ -10,6 +10,7 @@
 #include <nscapi/protobuf/metrics.hpp>
 
 #include "check_pdh.hpp"
+#include "check_registry.hpp"
 #include "filter_config_object.hpp"
 #include "pdh_thread.hpp"
 
@@ -24,6 +25,11 @@ class CheckSystem : public nscapi::impl::simple_plugin {
   //	std::map<DWORD,std::string> lookups_;
 
   check_pdh::check pdh_checker;
+
+  // Which registry keys a caller may name in check_registry_key /
+  // check_registry_value. Open by default; see
+  // docs/docs/concepts/check-access.md.
+  check::access::prefix_policy registry_access_{"registry key", "registry keys", "/settings/system/windows", '\\', &normalize_registry_hive};
 
   // Configured timezone for `check_uptime`, cached in loadModuleEx (issue #365).
   // See `include/nscp_time.hpp` for the supported value syntax.

--- a/modules/CheckSystem/check_pdh.cpp
+++ b/modules/CheckSystem/check_pdh.cpp
@@ -74,6 +74,38 @@ filter_obj_handler::filter_obj_handler() {
 }
 
 void check::clear() { counters_.clear(); }
+
+bool check::allow_counter(const std::string &counter, const bool is_named, std::string &error) const {
+  if (!counter_access_.get_config_error().empty()) {
+    error = counter_access_.get_config_error();
+    return false;
+  }
+  if (counter_access_.get_mode() == ::check::access::mode::any) return true;
+
+  // A named counter is one an operator already wrote into
+  // [/settings/system/windows/counters], so it is trusted in every mode - that
+  // section *is* the predefined list. What it expands to is never taken from
+  // the caller.
+  if (is_named) {
+    if (counters_.has_object(counter)) return true;
+    error = "Refusing counter '" + counter +
+            "': it is not defined in [/settings/system/windows/counters] and 'counter access' is restricted (see [/settings/system/windows] in the "
+            "configuration)";
+    return false;
+  }
+
+  if (counter_access_.get_mode() == ::check::access::mode::predefined) {
+    error = "Refusing counter '" + counter +
+            "': 'counter access' is set to predefined, so only a counter defined in [/settings/system/windows/counters] may be used (see "
+            "[/settings/system/windows] in the configuration)";
+    return false;
+  }
+
+  const ::check::access::decision d = counter_access_.resolve(counter);
+  if (d.allowed) return true;
+  error = d.error;
+  return false;
+}
 void check::add_counter(std::shared_ptr<nscapi::settings_proxy> proxy, std::string key, std::string query) {
   try {
     counters_.add(proxy, key, query);
@@ -116,7 +148,9 @@ void check::check_pdh(std::shared_ptr<pdh_thread> &collector, const PB::Commands
   filter_helper.add_options("", "", "", filter.get_filter_syntax(), "unknown");
   filter_helper.add_syntax("${status}: ${list}", "${alias} = ${value}", "${alias}", "", "");
   filter_helper.get_desc().add_options()
-    ("counter", po::value<std::vector<std::string>>(&counters), "Performance counter to check")
+    ("counter", po::value<std::vector<std::string>>(&counters), "Performance counter to check.\n"
+      "Which counters may be named here is governed by 'counter access' in [/settings/system/windows]: by default any counter is read, but an operator can "
+      "restrict this to paths matching 'allowed counters', or to the counters configured in [/settings/system/windows/counters].")
     ("expand-index", po::value<bool>(&expand_index)->implicit_value(true)->default_value(false), "Expand indexes in counter strings")
     ("resolution", po::value<std::string>(&resolution)->default_value("auto"), "How to resolve counter names against the system locale: auto (try the localized name, then the English API, then index expansion - the default), english (force English counter names regardless of the system language) or index (expand numeric counter indexes to their localized names)")
     ("instances", po::value<bool>(&expand_instance)->implicit_value(true)->default_value(false), "Expand wildcards and fetch all instances")
@@ -158,7 +192,10 @@ void check::check_pdh(std::shared_ptr<pdh_thread> &collector, const PB::Commands
   std::list<std::wstring> to_check;
   for (std::string &counter : counters) {
     try {
-      if (counter.find('\\') == std::string::npos) {
+      const bool is_named = counter.find('\\') == std::string::npos;
+      std::string access_error;
+      if (!allow_counter(counter, is_named, access_error)) return nscapi::protobuf::functions::set_response_bad(*response, access_error);
+      if (is_named) {
         named_counters[counter] = counter;
       } else {
         if (expand_index) {
@@ -194,7 +231,10 @@ void check::check_pdh(std::shared_ptr<pdh_thread> &collector, const PB::Commands
           return nscapi::protobuf::functions::set_response_bad(*response, "Invalid option: " + s);
       } else
         return nscapi::protobuf::functions::set_response_bad(*response, "Invalid option: " + s);
-      if (counter.find('\\') == std::string::npos) {
+      const bool is_named = counter.find('\\') == std::string::npos;
+      std::string access_error;
+      if (!allow_counter(counter, is_named, access_error)) return nscapi::protobuf::functions::set_response_bad(*response, access_error);
+      if (is_named) {
         named_counters[counter] = counter;
       } else {
         if (expand_index) {

--- a/modules/CheckSystem/check_pdh.hpp
+++ b/modules/CheckSystem/check_pdh.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <check/access_policy.hpp>
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/settings/object.hpp>
 #include <parsers/filter/modern_filter.hpp>
@@ -11,6 +12,11 @@
 #include "pdh_thread.hpp"
 
 namespace check_pdh {
+
+// `check_pdh::check` would otherwise shadow the `check` namespace the policy
+// lives in, so name it once here.
+typedef ::check::access::policy access_policy;
+
 struct counter_config_object : public nscapi::settings_objects::object_instance_interface {
   typedef nscapi::settings_objects::object_instance_interface parent;
 
@@ -66,10 +72,23 @@ typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;
 
 struct check {
   counter_config_handler counters_;
+  // Which counters a caller may name in `counter=`. Open by default, so an
+  // upgrade changes nothing. The predefined entries are the counters already
+  // configured in [/settings/system/windows/counters], so `predefined` mode
+  // needs no second list; see docs/docs/concepts/check-access.md.
+  access_policy counter_access_;
+
+  check() : counter_access_("counter", "counters", "/settings/system/windows") {}
+
   void check_pdh(std::shared_ptr<pdh_thread> &collector, const PB::Commands::QueryRequestMessage::Request &request,
                  PB::Commands::QueryResponseMessage::Response *response);
   void add_counter(std::shared_ptr<nscapi::settings_proxy> proxy, std::string key, std::string query);
   void add_rrd_counter(std::shared_ptr<nscapi::settings_proxy> proxy, std::string key, std::string query);
   void clear();
+
+  // Hold one counter argument against the access mode. `is_named` marks the
+  // form which refers to a counter configured in [/settings/system/windows/counters]
+  // rather than a raw PDH path. Returns false and fills `error` when refused.
+  bool allow_counter(const std::string &counter, bool is_named, std::string &error) const;
 };
 }  // namespace check_pdh

--- a/modules/CheckSystem/check_registry.cpp
+++ b/modules/CheckSystem/check_registry.cpp
@@ -12,6 +12,18 @@ namespace po = boost::program_options;
 //  check_registry_key
 // ══════════════════════════════════════════════════════════════════════════════
 
+std::string normalize_registry_hive(const std::string &key) {
+  static const char *pairs[][2] = {{"HKEY_LOCAL_MACHINE", "HKLM"}, {"HKEY_CURRENT_USER", "HKCU"}, {"HKEY_CLASSES_ROOT", "HKCR"},
+                                   {"HKEY_USERS", "HKU"},          {"HKEY_CURRENT_CONFIG", "HKCC"}};
+  for (const auto &pair : pairs) {
+    const std::string full(pair[0]);
+    if (key.size() >= full.size() && boost::algorithm::iequals(key.substr(0, full.size()), full)) {
+      return std::string(pair[1]) + key.substr(full.size());
+    }
+  }
+  return key;
+}
+
 namespace registry_key_checks {
 namespace check_rk_filter {
 
@@ -70,7 +82,9 @@ void registry_key_checks::check(const PB::Commands::QueryRequestMessage::Request
   // clang-format off
   filter_helper.get_desc().add_options()
     ("key",       po::value<std::vector<std::string>>(&keys),
-                  "One or more registry key paths to check (e.g. HKLM\\Software\\MyApp).")
+                  "One or more registry key paths to check (e.g. HKLM\\Software\\MyApp).\n"
+                  "Which keys may be named here is governed by 'registry access' in [/settings/system/windows]: by default any key is read, but an "
+                  "operator can restrict this to keys below an allowed entry, or to names predefined in [/settings/system/windows/registry].")
     ("exclude",   po::value<std::vector<std::string>>(&excludes),
                   "Registry key names to exclude from enumeration")
     ("computer",  po::value<std::string>(&computer),
@@ -92,6 +106,26 @@ void registry_key_checks::check(const PB::Commands::QueryRequestMessage::Request
 
   if (keys.empty()) {
     return nscapi::protobuf::functions::set_response_bad(*response, "No key specified. Please provide at least one key= argument.");
+  }
+
+  // Hold every key against [/settings/system/windows] 'registry access' before
+  // the registry is opened. Only the starting key is checked: enumeration below
+  // it stays within the subtree by construction, so a key which passed cannot
+  // walk out of the allowed part of the hive.
+  for (std::string &key_arg : keys) {
+    const check::access::decision decision = access.resolve(key_arg);
+    if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);
+    key_arg = decision.value;
+  }
+
+  // A remote computer is a destination, not a key: the allow list says nothing
+  // about it, and RegConnectRegistry authenticates outbound as the machine
+  // account. While access is restricted the local registry is the only one
+  // reachable.
+  if (!computer.empty() && access.is_restricted()) {
+    return nscapi::protobuf::functions::set_response_bad(
+        *response, "Refusing computer '" + computer +
+                       "': 'registry access' is restricted, so only the local registry may be read (see [/settings/system/windows] in the configuration)");
   }
 
   if (!filter_helper.build_filter(filter)) return;
@@ -216,7 +250,9 @@ void registry_value_checks::check(const PB::Commands::QueryRequestMessage::Reque
   // clang-format off
   filter_helper.get_desc().add_options()
     ("key",       po::value<std::vector<std::string>>(&keys),
-                  "One or more registry key paths whose values to check (e.g. HKLM\\Software\\MyApp)")
+                  "One or more registry key paths whose values to check (e.g. HKLM\\Software\\MyApp).\n"
+                  "Which keys may be named here is governed by 'registry access' in [/settings/system/windows]: by default any key is read, but an "
+                  "operator can restrict this to keys below an allowed entry, or to names predefined in [/settings/system/windows/registry].")
     ("value",     po::value<std::vector<std::string>>(&value_names),
                   "Restrict to specific value names (default: all values). Supports '*' to enumerate all.")
     ("exclude",   po::value<std::vector<std::string>>(&excludes),
@@ -238,6 +274,26 @@ void registry_value_checks::check(const PB::Commands::QueryRequestMessage::Reque
 
   if (keys.empty()) {
     return nscapi::protobuf::functions::set_response_bad(*response, "No key specified. Please provide at least one key= argument.");
+  }
+
+  // Hold every key against [/settings/system/windows] 'registry access' before
+  // the registry is opened. Only the starting key is checked: enumeration below
+  // it stays within the subtree by construction, so a key which passed cannot
+  // walk out of the allowed part of the hive.
+  for (std::string &key_arg : keys) {
+    const check::access::decision decision = access.resolve(key_arg);
+    if (!decision.allowed) return nscapi::protobuf::functions::set_response_bad(*response, decision.error);
+    key_arg = decision.value;
+  }
+
+  // A remote computer is a destination, not a key: the allow list says nothing
+  // about it, and RegConnectRegistry authenticates outbound as the machine
+  // account. While access is restricted the local registry is the only one
+  // reachable.
+  if (!computer.empty() && access.is_restricted()) {
+    return nscapi::protobuf::functions::set_response_bad(
+        *response, "Refusing computer '" + computer +
+                       "': 'registry access' is restricted, so only the local registry may be read (see [/settings/system/windows] in the configuration)");
   }
 
   if (!filter_helper.build_filter(filter)) return;

--- a/modules/CheckSystem/check_registry.cpp
+++ b/modules/CheckSystem/check_registry.cpp
@@ -62,7 +62,8 @@ filter_obj_handler::filter_obj_handler() {
 }  // namespace check_rk_filter
 }  // namespace registry_key_checks
 
-void registry_key_checks::check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+void registry_key_checks::check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+                                const check::access::prefix_policy &access) {
   typedef check_rk_filter::filter filter_type;
   modern_filter::data_container data;
   modern_filter::cli_helper<filter_type> filter_helper(request, response, data);
@@ -232,7 +233,8 @@ filter_obj_handler::filter_obj_handler() {
 }  // namespace check_rv_filter
 }  // namespace registry_value_checks
 
-void registry_value_checks::check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response) {
+void registry_value_checks::check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+                                  const check::access::prefix_policy &access) {
   typedef check_rv_filter::filter filter_type;
   modern_filter::data_container data;
   modern_filter::cli_helper<filter_type> filter_helper(request, response, data);

--- a/modules/CheckSystem/check_registry.hpp
+++ b/modules/CheckSystem/check_registry.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <check/prefix_access_policy.hpp>
+
 #include <memory>
 #include <nscapi/protobuf/command.hpp>
 #include <parsers/filter/modern_filter.hpp>
@@ -10,6 +12,11 @@
 #include <win/registry.hpp>
 
 // ── check_registry_key ───────────────────────────────────────────────────────
+
+// Normalise the long hive spelling to the abbreviation, so an allow list
+// written one way still matches a caller who used the other. Both are accepted
+// by win_registry::parse_hive.
+std::string normalize_registry_hive(const std::string &key);
 
 namespace registry_key_checks {
 
@@ -29,7 +36,11 @@ long long parse_type_name(const std::string &s);
 
 }  // namespace check_rk_filter
 
-void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+// `access` decides which keys the caller may name; see
+// docs/docs/concepts/check-access.md. It is passed in rather than looked up so
+// the gate can be unit tested without a live module.
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+           const check::access::prefix_policy &access);
 
 }  // namespace registry_key_checks
 
@@ -50,6 +61,9 @@ typedef modern_filter::modern_filters<filter_obj, filter_obj_handler> filter;
 
 }  // namespace check_rv_filter
 
-void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response);
+// `access` decides which keys the caller may name; see
+// docs/docs/concepts/check-access.md.
+void check(const PB::Commands::QueryRequestMessage::Request &request, PB::Commands::QueryResponseMessage::Response *response,
+           const check::access::prefix_policy &access);
 
 }  // namespace registry_value_checks

--- a/modules/CheckWMI/CheckWMI.cpp
+++ b/modules/CheckWMI/CheckWMI.cpp
@@ -107,7 +107,8 @@ bool CheckWMI::resolve_namespace(const std::string &requested, const std::string
     if (namespace_access_.allow_list_size() == 0) {
       if (!boost::algorithm::iequals(ns, "root\\cimv2")) {
         error = "Refusing namespace '" + ns +
-                "': 'allowed namespaces' is empty in [/settings/wmi], so only the default root\\cimv2 may be used while 'query access' is restricted";
+                "': 'allowed namespaces' is empty in [/settings/wmi], so only the default root\\cimv2 may be used while 'query access' is restricted"
+                " (list it there to permit it - a predefined query reading another namespace needs that too)";
         return false;
       }
     } else {

--- a/modules/CheckWMI/CheckWMI.cpp
+++ b/modules/CheckWMI/CheckWMI.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <boost/program_options.hpp>
+#include <check/wql_query.hpp>
 #include <map>
 #include <memory>
 #include <nscapi/nscapi_program_options.hpp>
@@ -25,16 +26,53 @@ bool CheckWMI::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
 
     targets.set_path(settings.alias().get_settings_path("targets"));
 
+    // A reload calls loadModuleEx again on the live module and the settings
+    // callbacks below append, so start from nothing or every reload doubles
+    // the lists.
+    query_access_.reset();
+    class_access_.reset();
+    namespace_access_.reset();
+
     // clang-format off
     settings.alias().add_path_to_settings()
       ("targets", sh::fun_values_path([this] (const auto& key, const auto& value) { targets.add_target(nscapi::settings_proxy::create(get_id(), get_core()), key, value); }),
         "TARGET LIST SECTION", "A list of available remote target systems",
         "TARGET DEFINITION", "For more configuration options add a dedicated section")
+
+      ("queries", sh::fun_values_path([this] (const auto& key, const auto& value) { query_access_.add_predefined(key, value); }),
+        "PREDEFINED WMI QUERIES", "WMI queries check_wmi may run by name, as <name> = <query>.\n"
+        "A name defined here can be used as query=<name> in any access mode, and is the only thing accepted when "
+        "'query access' is set to predefined. The query is not parsed: an operator who writes it here has vouched for it.")
       ;
     // clang-format on
 
+    settings.alias()
+        .add_key_to_settings()
+
+        .add_string("query access", sh::string_fun_key([this](const auto& value) { query_access_.set_mode(value); }, "any"), "WMI QUERY ACCESS MODE",
+                    "Which WMI queries a caller may ask check_wmi to run: any (the default - any query the caller sends, which is how every earlier release "
+                    "behaved), allowed (only a plain SELECT whose class matches 'allowed classes') or predefined (only names defined in the "
+                    "[/settings/wmi/queries] section).\n"
+                    "WMI reaches most of what the machine knows, including the filesystem through Win32_Directory and CIM_DataFile, so on a host where "
+                    "callers may pass arguments (NRPE with 'allow arguments', or the REST API) this decides how much of it a check can read. See the "
+                    "'Restricting what a check may read' section of the documentation.")
+
+        .add_string("allowed classes", sh::string_fun_key([this](const auto& value) { class_access_.set_allow_list(value); }, ""), "ALLOWED WMI CLASSES",
+                    "Comma separated list of WMI classes check_wmi may read when 'query access' is set to allowed. Entries may contain * and ?, for example "
+                    "Win32_Service, Win32_PerfFormattedData_*.\n"
+                    "Only a plain 'SELECT ... FROM <class> [WHERE ...]' can be checked this way. Anything else - ASSOCIATORS OF, REFERENCES OF, a class path "
+                    "carrying a namespace - is refused rather than guessed at, and has to be configured as a predefined query instead.")
+
+        .add_string("allowed namespaces", sh::string_fun_key([this](const auto& value) { namespace_access_.set_allow_list(value); }, ""),
+                    "ALLOWED WMI NAMESPACES",
+                    "Comma separated list of WMI namespaces check_wmi may bind to when 'query access' is not any. Entries may contain * and ?.\n"
+                    "Leaving this empty means the caller may not change the namespace at all: only the default root\\cimv2 is used. It has no effect in the "
+                    "default any mode.");
+
     settings.register_all();
     settings.notify();
+
+    if (!query_access_.get_config_error().empty()) NSC_LOG_ERROR_STD(query_access_.get_config_error());
 
     targets.finalize(nscapi::settings_proxy::create(get_id(), get_core()));
   } catch (const std::exception &e) {
@@ -52,6 +90,35 @@ std::string build_namespace(std::string ns, const std::string &computer) {
   if (ns.empty()) ns = "root\\cimv2";
   if (!computer.empty()) ns = "\\\\" + computer + "\\" + ns;
   return ns;
+}
+
+// Decide whether the caller may bind to the namespace it asked for, and build
+// the string WMI connects to.
+//
+// The rule is deliberately blunt when 'allowed namespaces' is empty: rather
+// than leave the namespace open while the class is restricted - which would
+// let the same class name be read from a different provider - an empty list in
+// a restricted mode means the namespace may not be moved off the default at
+// all. In the default `any` mode nothing is checked.
+bool CheckWMI::resolve_namespace(const std::string &requested, const std::string &computer, std::string &out, std::string &error) const {
+  const std::string ns = requested.empty() ? "root\\cimv2" : requested;
+  if (query_access_.get_mode() != check::access::mode::any) {
+    if (namespace_access_.allow_list_size() == 0) {
+      if (!boost::algorithm::iequals(ns, "root\\cimv2")) {
+        error = "Refusing namespace '" + ns +
+                "': 'allowed namespaces' is empty in [/settings/wmi], so only the default root\\cimv2 may be used while 'query access' is restricted";
+        return false;
+      }
+    } else {
+      const check::access::decision d = namespace_access_.check_value(ns, "namespace");
+      if (!d.allowed) {
+        error = d.error;
+        return false;
+      }
+    }
+  }
+  out = build_namespace(ns, computer);
+  return true;
 }
 
 #include <parsers/filter/cli_helper.hpp>
@@ -96,8 +163,11 @@ void CheckWMI::check_wmi(const PB::Commands::QueryRequestMessage::Request &reque
     ("target", po::value<std::string>(&given_target), "The target to check (for checking remote machines).")
     ("user", po::value<std::string>(&target_info.username), "Remote username when checking remote machines.")
     ("password", po::value<std::string>(&target_info.password), "Remote password when checking remote machines.")
-    ("namespace", po::value<std::string>(&ns)->default_value("root\\cimv2"), "The WMI root namespace to bind to.")
-    ("query", po::value<std::string>(&query), "The WMI query to execute.")
+    ("namespace", po::value<std::string>(&ns)->default_value("root\\cimv2"), "The WMI root namespace to bind to.\n"
+      "While 'query access' in [/settings/wmi] is restricted this must match 'allowed namespaces', and may not be changed at all when that list is empty.")
+    ("query", po::value<std::string>(&query), "The WMI query to execute.\n"
+      "Which queries may be run here is governed by 'query access' in [/settings/wmi]: by default any query is run, but an operator can restrict this to "
+      "queries reading an allowed class, or to names predefined in [/settings/wmi/queries], in which case this takes such a name.")
     ;
   // clang-format on
 
@@ -105,16 +175,50 @@ void CheckWMI::check_wmi(const PB::Commands::QueryRequestMessage::Request &reque
 
   if (query.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No query specified");
 
+  // Hold the query against [/settings/wmi] 'query access' before WMI is
+  // touched. A name defined in [/settings/wmi/queries] is operator-authored,
+  // so it expands and is trusted as-is; a raw query in `allowed` mode has to
+  // name a class on the allow list, which means it also has to be simple
+  // enough to say which class that is.
+  const bool is_predefined = query_access_.has_predefined(query);
+  {
+    const check::access::decision d = query_access_.resolve(query);
+    if (!d.allowed) return nscapi::protobuf::functions::set_response_bad(*response, d.error);
+    query = d.value;
+  }
+  if (!is_predefined && query_access_.get_mode() == check::access::mode::allowed) {
+    const check::wql::parse_result parsed = check::wql::extract_class(query);
+    if (!parsed.ok) {
+      return nscapi::protobuf::functions::set_response_bad(*response, "Refusing query: " + parsed.error + " (see [/settings/wmi] in the configuration)");
+    }
+    const check::access::decision d = class_access_.check_value(parsed.class_name, "WMI class");
+    if (!d.allowed) return nscapi::protobuf::functions::set_response_bad(*response, d.error);
+  }
+
   if (!given_target.empty()) {
     t = targets.find(given_target);
-    if (t)
+    if (t) {
       target_info.update_from(t.value());
-    else
+    } else if (query_access_.get_mode() != check::access::mode::any) {
+      // An unknown target is otherwise taken as a bare host name, which would
+      // let a caller point a restricted check at a machine of its choosing
+      // (and hand it the configured credentials). While access is restricted,
+      // only a target defined in [/settings/wmi/targets] is accepted.
+      return nscapi::protobuf::functions::set_response_bad(
+          *response, "Refusing target '" + given_target +
+                         "': it is not defined in [/settings/wmi/targets], and 'query access' is restricted (see [/settings/wmi] in the configuration)");
+    } else {
       target_info.hostname = given_target;
+    }
+  }
+
+  {
+    std::string resolved_ns, error;
+    if (!resolve_namespace(ns, target_info.hostname, resolved_ns, error)) return nscapi::protobuf::functions::set_response_bad(*response, error);
+    ns = resolved_ns;
   }
 
   try {
-    ns = build_namespace(ns, target_info.hostname);
     wmi_impl::query wmiQuery(query, ns, target_info.username, target_info.password);
     filter.context->registry_.add_string_var("line", &wmi_filter::filter_obj::get_row, "Get a list of all columns");
     for (const std::string &col : wmiQuery.get_columns()) {

--- a/modules/CheckWMI/CheckWMI.cpp
+++ b/modules/CheckWMI/CheckWMI.cpp
@@ -26,9 +26,10 @@ bool CheckWMI::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode) {
 
     targets.set_path(settings.alias().get_settings_path("targets"));
 
-    // A reload calls loadModuleEx again on the live module and the settings
-    // callbacks below append, so start from nothing or every reload doubles
-    // the lists.
+    // A reload calls loadModuleEx again on the live module and the predefined
+    // queries below are appended, so drop them or every reload doubles the
+    // list. The modes and allow lists are replaced by their callbacks and stay
+    // in force meanwhile.
     query_access_.reset();
     class_access_.reset();
     namespace_access_.reset();

--- a/modules/CheckWMI/CheckWMI.cpp
+++ b/modules/CheckWMI/CheckWMI.cpp
@@ -175,18 +175,26 @@ void CheckWMI::check_wmi(const PB::Commands::QueryRequestMessage::Request &reque
 
   if (query.empty()) return nscapi::protobuf::functions::set_response_bad(*response, "No query specified");
 
-  // Hold the query against [/settings/wmi] 'query access' before WMI is
-  // touched. A name defined in [/settings/wmi/queries] is operator-authored,
-  // so it expands and is trusted as-is; a raw query in `allowed` mode has to
-  // name a class on the allow list, which means it also has to be simple
-  // enough to say which class that is.
-  const bool is_predefined = query_access_.has_predefined(query);
-  {
-    const check::access::decision d = query_access_.resolve(query);
-    if (!d.allowed) return nscapi::protobuf::functions::set_response_bad(*response, d.error);
-    query = d.value;
-  }
-  if (!is_predefined && query_access_.get_mode() == check::access::mode::allowed) {
+  // Hold the query against [/settings/wmi] 'query access' before WMI is touched.
+  //
+  // This does not go through policy::resolve() the way the other checks do,
+  // because `allowed` means something different here: there is no list of
+  // permitted query *texts* to match against - a query is judged by the class
+  // it reads, which means it also has to be simple enough to say which class
+  // that is. Only the mode and the predefined names come from the policy.
+  std::string predefined_query;
+  if (query_access_.lookup_predefined(query, predefined_query)) {
+    // Operator-authored, so it is trusted as written: not parsed, and not held
+    // against 'allowed classes'.
+    query = predefined_query;
+  } else if (!query_access_.get_config_error().empty()) {
+    return nscapi::protobuf::functions::set_response_bad(*response, query_access_.get_config_error());
+  } else if (query_access_.get_mode() == check::access::mode::predefined) {
+    return nscapi::protobuf::functions::set_response_bad(
+        *response, "Refusing query '" + query +
+                       "': 'query access' is set to predefined, so only a query defined in [/settings/wmi/queries] may be used (see [/settings/wmi] in "
+                       "the configuration)");
+  } else if (query_access_.get_mode() == check::access::mode::allowed) {
     const check::wql::parse_result parsed = check::wql::extract_class(query);
     if (!parsed.ok) {
       return nscapi::protobuf::functions::set_response_bad(*response, "Refusing query: " + parsed.error + " (see [/settings/wmi] in the configuration)");

--- a/modules/CheckWMI/CheckWMI.h
+++ b/modules/CheckWMI/CheckWMI.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 
 #include <boost/optional.hpp>
+#include <check/access_policy.hpp>
 #include <nscapi/macros.hpp>
 #include <nscapi/nscapi_helper_singleton.hpp>
 #include <nscapi/nscapi_plugin_impl.hpp>
@@ -94,7 +95,14 @@ struct target_helper {
 
 class CheckWMI : public nscapi::impl::simple_plugin {
  public:
-  CheckWMI() {}
+  // Open by default, so an upgrade changes nothing. `queries` holds both the
+  // mode and the predefined queries; `classes` and `namespaces` carry only
+  // their own allow lists, and are consulted through check_value().
+  // See docs/docs/concepts/check-access.md.
+  CheckWMI()
+      : query_access_("query", "queries", "/settings/wmi"),
+        class_access_("class", "classes", "/settings/wmi"),
+        namespace_access_("namespace", "namespaces", "/settings/wmi") {}
   virtual ~CheckWMI() {}
   // Module calls
   bool loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode);
@@ -105,5 +113,13 @@ class CheckWMI : public nscapi::impl::simple_plugin {
   NSCAPI::nagiosReturn commandLineExec(int target_mode, const std::string &command, const std::list<std::string> &arguments, std::string &result);
 
  private:
+  // Resolve `namespace=` against the policy, and build the full namespace
+  // string WMI binds to. Returns false and fills `error` when the namespace is
+  // not permitted.
+  bool resolve_namespace(const std::string &requested, const std::string &computer, std::string &out, std::string &error) const;
+
   target_helper targets;
+  check::access::policy query_access_;
+  check::access::policy class_access_;
+  check::access::policy namespace_access_;
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -669,6 +669,18 @@ NSCP_CREATE_TEST(
 )
 
 NSCP_CREATE_TEST(
+    access_policy_test
+    SOURCES
+        ${NSCP_INCLUDEDIR}/check/access_policy_test.cpp
+    LIBRARIES
+        GTest::gtest_main
+        ${Boost_FILESYSTEM_LIBRARY}
+        ${Boost_REGEX_LIBRARY}
+    INCLUDES
+        ${NSCP_INCLUDEDIR}
+)
+
+NSCP_CREATE_TEST(
     pid_file_test
     SOURCES
         ${NSCP_INCLUDEDIR}/pid_file_test.cpp

--- a/tests/checkdisk-access.test.ts
+++ b/tests/checkdisk-access.test.ts
@@ -116,6 +116,51 @@ describe("CheckDisk file access modes", () => {
       expect(out).toMatch(/Refusing file/);
     });
 
+    // Only the scan root is held against the allow list, so `pattern` has to
+    // stay a file mask: the Windows scanner concatenates it onto the directory
+    // it is walking, and a pattern carrying separators walked straight out of
+    // the root which had just passed the gate.
+    it("check_files refuses a pattern which climbs out of the scan root", async () => {
+      for (const pattern of ["../secret/*", "..\\secret\\*", "../../*", "sub/../../secret/*"]) {
+        const { out, code } = await query("check_files", [
+          `path=${allowedDir}`,
+          `pattern=${pattern}`,
+          "detail-syntax=%(filename)",
+          "top-syntax=${list}",
+        ]);
+        expect(code).toBe(UNKNOWN);
+        expect(out).toMatch(/Refusing pattern/);
+        expect(out).not.toMatch(/credentials/);
+      }
+    });
+
+    it("check_files refuses a pattern naming a subdirectory while restricted", async () => {
+      const { out, code } = await query("check_files", [`path=${allowedDir}`, "pattern=sub/*.log"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing pattern/);
+    });
+
+    it("check_files still accepts an ordinary file mask", async () => {
+      const { out, code } = await query("check_files", [
+        `path=${allowedDir}`,
+        "pattern=*.log",
+        "detail-syntax=%(filename)",
+        "top-syntax=${list}",
+      ]);
+      expect(code).not.toBe(UNKNOWN);
+      expect(out).toMatch(/app\.log/);
+    });
+
+    // A traversal written with the other separator. On Windows it is a
+    // separator and must be flattened before the match; on Linux it is an
+    // ordinary character and must not become one afterwards. Either way the
+    // secret directory must not be enumerated.
+    it("check_files does not enumerate through a backslash traversal", async () => {
+      const escape = `${allowedDir}/..\\..\\secret`;
+      const { out } = await query("check_files", [`path=${escape}`, "pattern=*", "detail-syntax=%(filename)", "top-syntax=${list}"]);
+      expect(out).not.toMatch(/credentials/);
+    });
+
     // The checksum keywords are the reason this matters even though no content
     // keyword exists: a hash of an arbitrary file is a content oracle.
     it("check_files cannot hash a file outside the allowed directory", async () => {

--- a/tests/checkdisk-access.test.ts
+++ b/tests/checkdisk-access.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Exercises the `file access` gate on the disk checks which take a
+ * caller-supplied path: check_files, check_single_file and check_disk_write.
+ *
+ * These never return file contents, but check_files walks whole directory
+ * trees and reports every name, size and timestamp, and the checksum keywords
+ * turn any readable file into a hash oracle. Where the caller chooses the
+ * argument - NRPE with `allow arguments`, or REST - that reach is wide enough
+ * to be worth narrowing, and this is the setting that does it.
+ *
+ * Each case runs a one-shot client query - `nscp client --module CheckDisk
+ * --boot --query <cmd> ...` - which re-reads the settings file every time, so
+ * the mode can be rewritten between cases with no server to restart. That path
+ * also passes `k=v` as single tokens, the same way REST does.
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(180_000);
+
+const UNKNOWN = 3;
+
+describe("CheckDisk file access modes", () => {
+  let nscp: NscpInstance;
+  let scratch: string;
+  let allowedDir: string;
+  let secretDir: string;
+  let allowedLog: string;
+  let secretFile: string;
+
+  async function query(command: string, args: string[]): Promise<{ out: string; code: number }> {
+    const r = await nscp.run(["client", "--module", "CheckDisk", "--boot", "--query", command, ...args], {
+      allowFailure: true,
+    });
+    return { out: r.all ?? `${r.stdout}\n${r.stderr}`, code: r.exitCode };
+  }
+
+  /** Point [/settings/disk] at one mode, always writing both keys. */
+  async function setAccess(mode: string, allowed = "-"): Promise<void> {
+    await nscp.configure({
+      "/settings/disk": { "file access": mode, "allowed files": allowed },
+    });
+  }
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), "checkdisk-access-it-"));
+    allowedDir = path.join(scratch, "logs");
+    secretDir = path.join(scratch, "secret");
+    fs.mkdirSync(path.join(allowedDir, "sub"), { recursive: true });
+    fs.mkdirSync(secretDir, { recursive: true });
+
+    allowedLog = path.join(allowedDir, "app.log");
+    secretFile = path.join(secretDir, "credentials");
+    fs.writeFileSync(allowedLog, "one\ntwo\n");
+    fs.writeFileSync(path.join(allowedDir, "sub", "deep.log"), "deep\n");
+    fs.writeFileSync(secretFile, "hunter2\n");
+
+    await nscp.configure({ "/modules": { CheckDisk: "enabled" } });
+  });
+
+  afterAll(() => {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  // --- any: the default, and what every earlier release did ------------------
+
+  describe("any (default)", () => {
+    beforeAll(() => setAccess("any"));
+
+    it("check_files scans any root the caller names", async () => {
+      const { out, code } = await query("check_files", [`path=${secretDir}`, "pattern=*", "detail-syntax=%(filename)", "top-syntax=${list}"]);
+      expect(code).not.toBe(UNKNOWN);
+      expect(out).toMatch(/credentials/);
+    });
+
+    it("check_single_file stats any file the caller names", async () => {
+      const { out, code } = await query("check_single_file", [`file=${secretFile}`]);
+      expect(code).not.toBe(UNKNOWN);
+      expect(out).toMatch(/credentials/);
+    });
+  });
+
+  // --- allowed: only what matches the list ----------------------------------
+
+  describe("allowed", () => {
+    beforeAll(() => setAccess("allowed", allowedDir));
+
+    it("check_files scans a root inside the allowed directory", async () => {
+      const { out, code } = await query("check_files", [`path=${allowedDir}`, "pattern=*", "detail-syntax=%(filename)", "top-syntax=${list}"]);
+      expect(code).not.toBe(UNKNOWN);
+      expect(out).toMatch(/app\.log/);
+    });
+
+    it("check_files refuses a root outside the allowed directory", async () => {
+      const { out, code } = await query("check_files", [`path=${secretDir}`, "pattern=*", "detail-syntax=%(filename)", "top-syntax=${list}"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+      expect(out).not.toMatch(/credentials/);
+    });
+
+    it("check_files refuses a .. traversal out of the allowed directory", async () => {
+      const escape = path.join(allowedDir, "..", "secret");
+      const { out, code } = await query("check_files", [`path=${escape}`, "pattern=*", "detail-syntax=%(filename)", "top-syntax=${list}"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+      expect(out).not.toMatch(/credentials/);
+    });
+
+    it("check_files gates the paths= alias too", async () => {
+      const { out, code } = await query("check_files", [`paths=${allowedDir},${secretDir}`, "pattern=*"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+    });
+
+    // The checksum keywords are the reason this matters even though no content
+    // keyword exists: a hash of an arbitrary file is a content oracle.
+    it("check_files cannot hash a file outside the allowed directory", async () => {
+      const { out, code } = await query("check_files", [
+        `path=${secretDir}`,
+        "pattern=*",
+        "detail-syntax=%(filename)=%(sha256_checksum)",
+        "top-syntax=${list}",
+      ]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+      expect(out).not.toMatch(/[0-9a-f]{64}/);
+    });
+
+    it("check_single_file refuses a file outside the allowed directory", async () => {
+      const { out, code } = await query("check_single_file", [`file=${secretFile}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+    });
+
+    it("check_disk_write refuses a path outside the allowed directory", async () => {
+      const target = path.join(secretDir, "probe.tmp");
+      const { out, code } = await query("check_disk_write", [`file=${target}`, "size=1k"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+      expect(fs.existsSync(target)).toBe(false);
+    });
+
+    it("check_disk_write still works inside the allowed directory", async () => {
+      const { code } = await query("check_disk_write", [`file=${path.join(allowedDir, "probe.tmp")}`, "size=1k"]);
+      expect(code).not.toBe(UNKNOWN);
+    });
+
+    // A symlink is the other way a string comparison would be fooled.
+    (process.platform === "win32" ? it.skip : it)("refuses a symlink leading out of the allowed directory", async () => {
+      const link = path.join(allowedDir, "escape.log");
+      fs.rmSync(link, { force: true });
+      fs.symlinkSync(secretFile, link);
+      const { out, code } = await query("check_single_file", [`file=${link}`]);
+      fs.rmSync(link, { force: true });
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+    });
+
+    it("does not disclose the allow list in the refusal", async () => {
+      const { out } = await query("check_single_file", [`file=${secretFile}`]);
+      expect(out).not.toContain(allowedDir);
+    });
+  });
+
+  // --- predefined: only names the operator configured ------------------------
+
+  describe("predefined", () => {
+    beforeAll(async () => {
+      await nscp.configure({ "/settings/disk/files": { logs: allowedDir, app: allowedLog } });
+      await setAccess("predefined");
+    });
+
+    it("check_files scans a configured name", async () => {
+      const { out, code } = await query("check_files", ["path=logs", "pattern=*", "detail-syntax=%(filename)", "top-syntax=${list}"]);
+      expect(code).not.toBe(UNKNOWN);
+      expect(out).toMatch(/app\.log/);
+    });
+
+    it("check_single_file stats a configured name", async () => {
+      const { code } = await query("check_single_file", ["file=app"]);
+      expect(code).not.toBe(UNKNOWN);
+    });
+
+    it("refuses a raw path", async () => {
+      const { out, code } = await query("check_single_file", [`file=${allowedLog}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    it("resolves a configured name in any mode too", async () => {
+      await setAccess("any");
+      const { code } = await query("check_single_file", ["file=app"]);
+      expect(code).not.toBe(UNKNOWN);
+      await setAccess("predefined");
+    });
+  });
+
+  // --- a typo in the mode must not read as "no restriction" ------------------
+
+  describe("an invalid mode", () => {
+    it("fails closed and names the valid values", async () => {
+      await setAccess("allwed", allowedDir);
+      const { out, code } = await query("check_files", [`path=${allowedDir}`, "pattern=*"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/expected any, allowed or predefined/);
+      await setAccess("any");
+    });
+  });
+});

--- a/tests/checkeventlog-access.test.ts
+++ b/tests/checkeventlog-access.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Exercises the `log access` gate on check_eventlog: which event log channels
+ * a caller may ask it to read.
+ *
+ * The event text itself comes back through the `message`, `strings` and `xml`
+ * keywords, and `message` is part of the *default* detail syntax, so a caller
+ * needs no syntax argument to get it. Where the caller picks the channel (NRPE
+ * with `allow arguments`, or REST) that reaches everything SYSTEM can read -
+ * the Security channel, and the PowerShell and Sysmon operational channels
+ * among them.
+ *
+ * Each case runs a one-shot client query - `nscp client --module CheckEventLog
+ * --boot --query check_eventlog ...` - which re-reads the settings file every
+ * time. The event log is Windows-only, so the suite is skipped elsewhere.
+ *
+ * Cases assert on whether the gate let the channel through rather than on the
+ * events found: a CI machine's logs are not deterministic, and an empty result
+ * is a legitimate outcome. `scan-range` is pinned so no case depends on how
+ * much history the box happens to hold.
+ */
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(180_000);
+
+const onWindows = process.platform === "win32" ? describe : describe.skip;
+
+const UNKNOWN = 3;
+
+onWindows("CheckEventLog log access modes", () => {
+  let nscp: NscpInstance;
+
+  async function check(args: string[]): Promise<{ out: string; code: number }> {
+    const r = await nscp.run(
+      ["client", "--module", "CheckEventLog", "--boot", "--query", "check_eventlog", ...args, "scan-range=-10m", "empty-state=ok"],
+      { allowFailure: true },
+    );
+    return { out: r.all ?? `${r.stdout}\n${r.stderr}`, code: r.exitCode };
+  }
+
+  /** Point [/settings/eventlog] at one mode, always writing both keys. */
+  async function setAccess(mode: string, allowed = "-"): Promise<void> {
+    await nscp.configure({
+      "/settings/eventlog": { "log access": mode, "allowed logs": allowed },
+    });
+  }
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    await nscp.configure({ "/modules": { CheckEventLog: "enabled" } });
+  });
+
+  // --- any: the default, and what every earlier release did ------------------
+
+  describe("any (default)", () => {
+    beforeAll(() => setAccess("any"));
+
+    it("reads any channel the caller names", async () => {
+      const { out } = await check(["file=Security"]);
+      expect(out).not.toMatch(/Refusing log/);
+    });
+
+    it("does not enforce an allow list which is configured but unused", async () => {
+      await setAccess("any", "Application");
+      const { out } = await check(["file=Security"]);
+      expect(out).not.toMatch(/Refusing log/);
+      await setAccess("any");
+    });
+  });
+
+  // --- allowed: only channels at or below an entry ---------------------------
+
+  describe("allowed", () => {
+    beforeAll(() => setAccess("allowed", "Application, System"));
+
+    it("reads an allowed channel", async () => {
+      const { out } = await check(["file=Application"]);
+      expect(out).not.toMatch(/Refusing log/);
+    });
+
+    it("refuses a channel outside the list", async () => {
+      const { out, code } = await check(["file=Security"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing log 'Security'/);
+      expect(out).toMatch(/allowed logs/);
+    });
+
+    it("gates the log= alias the same way", async () => {
+      const { out, code } = await check(["log=Security"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing log/);
+    });
+
+    it("refuses every channel when one of several is not allowed", async () => {
+      const { out, code } = await check(["file=Application", "file=Security"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing log/);
+    });
+
+    // An entry covers the channel family below it, so a whole provider can be
+    // allowed without naming each of its channels.
+    it("covers a channel family by its prefix", async () => {
+      await setAccess("allowed", "Microsoft-Windows-Sysmon");
+      const { out } = await check(["file=Microsoft-Windows-Sysmon/Operational"]);
+      expect(out).not.toMatch(/Refusing log/);
+      await setAccess("allowed", "Application, System");
+    });
+
+    // The prefix must end on a separator, or an entry would cover an unrelated
+    // provider whose name merely starts with it.
+    it("does not cover a provider sharing the entry's name", async () => {
+      await setAccess("allowed", "Microsoft-Windows-Sysmon");
+      const { out, code } = await check(["file=Microsoft-Windows-SysmonOther/Operational"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing log/);
+      await setAccess("allowed", "Application, System");
+    });
+
+    // The defaults are not exempt: an operator who restricted access did not
+    // opt Application and System in by leaving the argument off.
+    it("applies to the default channels when none is named", async () => {
+      await setAccess("allowed", "Microsoft-Windows-Sysmon");
+      const { out, code } = await check([]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing log/);
+      await setAccess("allowed", "Application, System");
+    });
+
+    it("does not disclose the allow list in the refusal", async () => {
+      await setAccess("allowed", "Microsoft-Windows-SecretProvider");
+      const { out } = await check(["file=Security"]);
+      expect(out).not.toMatch(/SecretProvider/);
+      await setAccess("allowed", "Application, System");
+    });
+  });
+
+  // --- predefined: only names the operator configured ------------------------
+
+  describe("predefined", () => {
+    beforeAll(async () => {
+      await nscp.configure({ "/settings/eventlog/logs": { app: "Application" } });
+      await setAccess("predefined");
+    });
+
+    it("reads a channel by its configured name", async () => {
+      const { out } = await check(["file=app"]);
+      expect(out).not.toMatch(/Refusing log/);
+    });
+
+    it("refuses a raw channel name", async () => {
+      const { out, code } = await check(["file=Security"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    it("refuses a name which is not configured", async () => {
+      const { out, code } = await check(["file=nosuchname"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    it("resolves a configured name in any mode too", async () => {
+      await setAccess("any");
+      expect((await check(["file=app"])).out).not.toMatch(/Refusing log/);
+      await setAccess("predefined");
+    });
+  });
+
+  // --- a typo in the mode must not read as "no restriction" ------------------
+
+  describe("an invalid mode", () => {
+    it("fails closed and names the valid values", async () => {
+      await setAccess("allwed", "Application");
+      const { out, code } = await check(["file=Application"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/expected any, allowed or predefined/);
+      await setAccess("any");
+    });
+  });
+});

--- a/tests/checklogfile-access.test.ts
+++ b/tests/checklogfile-access.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Exercises the `file access` gate on CheckLogFile: which files a caller may
+ * name in `file=` once an operator has restricted it.
+ *
+ * check_logfile reads whatever path it is given with the privileges of the
+ * agent, so on a host where callers pass arguments (NRPE with `allow
+ * arguments`, or REST) that argument decides how much of the machine a single
+ * check can read back. The three modes here are what lets an operator narrow
+ * that, and the cases which matter most are the two ways a plain string
+ * comparison would be fooled: `..` out of an allowed directory, and a symlink
+ * planted inside one.
+ *
+ * Each case runs a one-shot client query — `nscp client --module CheckLogFile
+ * --boot --query check_logfile ...` — which loads the module, re-reads the
+ * settings file and runs the check. That still passes `k=v` as single tokens,
+ * so it exercises the same argument parsing REST does, with no web server to
+ * stand up. Settings are rewritten between cases because `--boot` reads them
+ * fresh on every invocation.
+ */
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(180_000);
+
+const UNKNOWN = 3;
+
+describe("CheckLogFile file access modes", () => {
+  let nscp: NscpInstance;
+  let scratch: string;
+  let allowedDir: string;
+  let secretDir: string;
+  let allowedLog: string;
+  let allowedNotes: string;
+  let secretFile: string;
+
+  /** Run check_logfile and return its output plus the Nagios exit code. */
+  async function check(args: string[]): Promise<{ out: string; code: number }> {
+    const r = await nscp.run(
+      [
+        "client",
+        "--module",
+        "CheckLogFile",
+        "--boot",
+        "--query",
+        "check_logfile",
+        ...args,
+        "filter=column1 like 'SECRET'",
+        "warning=count > 0",
+        "empty-state=ok",
+      ],
+      { allowFailure: true },
+    );
+    return { out: r.all ?? `${r.stdout}\n${r.stderr}`, code: r.exitCode };
+  }
+
+  /**
+   * Point [/settings/logfile] at one mode. Both keys are always written so a
+   * previous case's allow list can never leak into the next one.
+   */
+  async function setAccess(mode: string, allowed = "-"): Promise<void> {
+    await nscp.configure({
+      "/settings/logfile": { "file access": mode, "allowed files": allowed },
+    });
+  }
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    scratch = fs.mkdtempSync(path.join(os.tmpdir(), "logfile-access-it-"));
+    allowedDir = path.join(scratch, "logs");
+    secretDir = path.join(scratch, "secret");
+    fs.mkdirSync(path.join(allowedDir, "sub"), { recursive: true });
+    fs.mkdirSync(secretDir, { recursive: true });
+
+    allowedLog = path.join(allowedDir, "app.log");
+    allowedNotes = path.join(allowedDir, "notes.txt");
+    secretFile = path.join(secretDir, "credentials");
+    fs.writeFileSync(allowedLog, "SECRET in an allowed file\n");
+    fs.writeFileSync(allowedNotes, "SECRET in an allowed directory\n");
+    fs.writeFileSync(path.join(allowedDir, "sub", "deep.log"), "SECRET deeper down\n");
+    fs.writeFileSync(secretFile, "SECRET which must not come back\n");
+
+    await nscp.configure({ "/modules": { CheckLogFile: "enabled" } });
+  });
+
+  afterAll(() => {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  // --- any: the default, and what every earlier release did -----------------
+
+  describe("any (default)", () => {
+    beforeAll(() => setAccess("any"));
+
+    it("reads a file the caller names", async () => {
+      const { out } = await check([`file=${secretFile}`]);
+      expect(out).toMatch(/SECRET which must not come back/);
+    });
+
+    it("still reads a file when an allow list is configured but unused", async () => {
+      await setAccess("any", allowedDir);
+      const { out } = await check([`file=${secretFile}`]);
+      expect(out).toMatch(/SECRET which must not come back/);
+      await setAccess("any");
+    });
+  });
+
+  // --- allowed: only what matches the list ----------------------------------
+
+  describe("allowed", () => {
+    beforeAll(() => setAccess("allowed", allowedDir));
+
+    it("reads a file inside an allowed directory", async () => {
+      const { out } = await check([`file=${allowedLog}`]);
+      expect(out).toMatch(/SECRET in an allowed file/);
+    });
+
+    it("reads a file nested deeper inside an allowed directory", async () => {
+      const { out } = await check([`file=${path.join(allowedDir, "sub", "deep.log")}`]);
+      expect(out).toMatch(/SECRET deeper down/);
+    });
+
+    it("refuses a file outside the allowed directory", async () => {
+      const { out, code } = await check([`file=${secretFile}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+      expect(out).toMatch(/allowed files/);
+      expect(out).not.toMatch(/SECRET which must not come back/);
+    });
+
+    // The reason a path needs resolving before it is matched: as plain text
+    // this one reads as "under the allowed directory" and is not.
+    it("refuses a .. traversal out of the allowed directory", async () => {
+      const escape = path.join(allowedDir, "..", "secret", "credentials");
+      const { out, code } = await check([`file=${escape}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing file/);
+      expect(out).not.toMatch(/SECRET which must not come back/);
+    });
+
+    it("refuses a sibling directory sharing the allowed prefix", async () => {
+      const sibling = path.join(scratch, "logs-private");
+      fs.mkdirSync(sibling, { recursive: true });
+      fs.writeFileSync(path.join(sibling, "x.log"), "SECRET next door\n");
+      const { out, code } = await check([`file=${path.join(sibling, "x.log")}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).not.toMatch(/SECRET next door/);
+    });
+
+    it("refuses every file when one of several is not allowed", async () => {
+      const { out, code } = await check([`file=${allowedLog}`, `file=${secretFile}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).not.toMatch(/SECRET in an allowed file/);
+      expect(out).not.toMatch(/SECRET which must not come back/);
+    });
+
+    it("honours a wildcard entry", async () => {
+      await setAccess("allowed", path.join(allowedDir, "*.log"));
+      const allowed = await check([`file=${allowedLog}`]);
+      expect(allowed.out).toMatch(/SECRET in an allowed file/);
+
+      const refused = await check([`file=${allowedNotes}`]);
+      expect(refused.code).toBe(UNKNOWN);
+      expect(refused.out).toMatch(/Refusing file/);
+
+      await setAccess("allowed", allowedDir);
+    });
+
+    it("accepts several entries", async () => {
+      await setAccess("allowed", `${allowedLog},${secretDir}`);
+      expect((await check([`file=${allowedLog}`])).out).toMatch(/SECRET in an allowed file/);
+      expect((await check([`file=${secretFile}`])).out).toMatch(/SECRET which must not come back/);
+      expect((await check([`file=${allowedNotes}`])).code).toBe(UNKNOWN);
+      await setAccess("allowed", allowedDir);
+    });
+
+    // A symlink is the other way the string comparison lies; the path is
+    // resolved before it is matched, so the link is followed out of the
+    // allowed directory and refused there.
+    (process.platform === "win32" ? it.skip : it)(
+      "refuses a symlink leading out of the allowed directory",
+      async () => {
+        const link = path.join(allowedDir, "escape.log");
+        fs.rmSync(link, { force: true });
+        fs.symlinkSync(secretFile, link);
+        const { out, code } = await check([`file=${link}`]);
+        fs.rmSync(link, { force: true });
+        expect(code).toBe(UNKNOWN);
+        expect(out).toMatch(/Refusing file/);
+        expect(out).not.toMatch(/SECRET which must not come back/);
+      },
+    );
+
+    it("does not disclose the allow list in the refusal", async () => {
+      const { out } = await check([`file=${secretFile}`]);
+      expect(out).not.toContain(allowedDir);
+    });
+  });
+
+  // --- predefined: only names the operator configured ------------------------
+
+  describe("predefined", () => {
+    beforeAll(async () => {
+      await nscp.configure({ "/settings/logfile/files": { app: allowedLog } });
+      await setAccess("predefined");
+    });
+
+    it("reads a file by its configured name", async () => {
+      const { out } = await check(["file=app"]);
+      expect(out).toMatch(/SECRET in an allowed file/);
+    });
+
+    it("refuses a raw path", async () => {
+      const { out, code } = await check([`file=${secretFile}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+      expect(out).not.toMatch(/SECRET which must not come back/);
+    });
+
+    it("refuses a name which is not configured", async () => {
+      const { out, code } = await check(["file=nosuchname"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    // Operator-authored names resolve in every mode, which is what lets a site
+    // name its checks first and tighten the mode afterwards.
+    it("resolves a configured name in any mode too", async () => {
+      await setAccess("any");
+      const { out } = await check(["file=app"]);
+      expect(out).toMatch(/SECRET in an allowed file/);
+      await setAccess("predefined");
+    });
+  });
+
+  // --- a typo in the mode must not read as "no restriction" ------------------
+
+  describe("an invalid mode", () => {
+    it("fails closed and names the valid values", async () => {
+      await setAccess("allwed", allowedDir);
+      const { out, code } = await check([`file=${allowedLog}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/expected any, allowed or predefined/);
+      expect(out).not.toMatch(/SECRET in an allowed file/);
+      await setAccess("any");
+    });
+  });
+});

--- a/tests/checklogfile-access.test.ts
+++ b/tests/checklogfile-access.test.ts
@@ -140,6 +140,35 @@ describe("CheckLogFile file access modes", () => {
       expect(out).not.toMatch(/SECRET which must not come back/);
     });
 
+    // The same traversal written with the other separator. On Windows `\` is
+    // a separator and has to be flattened before the match; on Linux it is an
+    // ordinary character and must not turn into one afterwards, which is how
+    // this escaped an allow list (folding happened after resolution).
+    it("refuses a .. traversal written with a backslash", async () => {
+      for (const escape of [
+        `${allowedDir}/..\\secret\\credentials`,
+        `${allowedDir}/..\\..\\secret/credentials`,
+        `${allowedDir}\\..\\secret\\credentials`,
+      ]) {
+        const { out, code } = await check([`file=${escape}`]);
+        expect(code).toBe(UNKNOWN);
+        expect(out).not.toMatch(/SECRET which must not come back/);
+      }
+    });
+
+    // `files=` is the comma-separated form of `file=`, and it goes through the
+    // same gate: it used to be parsed before the arguments were read, so it
+    // did nothing at all.
+    it("gates the files= alias, and it actually reads now", async () => {
+      const both = await check([`files=${allowedLog}`]);
+      expect(both.out).toMatch(/SECRET in an allowed file/);
+
+      const mixed = await check([`files=${allowedLog},${secretFile}`]);
+      expect(mixed.code).toBe(UNKNOWN);
+      expect(mixed.out).toMatch(/Refusing file/);
+      expect(mixed.out).not.toMatch(/SECRET which must not come back/);
+    });
+
     it("refuses a sibling directory sharing the allowed prefix", async () => {
       const sibling = path.join(scratch, "logs-private");
       fs.mkdirSync(sibling, { recursive: true });

--- a/tests/checksystem-pdh-access.test.ts
+++ b/tests/checksystem-pdh-access.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Exercises the `counter access` gate on CheckSystem: which performance
+ * counters a caller may ask check_pdh (check_counter) to read once an operator
+ * has restricted it.
+ *
+ * PDH exposes every performance object on the machine, so on a host where
+ * callers pass arguments (NRPE with `allow arguments`, or REST) an
+ * unrestricted `counter=` reads any of them. Unlike the logfile and WMI gates
+ * this one needs no new predefined list: the counters an operator already
+ * configured in [/settings/system/windows/counters] are the predefined set.
+ *
+ * Each case runs a one-shot client query - `nscp client --module CheckSystem
+ * --boot --query check_pdh ...` - which re-reads the settings file every time.
+ * PDH is Windows-only, so the suite is skipped elsewhere.
+ *
+ * Note on the accept cases: a counter referenced by name is served from the
+ * background collector, which may not have sampled yet in a one-shot process.
+ * Those cases therefore assert that the gate let the counter through (no
+ * refusal) rather than asserting a value came back - the value is the
+ * collector's business and is covered by the main CheckSystem suite.
+ */
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(180_000);
+
+const onWindows = process.platform === "win32" ? describe : describe.skip;
+
+const UNKNOWN = 3;
+/** Present on every Windows install, and free of characters needing quoting. */
+const THREADS = "\\System\\Threads";
+const PROCESSES = "\\System\\Processes";
+const MEMORY = "\\Memory\\Pages/sec";
+
+onWindows("CheckSystem counter access modes", () => {
+  let nscp: NscpInstance;
+
+  async function check(args: string[]): Promise<{ out: string; code: number }> {
+    const r = await nscp.run(["client", "--module", "CheckSystem", "--boot", "--query", "check_pdh", ...args], {
+      allowFailure: true,
+    });
+    return { out: r.all ?? `${r.stdout}\n${r.stderr}`, code: r.exitCode };
+  }
+
+  /** Point [/settings/system/windows] at one mode, always writing both keys. */
+  async function setAccess(mode: string, allowed = "-"): Promise<void> {
+    await nscp.configure({
+      "/settings/system/windows": { "counter access": mode, "allowed counters": allowed },
+    });
+  }
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    await nscp.configure({ "/modules": { CheckSystem: "enabled" } });
+  });
+
+  // --- any: the default, and what every earlier release did ------------------
+
+  describe("any (default)", () => {
+    beforeAll(() => setAccess("any"));
+
+    it("reads any counter the caller names", async () => {
+      const { out, code } = await check([`counter=${THREADS}`, "warning=value > 0"]);
+      expect(code).not.toBe(UNKNOWN);
+      expect(out).not.toMatch(/Refusing counter/);
+    });
+
+    it("does not enforce an allow list which is configured but unused", async () => {
+      await setAccess("any", "\\Memory\\*");
+      const { out } = await check([`counter=${THREADS}`, "warning=value > 0"]);
+      expect(out).not.toMatch(/Refusing counter/);
+      await setAccess("any");
+    });
+  });
+
+  // --- allowed: only paths matching the list ---------------------------------
+
+  describe("allowed", () => {
+    beforeAll(() => setAccess("allowed", "\\System\\*"));
+
+    it("reads a counter matching the allow list", async () => {
+      const { out } = await check([`counter=${THREADS}`, "warning=value > 0"]);
+      expect(out).not.toMatch(/Refusing counter/);
+    });
+
+    it("refuses a counter outside the allow list", async () => {
+      const { out, code } = await check([`counter=${MEMORY}`, "warning=value > 0"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing counter/);
+      expect(out).toMatch(/allowed counters/);
+    });
+
+    it("refuses the whole check when one of several counters is not allowed", async () => {
+      const { out, code } = await check([`counter=${THREADS}`, `counter=${MEMORY}`, "warning=value > 0"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing counter/);
+    });
+
+    it("accepts several entries", async () => {
+      await setAccess("allowed", "\\System\\*, \\Memory\\*");
+      expect((await check([`counter=${THREADS}`, "warning=value > 0"])).out).not.toMatch(/Refusing counter/);
+      expect((await check([`counter=${MEMORY}`, "warning=value > 0"])).out).not.toMatch(/Refusing counter/);
+      await setAccess("allowed", "\\System\\*");
+    });
+
+    // The parentheses and backslashes a counter path is full of must be
+    // matched literally, not read as regular-expression syntax.
+    it("treats an instance name as literal text", async () => {
+      await setAccess("allowed", "\\Processor(_Total)\\*");
+      const { out } = await check(["counter=\\Processor(_Total)\\% Processor Time", "warning=value > 100"]);
+      expect(out).not.toMatch(/Refusing counter/);
+      await setAccess("allowed", "\\System\\*");
+    });
+
+    it("also gates the counter:<alias>= form", async () => {
+      const { out, code } = await check([`counter:mem=${MEMORY}`, "warning=value > 0"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing counter/);
+    });
+  });
+
+  // --- predefined: only the configured counters ------------------------------
+
+  describe("predefined", () => {
+    beforeAll(async () => {
+      await nscp.configure({ "/settings/system/windows/counters": { threads: THREADS } });
+      await setAccess("predefined");
+    });
+
+    it("accepts a counter referenced by its configured name", async () => {
+      const { out } = await check(["counter=threads", "warning=value > 0"]);
+      expect(out).not.toMatch(/Refusing counter/);
+    });
+
+    it("refuses a raw counter path", async () => {
+      const { out, code } = await check([`counter=${PROCESSES}`, "warning=value > 0"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    it("refuses a name which is not configured", async () => {
+      const { out, code } = await check(["counter=nosuchname", "warning=value > 0"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing counter/);
+    });
+
+    it("accepts a configured name in allowed mode too", async () => {
+      await setAccess("allowed", "\\Memory\\*");
+      const { out } = await check(["counter=threads", "warning=value > 0"]);
+      expect(out).not.toMatch(/Refusing counter/);
+      await setAccess("predefined");
+    });
+  });
+
+  // --- a typo in the mode must not read as "no restriction" ------------------
+
+  describe("an invalid mode", () => {
+    it("fails closed and names the valid values", async () => {
+      await setAccess("allwed", "*");
+      const { out, code } = await check([`counter=${THREADS}`, "warning=value > 0"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/expected any, allowed or predefined/);
+      await setAccess("any");
+    });
+  });
+});

--- a/tests/checksystem-registry-access.test.ts
+++ b/tests/checksystem-registry-access.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Exercises the `registry access` gate on check_registry_key and
+ * check_registry_value.
+ *
+ * This is the sharpest of the access gates. check_registry_value returns the
+ * value data itself - with binary values rendered as hex, and the value in the
+ * *default* detail syntax, so no syntax argument is needed - and `recursive`
+ * walks a whole subtree. Where the caller picks the argument (NRPE with `allow
+ * arguments`, or REST) that is an arbitrary registry read as SYSTEM.
+ *
+ * Each case runs a one-shot client query - `nscp client --module CheckSystem
+ * --boot --query ...` - which re-reads the settings file every time, so the
+ * mode can be rewritten between cases without restarting a server.
+ * The registry is Windows-only, so the suite is skipped elsewhere.
+ */
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(180_000);
+
+const onWindows = process.platform === "win32" ? describe : describe.skip;
+
+const UNKNOWN = 3;
+/** Present on every Windows install and safe to read. */
+const CURRENT_VERSION = "HKLM\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
+const CV_LONG = "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
+/** Deliberately outside anything the tests allow. */
+const ELSEWHERE = "HKLM\\SYSTEM\\CurrentControlSet\\Control";
+
+onWindows("CheckSystem registry access modes", () => {
+  let nscp: NscpInstance;
+
+  async function query(command: string, args: string[]): Promise<{ out: string; code: number }> {
+    const r = await nscp.run(["client", "--module", "CheckSystem", "--boot", "--query", command, ...args], {
+      allowFailure: true,
+    });
+    return { out: r.all ?? `${r.stdout}\n${r.stderr}`, code: r.exitCode };
+  }
+
+  /** Point [/settings/system/windows] at one mode, always writing both keys. */
+  async function setAccess(mode: string, allowed = "-"): Promise<void> {
+    await nscp.configure({
+      "/settings/system/windows": { "registry access": mode, "allowed registry keys": allowed },
+    });
+  }
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    await nscp.configure({ "/modules": { CheckSystem: "enabled" } });
+  });
+
+  // --- any: the default, and what every earlier release did ------------------
+
+  describe("any (default)", () => {
+    beforeAll(() => setAccess("any"));
+
+    it("reads any key the caller names", async () => {
+      const { out, code } = await query("check_registry_value", [`key=${CURRENT_VERSION}`, "value=ProductName"]);
+      expect(code).not.toBe(UNKNOWN);
+      expect(out).not.toMatch(/Refusing/);
+    });
+
+    it("does not enforce an allow list which is configured but unused", async () => {
+      await setAccess("any", "HKLM\\SOFTWARE\\Nothing");
+      const { out } = await query("check_registry_value", [`key=${CURRENT_VERSION}`, "value=ProductName"]);
+      expect(out).not.toMatch(/Refusing/);
+      await setAccess("any");
+    });
+  });
+
+  // --- allowed: only keys at or below an entry -------------------------------
+
+  describe("allowed", () => {
+    beforeAll(() => setAccess("allowed", "HKLM\\SOFTWARE\\Microsoft\\Windows NT"));
+
+    it("reads a key below an allowed entry", async () => {
+      const { out } = await query("check_registry_value", [`key=${CURRENT_VERSION}`, "value=ProductName"]);
+      expect(out).not.toMatch(/Refusing/);
+    });
+
+    it("refuses a key outside the allowed subtree", async () => {
+      const { out, code } = await query("check_registry_value", [`key=${ELSEWHERE}`, "value=*"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing registry key/);
+      expect(out).toMatch(/allowed registry keys/);
+    });
+
+    it("gates check_registry_key the same way", async () => {
+      const { out, code } = await query("check_registry_key", [`key=${ELSEWHERE}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing registry key/);
+    });
+
+    // The reason this is a prefix match and not a glob: an entry must not cover
+    // a sibling whose name merely starts with it.
+    it("does not cover a sibling sharing the entry's name", async () => {
+      await setAccess("allowed", "HKLM\\SOFTWARE\\Microsoft\\Windows");
+      const { out, code } = await query("check_registry_key", ["key=HKLM\\SOFTWARE\\Microsoft\\Windows NT"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing registry key/);
+      await setAccess("allowed", "HKLM\\SOFTWARE\\Microsoft\\Windows NT");
+    });
+
+    // Both hive spellings mean the same hive, so an allow list written one way
+    // must still match a caller who used the other.
+    it("accepts the long hive spelling against a short entry", async () => {
+      const { out } = await query("check_registry_value", [`key=${CV_LONG}`, "value=ProductName"]);
+      expect(out).not.toMatch(/Refusing/);
+    });
+
+    it("refuses the long hive spelling of a key outside the subtree", async () => {
+      const { out, code } = await query("check_registry_value", ["key=HKEY_LOCAL_MACHINE\\SYSTEM", "value=*"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing registry key/);
+    });
+
+    it("refuses every key when one of several is not allowed", async () => {
+      const { out, code } = await query("check_registry_value", [`key=${CURRENT_VERSION}`, `key=${ELSEWHERE}`, "value=*"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing registry key/);
+    });
+
+    // A restricted check reads the local registry only: `computer=` is an
+    // outbound destination the allow list says nothing about.
+    it("refuses a remote computer while restricted", async () => {
+      const { out, code } = await query("check_registry_value", [`key=${CURRENT_VERSION}`, "value=ProductName", "computer=some-other-host"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing computer/);
+    });
+
+    it("honours a wildcard entry", async () => {
+      await setAccess("allowed", "HKLM\\SOFTWARE\\Microsoft\\*\\CurrentVersion");
+      expect((await query("check_registry_value", [`key=${CURRENT_VERSION}`, "value=ProductName"])).out).not.toMatch(/Refusing/);
+      expect((await query("check_registry_key", [`key=${ELSEWHERE}`])).code).toBe(UNKNOWN);
+      await setAccess("allowed", "HKLM\\SOFTWARE\\Microsoft\\Windows NT");
+    });
+
+    it("does not disclose the allow list in the refusal", async () => {
+      await setAccess("allowed", "HKLM\\SOFTWARE\\SecretVendor");
+      const { out } = await query("check_registry_key", [`key=${ELSEWHERE}`]);
+      expect(out).not.toMatch(/SecretVendor/);
+      await setAccess("allowed", "HKLM\\SOFTWARE\\Microsoft\\Windows NT");
+    });
+  });
+
+  // --- predefined: only names the operator configured ------------------------
+
+  describe("predefined", () => {
+    beforeAll(async () => {
+      await nscp.configure({ "/settings/system/windows/registry": { winver: CURRENT_VERSION } });
+      await setAccess("predefined");
+    });
+
+    it("reads a key by its configured name", async () => {
+      const { out } = await query("check_registry_value", ["key=winver", "value=ProductName"]);
+      expect(out).not.toMatch(/Refusing/);
+    });
+
+    it("refuses a raw key", async () => {
+      const { out, code } = await query("check_registry_value", [`key=${CURRENT_VERSION}`, "value=ProductName"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    it("refuses a name which is not configured", async () => {
+      const { out, code } = await query("check_registry_key", ["key=nosuchname"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    it("resolves a configured name in any mode too", async () => {
+      await setAccess("any");
+      expect((await query("check_registry_value", ["key=winver", "value=ProductName"])).out).not.toMatch(/Refusing/);
+      await setAccess("predefined");
+    });
+  });
+
+  // --- a typo in the mode must not read as "no restriction" ------------------
+
+  describe("an invalid mode", () => {
+    it("fails closed and names the valid values", async () => {
+      await setAccess("allwed", "HKLM\\SOFTWARE");
+      const { out, code } = await query("check_registry_key", [`key=${CURRENT_VERSION}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/expected any, allowed or predefined/);
+      await setAccess("any");
+    });
+  });
+});

--- a/tests/checkwmi-access.test.ts
+++ b/tests/checkwmi-access.test.ts
@@ -43,8 +43,13 @@ onWindows("CheckWMI query access modes", () => {
   /**
    * Point [/settings/wmi] at one mode. Every key is always written so a
    * previous case's list can never leak into the next one.
+   *
+   * Both lists default to empty rather than to a placeholder: an empty
+   * 'allowed namespaces' is what means "the default root\\cimv2 only", so a
+   * placeholder there would silently refuse every case that does not name a
+   * namespace.
    */
-  async function setAccess(mode: string, classes = "-", namespaces = "-"): Promise<void> {
+  async function setAccess(mode: string, classes = "", namespaces = ""): Promise<void> {
     await nscp.configure({
       "/settings/wmi": {
         "query access": mode,

--- a/tests/checkwmi-access.test.ts
+++ b/tests/checkwmi-access.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Exercises the `query access` gate on CheckWMI: which WMI queries a caller
+ * may ask check_wmi to run once an operator has restricted it.
+ *
+ * WMI reaches most of what a Windows machine knows - including the filesystem,
+ * through CIM_DataFile and Win32_Directory - so on a host where callers pass
+ * arguments (NRPE with `allow arguments`, or REST) an unrestricted `query=` is
+ * a general read primitive running as SYSTEM. The three modes here are what
+ * lets an operator narrow it.
+ *
+ * The case which matters most is the one where the gate could be fooled rather
+ * than merely bypassed: a query whose real class differs from the one a naive
+ * reading would approve. Those forms are refused outright rather than guessed
+ * at, and that is asserted here.
+ *
+ * Each case runs a one-shot client query - `nscp client --module CheckWMI
+ * --boot --query check_wmi ...` - which re-reads the settings file every time,
+ * so the mode can be rewritten between cases without restarting a server.
+ * WMI is Windows-only, so the suite is skipped elsewhere.
+ */
+import { NscpInstance } from "@fixtures/index";
+
+jest.setTimeout(180_000);
+
+const onWindows = process.platform === "win32" ? describe : describe.skip;
+
+const UNKNOWN = 3;
+const OS_QUERY = "SELECT Caption FROM Win32_OperatingSystem";
+const SERVICE_QUERY = "SELECT Name, State FROM Win32_Service";
+/** The filesystem side of WMI: what restricting by class is meant to shut out. */
+const FILE_QUERY = "SELECT Name FROM CIM_DataFile WHERE Drive = 'C:' AND Path = '\\\\Windows\\\\'";
+
+onWindows("CheckWMI query access modes", () => {
+  let nscp: NscpInstance;
+
+  async function check(args: string[]): Promise<{ out: string; code: number }> {
+    const r = await nscp.run(["client", "--module", "CheckWMI", "--boot", "--query", "check_wmi", ...args], {
+      allowFailure: true,
+    });
+    return { out: r.all ?? `${r.stdout}\n${r.stderr}`, code: r.exitCode };
+  }
+
+  /**
+   * Point [/settings/wmi] at one mode. Every key is always written so a
+   * previous case's list can never leak into the next one.
+   */
+  async function setAccess(mode: string, classes = "-", namespaces = "-"): Promise<void> {
+    await nscp.configure({
+      "/settings/wmi": {
+        "query access": mode,
+        "allowed classes": classes,
+        "allowed namespaces": namespaces,
+      },
+    });
+  }
+
+  beforeAll(async () => {
+    nscp = new NscpInstance();
+    await nscp.configure({ "/modules": { CheckWMI: "enabled" } });
+  });
+
+  // --- any: the default, and what every earlier release did ------------------
+
+  describe("any (default)", () => {
+    beforeAll(() => setAccess("any"));
+
+    it("runs any query the caller sends", async () => {
+      const { out, code } = await check([`query=${OS_QUERY}`]);
+      expect(code).not.toBe(UNKNOWN);
+      expect(out).not.toMatch(/Refusing/);
+    });
+
+    it("does not enforce an allow list which is configured but unused", async () => {
+      await setAccess("any", "Win32_Service");
+      const { out } = await check([`query=${OS_QUERY}`]);
+      expect(out).not.toMatch(/Refusing/);
+      await setAccess("any");
+    });
+  });
+
+  // --- allowed: only queries reading a class on the list ---------------------
+
+  describe("allowed", () => {
+    beforeAll(() => setAccess("allowed", "Win32_OperatingSystem"));
+
+    it("runs a query reading an allowed class", async () => {
+      const { out } = await check([`query=${OS_QUERY}`]);
+      expect(out).not.toMatch(/Refusing/);
+    });
+
+    it("refuses a query reading a class which is not allowed", async () => {
+      const { out, code } = await check([`query=${SERVICE_QUERY}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing WMI class 'Win32_Service'/);
+      expect(out).toMatch(/allowed classes/);
+    });
+
+    it("refuses the filesystem classes", async () => {
+      const { out, code } = await check([`query=${FILE_QUERY}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing/);
+    });
+
+    it("honours a wildcard entry", async () => {
+      await setAccess("allowed", "Win32_Perf*, Win32_OperatingSystem");
+      expect((await check([`query=${OS_QUERY}`])).out).not.toMatch(/Refusing/);
+      expect((await check([`query=${SERVICE_QUERY}`])).code).toBe(UNKNOWN);
+      await setAccess("allowed", "Win32_OperatingSystem");
+    });
+
+    // A gate which cannot say for certain which class WMI will read has to
+    // refuse, not guess: approving the trailing identifier of a qualified path
+    // would let the query read from another namespace entirely.
+    it("refuses a query whose class it cannot determine", async () => {
+      for (const query of [
+        "ASSOCIATORS OF {Win32_LogicalDisk.DeviceID='C:'}",
+        "SELECT * FROM root\\cimv2:Win32_OperatingSystem",
+        "SELECT Caption FROM Win32_OperatingSystem; SELECT Name FROM Win32_Service",
+      ]) {
+        const { out, code } = await check([`query=${query}`]);
+        expect(code).toBe(UNKNOWN);
+        expect(out).toMatch(/Refusing query/);
+      }
+    });
+
+    it("refuses a namespace other than the default when no list is set", async () => {
+      const { out, code } = await check([`query=${OS_QUERY}`, "namespace=root\\securitycenter2"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing namespace/);
+    });
+
+    it("accepts a namespace on the list", async () => {
+      await setAccess("allowed", "*", "root\\cimv2, root\\securitycenter2");
+      const { out } = await check([`query=${OS_QUERY}`, "namespace=root\\cimv2"]);
+      expect(out).not.toMatch(/Refusing/);
+      await setAccess("allowed", "Win32_OperatingSystem");
+    });
+
+    // An unknown target would otherwise be taken as a bare host name, pointing
+    // a restricted check at a machine of the caller's choosing.
+    it("refuses a target which is not configured", async () => {
+      const { out, code } = await check([`query=${OS_QUERY}`, "target=some-other-host"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/Refusing target/);
+    });
+  });
+
+  // --- predefined: only queries the operator configured ----------------------
+
+  describe("predefined", () => {
+    beforeAll(async () => {
+      await nscp.configure({ "/settings/wmi/queries": { os: OS_QUERY } });
+      await setAccess("predefined");
+    });
+
+    it("runs a query by its configured name", async () => {
+      const { out } = await check(["query=os"]);
+      expect(out).not.toMatch(/Refusing/);
+    });
+
+    it("refuses a raw query", async () => {
+      const { out, code } = await check([`query=${OS_QUERY}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    it("refuses a name which is not configured", async () => {
+      const { out, code } = await check(["query=nosuchname"]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/set to predefined/);
+    });
+
+    it("resolves a configured name in any mode too", async () => {
+      await setAccess("any");
+      expect((await check(["query=os"])).out).not.toMatch(/Refusing/);
+      await setAccess("predefined");
+    });
+
+    // A predefined query is operator-authored, so it is trusted as written -
+    // it is not parsed and not held against the class list.
+    it("runs a predefined query whose class is not on the allow list", async () => {
+      await nscp.configure({ "/settings/wmi/queries": { svc: SERVICE_QUERY } });
+      await setAccess("allowed", "Win32_OperatingSystem");
+      const { out } = await check(["query=svc"]);
+      expect(out).not.toMatch(/Refusing/);
+      await setAccess("predefined");
+    });
+  });
+
+  // --- a typo in the mode must not read as "no restriction" ------------------
+
+  describe("an invalid mode", () => {
+    it("fails closed and names the valid values", async () => {
+      await setAccess("allwed", "*");
+      const { out, code } = await check([`query=${OS_QUERY}`]);
+      expect(code).toBe(UNKNOWN);
+      expect(out).toMatch(/expected any, allowed or predefined/);
+      await setAccess("any");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds configurable access control modes to checks whose arguments decide *what data is read* rather than how it is judged. These checks run with agent privileges (SYSTEM/root) and can now be restricted to operator-approved values, preventing callers from reading arbitrary files, WMI classes, performance counters, registry keys, or event logs.

## Key Changes

- **New access policy framework** (`include/check/access_policy.hpp`):
  - Three modes: `any` (default, unrestricted), `allowed` (glob-matched allow list), `predefined` (operator-configured names only)
  - Glob matching with `*` and `?` wildcards, case-insensitive by default
  - Predefined entries resolve in all modes, allowing gradual tightening without rewriting monitoring servers

- **Specialized policy variants**:
  - `path_access_policy.hpp`: For file paths; resolves `..` and symlinks before matching to prevent directory escape
  - `prefix_access_policy.hpp`: For hierarchical namespaces (registry keys, event log channels); supports prefix matching and optional normalization
  - `wql_query.hpp`: Extracts WMI class names from WQL queries for validation; refuses complex forms (ASSOCIATORS OF, REFERENCES OF, etc.) to prevent bypass

- **Integration with checks**:
  - `check_logfile`: `file access` mode with `allowed files` list
  - `check_wmi`: `query access` mode with `allowed classes` and `allowed namespaces` lists
  - `check_pdh` (check_counter): `counter access` mode; predefined set comes from existing `[/settings/system/windows/counters]`
  - `check_files`, `check_single_file`, `check_disk_write`: `file access` mode with `allowed files` list
  - `check_registry_key`, `check_registry_value`: `registry access` mode with `allowed registry keys` list
  - `check_eventlog`: `log access` mode with `allowed logs` list

- **Comprehensive test coverage**:
  - Unit tests for policy parsing, glob matching, mode behavior (`access_policy_test.cpp`)
  - Integration tests for each check module (TypeScript, one-shot client queries)
  - Tests verify refusals don't disclose the allow list and that symlinks/`..` cannot escape restrictions

- **Documentation**:
  - Concepts guide (`docs/docs/concepts/check-access.md`) with examples for each check
  - Security advisory (`docs/security/250-check-access-modes.md`)
  - Upgrade notes (`docs/upgrades/next/check-access-modes.md`)
  - Setup guide integration in `docs/docs/setup/securing.md`

## Notable Implementation Details

- **Fail-closed on configuration error**: Invalid mode values (typos) refuse everything until fixed, not silently fall back to `any`
- **Path resolution before matching**: File paths are canonicalized (symlinks followed, `..` flattened) before glob matching, preventing directory-escape attacks
- **No list disclosure**: Refusal messages name what was rejected and which setting governs it, but never reveal the allow list contents
- **Backward compatible**: All modes default to `any`, preserving existing behavior; upgrading requires no configuration changes
- **Predefined names trusted**: Operator-configured values bypass parsing and validation (e.g., WQL queries are not parsed for class extraction)

https://claude.ai/code/session_01GrJv6RJxMGcFpR8tjE3wh5