### PR TITLE
feature: add queries.execute.noargs grant for argument-less query execution

### DIFF
--- a/docs/docs/api/rest/aliases.md
+++ b/docs/docs/api/rest/aliases.md
@@ -73,6 +73,8 @@ The bundled roles grant `aliases.list` to:
 
 * `client` — read-only role used by the web UI.
 * `monitoring` — minimal grant for clients that only run checks.
+* `restricted` — as `monitoring`, but the checks and aliases it lists here are
+  the only thing it can run: any request carrying arguments is refused.
 * `full` — `*` (everything).
 
 A custom role needs the `aliases.list` privilege to call this endpoint:

--- a/docs/docs/api/rest/queries.md
+++ b/docs/docs/api/rest/queries.md
@@ -5,6 +5,7 @@ provided by the loaded modules.
 
 * [List queries](#list-queries)
 * [Get query](#get-query)
+* [Executing without arguments](#executing-without-arguments)
 * [Execute query](#command-execute)
 * [Execute Query (Nagios format)](#command-execute_nagios)
 
@@ -95,6 +96,50 @@ shape of the result:
 | `execute`        | Structured JSON with parsed performance data.            |
 | `execute_nagios` | Plain Nagios-style payload (`message` + `perf` strings). |
 
+## Executing without arguments
+
+Two grants open the execute endpoints:
+
+| Grant                    | May run a query | May pass arguments |
+|--------------------------|-----------------|--------------------|
+| `queries.execute`        | yes             | yes                |
+| `queries.execute.noargs` | yes             | no                 |
+
+`queries.execute.noargs` is the REST equivalent of the NRPE server's
+`allow arguments = false`: the caller may run the checks the agent defines,
+but cannot shape what they do. A request that carries any query-string
+parameter is answered with `403 Arguments are not allowed for this user`
+and the refusal is logged.
+
+The built-in [`restricted`](../../setup/web-interface.md) role
+(`public,queries.execute.noargs,aliases.list,login.get`) is exactly this.
+Neither grant implies the other, so a `restricted` role can never widen into
+the full privilege, and the existing `client` / `monitoring` roles keep
+passing arguments as before. `full` (`*`) confers both.
+
+To give such a caller a check that does need arguments, define an
+[alias](aliases.md) — the arguments live in the agent's configuration and
+the caller only names the alias:
+
+```ini
+[/settings/check helpers/alias]
+check_root_disk = check_drivesize drive=/ warning=free<10% critical=free<5%
+```
+
+```
+GET /api/v2/queries/check_root_disk/commands/execute
+```
+
+<!-- @formatter:off -->
+!!! note "Credentials must travel in a header"
+    Every query-string parameter counts as an argument, including a
+    credential passed the legacy way as `?TOKEN=` or `?password=` — those
+    are forwarded to the check like any other parameter, so exempting them
+    would reopen the argument smuggling the grant exists to prevent. A
+    no-arguments caller authenticates with the `Authorization`,
+    `X-Auth-Token` or `TOKEN` header.
+<!-- @formatter:on -->
+
 ## Command: execute
 
 Executes a query and returns the result as structured JSON.
@@ -103,7 +148,7 @@ Executes a query and returns the result as structured JSON.
 |-----------|------------------------------------------------------|
 | Verb      | GET                                                  |
 | Address   | /api/v2/queries/{query}/commands/execute             |
-| Privilege | queries.execute                                      |
+| Privilege | queries.execute (or queries.execute.noargs)          |
 
 ### Parameters
 
@@ -113,6 +158,9 @@ to configure `check_cpu` with three time windows:
 ```
 GET /api/v2/queries/check_cpu/commands/execute?time=5m&time=30m&time=90m
 ```
+
+A caller holding only `queries.execute.noargs` may not pass any — see
+[Executing without arguments](#executing-without-arguments).
 
 !!! note "Client-module commands and configured targets"
     The `submit_*` / `check_*` commands of the outbound client modules
@@ -169,12 +217,13 @@ Executes a query and returns a Nagios-style payload.
 |-----------|------------------------------------------------------|
 | Verb      | GET                                                  |
 | Address   | /api/v2/queries/{query}/commands/execute_nagios      |
-| Privilege | queries.execute                                      |
+| Privilege | queries.execute (or queries.execute.noargs)          |
 
 ### Parameters
 
 Identical to [`execute`](#command-execute) — any query-string parameter is
-forwarded to the check.
+forwarded to the check, and the same
+[no-arguments restriction](#executing-without-arguments) applies.
 
 ### Response
 

--- a/docs/docs/concepts/index.md
+++ b/docs/docs/concepts/index.md
@@ -105,7 +105,9 @@ Aliases solve two problems:
    monitoring side just calls `my_check_cpu`.
 2. **Avoid `allow arguments = true` on the network.** Accepting arbitrary arguments from the monitoring server widens
    the attack surface (see [Securing NSClient++](../setup/securing.md)). Aliases bake the arguments into the local
-   config so the protocol layer doesn't need to pass anything dangerous.
+   config so the protocol layer doesn't need to pass anything dangerous. The REST API has the same switch in role form:
+   the built-in `restricted` role runs checks and aliases but refuses a request that carries arguments, where
+   `monitoring` and `client` allow them.
 
 ### Where to define them
 

--- a/docs/docs/scenarios/external-scripts.md
+++ b/docs/docs/scenarios/external-scripts.md
@@ -260,7 +260,9 @@ The arguments `C:`, `20`, and `10` are always passed to the script — they cann
 There are actually **two** independent `allow arguments` flags — one on the
 NRPE server, one on `CheckExternalScripts` — and the combination determines
 how exposed your scripts are. Pick the strategy that matches your threat
-model:
+model (if the agent also serves the REST API, the web role decides the same
+thing for those callers: `restricted` is the no-arguments one, `monitoring`
+and `client` pass them through):
 
 | Strategy                                | NRPE `allow arguments` | External-scripts `allow arguments` | Trade-off                                                                                            |
 |-----------------------------------------|------------------------|------------------------------------|------------------------------------------------------------------------------------------------------|
@@ -315,6 +317,14 @@ Arguments are accessed in scripts as `$ARG1$`, `$ARG2$`, etc.
     no longer the only thing standing between the network and a shell
     interpreter — argv isolation is — but leaving it `false` continues to
     block the most obvious abuse patterns.
+
+!!! note "Locking the REST door too"
+    These flags cover NRPE. A caller on the REST API holding `queries.execute`
+    passes arguments regardless of what the NRPE server allows. Assign such
+    clients the built-in `restricted` role instead — it grants
+    `queries.execute.noargs`, so an argument-carrying request is refused — and
+    the "locked down" row above holds on both transports. See
+    [Securing NSClient++](../setup/securing.md).
 <!-- @formatter:on -->
 
 ### Protocol payload limits

--- a/docs/docs/scenarios/linux-server-health.md
+++ b/docs/docs/scenarios/linux-server-health.md
@@ -177,7 +177,11 @@ alias_services    = check_service
 ```
 
 Each alias is then callable by name from the monitoring server over NRPE
-(`check_nrpe -H <agent> -c alias_load`).
+(`check_nrpe -H <agent> -c alias_load`). Serving the same checks over the REST
+API? Give that client the built-in `restricted` web role rather than
+`monitoring` — it is the REST counterpart of `allow arguments = false` above,
+refusing any request that carries arguments, so the aliases stay the only thing
+on offer. See [Securing NSClient++](../setup/securing.md).
 
 ---
 

--- a/docs/docs/scenarios/nrpe.md
+++ b/docs/docs/scenarios/nrpe.md
@@ -348,6 +348,14 @@ port                   = 5666
 ```
 
 <!-- @formatter:off -->
+!!! tip "The same control over REST"
+    `allow arguments` governs callers arriving over NRPE. If the same agent
+    also serves the REST API, give those clients the built-in `restricted`
+    web role instead of `monitoring`: it grants `queries.execute.noargs`, so
+    a request carrying any argument is refused. That keeps the
+    no-arguments rule you set here from being bypassed through the other
+    door. See [Web interface](../setup/web-interface.md).
+
 !!! danger
     Combine `allow arguments = true` with a tight `allowed hosts` list (and
     a firewall) so only your monitoring server can reach the NRPE port. Any

--- a/docs/docs/scenarios/security-posture.md
+++ b/docs/docs/scenarios/security-posture.md
@@ -202,6 +202,13 @@ alias_users = check_users "crit=count > 10"
 Each alias is then callable by name over NRPE
 (`check_nrpe -H <agent> -c alias_cert`).
 
+`allow arguments = false` is what keeps a caller from re-pointing these checks
+at something else. If this agent also serves the REST API, give those clients
+the built-in `restricted` web role rather than `monitoring` — it refuses any
+request carrying arguments, so the same rule applies on both transports and the
+aliases above stay the only thing a monitoring server can ask for. See
+[Securing NSClient++](../setup/securing.md).
+
 ---
 
 ## Next Steps

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -143,8 +143,15 @@ Options:
 * `--password`: Plaintext password. Hashed before being written to the config. If omitted, a random one is generated
   and printed once — copy it then.
 * `--role`: Built-in roles shipped by the module:
+    * `restricted` — `public, queries.execute.noargs, aliases.list, login.get`. The tightest useful role: it can run
+      the checks the agent defines but **cannot pass arguments** to them, which is the REST equivalent of the NRPE
+      server's `allow arguments = false`. A request that carries any query-string parameter is refused with
+      `403 Arguments are not allowed for this user`. Give such a caller the checks it needs as
+      [aliases](../api/rest/aliases.md), so the arguments live in your configuration rather than in the request. Note
+      that every query parameter counts, so this role must authenticate with a header rather than a legacy
+      `?password=` / `?TOKEN=` query parameter.
     * `monitoring` — `queries.execute, login.get, metrics.get`. Recommended for monitoring servers and Prometheus
-      scrapes.
+      scrapes that need to pass arguments.
     * `client` — adds query listing; needed for the legacy `check_nscp_api` integration.
     * `full` — admin (settings, modules, scripts). Avoid for monitoring callers.
     * `legacy` — `legacy,login.get`. **Dangerous — do not use for normal clients.** It unlocks the deprecated

--- a/docs/docs/setup/securing.md
+++ b/docs/docs/setup/securing.md
@@ -128,12 +128,18 @@ $ nscp web install ^
 $ nscp web add-user monitoring --role monitoring --password "<strong password>"
 ```
 
+If the monitoring server only runs checks the agent already defines — no
+thresholds or targets supplied in the request — use `--role restricted`
+instead. It is the same role with arguments refused, the REST counterpart of
+NRPE's `allow arguments = false`; see the role list below.
+
 ### Adding a dedicated user
 
 `nscp web add-user` creates or updates a per-user row under `[/settings/WEB/server/users/<name>]`:
 
 ```commandline
 $ nscp web add-user monitoring --role monitoring --password "<strong password>"
+$ nscp web add-user poller     --role restricted --password "<strong password>"
 $ nscp web add-user dashboard  --role client
 ```
 
@@ -151,7 +157,8 @@ Options:
       that every query parameter counts, so this role must authenticate with a header rather than a legacy
       `?password=` / `?TOKEN=` query parameter.
     * `monitoring` — `queries.execute, login.get, metrics.get`. Recommended for monitoring servers and Prometheus
-      scrapes that need to pass arguments.
+      scrapes that need to pass arguments. Where they don't, `restricted` above is the tighter choice — it is the
+      same role with arguments refused.
     * `client` — adds query listing; needed for the legacy `check_nscp_api` integration.
     * `full` — admin (settings, modules, scripts). Avoid for monitoring callers.
     * `legacy` — `legacy,login.get`. **Dangerous — do not use for normal clients.** It unlocks the deprecated
@@ -178,6 +185,12 @@ invoke through `/queries/{command}/commands/execute`, layer the [Permission poli
 WEBServer:admin      = *
 WEBServer:monitoring = CheckSystem.check_cpu, CheckSystem.check_drivesize, CheckDisk.check_drivesize
 ```
+
+The two controls are complementary and worth pairing: the policy decides *which
+commands* the user may invoke, the `restricted` role decides *whether it may
+shape them*. A `restricted` user pinned to a policy runs a fixed set of checks
+exactly as you defined them — which, over REST, is what NRPE with
+`allow arguments = false` gives you.
 
 For deeper coverage of the WEB module's attack surface — including the `--disable-admin` trade-off and the
 `scripts_controller` endpoint — see the [WEB module](#web-module) section further down.
@@ -499,6 +512,11 @@ The default posture is that arguments and shell metacharacters are **both reject
 `allow arguments = true`, the agent only substitutes arguments into the *already-configured* command line — the command
 itself is not user-controllable.
 
+This gate is per-transport. `allow arguments` covers callers arriving over NRPE; the equivalent for the REST API is the
+`restricted` web role (`queries.execute.noargs`), which refuses any request carrying arguments. If you rely on
+`allow arguments = false` for your NRPE clients, give your REST clients `restricted` rather than `monitoring` so the
+same rule holds on both doors.
+
 ```ini
 [/settings/external scripts]
 allow arguments = false             ; default; clients cannot pass extra args
@@ -610,6 +628,13 @@ $ nscp web add-user monitoring ^
     --password "$(openssl rand -base64 32)"
 ```
 
+Swap `--role monitoring` for `--role restricted` if the monitoring server only
+needs to run the checks this agent defines: the `restricted` role refuses any
+request that carries arguments, which is the REST equivalent of NRPE's
+`allow arguments = false`. Checks that do need arguments are then defined as
+aliases on the agent, so the arguments live in your configuration rather than in
+whatever the caller sends.
+
 With `--disable-admin`, the install command does three things differently:
 
 1. Sets `disable admin user = true` under `[/settings/WEB/server]`.
@@ -630,7 +655,9 @@ password = <hash>
 The `monitoring` role is registered by the WEB module at startup and grants only
 `public,queries.execute,login.get,metrics.get` — enough for a monitoring server to log in, run queries and scrape
 metrics, and nothing else. No `settings.*`, no `modules.*`, no `scripts.*`. If you need more (e.g. the legacy
-`check_nscp_api` integration that lists queries), prefer the `client` role over `full`.
+`check_nscp_api` integration that lists queries), prefer the `client` role over `full`. If you need *less*, the
+`restricted` role (`public,queries.execute.noargs,aliases.list,login.get`) runs the same checks but refuses any request
+carrying arguments.
 
 With `disable admin user = true`, the agent never creates or activates the `admin` account. The script-upload path is
 still wired up in the code, but no account can authenticate to it — so even an attacker who recovers the

--- a/docs/docs/setup/web-interface.md
+++ b/docs/docs/setup/web-interface.md
@@ -126,8 +126,8 @@ rather than as a legacy `?password=` / `?TOKEN=` parameter.
     for running checks.
 
     Do **not** grant `legacy` to a normal user or monitoring server: modern
-    clients should use the `monitoring` or `client` role and the versioned
-    `/api/v2/queries/...` endpoints. Grant `legacy` only for a specific,
+    clients should use the `restricted`, `monitoring` or `client` role and the
+    versioned `/api/v2/queries/...` endpoints. Grant `legacy` only for a specific,
     trusted legacy system that genuinely cannot be upgraded, and pair it with
     the [permission policy](../concepts/permissions.md) to restrict which
     commands it may run. A normal install grants this permission to no role

--- a/docs/docs/setup/web-interface.md
+++ b/docs/docs/setup/web-interface.md
@@ -72,6 +72,40 @@ WEBServer = enabled
 port = 8443
 ```
 
+### Built-in roles
+
+| Role         | Grants                                                                                       | Use for                                                                  |
+|--------------|----------------------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| `full`       | `*`                                                                                          | Administration: settings, modules, scripts.                              |
+| `client`     | `public,info.get,info.get.version,queries.list,queries.get,queries.execute,aliases.list,login.get,modules.list` | A monitoring client that also browses the agent.       |
+| `monitoring` | `public,queries.execute,aliases.list,login.get,metrics.get`                                  | A monitoring server running checks with arguments.                       |
+| `restricted` | `public,queries.execute.noargs,aliases.list,login.get`                                       | A monitoring server that may run checks but **not pass arguments**.      |
+| `legacy`     | `legacy,login.get`                                                                           | Old clients only — see the warning below. Not created on a fresh install. |
+
+The `restricted` role is the REST equivalent of the NRPE server's
+`allow arguments = false`: it holds `queries.execute.noargs` instead of
+`queries.execute`, so it can run the checks the agent defines but any request
+carrying a query-string parameter is refused with
+`403 Arguments are not allowed for this user`. Neither grant implies the
+other, so the role can never widen into the full privilege — and existing
+`client` / `monitoring` users keep passing arguments exactly as before. Hand a
+restricted caller the checks it needs as
+[aliases](../api/rest/aliases.md), where the arguments live in your
+configuration:
+
+```ini
+[/settings/WEB/server/users/monitor]
+role = restricted
+password = ...
+
+[/settings/check helpers/alias]
+check_root_disk = check_drivesize drive=/ warning=free<10% critical=free<5%
+```
+
+Because every query parameter counts as an argument, a restricted client must
+send its credentials in a header (`Authorization`, `X-Auth-Token` or `TOKEN`)
+rather than as a legacy `?password=` / `?TOKEN=` parameter.
+
 <!-- @formatter:off -->
 !!! danger "The `legacy` role is powerful — only for legacy integrations"
     The `legacy` role (`legacy,login.get`) exists so that old clients which

--- a/docs/upgrades/next/010-web-restricted-role.md
+++ b/docs/upgrades/next/010-web-restricted-role.md
@@ -1,0 +1,28 @@
+---
+icon: "🔧"
+modules: [WEBServer]
+action: none
+---
+**A new built-in WEB role, `restricted`, runs checks without arguments.** Nothing
+to do on an existing install: the role is added to `[/settings/WEB/server/roles]`
+but no user is assigned to it, and `client`, `monitoring` and any custom role
+holding `queries.execute` keep passing arguments exactly as before. The new role
+holds `queries.execute.noargs` instead of `queries.execute`, which is the REST
+equivalent of the NRPE server's `allow arguments = false`: the caller may run the
+checks the agent defines, but a request carrying any query-string parameter is
+refused with `403 Arguments are not allowed for this user`. Neither grant implies
+the other, so the role can never widen into the full privilege; `full` (`*`)
+still confers both.
+
+```ini
+[/settings/WEB/server/users/monitor]
+role = restricted
+
+[/settings/check helpers/alias]
+check_root_disk = check_drivesize drive=/ warning=free<10% critical=free<5%
+```
+
+Give a restricted caller the checks that need arguments as aliases, as above, so
+the arguments live in your configuration. Note that *every* query parameter
+counts as an argument, including a credential passed the legacy way as
+`?password=` or `?TOKEN=`, so such a client must authenticate with a header.

--- a/modules/WEBServer/WEBServer.cpp
+++ b/modules/WEBServer/WEBServer.cpp
@@ -335,6 +335,14 @@ bool WEBServer::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
               "public,info.get,info.get.version,queries.list,queries.get,queries.execute,aliases.list,login.get,modules.list",
               "read + run checks (queries.execute can run side-effecting commands)");
   ensure_role(roles, settings, role_path, "monitoring", "public,queries.execute,aliases.list,login.get,metrics.get", "checks and queries only");
+  // `queries.execute.noargs` runs a query only when the request carries no
+  // arguments at all - the REST twin of the NRPE server's
+  // `allow arguments = false`. The caller can run the checks the agent
+  // defines (including aliases, which is how you give it a check with
+  // arguments baked in) but cannot shape what they do. It does not imply
+  // `queries.execute`, so this role can never widen into the full privilege.
+  ensure_role(roles, settings, role_path, "restricted", "public,queries.execute.noargs,aliases.list,login.get",
+              "checks and queries only, without arguments");
 
   if (!disable_admin_user) {
     ensure_user(settings, user_path, "admin", "full", admin_password, "Administrator");

--- a/modules/WEBServer/query_controller.cpp
+++ b/modules/WEBServer/query_controller.cpp
@@ -6,6 +6,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/json.hpp>
 #include <boost/regex.hpp>
+#include <nscapi/macros.hpp>
 #include <nscapi/nscapi_helper.hpp>
 #include <nscapi/protobuf/command.hpp>
 #include <nscapi/protobuf/functions_convert.hpp>
@@ -107,7 +108,17 @@ void query_controller::get_query(Mongoose::Request &request, boost::smatch &what
 }
 
 void query_controller::query_command(Mongoose::Request &request, boost::smatch &what, Mongoose::StreamResponse &response) {
-  if (!session->is_logged_in("queries.execute", request, response)) return;
+  // Two grants open this endpoint:
+  //   queries.execute         - run a query with or without arguments.
+  //   queries.execute.noargs  - run a query only when the request carries no
+  //                             arguments at all. This is the REST twin of
+  //                             the NRPE server's `allow arguments = false`:
+  //                             the caller may run the commands the agent
+  //                             defines, but cannot shape what they do.
+  // They are disjoint in the grant tree (neither implies the other), so a
+  // role granting only `queries.execute.noargs` never widens into the full
+  // privilege; the `*` wildcard of `full` still confers both.
+  if (!session->is_logged_in(session_manager_interface::grant_options{"queries.execute", "queries.execute.noargs"}, request, response)) return;
 
   if (what.size() != 3) {
     response.setCodeNotFound("Invalid request");
@@ -116,17 +127,32 @@ void query_controller::query_command(Mongoose::Request &request, boost::smatch &
   const std::string module = what.str(1);
   const std::string command = what.str(2);
 
+  const arg_vector args = request.getVariablesVector();
+  // Every query-string parameter counts, including a credential passed as
+  // `?TOKEN=` / `?password=` by a legacy client - those are forwarded to the
+  // check as arguments like any other, so exempting them would hand the
+  // restricted role exactly the argument smuggling this grant forbids. A
+  // no-arguments caller must authenticate with a header.
+  if (!args.empty() && !session->has_grant("queries.execute", response)) {
+    std::string user, token;
+    session_manager_interface::get_user_from_response(response, user, token);
+    NSC_LOG_ERROR("Request from " + request.getRemoteIp() + " for query " + module + " contained arguments but user '" + user +
+                  "' only holds the 'queries.execute.noargs' grant (arguments are not allowed for this role).");
+    response.setCodeForbidden("403 Arguments are not allowed for this user");
+    return;
+  }
+
   if (command == "execute") {
     if (request.readHeader("Accept") == "text/plain") {
-      execute_query_text(module, request.getVariablesVector(), response);
+      execute_query_text(module, args, response);
     } else {
-      execute_query(module, request.getVariablesVector(), response);
+      execute_query(module, args, response);
     }
   } else if (command == "execute_nagios") {
     if (request.readHeader("Accept") == "text/plain") {
-      execute_query_text(module, request.getVariablesVector(), response);
+      execute_query_text(module, args, response);
     } else {
-      execute_query_nagios(module, request.getVariablesVector(), response);
+      execute_query_nagios(module, args, response);
     }
   } else {
     response.setCodeNotFound("unknown command: " + command);

--- a/modules/WEBServer/session_manager_interface.cpp
+++ b/modules/WEBServer/session_manager_interface.cpp
@@ -100,6 +100,10 @@ bool session_manager_interface::client_allows_legacy_query_auth(const std::strin
 std::string decode_key(const std::string &encoded) { return Mongoose::Helpers::decode_b64(encoded); }
 
 bool session_manager_interface::process_auth_header(const std::string &grant, Mongoose::Request &request, Mongoose::StreamResponse &response) {
+  return process_auth_header(grant_options{grant}, request, response);
+}
+
+bool session_manager_interface::process_auth_header(const grant_options &grants, Mongoose::Request &request, Mongoose::StreamResponse &response) {
   const std::string remote_ip = request.getRemoteIp();
   if (rate_limiter.is_blocked(remote_ip)) {
     NSC_LOG_ERROR("Rate-limited authentication attempt from " + remote_ip);
@@ -134,7 +138,7 @@ bool session_manager_interface::process_auth_header(const std::string &grant, Mo
       response.setCodeServerError("500 Failed to issue token");
       return false;
     }
-    return can(grant, response);
+    return can(grants, response);
   }
   if (is_bearer_auth(auth)) {
     const std::string token = auth.substr(7);
@@ -147,7 +151,7 @@ bool session_manager_interface::process_auth_header(const std::string &grant, Mo
     }
     rate_limiter.record_success(remote_ip);
     store_session_in_response(token, user, response);
-    return can(grant, response);
+    return can(grants, response);
   }
   NSC_LOG_ERROR("Unknown authentication scheme for " + remote_ip);
   response.setCodeForbidden(NOT_ALLOWED);
@@ -155,6 +159,11 @@ bool session_manager_interface::process_auth_header(const std::string &grant, Mo
 }
 
 bool session_manager_interface::process_password_header(const std::string &grant, Mongoose::Request &request, Mongoose::StreamResponse &response,
+                                                        const std::string &password) {
+  return process_password_header(grant_options{grant}, request, response, password);
+}
+
+bool session_manager_interface::process_password_header(const grant_options &grants, Mongoose::Request &request, Mongoose::StreamResponse &response,
                                                         const std::string &password) {
   const std::string remote_ip = request.getRemoteIp();
   if (rate_limiter.is_blocked(remote_ip)) {
@@ -186,10 +195,14 @@ bool session_manager_interface::process_password_header(const std::string &grant
     response.setCodeServerError("500 Failed to issue token");
     return false;
   }
-  return can(grant, response);
+  return can(grants, response);
 }
 
 bool session_manager_interface::is_logged_in(const std::string &grant, Mongoose::Request &request, Mongoose::StreamResponse &response) {
+  return is_logged_in(grant_options{grant}, request, response);
+}
+
+bool session_manager_interface::is_logged_in(const grant_options &grants, Mongoose::Request &request, Mongoose::StreamResponse &response) {
   std::list<std::string> errors;
   if (!allowed_hosts.is_allowed(boost::asio::ip::make_address(request.getRemoteIp()), errors)) {
     const std::string error = str::utils::joinEx(errors, ", ");
@@ -198,7 +211,7 @@ bool session_manager_interface::is_logged_in(const std::string &grant, Mongoose:
     return false;
   }
   if (has_auth_header(request)) {
-    return process_auth_header(grant, request, response);
+    return process_auth_header(grants, request, response);
   }
   // Legacy `password` HTTP header used by Icinga's check_nscp_api (and any
   // other plugin that follows the same convention). The header carries just
@@ -209,7 +222,7 @@ bool session_manager_interface::is_logged_in(const std::string &grant, Mongoose:
   // Basic auth path uses.
   const std::string password_header = request.readHeader("password");
   if (!password_header.empty()) {
-    return process_password_header(grant, request, response, password_header);
+    return process_password_header(grants, request, response, password_header);
   }
   const std::string token = find_token(request, *this);
   if (token.empty()) {
@@ -224,7 +237,7 @@ bool session_manager_interface::is_logged_in(const std::string &grant, Mongoose:
     return false;
   }
   store_session_in_response(token, user, response);
-  if (!can(grant, response)) {
+  if (!can(grants, response)) {
     NSC_LOG_ERROR("Rejected connection from: " + request.getRemoteIp() + " due to insufficient permissions");
     response.setCodeForbidden(NOT_ALLOWED);
     return false;
@@ -266,7 +279,7 @@ void session_manager_interface::get_user_from_response(const Mongoose::StreamRes
   key = response.getCookie("token");
 }
 
-bool session_manager_interface::can(const std::string &grant, Mongoose::StreamResponse &response) {
+bool session_manager_interface::has_grant(const std::string &grant, const Mongoose::StreamResponse &response) {
   const std::string uid = response.getCookie("uid");
   if (uid.empty()) {
     // Only consult the "anonymous" grants if anonymous access is explicitly
@@ -274,17 +287,23 @@ bool session_manager_interface::can(const std::string &grant, Mongoose::StreamRe
     // `anonymous` role for any reason (often by mistake or for
     // experimentation) would expose every endpoint listed in that role to
     // unauthenticated callers.
-    if (allow_anonymous_ && tokens.can("anonymous", grant)) {
+    return allow_anonymous_ && tokens.can("anonymous", grant);
+  }
+  return tokens.can(uid, grant);
+}
+
+bool session_manager_interface::can(const std::string &grant, Mongoose::StreamResponse &response) { return can(grant_options{grant}, response); }
+
+bool session_manager_interface::can(const grant_options &grants, Mongoose::StreamResponse &response) {
+  // Any one of the alternatives is enough: a call site listing several is
+  // saying "this endpoint is reachable by either privilege", not "both".
+  for (const std::string &grant : grants) {
+    if (has_grant(grant, response)) {
       return true;
     }
-    response.setCodeForbidden(NOT_ALLOWED);
-    return false;
   }
-  if (!tokens.can(uid, grant)) {
-    response.setCodeForbidden(NOT_ALLOWED);
-    return false;
-  }
-  return true;
+  response.setCodeForbidden(NOT_ALLOWED);
+  return false;
 }
 
 void session_manager_interface::add_user(const std::string &user, const std::string &role, const std::string &password) {

--- a/modules/WEBServer/session_manager_interface.hpp
+++ b/modules/WEBServer/session_manager_interface.hpp
@@ -51,6 +51,12 @@ struct session_manager_interface {
   mutable boost::mutex legacy_query_auth_mutex_;
 
  public:
+  // A set of alternative grants: the caller is authorised when the role
+  // confers ANY of them. The query endpoints use it to accept either the
+  // full `queries.execute` grant or the argument-less
+  // `queries.execute.noargs` one (see query_controller).
+  typedef std::vector<std::string> grant_options;
+
   // The single source of truth for the default allowlist. Used both by the
   // settings layer (so `show-default` reports it accurately) and by the
   // constructor (so `session_manager_interface` constructed without going
@@ -62,13 +68,16 @@ struct session_manager_interface {
   session_manager_interface();
 
   bool process_auth_header(const std::string &grant, Mongoose::Request &request, Mongoose::StreamResponse &response);
+  bool process_auth_header(const grant_options &grants, Mongoose::Request &request, Mongoose::StreamResponse &response);
   // Handle the legacy `password` HTTP header used by Icinga's
   // check_nscp_api (and any client that follows the same convention). The
   // header carries the password only; the user is implied to be "admin".
   // Applies the same rate-limit / constant-time-compare guards as
   // process_auth_header.
   bool process_password_header(const std::string &grant, Mongoose::Request &request, Mongoose::StreamResponse &response, const std::string &password);
+  bool process_password_header(const grant_options &grants, Mongoose::Request &request, Mongoose::StreamResponse &response, const std::string &password);
   bool is_logged_in(const std::string &grant, Mongoose::Request &request, Mongoose::StreamResponse &response);
+  bool is_logged_in(const grant_options &grants, Mongoose::Request &request, Mongoose::StreamResponse &response);
 
   bool is_allowed(const std::string &ip);
 
@@ -110,6 +119,12 @@ struct session_manager_interface {
   bool store_user_in_response(const std::string &user, Mongoose::StreamResponse &response);
   void store_session_in_response(const std::string &token, const std::string &user, Mongoose::StreamResponse &response) const;
   bool can(const std::string &grant, Mongoose::StreamResponse &response);
+  bool can(const grant_options &grants, Mongoose::StreamResponse &response);
+  // Non-mutating privilege test: unlike can() it never writes a 403 into the
+  // response. For call sites that need to *branch* on a privilege the caller
+  // may legitimately lack (the query endpoints branch on `queries.execute` to
+  // decide whether arguments are permitted) rather than gate on it.
+  bool has_grant(const std::string &grant, const Mongoose::StreamResponse &response);
   static void get_user_from_response(const Mongoose::StreamResponse &response, std::string &user, std::string &key);
   void add_user(const std::string &user, const std::string &role, const std::string &password);
   bool has_user(const std::string &user) const;

--- a/modules/WEBServer/session_manager_interface_test.cpp
+++ b/modules/WEBServer/session_manager_interface_test.cpp
@@ -144,6 +144,61 @@ TEST_F(SessionManagerTest, CanCheckPermissionsAnonymous) {
   EXPECT_TRUE(smi.can("nothing:read", resp));
 }
 
+TEST_F(SessionManagerTest, CanAcceptsAnyOneOfSeveralGrants) {
+  // The multi-grant form is an OR: the endpoint is reachable by either
+  // privilege. query_controller uses it to let both `queries.execute` and
+  // `queries.execute.noargs` through the same door.
+  Mongoose::StreamResponse resp;
+  smi.store_user_in_response("user", resp);
+  EXPECT_TRUE(smi.can(session_manager_interface::grant_options{"something:write", "something:read"}, resp));
+}
+
+TEST_F(SessionManagerTest, CanRefusesWhenNoneOfTheGrantsMatch) {
+  Mongoose::StreamResponse resp;
+  smi.store_user_in_response("user", resp);
+  EXPECT_FALSE(smi.can(session_manager_interface::grant_options{"something:write", "other:read"}, resp));
+}
+
+TEST_F(SessionManagerTest, HasGrantDoesNotTouchTheResponse) {
+  // has_grant() is the non-mutating twin of can(): call sites that branch on
+  // a privilege (may this caller pass arguments?) must not have a 403 written
+  // into the response as a side effect of asking.
+  Mongoose::StreamResponse resp;
+  smi.store_user_in_response("user", resp);
+  EXPECT_FALSE(smi.has_grant("something:write", resp));
+  EXPECT_TRUE(smi.has_grant("something:read", resp));
+  EXPECT_EQ(resp.getCode(), 200);
+}
+
+TEST(SessionManagerNoArgs, ExecuteAndNoargsGrantsAreDisjoint) {
+  // The `restricted` role's `queries.execute.noargs` must never widen into
+  // the full `queries.execute` privilege, and an existing `queries.execute`
+  // role must not accidentally be treated as a no-arguments one. Neither
+  // implies the other; only the `*` wildcard confers both.
+  session_manager_interface smi;
+  smi.add_user("restricted", "restricted", "password");
+  smi.add_grant("restricted", "public,queries.execute.noargs,login.get");
+  smi.add_user("monitoring", "monitoring", "password");
+  smi.add_grant("monitoring", "public,queries.execute,login.get");
+  smi.add_user("admin", "full", "password");
+  smi.add_grant("full", "*");
+
+  Mongoose::StreamResponse restricted;
+  smi.store_user_in_response("restricted", restricted);
+  EXPECT_TRUE(smi.has_grant("queries.execute.noargs", restricted));
+  EXPECT_FALSE(smi.has_grant("queries.execute", restricted));
+
+  Mongoose::StreamResponse monitoring;
+  smi.store_user_in_response("monitoring", monitoring);
+  EXPECT_TRUE(smi.has_grant("queries.execute", monitoring));
+  EXPECT_FALSE(smi.has_grant("queries.execute.noargs", monitoring));
+
+  Mongoose::StreamResponse admin;
+  smi.store_user_in_response("admin", admin);
+  EXPECT_TRUE(smi.has_grant("queries.execute", admin));
+  EXPECT_TRUE(smi.has_grant("queries.execute.noargs", admin));
+}
+
 TEST_F(SessionManagerTest, IsAllowedIp) { EXPECT_TRUE(smi.is_allowed("127.0.0.1")); }
 
 TEST_F(SessionManagerTest, RevokeToken) {

--- a/tests/rest-permissions.test.ts
+++ b/tests/rest-permissions.test.ts
@@ -160,5 +160,120 @@ describe("REST permissions", () => {
         .trustLocalhost(true)
         .expect(403);
     });
+
+    it("can execute a query with arguments", async () => {
+      // The counterpart to the restricted user below: `queries.execute`
+      // still carries arguments, this change must not narrow it.
+      await request(REST_URL)
+        .get("/api/v2/queries/mock_query/commands/execute?a=b")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(200)
+        .then((response) => {
+          expect(response.body.lines[0].message).toEqual("mock_query::a=b");
+        });
+    });
+  });
+
+  // The `restricted` role holds `queries.execute.noargs` instead of
+  // `queries.execute`: it may run the checks the agent defines but may not
+  // shape what they do — the REST twin of the NRPE server's
+  // `allow arguments = false`.
+  describe("restricted user (no arguments)", () => {
+    let key: string | undefined = undefined;
+    it("can login", async () => {
+      await request(REST_URL)
+        .get("/api/v2/login")
+        .auth("restricted", "restricted-password")
+        .trustLocalhost(true)
+        .expect(200)
+        .then((response) => {
+          expect(response.body.user).toEqual("restricted");
+          expect(response.body.key).toBeDefined();
+          key = response.body.key;
+        });
+    });
+
+    it("can execute a query without arguments", async () => {
+      await request(REST_URL)
+        .get("/api/v2/queries/mock_query/commands/execute")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(200)
+        .then((response) => {
+          expect(response.body.command).toEqual("mock_query");
+          expect(response.body.lines[0].message).toEqual("mock_query::");
+        });
+    });
+
+    it("can execute a query without arguments (nagios)", async () => {
+      await request(REST_URL)
+        .get("/api/v2/queries/mock_query/commands/execute_nagios")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(200)
+        .then((response) => {
+          expect(response.body.result).toEqual("OK");
+        });
+    });
+
+    it("can not execute a query with arguments", async () => {
+      await request(REST_URL)
+        .get("/api/v2/queries/mock_query/commands/execute?a=b")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(403)
+        .then((response) => {
+          expect(response.text).toContain("Arguments are not allowed");
+        });
+    });
+
+    it("can not execute a query with a valueless argument", async () => {
+      // `?show-all` carries no value but is still an argument: the check
+      // sees it, so it must be refused like any other.
+      await request(REST_URL)
+        .get("/api/v2/queries/mock_query/commands/execute?show-all")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(403);
+    });
+
+    it("can not execute a query with arguments (nagios)", async () => {
+      await request(REST_URL)
+        .get("/api/v2/queries/mock_query/commands/execute_nagios?a=b")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(403);
+    });
+
+    it("can run an alias that has arguments baked in", async () => {
+      // Aliases are how an operator hands a no-arguments caller a check that
+      // needs arguments: the alias resolves to `check_warning message=hello`
+      // on the agent, the caller only names it.
+      await request(REST_URL)
+        .get("/api/v2/queries/echo_alias/commands/execute")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(200)
+        .then((response) => {
+          expect(response.body.lines[0].message).toEqual("hello");
+        });
+    });
+
+    it("can not access /modules", async () => {
+      await request(REST_URL)
+        .get("/api/v2/modules")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(403);
+    });
+
+    it("can not use the legacy query endpoint", async () => {
+      await request(REST_URL)
+        .get("/query/mock_query?a=b")
+        .set("Authorization", `Bearer ${key}`)
+        .trustLocalhost(true)
+        .expect(403);
+    });
   });
 });

--- a/tests/src/rest-fixture.ts
+++ b/tests/src/rest-fixture.ts
@@ -47,6 +47,9 @@ export async function setupRestNscp(nscp: NscpInstance): Promise<void> {
       full: "*",
       client:
         "public,info.get,info.get.version,queries.list,queries.get,queries.execute,aliases.list,login.get,modules.list",
+      // The built-in `restricted` role: query execution without arguments,
+      // the REST twin of NRPE's `allow arguments = false`.
+      restricted: "public,queries.execute.noargs,aliases.list,login.get",
     },
     // CheckHelpers aliases used by the alias-endpoint and queries scenarios:
     // mock_alias is mapped to a real QUERY (so we can confirm QUERY_ALIAS
@@ -63,6 +66,10 @@ export async function setupRestNscp(nscp: NscpInstance): Promise<void> {
     "/settings/WEB/server/users/legacy": {
       role: "legacy",
       password: "legacy-password",
+    },
+    "/settings/WEB/server/users/restricted": {
+      role: "restricted",
+      password: "restricted-password",
     },
     // The admin password is set explicitly so the Jest suite's
     // auth("admin", "default-password") calls work. Pre-0.13 the


### PR DESCRIPTION
Introduce a new `queries.execute.noargs` grant that allows executing queries without passing arguments, equivalent to NRPE's `allow arguments = false`. This enables a restricted monitoring role that can run predefined checks but cannot modify their behavior through query parameters.

## Summary

This change adds support for argument-less query execution in the WEB server REST API. A new built-in `restricted` role holds `queries.execute.noargs` instead of `queries.execute`, allowing it to run checks the agent defines but refusing any request carrying query-string parameters with `403 Arguments are not allowed for this user`. The two grants are disjoint in the privilege hierarchy — neither implies the other — so a restricted role can never widen into full query execution privileges.

## Key Changes

- **Session manager interface**: Added `grant_options` typedef (vector of alternative grants) and overloaded `is_logged_in()`, `process_auth_header()`, and `process_password_header()` methods to accept multiple grants. Added `has_grant()` method for non-mutating privilege checks.

- **Query controller**: Modified `query_command()` to accept either `queries.execute` or `queries.execute.noargs` grants. Added validation to reject requests with query-string parameters when the user holds only `queries.execute.noargs`, logging the attempt and returning `403 Arguments are not allowed for this user`.

- **Built-in roles**: Added `restricted` role with grants `public,queries.execute.noargs,aliases.list,login.get`. Updated `client` and `monitoring` role documentation in the web interface setup guide.

- **Documentation**: Added comprehensive documentation explaining the new grant, its use cases, and how to configure aliases for restricted users who need parameterized checks. Updated API documentation for query execution endpoints to note the privilege requirements.

- **Tests**: Added extensive test coverage for the restricted role, including successful execution without arguments, rejection with arguments, and validation that the two grants are truly disjoint.

## Implementation Details

- Every query-string parameter counts as an argument, including legacy credentials passed as `?TOKEN=` or `?password=`. This prevents argument smuggling and requires restricted clients to authenticate via headers (`Authorization`, `X-Auth-Token`, or `TOKEN`).

- Aliases provide the mechanism for restricted users to run checks requiring arguments: the arguments are baked into the agent's configuration rather than passed in the request.

- The `has_grant()` method is non-mutating (does not write to response), allowing call sites to branch on privileges without side effects.

- The grant hierarchy ensures `queries.execute.noargs` never implies `queries.execute` and vice versa; only the `*` wildcard of the `full` role confers both.

https://claude.ai/code/session_0162T9u4EwgKXwSJyexFpHPz