### PR TITLE
Fleet: encrypted bundles, unenroll, and an nscp test prompt that survives a config push

### DIFF
--- a/docs/docs/setup/fleet.md
+++ b/docs/docs/setup/fleet.md
@@ -406,6 +406,20 @@ ordinary plain bundles, which are refused with an error in the state report.
 
 ## Step 6 — Living with it
 
+**Leaving the fleet** is one command, run as root or from an elevated prompt:
+
+```bash
+sudo nscp enroll --unenroll
+sudo systemctl restart nsclient
+```
+
+It deletes the enrollment manifest (the host's identity and any bundle keys), the
+fleet-managed directory (`fleet.ini`, synced scripts, the bundle cache) and the
+`[/includes] fleet` entry, and reports each. The service stops syncing at the next
+restart, because the sync only starts at boot when the manifest exists. Nothing is sent to
+the server, so remove the host there as well — its certificate is simply no longer used.
+Running it on a host that is not enrolled is harmless.
+
 **Certificates renew themselves.** The client certificate an agent gets is short-lived and
 the agent renews it over its existing mTLS session, before expiry. Nothing to schedule.
 

--- a/docs/docs/setup/fleet.md
+++ b/docs/docs/setup/fleet.md
@@ -388,15 +388,15 @@ What the agent does with a sealed bundle:
 debug level on start, so a mismatch is visible without exposing the key.
 
 For a server you do not trust with plaintext at all, make sealed bundles the only kind the
-host accepts:
+host accepts: pass `--require-encrypted-bundles` to `nscp enroll` (at enrollment, or later
+with `--update-bundle-keys`), or `FLEET_REQUIRE_ENCRYPTED_BUNDLES=1` to the installer. Then
+nothing the server sends is applied unless a key holder produced it — including ordinary
+plain bundles, which are refused with an error in the state report.
 
-```ini
-[/settings/fleet]
-require encrypted bundles = true
-```
-
-Then nothing the server sends is applied unless a key holder produced it — including
-ordinary plain bundles, which are refused with an error in the state report.
+This is deliberately not a setting. It is stored in the enrollment manifest with the keys,
+where the fleet-managed include cannot reach it: a server that could switch the requirement
+off would not be much of a requirement. To switch it off yourself, run
+`nscp enroll --update-bundle-keys` with your keys and without the flag.
 
 <!-- @formatter:off -->
 !!! warning "There is no key escrow"

--- a/docs/docs/setup/fleet.md
+++ b/docs/docs/setup/fleet.md
@@ -324,6 +324,86 @@ sudo nscp settings --path /settings/default --key "allowed hosts" --show
 Never edit `fleet.ini` itself. It is rewritten wholesale on the next sync, which is exactly
 what the banner at the top of it says.
 
+### Encrypted bundles
+
+A bundle can hold things the fleet server has no business reading — an API token, a
+database password, a script that embeds a credential. For those, the server supports
+**encrypted bundles**: you seal the bundle in the browser before it is uploaded, the server
+stores and serves only the ciphertext, and the agent opens it with a key that never passed
+through the server.
+
+The key is a tenant-wide secret. The server shows it **once**, when you create it under
+**Bundles → Encryption key**, and keeps only its fingerprint. Put it in a password manager,
+then hand it to each agent out of band — never through the fleet itself:
+
+=== "Linux"
+
+    ```bash
+    sudo nscp enroll --server https://fleet.example.internal:8443 \
+                     --token <bootstrap-token> \
+                     --ca /etc/nsclient/security/fleet-ca.pem \
+                     --bundle-key <key>
+    ```
+
+    On a host that is already enrolled, rotate or add keys without touching the identity:
+
+    ```bash
+    sudo nscp enroll --update-bundle-keys --bundle-key <new-key> --bundle-key <old-key>
+    sudo systemctl restart nsclient
+    ```
+
+=== "Windows"
+
+    At install time, next to the other fleet properties:
+
+    ```
+    msiexec /qn /i NSCP-<version>-x64.msi ^
+      FLEET_SERVER=https://fleet.example.internal:8443 ^
+      FLEET_TOKEN=<bootstrap-token> ^
+      FLEET_BUNDLE_KEY=<key>
+    ```
+
+    Running the installer again on an enrolled host with only `FLEET_BUNDLE_KEY` replaces the
+    stored keys and keeps the enrollment; separate several keys with commas. From an elevated
+    prompt, `nscp enroll --update-bundle-keys --bundle-key <key>` does the same.
+
+The key lives in the enrollment manifest (`agent-state.json`) beside the host's private key,
+and nowhere else: not in `nsclient.ini`, and not in anything the server sends. That is
+deliberate — the fleet-managed configuration is an include of the settings store, so a key
+kept there could be planted by the server the bundles are meant to be sealed against.
+
+What the agent does with a sealed bundle:
+
+- The download is verified exactly as before: the published SHA-256 and the Ed25519 signature
+  cover the sealed envelope. Only then is it opened, with the key whose fingerprint the
+  envelope names. The plaintext exists on disk only while it is being unpacked; the cache
+  keeps the envelope.
+- The bundle's name and version are bound into the seal. A server that re-labels a sealed
+  bundle — serving last year's `secrets 1.0` as `secrets 2.0` — gets a refusal, not an apply.
+- A bundle sealed with a key the host does not hold is refused, and the state report names
+  the missing key's fingerprint so you can match it against the server's key page. The
+  previously applied configuration stays in force.
+
+`nscp enroll` prints the fingerprint of each key it stores, and the service logs them at
+debug level on start, so a mismatch is visible without exposing the key.
+
+For a server you do not trust with plaintext at all, make sealed bundles the only kind the
+host accepts:
+
+```ini
+[/settings/fleet]
+require encrypted bundles = true
+```
+
+Then nothing the server sends is applied unless a key holder produced it — including
+ordinary plain bundles, which are refused with an error in the state report.
+
+<!-- @formatter:off -->
+!!! warning "There is no key escrow"
+    The server holds only the fingerprint. Lose the key and every bundle sealed with it is
+    unreadable, on the server and on every host; re-seal and re-upload with a new one.
+<!-- @formatter:on -->
+
 ## Step 6 — Living with it
 
 **Certificates renew themselves.** The client certificate an agent gets is short-lived and

--- a/docs/docs/setup/installing.md
+++ b/docs/docs/setup/installing.md
@@ -269,6 +269,7 @@ A list of all the MSI options can be found below.
 | FLEET_VERIFY_MODE   | TLS verify mode for the enrollment call (*certificate*, none). `none` requires FLEET_INSECURE=1                         |
 | FLEET_INSECURE      | Set to 1 to allow an unauthenticated enrollment: a plain `http://` FLEET_SERVER, or FLEET_VERIFY_MODE=none              |
 | FLEET_BUNDLE_KEY    | Bundle encryption key(s) for sealed bundles, as shown once by the fleet server; several separated by commas             |
+| FLEET_REQUIRE_ENCRYPTED_BUNDLES | Set to 1 to refuse every bundle that is not sealed with one of the bundle keys                              |
 | LAYOUT              | On-disk layout: `modern` keeps the writable state in `%ProgramData%\NSClient++` restricted to SYSTEM and administrators, `legacy` (default) keeps it in the install folder. Omit it to keep whatever the host already uses. **Experimental** - see below |
 
 ### On-disk layout (LAYOUT)
@@ -417,6 +418,7 @@ msiexec /qn /i NSCP-<version>-x64.msi FLEET_SERVER=https://fleet.example.com FLE
 | `FLEET_VERIFY_MODE` | no                                        | `certificate`              | `none` stops the fleet server being verified at all, and is only accepted together with `FLEET_INSECURE=1`.              |
 | `FLEET_INSECURE`    | no                                        | unset                      | `1` opts into an unauthenticated enrollment: a plain `http://` url, `FLEET_VERIFY_MODE=none`, or both.                   |
 | `FLEET_BUNDLE_KEY`  | for [encrypted bundles](fleet.md#encrypted-bundles) | unset            | The bundle encryption key (44 base64 characters) the fleet server showed once when it was created; several, comma separated, while rotating. Stored in the enrollment manifest, never sent to the server. On an already enrolled host it may be given on its own, without `FLEET_SERVER`, to replace the stored keys. |
+| `FLEET_REQUIRE_ENCRYPTED_BUNDLES` | no                          | unset                      | `1` refuses every bundle that is not sealed with one of the bundle keys, plain ones included. Stored in the enrollment manifest, so the fleet server cannot switch it off; may be given on its own on an enrolled host. |
 
 ### Running the installer with fleet arguments
 

--- a/docs/docs/setup/installing.md
+++ b/docs/docs/setup/installing.md
@@ -268,6 +268,7 @@ A list of all the MSI options can be found below.
 | FLEET_CA            | CA bundle used to verify the fleet server certificate (defaults to the Windows ROOT store)                              |
 | FLEET_VERIFY_MODE   | TLS verify mode for the enrollment call (*certificate*, none). `none` requires FLEET_INSECURE=1                         |
 | FLEET_INSECURE      | Set to 1 to allow an unauthenticated enrollment: a plain `http://` FLEET_SERVER, or FLEET_VERIFY_MODE=none              |
+| FLEET_BUNDLE_KEY    | Bundle encryption key(s) for sealed bundles, as shown once by the fleet server; several separated by commas             |
 | LAYOUT              | On-disk layout: `modern` keeps the writable state in `%ProgramData%\NSClient++` restricted to SYSTEM and administrators, `legacy` (default) keeps it in the install folder. Omit it to keep whatever the host already uses. **Experimental** - see below |
 
 ### On-disk layout (LAYOUT)
@@ -415,6 +416,7 @@ msiexec /qn /i NSCP-<version>-x64.msi FLEET_SERVER=https://fleet.example.com FLE
 | `FLEET_HOSTNAME`    | no                                        | this machine's host name   | The name this host reports to the fleet server.                                                                         |
 | `FLEET_VERIFY_MODE` | no                                        | `certificate`              | `none` stops the fleet server being verified at all, and is only accepted together with `FLEET_INSECURE=1`.              |
 | `FLEET_INSECURE`    | no                                        | unset                      | `1` opts into an unauthenticated enrollment: a plain `http://` url, `FLEET_VERIFY_MODE=none`, or both.                   |
+| `FLEET_BUNDLE_KEY`  | for [encrypted bundles](fleet.md#encrypted-bundles) | unset            | The bundle encryption key (44 base64 characters) the fleet server showed once when it was created; several, comma separated, while rotating. Stored in the enrollment manifest, never sent to the server. On an already enrolled host it may be given on its own, without `FLEET_SERVER`, to replace the stored keys. |
 
 ### Running the installer with fleet arguments
 

--- a/docs/security/260-fleet-encrypted-bundles.md
+++ b/docs/security/260-fleet-encrypted-bundles.md
@@ -1,0 +1,46 @@
+---
+title: "Fleet: encrypted bundles are opened by the agent, not the server"
+fixed_in: next
+severity: "Low"
+modules: [core]
+action: conditional
+---
+A fleet server distributes configuration, scripts and other files to its
+agents as signed bundles. The signature and the published SHA-256 establish
+that a bundle arrived as the operator uploaded it, but the server stores and
+serves its contents, so anything in a bundle — credentials in a generated
+`nsclient.ini` fragment, a script carrying a token — was readable by whoever
+could read the server's storage or stand in front of it with a valid
+certificate.
+
+The agent can now open a bundle the operator sealed in the browser before
+upload (`enc-v1`: AES-256-GCM under a 32-byte key, the bundle's name and
+version authenticated alongside the ciphertext). The key reaches the agent out
+of band and is never sent to the server:
+
+* `nscp enroll --bundle-key <key>` at enrollment, the `FLEET_BUNDLE_KEY`
+  installer property, or `nscp enroll --update-bundle-keys` on an already
+  enrolled host. Several keys may be configured so a key can be rotated
+  without a window where neither key works.
+* The key is stored in the enrollment manifest (`agent-state.json`), beside
+  the host's private key and under the same permissions — not in
+  `nsclient.ini`.
+* A sealed bundle served under another name or version fails to open rather
+  than being applied, and a bundle that names a configured key but fails to
+  authenticate is refused outright instead of being retried against the
+  remaining keys.
+* Plaintext exists only in the sync's staging directory and is removed on
+  every exit path.
+
+`nscp enroll --require-encrypted-bundles` (or
+`FLEET_REQUIRE_ENCRYPTED_BUNDLES=1`) additionally refuses every bundle that is
+not sealed, for a fleet server that is trusted to distribute configuration but
+not to read it. It is held in the manifest rather than in the synced
+configuration, so a compromised server cannot switch it off by sending a
+bundle that turns it off.
+
+**What to do:** nothing required — an unsealed bundle is still applied unless
+you ask for the requirement, and an agent with no key configured behaves
+exactly as before. If you use the fleet server's *Encryption key* feature,
+hand each agent the key as above; agents without it refuse the sealed bundle
+rather than applying something they cannot read.

--- a/docs/security/270-test-prompt-settings-redacted.md
+++ b/docs/security/270-test-prompt-settings-redacted.md
@@ -1,0 +1,24 @@
+---
+title: "Sensitive settings are redacted in the nscp test settings dump"
+fixed_in: next
+severity: "Low"
+modules: [core]
+action: none
+---
+The `settings` command of the `nscp test` prompt listed the configured
+settings with their values in clear text, including keys a module registered
+as sensitive with `add_password`. The REST read paths and
+`nscp settings --list` were changed to answer `***` for those keys in 0.16.2
+([Settings values for sensitive keys are redacted on
+read](#settings-values-for-sensitive-keys-are-redacted-on-read)); this
+listing was not, and it is the one most likely to be pasted into a ticket or
+a chat window.
+
+It now redacts the same keys. As with the other read paths, only keys a
+loaded module has declared sensitive are covered, and a module reading its
+own configuration is unaffected. This is a defense-in-depth change, not an
+authorization boundary: the values are still stored in plaintext in
+`nsclient.ini` and readable by anyone who can read that file.
+
+**What to do:** nothing required. Read the value out of `nsclient.ini` when
+you need the secret itself.

--- a/docs/upgrades/next/020-fleet-encrypted-bundles.md
+++ b/docs/upgrades/next/020-fleet-encrypted-bundles.md
@@ -13,8 +13,8 @@ or to an already enrolled host with `nscp enroll --update-bundle-keys
 --bundle-key <key>` (several `--bundle-key` while rotating; on Windows,
 re-running the installer with only `FLEET_BUNDLE_KEY` does the same). The key
 is stored in the enrollment manifest (`agent-state.json`) beside the host's
-private key, never in `nsclient.ini`. A new setting,
-`[/settings/fleet] require encrypted bundles = true` (default `false`), refuses
-every bundle that is not sealed, for a fleet server you do not trust with
-plaintext configuration. See
+private key, never in `nsclient.ini`. `nscp enroll --require-encrypted-bundles`
+(or `FLEET_REQUIRE_ENCRYPTED_BUNDLES=1`) refuses every bundle that is not
+sealed, for a fleet server you do not trust with plaintext configuration; it
+is stored in the manifest too, so the server cannot switch it off. See
 [Central management with NSClient Fleet](fleet.md#encrypted-bundles).

--- a/docs/upgrades/next/020-fleet-encrypted-bundles.md
+++ b/docs/upgrades/next/020-fleet-encrypted-bundles.md
@@ -1,0 +1,20 @@
+---
+icon: "🔒"
+modules: [core]
+action: conditional
+---
+**Fleet: encrypted bundles are now opened by the agent.** Nothing to do unless
+you use the fleet server's *Encryption key* feature. A bundle the operator seals
+in the browser (`format: enc-v1`) used to be refused by the agent as an
+unreadable archive; the agent now opens it with a key you hand it out of band,
+and the server never sees that key. Give the key at enrollment with
+`nscp enroll --bundle-key <key>` or the `FLEET_BUNDLE_KEY` installer property,
+or to an already enrolled host with `nscp enroll --update-bundle-keys
+--bundle-key <key>` (several `--bundle-key` while rotating; on Windows,
+re-running the installer with only `FLEET_BUNDLE_KEY` does the same). The key
+is stored in the enrollment manifest (`agent-state.json`) beside the host's
+private key, never in `nsclient.ini`. A new setting,
+`[/settings/fleet] require encrypted bundles = true` (default `false`), refuses
+every bundle that is not sealed, for a fleet server you do not trust with
+plaintext configuration. See
+[Central management with NSClient Fleet](fleet.md#encrypted-bundles).

--- a/docs/upgrades/next/020-fleet-encrypted-bundles.md
+++ b/docs/upgrades/next/020-fleet-encrypted-bundles.md
@@ -17,4 +17,5 @@ private key, never in `nsclient.ini`. `nscp enroll --require-encrypted-bundles`
 (or `FLEET_REQUIRE_ENCRYPTED_BUNDLES=1`) refuses every bundle that is not
 sealed, for a fleet server you do not trust with plaintext configuration; it
 is stored in the manifest too, so the server cannot switch it off. See
-[Central management with NSClient Fleet](fleet.md#encrypted-bundles).
+[Central management with NSClient Fleet](fleet.md#encrypted-bundles) and the
+[security notice](../security/notices.md#fleet-encrypted-bundles-are-opened-by-the-agent-not-the-server).

--- a/docs/upgrades/next/021-fleet-unenroll.md
+++ b/docs/upgrades/next/021-fleet-unenroll.md
@@ -1,0 +1,11 @@
+---
+icon: "🔧"
+modules: [core]
+action: none
+---
+**Fleet: `nscp enroll --unenroll` leaves the fleet.** Nothing to do. Until now
+leaving meant deleting the enrollment manifest, the fleet directory and the
+`[/includes] fleet` entry by hand; `nscp enroll --unenroll` does all three and
+reports each, then a service restart stops the sync. It is a local act: the
+host stays listed on the fleet server until you remove it there. See
+[Central management with NSClient Fleet](fleet.md#step-6-living-with-it).

--- a/include/breakpad/exception_handler_win32.cpp
+++ b/include/breakpad/exception_handler_win32.cpp
@@ -9,6 +9,7 @@
 #include <file_helpers.hpp>
 #include <iostream>
 #include <str/format.hpp>
+#include <str/utf8.hpp>
 #include <string>
 #include <win/psapi.hpp>
 #include <win/windows.hpp>
@@ -147,16 +148,19 @@ void ExceptionManager::handle_exception(EXCEPTION_POINTERS *exinfo) {
       return;
     }
 
-    HMODULE hm;
+    HMODULE hm = nullptr;
     ::GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, static_cast<LPCTSTR>(exinfo->ExceptionRecord->ExceptionAddress), &hm);
-    MODULEINFO mi;
+    MODULEINFO mi = {};
     ::GetModuleInformation(::GetCurrentProcess(), hm, &mi, sizeof(mi));
-    wchar_t fn[MAX_PATH];
+    wchar_t fn[MAX_PATH] = {};
     ::GetModuleFileNameEx(::GetCurrentProcess(), hm, fn, MAX_PATH);
+    // The buffer is wide; streaming it into a narrow stream prints its
+    // address, which is what every crash file used to say for the module.
+    const std::string module_name = fn[0] == 0 ? std::string("<unknown module>") : utf8::cvt<std::string>(std::wstring(fn));
 
     DWORD code = exinfo->ExceptionRecord->ExceptionCode;
     std::ofstream oss(crash_file, std::ios::out);
-    oss << "SE " << seDescription(code) << " at address 0x" << std::hex << exinfo->ExceptionRecord->ExceptionAddress << std::dec << " inside " << fn
+    oss << "SE " << seDescription(code) << " at address 0x" << std::hex << exinfo->ExceptionRecord->ExceptionAddress << std::dec << " inside " << module_name
         << " loaded at base address 0x" << std::hex << mi.lpBaseOfDll << "\n";
 
     if (code == EXCEPTION_ACCESS_VIOLATION || code == EXCEPTION_IN_PAGE_ERROR) {

--- a/include/client/simple_client.cpp
+++ b/include/client/simple_client.cpp
@@ -84,7 +84,7 @@ const std::vector<command_info> &builtin_commands() {
       {"plugins", "", "list all plugins and whether they are loaded"},
       {"desc", "<query>", "describe a query and its parameters"},
       {"metrics", "[prefix]", "show the metrics collected so far"},
-      {"settings", "", "dump the current settings"},
+      {"settings", "", "show the configured settings (keys set in the configuration, not every registered default)"},
       {"exec", "<target> <command> [args]", "run a command on one module"},
       {"load", "<module>", "load a module now"},
       {"unload", "<module>", "unload a module now"},
@@ -365,19 +365,23 @@ void cli_client::handle_command(const std::string &command) {
     namespace pf = nscapi::protobuf::functions;
 
     pf::settings_query q(handler->get_plugin_id());
-    q.list("/", true);
+    // Walk the settings store rather than the registry: the registry lists
+    // every key any loaded module has declared, almost all of them unset,
+    // which buried the handful of lines that are actually configured.
+    q.list_configured("/");
 
     handler->get_core()->settings_query(q.request(), q.response());
     if (!q.validate_response()) {
       handler->output_message("ERROR: " + q.get_response_error());
     } else {
+      std::string out;
       for (const pf::settings_query::key_values &val : q.get_query_key_response()) {
-        std::string tmp;
-        tmp += val.path();
-        tmp += "/" + val.key();
-        tmp += "=" + val.get_string();
-        handler->output_message(tmp);
+        // Section entries come back too; only keys are worth a line.
+        if (val.key().empty()) continue;
+        if (!out.empty()) out += "\n";
+        out += val.path() + "/" + val.key() + "=" + val.get_string();
       }
+      handler->output_message(out.empty() ? "Nothing configured" : out);
     }
   } else if (!command.empty()) {
     try {

--- a/include/client/simple_client.cpp
+++ b/include/client/simple_client.cpp
@@ -368,7 +368,10 @@ void cli_client::handle_command(const std::string &command) {
     // Walk the settings store rather than the registry: the registry lists
     // every key any loaded module has declared, almost all of them unset,
     // which buried the handful of lines that are actually configured.
-    q.list_configured("/");
+    // Sensitive keys come back as "***": this dump ends up in tickets and
+    // chat windows, and the file is right there for anyone who needs the
+    // real value.
+    q.list_configured("/", true, true);
 
     handler->get_core()->settings_query(q.request(), q.response());
     if (!q.validate_response()) {

--- a/include/nscapi/protobuf/settings_functions.cpp
+++ b/include/nscapi/protobuf/settings_functions.cpp
@@ -179,12 +179,13 @@ void settings_query::list(const std::string &path, const bool recursive) const {
   r->mutable_inventory()->set_recursive_fetch(recursive);
 }
 
-void settings_query::list_configured(const std::string &path, const bool recursive) const {
+void settings_query::list_configured(const std::string &path, const bool recursive, const bool redact_sensitive) const {
   auto *r = pimpl->request_message.add_payload();
   r->set_plugin_id(pimpl->plugin_id);
   r->mutable_query()->mutable_node()->set_path(path);
   r->mutable_query()->set_include_keys(true);
   r->mutable_query()->set_recursive(recursive);
+  r->mutable_query()->set_redact_sensitive(redact_sensitive);
 }
 
 void settings_query::save() const {

--- a/include/nscapi/protobuf/settings_functions.cpp
+++ b/include/nscapi/protobuf/settings_functions.cpp
@@ -179,6 +179,14 @@ void settings_query::list(const std::string &path, const bool recursive) const {
   r->mutable_inventory()->set_recursive_fetch(recursive);
 }
 
+void settings_query::list_configured(const std::string &path, const bool recursive) const {
+  auto *r = pimpl->request_message.add_payload();
+  r->set_plugin_id(pimpl->plugin_id);
+  r->mutable_query()->mutable_node()->set_path(path);
+  r->mutable_query()->set_include_keys(true);
+  r->mutable_query()->set_recursive(recursive);
+}
+
 void settings_query::save() const {
   auto *r = pimpl->request_message.add_payload();
   r->set_plugin_id(pimpl->plugin_id);
@@ -219,8 +227,17 @@ std::list<settings_query::key_values> settings_query::get_query_key_response() c
       const auto &q = pl.query();
       if (!q.node().key().empty()) {
         ret.emplace_back(q.node().path(), q.node().key(), q.node().value());
-      } else {
+      } else if (q.nodes_size() == 0) {
         ret.emplace_back(q.node().path());
+      }
+      // A path query (list_configured) answers with the walk under `nodes`;
+      // `node` then only echoes what was asked for.
+      for (const auto &n : q.nodes()) {
+        if (!n.key().empty()) {
+          ret.emplace_back(n.path(), n.key(), n.value());
+        } else {
+          ret.emplace_back(n.path());
+        }
       }
     } else if (pl.inventory_size() > 0) {
       for (const auto &q : pl.inventory()) {

--- a/include/nscapi/protobuf/settings_functions.hpp
+++ b/include/nscapi/protobuf/settings_functions.hpp
@@ -45,6 +45,12 @@ class NSCAPI_EXPORT settings_query {
   void get(const std::string &path, const std::string &key, const long long def) const;
   void get(const std::string &path, const std::string &key, const bool def) const;
   void list(const std::string &path, const bool recursive = false) const;
+  // Only what is actually configured: the sections and keys present in the
+  // settings store (the ini file, its includes and anything set in memory).
+  // list() above answers from the registry instead, so it reports every key
+  // a loaded module knows about, set or not, and its default is not in the
+  // value either - which for a dump reads as page after page of `key=`.
+  void list_configured(const std::string &path, const bool recursive = true) const;
 
   void set(const std::string &path, const std::string &key, const std::string &value) const;
   void erase(const std::string &path, const std::string &key) const;

--- a/include/nscapi/protobuf/settings_functions.hpp
+++ b/include/nscapi/protobuf/settings_functions.hpp
@@ -50,7 +50,10 @@ class NSCAPI_EXPORT settings_query {
   // list() above answers from the registry instead, so it reports every key
   // a loaded module knows about, set or not, and its default is not in the
   // value either - which for a dump reads as page after page of `key=`.
-  void list_configured(const std::string &path, const bool recursive = true) const;
+  // Values of keys their module registered sensitive (add_password) come
+  // back as "***" unless redact_sensitive is turned off: this is a listing
+  // meant for eyes, not a module reading its own secret.
+  void list_configured(const std::string &path, const bool recursive = true, const bool redact_sensitive = true) const;
 
   void set(const std::string &path, const std::string &key, const std::string &value) const;
   void erase(const std::string &path, const std::string &key) const;

--- a/include/nscapi/protobuf/settings_functions_test.cpp
+++ b/include/nscapi/protobuf/settings_functions_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <nscapi/protobuf/settings.hpp>
 #include <nscapi/protobuf/settings_functions.hpp>
 #include <string>
 
@@ -305,6 +306,80 @@ TEST_F(SettingsQueryTest, GetQueryKeyResponseEmpty) {
   // Empty response should return empty list
   const std::list<settings_query::key_values> results = query.get_query_key_response();
   EXPECT_TRUE(results.empty());
+}
+
+TEST_F(SettingsQueryTest, ListConfiguredAsksForAWalkOfTheStore) {
+  // list() is an inventory request (the registry: every declared key);
+  // list_configured() must be a query with keys, so the core walks the
+  // settings store and answers with what is actually set.
+  settings_query query(7);
+  query.list_configured("/", true);
+
+  PB::Settings::SettingsRequestMessage request;
+  ASSERT_TRUE(request.ParseFromString(query.request()));
+  ASSERT_EQ(1, request.payload_size());
+  EXPECT_EQ(7, request.payload(0).plugin_id());
+  ASSERT_TRUE(request.payload(0).has_query());
+  EXPECT_EQ("/", request.payload(0).query().node().path());
+  EXPECT_TRUE(request.payload(0).query().include_keys());
+  EXPECT_TRUE(request.payload(0).query().recursive());
+  EXPECT_FALSE(request.payload(0).has_inventory());
+}
+
+TEST_F(SettingsQueryTest, GetQueryKeyResponseReadsTheNodesOfAPathQuery) {
+  // A path query comes back with the walk under `nodes` and only the queried
+  // path echoed in `node`. The list used to read `node` alone, so a
+  // list_configured() answer collapsed to a single path entry.
+  PB::Settings::SettingsResponseMessage response;
+  PB::Settings::SettingsResponseMessage::Response *payload = response.add_payload();
+  payload->mutable_result()->set_code(PB::Common::Result_StatusCodeType_STATUS_OK);
+  PB::Settings::SettingsResponseMessage::Response::Query *q = payload->mutable_query();
+  q->mutable_node()->set_path("/");
+  PB::Settings::Node *section = q->add_nodes();
+  section->set_path("/modules");
+  PB::Settings::Node *key = q->add_nodes();
+  key->set_path("/modules");
+  key->set_key("CheckHelpers");
+  key->set_value("enabled");
+  PB::Settings::Node *other = q->add_nodes();
+  other->set_path("/settings/log");
+  other->set_key("level");
+  other->set_value("info");
+
+  const settings_query query(1);
+  query.response() = response.SerializeAsString();
+  ASSERT_TRUE(query.validate_response());
+
+  const std::list<settings_query::key_values> results = query.get_query_key_response();
+  ASSERT_EQ(3u, results.size());
+  auto it = results.begin();
+  EXPECT_EQ("/modules", it->path());
+  EXPECT_EQ("", it->key());
+  ++it;
+  EXPECT_TRUE(it->matches("/modules", "CheckHelpers"));
+  EXPECT_EQ("enabled", it->get_string());
+  ++it;
+  EXPECT_TRUE(it->matches("/settings/log", "level"));
+  EXPECT_EQ("info", it->get_string());
+}
+
+TEST_F(SettingsQueryTest, GetQueryKeyResponseStillReadsASingleKeyQuery) {
+  PB::Settings::SettingsResponseMessage response;
+  PB::Settings::SettingsResponseMessage::Response *payload = response.add_payload();
+  payload->mutable_result()->set_code(PB::Common::Result_StatusCodeType_STATUS_OK);
+  PB::Settings::Node *node = payload->mutable_query()->mutable_node();
+  node->set_path("/settings/log");
+  node->set_key("level");
+  node->set_value("debug");
+
+  const settings_query query(1);
+  query.response() = response.SerializeAsString();
+  ASSERT_TRUE(query.validate_response());
+
+  const std::list<settings_query::key_values> results = query.get_query_key_response();
+  ASSERT_EQ(1u, results.size());
+  EXPECT_TRUE(results.front().matches("/settings/log", "level"));
+  EXPECT_EQ("debug", results.front().get_string());
 }
 
 // ============================================================================

--- a/include/nscapi/protobuf/settings_functions_test.cpp
+++ b/include/nscapi/protobuf/settings_functions_test.cpp
@@ -323,7 +323,19 @@ TEST_F(SettingsQueryTest, ListConfiguredAsksForAWalkOfTheStore) {
   EXPECT_EQ("/", request.payload(0).query().node().path());
   EXPECT_TRUE(request.payload(0).query().include_keys());
   EXPECT_TRUE(request.payload(0).query().recursive());
+  // A listing for display: passwords must come back masked by default.
+  EXPECT_TRUE(request.payload(0).query().redact_sensitive());
   EXPECT_FALSE(request.payload(0).has_inventory());
+}
+
+TEST_F(SettingsQueryTest, ListConfiguredCanAskForTheRealValues) {
+  settings_query query(7);
+  query.list_configured("/", true, false);
+
+  PB::Settings::SettingsRequestMessage request;
+  ASSERT_TRUE(request.ParseFromString(query.request()));
+  ASSERT_EQ(1, request.payload_size());
+  EXPECT_FALSE(request.payload(0).query().redact_sensitive());
 }
 
 TEST_F(SettingsQueryTest, GetQueryKeyResponseReadsTheNodesOfAPathQuery) {

--- a/include/onboarding/bundle_crypto.hpp
+++ b/include/onboarding/bundle_crypto.hpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+// Encrypted fleet bundles ("enc-v1"): the operator seals a bundle in the
+// browser before it is uploaded, so the fleet server only ever stores and
+// serves ciphertext. The key never travels through the server - it reaches the
+// agent out of band (`nscp enroll --bundle-key`, the FLEET_BUNDLE_KEY installer
+// property) and lives in the enrollment manifest next to the identity.
+//
+// Envelope, byte for byte what the server's reference implementation
+// (crates/core/src/encbundle.rs, web/src/crypto.ts) produces:
+//
+//   "NSEB1" (5) | key fingerprint (8) | nonce (12) | AES-256-GCM ciphertext | tag (16)
+//
+// The fingerprint is the first 8 bytes of SHA-256 over the raw 32-byte key and
+// is what the server shows the operator. The AEAD additional data is
+// `name || 0x00 || version` from the desired-state entry, so a sealed bundle
+// served under another name or version fails to open: the server cannot
+// re-label what it cannot read. There is no key derivation: the 32 bytes the
+// operator was given are the AES key.
+//
+// The SHA-256 the server publishes, and the Ed25519 signature over it, cover
+// the envelope, so download verification happens before and independently of
+// decryption.
+namespace onboarding {
+
+// Raw key length; the operator-facing form is standard base64 of these bytes.
+const std::size_t bundle_key_bytes = 32;
+
+// Split a list of keys as one installer property carries them: separated by
+// commas, semicolons or whitespace (none of which occur in base64), empties
+// dropped. Order is preserved.
+std::vector<std::string> split_bundle_keys(const std::string &list);
+
+// Decode an operator-supplied key. Standard base64 with padding, surrounding
+// whitespace ignored, and the result must be exactly 32 bytes. `error` never
+// echoes the input.
+bool parse_bundle_key(const std::string &key_b64, std::string &raw_key, std::string &error);
+
+// The 16 lowercase hex characters the fleet server displays for a key: the
+// first 8 bytes of SHA-256 over the raw key.
+std::string bundle_key_fingerprint(const std::string &raw_key);
+
+// Whether `bytes` carries the envelope magic. Agents go by this, not by the
+// advisory `format` field of the desired state: the magic is inside what the
+// signature covers.
+bool is_encrypted_bundle(const std::string &bytes);
+
+// Fingerprint (hex) of the key an envelope was sealed with, for "no key for
+// this bundle" diagnostics. Empty when `bytes` is not a complete envelope.
+std::string encrypted_bundle_fingerprint(const std::string &bytes);
+
+enum class unseal_status {
+  ok,
+  not_encrypted,  // no envelope magic
+  wrong_key,      // the envelope names a different key: try the next one
+  corrupt,        // magic present but the envelope is truncated
+  failed          // authentication failed: tampered, or name/version substituted
+};
+
+// Open one envelope with one raw 32-byte key. `name`/`version` are the
+// desired-state values for the bundle (the AEAD additional data).
+unseal_status decrypt_bundle(const std::string &raw_key, const std::string &name, const std::string &version, const std::string &blob, std::string &plaintext,
+                             std::string &error);
+
+// Seal `plaintext` with a caller-supplied 12-byte nonce. The agent never needs
+// to encrypt; this exists so tests can build envelopes deterministically and
+// cross-check them against the server's fixed vector. Throws onboarding_error
+// on a bad key or nonce length.
+std::string encrypt_bundle(const std::string &raw_key, const std::string &nonce, const std::string &name, const std::string &version,
+                           const std::string &plaintext);
+
+// The agent's policy for a downloaded, already verified bundle:
+//   - not an envelope: passed through unchanged, unless `require_encrypted`
+//     (the "server is untrusted" posture) in which case it is refused;
+//   - an envelope: opened with the key whose fingerprint it names. A key that
+//     does not match is skipped; a key that matches but fails to authenticate
+//     is fatal for the bundle (the content was tampered with or re-labelled),
+//     it is not a reason to try another key.
+// `keys_b64` are the configured keys in operator form; an unparsable entry is
+// reported, never silently skipped. Returns false with `error` set (no key
+// material in it) when the bundle must not be applied.
+bool open_bundle(const std::vector<std::string> &keys_b64, const std::string &name, const std::string &version, const std::string &bytes,
+                 bool require_encrypted, std::string &plaintext, std::string &error);
+
+}  // namespace onboarding

--- a/include/onboarding/onboarding.hpp
+++ b/include/onboarding/onboarding.hpp
@@ -109,6 +109,11 @@ struct enrolled_identity {
   // a key the server could plant there would defeat the point of sealing
   // bundles against the server. Only local enrollment writes this file.
   std::vector<std::string> bundle_keys;
+  // Refuse any bundle that is not a sealed envelope: the posture for a fleet
+  // server that is not trusted with plaintext configuration. Lives here for
+  // the same reason the keys do - in the settings store the server could
+  // reach it through the fleet-managed include.
+  bool require_encrypted_bundles = false;
 };
 
 // Parse a Retry-After header value (429/503) as RFC 9110 delay-seconds; none

--- a/include/onboarding/onboarding.hpp
+++ b/include/onboarding/onboarding.hpp
@@ -8,6 +8,7 @@
 #include <net/http/http_response.hpp>
 #include <stdexcept>
 #include <string>
+#include <vector>
 
 // One-time onboarding (enrollment) of this host against an NSClient fleet
 // server. The flow is: generate an Ed25519 keypair, build a PKCS#10 CSR from
@@ -102,6 +103,12 @@ struct enrolled_identity {
   std::string server_url;              // public API base
   std::string mtls_url;                // base URL for all /agent/v1/* calls
   std::string mtls_server_cert_pem;    // cert to pin when connecting to mtls_url
+  // Bundle-encryption keys in operator form (base64 of 32 bytes), newest
+  // first; several exist only mid-rotation. They live here, not in the
+  // settings store, because the fleet-managed include is part of that store:
+  // a key the server could plant there would defeat the point of sealing
+  // bundles against the server. Only local enrollment writes this file.
+  std::vector<std::string> bundle_keys;
 };
 
 // Parse a Retry-After header value (429/503) as RFC 9110 delay-seconds; none

--- a/include/onboarding/sync.hpp
+++ b/include/onboarding/sync.hpp
@@ -27,6 +27,7 @@ struct bundle_info {
   std::string signature;  // base64 Ed25519 signature over the 32-byte digest
   std::string url;        // server-relative download path
   long long priority = 0;
+  std::string format;  // "plain" or "enc-v1"; advisory, the envelope magic decides
 };
 
 struct desired_state {

--- a/installer_lib/CMakeLists.txt
+++ b/installer_lib/CMakeLists.txt
@@ -252,6 +252,7 @@ set(SRCS
     ../libs/onboarding/identity.cpp
     ../libs/onboarding/enroll.cpp
     ../libs/onboarding/state.cpp
+    ../libs/onboarding/bundle_crypto.cpp
     ${NSCP_INCLUDEDIR}/json/use_json.cpp
     ${NSCP_INCLUDEDIR}/nscapi/nscapi_helper.cpp
     ${NSCP_INCLUDEDIR}/str/utf8.cpp

--- a/installer_lib/installer_lib.cpp
+++ b/installer_lib/installer_lib.cpp
@@ -23,6 +23,7 @@
 #include <nsclient/logger/log_message_factory.hpp>
 #include <nsclient/logger/logger.hpp>
 #include <nsclient/nsclient_exception.hpp>
+#include <onboarding/bundle_crypto.hpp>
 #include <onboarding/onboarding.hpp>
 #include <str/utils.hpp>
 #include <str/wstring.hpp>
@@ -1803,13 +1804,61 @@ extern "C" UINT __stdcall ExecRemoveSecrets(MSIHANDLE hInstall) {
   }
 }
 
+namespace {
+// Hand the deferred half what it needs. One writer, so the two halves cannot
+// disagree about the field order.
+UINT schedule_enroll_fleet(msi_helper &h, const std::wstring &server, const std::wstring &token, const std::wstring &verify_mode, const bool insecure,
+                           const std::wstring &bundle_keys) {
+  msi_helper::custom_action_data_w data;
+  data.write_string(h.getTargetPath(L"INSTALLLOCATION"));
+  data.write_string(server);
+  data.write_string(token);
+  data.write_string(boost::algorithm::trim_copy(h.getMsiPropery(FLEET_HOSTNAME)));
+  data.write_string(boost::algorithm::trim_copy(h.getMsiPropery(FLEET_CA)));
+  data.write_string(verify_mode);
+  data.write_int(insecure ? 1 : 0);
+  data.write_string(bundle_keys);
+  // Deliberately not logged: it carries the bootstrap token and the bundle
+  // keys (which is also why FLEET_TOKEN, FLEET_BUNDLE_KEY and ExecEnrollFleet
+  // are hidden properties).
+  h.logMessage(L"Scheduling fleet enrollment (ExecEnrollFleet) with: " + (server.empty() ? std::wstring(L"<bundle keys only>") : server));
+  const HRESULT hr = h.do_deferred_action(L"ExecEnrollFleet", data, COST_SERVICE_INSTALL);
+  if (hr == ERROR_INSTALL_USEREXIT) return ERROR_INSTALL_USEREXIT;
+  if (FAILED(hr)) {
+    h.errorMessage(L"Failed to schedule the fleet enrollment.");
+    return ERROR_INSTALL_FAILURE;
+  }
+  return ERROR_SUCCESS;
+}
+}  // namespace
+
 extern "C" UINT __stdcall ScheduleEnrollFleet(MSIHANDLE hInstall) {
   msi_helper h(hInstall, L"ScheduleEnrollFleet");
   try {
     const std::wstring server = boost::algorithm::trim_copy(h.getMsiPropery(FLEET_SERVER));
-    if (server.empty()) {
+    const std::wstring bundle_keys = boost::algorithm::trim_copy(h.getMsiPropery(FLEET_BUNDLE_KEY));
+    if (server.empty() && bundle_keys.empty()) {
       h.logMessage(L"No FLEET_SERVER given: not enrolling with a fleet server");
       return ERROR_SUCCESS;
+    }
+    // Every key is checked here, before anything is installed: a paste error
+    // found in the deferred half would fail the install after the bootstrap
+    // token has been spent. The message names the position, never the value.
+    const std::vector<std::string> keys = onboarding::split_bundle_keys(utf8::cvt<std::string>(bundle_keys));
+    for (std::size_t i = 0; i < keys.size(); ++i) {
+      std::string raw_key, key_error;
+      if (!onboarding::parse_bundle_key(keys[i], raw_key, key_error)) {
+        h.errorMessage(L"FLEET_BUNDLE_KEY entry " + std::to_wstring(i + 1) + L" of " + std::to_wstring(keys.size()) + L" is not a valid bundle key: " +
+                       utf8::cvt<std::wstring>(key_error) +
+                       L". Pass the key exactly as the fleet server showed it when it was created (44 base64 characters); separate several with commas.");
+        return ERROR_INSTALL_FAILURE;
+      }
+    }
+    if (server.empty()) {
+      // Key rotation on an already enrolled host, e.g. an upgrade run with only
+      // FLEET_BUNDLE_KEY. The deferred half refuses if there is no enrollment.
+      h.logMessage(L"No FLEET_SERVER given: storing FLEET_BUNDLE_KEY into this host's existing enrollment");
+      return schedule_enroll_fleet(h, L"", L"", L"", false, bundle_keys);
     }
     const std::wstring token = boost::algorithm::trim_copy(h.getMsiPropery(FLEET_TOKEN));
     const std::wstring verify_mode = boost::algorithm::trim_copy(h.getMsiPropery(FLEET_VERIFY_MODE));
@@ -1869,24 +1918,7 @@ extern "C" UINT __stdcall ScheduleEnrollFleet(MSIHANDLE hInstall) {
       return ERROR_INSTALL_FAILURE;
     }
 
-    msi_helper::custom_action_data_w data;
-    data.write_string(h.getTargetPath(L"INSTALLLOCATION"));
-    data.write_string(server);
-    data.write_string(token);
-    data.write_string(boost::algorithm::trim_copy(h.getMsiPropery(FLEET_HOSTNAME)));
-    data.write_string(boost::algorithm::trim_copy(h.getMsiPropery(FLEET_CA)));
-    data.write_string(verify_mode);
-    data.write_int(insecure ? 1 : 0);
-
-    // Deliberately not logged: it carries the bootstrap token (which is also
-    // why FLEET_TOKEN and ExecEnrollFleet are in MsiHiddenProperties).
-    h.logMessage(L"Scheduling fleet enrollment (ExecEnrollFleet) with: " + server);
-    const HRESULT hr = h.do_deferred_action(L"ExecEnrollFleet", data, COST_SERVICE_INSTALL);
-    if (hr == ERROR_INSTALL_USEREXIT) return ERROR_INSTALL_USEREXIT;
-    if (FAILED(hr)) {
-      h.errorMessage(L"Failed to schedule the fleet enrollment.");
-      return ERROR_INSTALL_FAILURE;
-    }
+    return schedule_enroll_fleet(h, server, token, verify_mode, insecure, bundle_keys);
   } catch (const installer_exception &e) {
     h.errorMessage(L"Failed to schedule the fleet enrollment: " + e.what());
     return ERROR_INSTALL_FAILURE;
@@ -1912,6 +1944,9 @@ extern "C" UINT __stdcall ExecEnrollFleet(MSIHANDLE hInstall) {
     request.ca = utf8::cvt<std::string>(boost::algorithm::trim_copy(data.get_next_string()));
     request.verify_mode = utf8::cvt<std::string>(boost::algorithm::trim_copy(data.get_next_string()));
     const bool insecure = data.get_next_int() == 1;
+    // Already validated by the immediate half; split here so the manifest
+    // stores one entry per key.
+    const std::vector<std::string> bundle_keys = onboarding::split_bundle_keys(utf8::cvt<std::string>(data.get_next_string()));
 
     // The enrollment manifest lives where the service looks for it:
     // ${certificate-path}/agent-state.json, i.e. inside the install folder.
@@ -1941,8 +1976,27 @@ extern "C" UINT __stdcall ExecEnrollFleet(MSIHANDLE hInstall) {
     boost::system::error_code ec;
     if (boost::filesystem::exists(state_file, ec)) {
       h.logMessage(L"This host is already enrolled: keeping the existing identity (delete the manifest above to enroll again).");
+      if (!bundle_keys.empty()) {
+        // Re-running the installer with FLEET_BUNDLE_KEY is how a rotated key
+        // reaches an enrolled host: the identity stays, the keys are replaced.
+        const boost::optional<onboarding::enrolled_identity> current = onboarding::load_state(state_file);
+        if (!current) {
+          h.errorMessage(L"Fleet enrollment failed: the enrollment manifest exists but could not be read, so FLEET_BUNDLE_KEY cannot be stored.");
+          return ERROR_INSTALL_FAILURE;
+        }
+        onboarding::enrolled_identity updated = current.value();
+        updated.bundle_keys = bundle_keys;
+        onboarding::save_state(updated, state_file);
+        h.logMessage(L"Stored " + std::to_wstring(bundle_keys.size()) + L" bundle key(s) into the existing enrollment.");
+      }
       ensure_fleet_ini(install_folder, shared_folder);
       return ERROR_SUCCESS;
+    }
+    if (request.server_url.empty()) {
+      h.errorMessage(
+          L"FLEET_BUNDLE_KEY was given without FLEET_SERVER, but this host is not enrolled, so there is no enrollment to store the key in. Pass "
+          L"FLEET_SERVER and FLEET_TOKEN as well to enroll.");
+      return ERROR_INSTALL_FAILURE;
     }
 
     const boost::filesystem::path state_dir = boost::filesystem::path(state_file).parent_path();
@@ -1981,7 +2035,8 @@ extern "C" UINT __stdcall ExecEnrollFleet(MSIHANDLE hInstall) {
     }
 
     h.logMessage(L"Enrolling with the fleet server...");
-    const onboarding::enrolled_identity state = onboarding::enroll(request);
+    onboarding::enrolled_identity state = onboarding::enroll(request);
+    state.bundle_keys = bundle_keys;
     onboarding::save_state(state, state_file);
     h.logMessage("Enrollment successful, agent API (mTLS): " + state.mtls_url);
     ensure_fleet_ini(install_folder, shared_folder);

--- a/installer_lib/installer_lib.cpp
+++ b/installer_lib/installer_lib.cpp
@@ -2000,9 +2000,19 @@ extern "C" UINT __stdcall ExecEnrollFleet(MSIHANDLE hInstall) {
       return ERROR_SUCCESS;
     }
     if (request.server_url.empty()) {
-      h.errorMessage(
-          L"FLEET_BUNDLE_KEY was given without FLEET_SERVER, but this host is not enrolled, so there is no enrollment to store the key in. Pass "
-          L"FLEET_SERVER and FLEET_TOKEN as well to enroll.");
+      // Name the properties that were actually passed: the scheduling
+      // condition fires on FLEET_REQUIRE_ENCRYPTED_BUNDLES too, so an install
+      // that set only that one used to be told to fix FLEET_BUNDLE_KEY, which
+      // it never gave.
+      std::wstring given;
+      if (!bundle_keys.empty()) given = FLEET_BUNDLE_KEY;
+      if (require_encrypted_bundles) {
+        if (!given.empty()) given += L" and ";
+        given += FLEET_REQUIRE_ENCRYPTED_BUNDLES;
+      }
+      h.errorMessage(given +
+                     L" was given without FLEET_SERVER, but this host is not enrolled, so there is no enrollment to store it in. Pass FLEET_SERVER and "
+                     L"FLEET_TOKEN as well to enroll.");
       return ERROR_INSTALL_FAILURE;
     }
 

--- a/installer_lib/installer_lib.cpp
+++ b/installer_lib/installer_lib.cpp
@@ -1808,7 +1808,7 @@ namespace {
 // Hand the deferred half what it needs. One writer, so the two halves cannot
 // disagree about the field order.
 UINT schedule_enroll_fleet(msi_helper &h, const std::wstring &server, const std::wstring &token, const std::wstring &verify_mode, const bool insecure,
-                           const std::wstring &bundle_keys) {
+                           const std::wstring &bundle_keys, const bool require_encrypted_bundles) {
   msi_helper::custom_action_data_w data;
   data.write_string(h.getTargetPath(L"INSTALLLOCATION"));
   data.write_string(server);
@@ -1818,6 +1818,7 @@ UINT schedule_enroll_fleet(msi_helper &h, const std::wstring &server, const std:
   data.write_string(verify_mode);
   data.write_int(insecure ? 1 : 0);
   data.write_string(bundle_keys);
+  data.write_int(require_encrypted_bundles ? 1 : 0);
   // Deliberately not logged: it carries the bootstrap token and the bundle
   // keys (which is also why FLEET_TOKEN, FLEET_BUNDLE_KEY and ExecEnrollFleet
   // are hidden properties).
@@ -1837,7 +1838,8 @@ extern "C" UINT __stdcall ScheduleEnrollFleet(MSIHANDLE hInstall) {
   try {
     const std::wstring server = boost::algorithm::trim_copy(h.getMsiPropery(FLEET_SERVER));
     const std::wstring bundle_keys = boost::algorithm::trim_copy(h.getMsiPropery(FLEET_BUNDLE_KEY));
-    if (server.empty() && bundle_keys.empty()) {
+    const bool require_encrypted_bundles = is_true(h.getMsiPropery(FLEET_REQUIRE_ENCRYPTED_BUNDLES));
+    if (server.empty() && bundle_keys.empty() && !require_encrypted_bundles) {
       h.logMessage(L"No FLEET_SERVER given: not enrolling with a fleet server");
       return ERROR_SUCCESS;
     }
@@ -1857,8 +1859,8 @@ extern "C" UINT __stdcall ScheduleEnrollFleet(MSIHANDLE hInstall) {
     if (server.empty()) {
       // Key rotation on an already enrolled host, e.g. an upgrade run with only
       // FLEET_BUNDLE_KEY. The deferred half refuses if there is no enrollment.
-      h.logMessage(L"No FLEET_SERVER given: storing FLEET_BUNDLE_KEY into this host's existing enrollment");
-      return schedule_enroll_fleet(h, L"", L"", L"", false, bundle_keys);
+      h.logMessage(L"No FLEET_SERVER given: updating the bundle keys / encrypted-bundle requirement of this host's existing enrollment");
+      return schedule_enroll_fleet(h, L"", L"", L"", false, bundle_keys, require_encrypted_bundles);
     }
     const std::wstring token = boost::algorithm::trim_copy(h.getMsiPropery(FLEET_TOKEN));
     const std::wstring verify_mode = boost::algorithm::trim_copy(h.getMsiPropery(FLEET_VERIFY_MODE));
@@ -1918,7 +1920,7 @@ extern "C" UINT __stdcall ScheduleEnrollFleet(MSIHANDLE hInstall) {
       return ERROR_INSTALL_FAILURE;
     }
 
-    return schedule_enroll_fleet(h, server, token, verify_mode, insecure, bundle_keys);
+    return schedule_enroll_fleet(h, server, token, verify_mode, insecure, bundle_keys, require_encrypted_bundles);
   } catch (const installer_exception &e) {
     h.errorMessage(L"Failed to schedule the fleet enrollment: " + e.what());
     return ERROR_INSTALL_FAILURE;
@@ -1947,6 +1949,7 @@ extern "C" UINT __stdcall ExecEnrollFleet(MSIHANDLE hInstall) {
     // Already validated by the immediate half; split here so the manifest
     // stores one entry per key.
     const std::vector<std::string> bundle_keys = onboarding::split_bundle_keys(utf8::cvt<std::string>(data.get_next_string()));
+    const bool require_encrypted_bundles = data.get_next_int() == 1;
 
     // The enrollment manifest lives where the service looks for it:
     // ${certificate-path}/agent-state.json, i.e. inside the install folder.
@@ -1976,18 +1979,22 @@ extern "C" UINT __stdcall ExecEnrollFleet(MSIHANDLE hInstall) {
     boost::system::error_code ec;
     if (boost::filesystem::exists(state_file, ec)) {
       h.logMessage(L"This host is already enrolled: keeping the existing identity (delete the manifest above to enroll again).");
-      if (!bundle_keys.empty()) {
+      if (!bundle_keys.empty() || require_encrypted_bundles) {
         // Re-running the installer with FLEET_BUNDLE_KEY is how a rotated key
         // reaches an enrolled host: the identity stays, the keys are replaced.
+        // The requirement can only be switched on here; switching it off is
+        // `nscp enroll --update-bundle-keys` without the flag, on purpose.
         const boost::optional<onboarding::enrolled_identity> current = onboarding::load_state(state_file);
         if (!current) {
           h.errorMessage(L"Fleet enrollment failed: the enrollment manifest exists but could not be read, so FLEET_BUNDLE_KEY cannot be stored.");
           return ERROR_INSTALL_FAILURE;
         }
         onboarding::enrolled_identity updated = current.value();
-        updated.bundle_keys = bundle_keys;
+        if (!bundle_keys.empty()) updated.bundle_keys = bundle_keys;
+        if (require_encrypted_bundles) updated.require_encrypted_bundles = true;
         onboarding::save_state(updated, state_file);
-        h.logMessage(L"Stored " + std::to_wstring(bundle_keys.size()) + L" bundle key(s) into the existing enrollment.");
+        h.logMessage(L"Updated the existing enrollment: " + std::to_wstring(updated.bundle_keys.size()) + L" bundle key(s), encrypted bundles " +
+                     (updated.require_encrypted_bundles ? L"required" : L"not required") + L".");
       }
       ensure_fleet_ini(install_folder, shared_folder);
       return ERROR_SUCCESS;
@@ -2037,6 +2044,7 @@ extern "C" UINT __stdcall ExecEnrollFleet(MSIHANDLE hInstall) {
     h.logMessage(L"Enrolling with the fleet server...");
     onboarding::enrolled_identity state = onboarding::enroll(request);
     state.bundle_keys = bundle_keys;
+    state.require_encrypted_bundles = require_encrypted_bundles;
     onboarding::save_state(state, state_file);
     h.logMessage("Enrollment successful, agent API (mTLS): " + state.mtls_url);
     ensure_fleet_ini(install_folder, shared_folder);

--- a/installer_lib/keys.hpp
+++ b/installer_lib/keys.hpp
@@ -53,6 +53,9 @@
 #define FLEET_CA L"FLEET_CA"
 #define FLEET_VERIFY_MODE L"FLEET_VERIFY_MODE"
 #define FLEET_INSECURE L"FLEET_INSECURE"
+// Bundle encryption key(s), base64, comma separated when rotating. Reaches the
+// host only this way or via `nscp enroll --bundle-key`: never from the server.
+#define FLEET_BUNDLE_KEY L"FLEET_BUNDLE_KEY"
 
 // Operator-supplied TLS material (GitHub #568): install your own certificate,
 // private key and CA into ${certificate-path} instead of letting the service

--- a/installer_lib/keys.hpp
+++ b/installer_lib/keys.hpp
@@ -56,6 +56,9 @@
 // Bundle encryption key(s), base64, comma separated when rotating. Reaches the
 // host only this way or via `nscp enroll --bundle-key`: never from the server.
 #define FLEET_BUNDLE_KEY L"FLEET_BUNDLE_KEY"
+// 1 to refuse every bundle that is not sealed. Stored in the manifest with the
+// keys, out of the server's reach.
+#define FLEET_REQUIRE_ENCRYPTED_BUNDLES L"FLEET_REQUIRE_ENCRYPTED_BUNDLES"
 
 // Operator-supplied TLS material (GitHub #568): install your own certificate,
 // private key and CA into ${certificate-path} instead of letting the service

--- a/installers/installer-NSCP/Product.wxs
+++ b/installers/installer-NSCP/Product.wxs
@@ -498,7 +498,7 @@
            the time the configuration gains a `certificate key` pointing at
            it. -->
       <Custom Action="ScheduleInstallCerts" After="SchedulePrepareLayout">NOT (REMOVE ="ALL") AND (CERTIFICATE OR CERTIFICATE_KEY OR CERTIFICATE_CA)</Custom>
-      <Custom Action="ScheduleEnrollFleet" After="ScheduleInstallCerts">NOT (REMOVE ="ALL") AND (FLEET_SERVER OR FLEET_BUNDLE_KEY)</Custom>
+      <Custom Action="ScheduleEnrollFleet" After="ScheduleInstallCerts">NOT (REMOVE ="ALL") AND (FLEET_SERVER OR FLEET_BUNDLE_KEY OR FLEET_REQUIRE_ENCRYPTED_BUNDLES)</Custom>
       <Custom Action="ScheduleWriteConfig" After="ScheduleEnrollFleet">NOT (REMOVE ="ALL")</Custom>
       <Custom Action="GenConfig.Command" After="ScheduleWriteConfig">NOT (REMOVE ="ALL") AND GENERATE_SAMPLE_CONFIG = 1</Custom>
       <Custom Action="GenConfig" After="GenConfig.Command">NOT (REMOVE ="ALL") AND GENERATE_SAMPLE_CONFIG = 1</Custom>

--- a/installers/installer-NSCP/Product.wxs
+++ b/installers/installer-NSCP/Product.wxs
@@ -498,7 +498,7 @@
            the time the configuration gains a `certificate key` pointing at
            it. -->
       <Custom Action="ScheduleInstallCerts" After="SchedulePrepareLayout">NOT (REMOVE ="ALL") AND (CERTIFICATE OR CERTIFICATE_KEY OR CERTIFICATE_CA)</Custom>
-      <Custom Action="ScheduleEnrollFleet" After="ScheduleInstallCerts">NOT (REMOVE ="ALL") AND FLEET_SERVER</Custom>
+      <Custom Action="ScheduleEnrollFleet" After="ScheduleInstallCerts">NOT (REMOVE ="ALL") AND (FLEET_SERVER OR FLEET_BUNDLE_KEY)</Custom>
       <Custom Action="ScheduleWriteConfig" After="ScheduleEnrollFleet">NOT (REMOVE ="ALL")</Custom>
       <Custom Action="GenConfig.Command" After="ScheduleWriteConfig">NOT (REMOVE ="ALL") AND GENERATE_SAMPLE_CONFIG = 1</Custom>
       <Custom Action="GenConfig" After="GenConfig.Command">NOT (REMOVE ="ALL") AND GENERATE_SAMPLE_CONFIG = 1</Custom>

--- a/installers/installer-NSCP/properties.wxs
+++ b/installers/installer-NSCP/properties.wxs
@@ -39,6 +39,7 @@
 	<Property Id="FLEET_INSECURE" Secure="yes" />
 	<!-- Hidden for the same reason as the token: it opens every sealed bundle. -->
 	<Property Id="FLEET_BUNDLE_KEY" Secure="yes" Hidden="yes" />
+	<Property Id="FLEET_REQUIRE_ENCRYPTED_BUNDLES" Secure="yes" />
 	<Property Id="ExecEnrollFleet" Hidden="yes" />
 
 	<!-- OPERATOR-SUPPLIED TLS MATERIAL (GitHub #568)

--- a/installers/installer-NSCP/properties.wxs
+++ b/installers/installer-NSCP/properties.wxs
@@ -37,6 +37,8 @@
 	<Property Id="FLEET_CA" Secure="yes" />
 	<Property Id="FLEET_VERIFY_MODE" Secure="yes" />
 	<Property Id="FLEET_INSECURE" Secure="yes" />
+	<!-- Hidden for the same reason as the token: it opens every sealed bundle. -->
+	<Property Id="FLEET_BUNDLE_KEY" Secure="yes" Hidden="yes" />
 	<Property Id="ExecEnrollFleet" Hidden="yes" />
 
 	<!-- OPERATOR-SUPPLIED TLS MATERIAL (GitHub #568)

--- a/libs/onboarding/CMakeLists.txt
+++ b/libs/onboarding/CMakeLists.txt
@@ -42,6 +42,7 @@ if(WIN32)
     set(onboarding_SRCS
         ${onboarding_SRCS}
         json_util.hpp
+        digest.hpp
         ${NSCP_INCLUDEDIR}/onboarding/onboarding.hpp
         ${NSCP_INCLUDEDIR}/onboarding/sync.hpp
         ${NSCP_INCLUDEDIR}/onboarding/bundle_crypto.hpp

--- a/libs/onboarding/CMakeLists.txt
+++ b/libs/onboarding/CMakeLists.txt
@@ -32,6 +32,7 @@ set(onboarding_SRCS
     state.cpp
     sync.cpp
     verify.cpp
+    bundle_crypto.cpp
     ${NSCP_INCLUDEDIR}/net/socket/socket_helpers.cpp
     ${NSCP_INCLUDEDIR}/bytes/base64.c
     ${NSCP_INCLUDEDIR}/str/utf8.cpp
@@ -43,6 +44,7 @@ if(WIN32)
         json_util.hpp
         ${NSCP_INCLUDEDIR}/onboarding/onboarding.hpp
         ${NSCP_INCLUDEDIR}/onboarding/sync.hpp
+        ${NSCP_INCLUDEDIR}/onboarding/bundle_crypto.hpp
         ${NSCP_INCLUDEDIR}/net/http/client.hpp
     )
 endif(WIN32)

--- a/libs/onboarding/bundle_crypto.cpp
+++ b/libs/onboarding/bundle_crypto.cpp
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: 2004-2026 Michael Medin
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 
+#include <boost/algorithm/string/trim.hpp>
 #include <bytes/base64.h>
 #include <openssl/evp.h>
-#include <openssl/sha.h>
 
-#include <algorithm>
 #include <cctype>
 #include <memory>
 #include <onboarding/bundle_crypto.hpp>
 #include <onboarding/onboarding.hpp>
+
+#include "digest.hpp"
 
 namespace {
 
@@ -25,27 +26,8 @@ struct cipher_ctx_deleter {
 };
 typedef std::unique_ptr<EVP_CIPHER_CTX, cipher_ctx_deleter> cipher_ctx_ptr;
 
-std::string sha256_raw(const std::string &bytes) {
-  unsigned char digest[SHA256_DIGEST_LENGTH];
-  unsigned int len = 0;
-  const std::unique_ptr<EVP_MD_CTX, void (*)(EVP_MD_CTX *)> ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
-  if (!ctx || EVP_DigestInit_ex(ctx.get(), EVP_sha256(), nullptr) != 1 || EVP_DigestUpdate(ctx.get(), bytes.data(), bytes.size()) != 1 ||
-      EVP_DigestFinal_ex(ctx.get(), digest, &len) != 1) {
-    throw onboarding::onboarding_error("SHA-256 failed", false);
-  }
-  return std::string(reinterpret_cast<const char *>(digest), len);
-}
-
-std::string to_hex(const std::string &bytes) {
-  static const char digits[] = "0123456789abcdef";
-  std::string out;
-  out.reserve(bytes.size() * 2);
-  for (const unsigned char c : bytes) {
-    out.push_back(digits[c >> 4]);
-    out.push_back(digits[c & 0x0f]);
-  }
-  return out;
-}
+using onboarding::detail::sha256_raw;
+using onboarding::detail::to_hex;
 
 std::string raw_fingerprint(const std::string &raw_key) { return sha256_raw(raw_key).substr(0, fingerprint_len); }
 
@@ -78,17 +60,25 @@ std::vector<std::string> onboarding::split_bundle_keys(const std::string &list) 
 }
 
 bool onboarding::parse_bundle_key(const std::string &key_b64, std::string &raw_key, std::string &error) {
-  std::string trimmed = key_b64;
-  trimmed.erase(trimmed.begin(), std::find_if(trimmed.begin(), trimmed.end(), [](const unsigned char c) { return !std::isspace(c); }));
-  trimmed.erase(std::find_if(trimmed.rbegin(), trimmed.rend(), [](const unsigned char c) { return !std::isspace(c); }).base(), trimmed.end());
+  const std::string trimmed = boost::algorithm::trim_copy(key_b64);
   if (trimmed.empty()) {
     error = "bundle key is empty";
     return false;
   }
-  // The decoder tolerates junk by skipping it; a key is short and fixed
-  // enough that anything outside the alphabet is a paste error worth naming.
-  for (const char c : trimmed) {
-    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '+' && c != '/' && c != '=') {
+  // Anything outside the alphabet is a paste error worth naming: the key is
+  // short and fixed, so "not base64" is a better answer than whatever the
+  // decoder makes of it. '=' is padding, so it is only allowed at the end and
+  // only up to a quantum's worth - an interior '=' is rejected here rather
+  // than reported as the wrong length further down.
+  const std::string::size_type last_data = trimmed.find_last_not_of('=');
+  const std::size_t data_len = last_data == std::string::npos ? 0 : last_data + 1;
+  if (data_len == 0 || trimmed.size() - data_len > 2) {
+    error = "bundle key is not base64";
+    return false;
+  }
+  for (std::size_t i = 0; i < data_len; ++i) {
+    const unsigned char c = static_cast<unsigned char>(trimmed[i]);
+    if (!std::isalnum(c) && c != '+' && c != '/') {
       error = "bundle key is not base64";
       return false;
     }

--- a/libs/onboarding/bundle_crypto.cpp
+++ b/libs/onboarding/bundle_crypto.cpp
@@ -1,0 +1,251 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#include <bytes/base64.h>
+#include <openssl/evp.h>
+#include <openssl/sha.h>
+
+#include <algorithm>
+#include <cctype>
+#include <memory>
+#include <onboarding/bundle_crypto.hpp>
+#include <onboarding/onboarding.hpp>
+
+namespace {
+
+const char magic[] = "NSEB1";
+const std::size_t magic_len = 5;
+const std::size_t fingerprint_len = 8;
+const std::size_t nonce_len = 12;
+const std::size_t tag_len = 16;
+const std::size_t header_len = magic_len + fingerprint_len + nonce_len;
+
+struct cipher_ctx_deleter {
+  void operator()(EVP_CIPHER_CTX *ctx) const { EVP_CIPHER_CTX_free(ctx); }
+};
+typedef std::unique_ptr<EVP_CIPHER_CTX, cipher_ctx_deleter> cipher_ctx_ptr;
+
+std::string sha256_raw(const std::string &bytes) {
+  unsigned char digest[SHA256_DIGEST_LENGTH];
+  unsigned int len = 0;
+  const std::unique_ptr<EVP_MD_CTX, void (*)(EVP_MD_CTX *)> ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
+  if (!ctx || EVP_DigestInit_ex(ctx.get(), EVP_sha256(), nullptr) != 1 || EVP_DigestUpdate(ctx.get(), bytes.data(), bytes.size()) != 1 ||
+      EVP_DigestFinal_ex(ctx.get(), digest, &len) != 1) {
+    throw onboarding::onboarding_error("SHA-256 failed", false);
+  }
+  return std::string(reinterpret_cast<const char *>(digest), len);
+}
+
+std::string to_hex(const std::string &bytes) {
+  static const char digits[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(bytes.size() * 2);
+  for (const unsigned char c : bytes) {
+    out.push_back(digits[c >> 4]);
+    out.push_back(digits[c & 0x0f]);
+  }
+  return out;
+}
+
+std::string raw_fingerprint(const std::string &raw_key) { return sha256_raw(raw_key).substr(0, fingerprint_len); }
+
+// name || 0x00 || version: the separator is what stops "secrets1"/".0.0" and
+// "secrets"/"1.0.0" from authenticating the same way.
+std::string aad_for(const std::string &name, const std::string &version) {
+  std::string aad;
+  aad.reserve(name.size() + 1 + version.size());
+  aad += name;
+  aad.push_back('\0');
+  aad += version;
+  return aad;
+}
+
+}  // namespace
+
+std::vector<std::string> onboarding::split_bundle_keys(const std::string &list) {
+  std::vector<std::string> keys;
+  std::string current;
+  for (const char c : list) {
+    if (c == ',' || c == ';' || std::isspace(static_cast<unsigned char>(c))) {
+      if (!current.empty()) keys.push_back(current);
+      current.clear();
+    } else {
+      current.push_back(c);
+    }
+  }
+  if (!current.empty()) keys.push_back(current);
+  return keys;
+}
+
+bool onboarding::parse_bundle_key(const std::string &key_b64, std::string &raw_key, std::string &error) {
+  std::string trimmed = key_b64;
+  trimmed.erase(trimmed.begin(), std::find_if(trimmed.begin(), trimmed.end(), [](const unsigned char c) { return !std::isspace(c); }));
+  trimmed.erase(std::find_if(trimmed.rbegin(), trimmed.rend(), [](const unsigned char c) { return !std::isspace(c); }).base(), trimmed.end());
+  if (trimmed.empty()) {
+    error = "bundle key is empty";
+    return false;
+  }
+  // The decoder tolerates junk by skipping it; a key is short and fixed
+  // enough that anything outside the alphabet is a paste error worth naming.
+  for (const char c : trimmed) {
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '+' && c != '/' && c != '=') {
+      error = "bundle key is not base64";
+      return false;
+    }
+  }
+  const std::size_t max_len = b64::b64_decode(nullptr, trimmed.size(), nullptr, 0);
+  if (max_len == 0) {
+    error = "bundle key is not base64";
+    return false;
+  }
+  std::string decoded(max_len, '\0');
+  const std::size_t len = b64::b64_decode(trimmed.data(), trimmed.size(), &decoded[0], decoded.size());
+  if (len != bundle_key_bytes) {
+    error = "bundle key must decode to 32 bytes";
+    return false;
+  }
+  decoded.resize(len);
+  raw_key.swap(decoded);
+  return true;
+}
+
+std::string onboarding::bundle_key_fingerprint(const std::string &raw_key) { return to_hex(raw_fingerprint(raw_key)); }
+
+bool onboarding::is_encrypted_bundle(const std::string &bytes) { return bytes.size() >= magic_len && bytes.compare(0, magic_len, magic, magic_len) == 0; }
+
+std::string onboarding::encrypted_bundle_fingerprint(const std::string &bytes) {
+  if (!is_encrypted_bundle(bytes) || bytes.size() < header_len + tag_len) return "";
+  return to_hex(bytes.substr(magic_len, fingerprint_len));
+}
+
+onboarding::unseal_status onboarding::decrypt_bundle(const std::string &raw_key, const std::string &name, const std::string &version, const std::string &blob,
+                                                     std::string &plaintext, std::string &error) {
+  if (raw_key.size() != bundle_key_bytes) {
+    error = "bundle key must be 32 bytes";
+    return unseal_status::failed;
+  }
+  if (!is_encrypted_bundle(blob)) {
+    error = "not an encrypted bundle";
+    return unseal_status::not_encrypted;
+  }
+  if (blob.size() < header_len + tag_len) {
+    error = "encrypted bundle is truncated";
+    return unseal_status::corrupt;
+  }
+  if (blob.compare(magic_len, fingerprint_len, raw_fingerprint(raw_key)) != 0) {
+    error = "sealed with another key";
+    return unseal_status::wrong_key;
+  }
+  const unsigned char *nonce = reinterpret_cast<const unsigned char *>(blob.data()) + magic_len + fingerprint_len;
+  const std::size_t ct_len = blob.size() - header_len - tag_len;
+  const unsigned char *ct = reinterpret_cast<const unsigned char *>(blob.data()) + header_len;
+  // OpenSSL wants the tag on its own; the envelope (like RustCrypto and
+  // WebCrypto) has it appended to the ciphertext.
+  std::string tag = blob.substr(blob.size() - tag_len);
+  const std::string aad = aad_for(name, version);
+
+  const cipher_ctx_ptr ctx(EVP_CIPHER_CTX_new());
+  std::string out(ct_len + 16, '\0');
+  int len = 0;
+  int total = 0;
+  bool ok = ctx && EVP_DecryptInit_ex(ctx.get(), EVP_aes_256_gcm(), nullptr, nullptr, nullptr) == 1 &&
+            EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_IVLEN, static_cast<int>(nonce_len), nullptr) == 1 &&
+            EVP_DecryptInit_ex(ctx.get(), nullptr, nullptr, reinterpret_cast<const unsigned char *>(raw_key.data()), nonce) == 1 &&
+            EVP_DecryptUpdate(ctx.get(), nullptr, &len, reinterpret_cast<const unsigned char *>(aad.data()), static_cast<int>(aad.size())) == 1;
+  if (ok && ct_len > 0) {
+    ok = EVP_DecryptUpdate(ctx.get(), reinterpret_cast<unsigned char *>(&out[0]), &len, ct, static_cast<int>(ct_len)) == 1;
+    total = len;
+  }
+  ok = ok && EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_TAG, static_cast<int>(tag_len), &tag[0]) == 1;
+  if (ok) {
+    len = 0;
+    ok = EVP_DecryptFinal_ex(ctx.get(), reinterpret_cast<unsigned char *>(&out[0]) + total, &len) == 1;
+    total += len;
+  }
+  if (!ok) {
+    error = "authentication failed: the bundle was tampered with, or is served under another name or version";
+    return unseal_status::failed;
+  }
+  out.resize(static_cast<std::size_t>(total));
+  plaintext.swap(out);
+  return unseal_status::ok;
+}
+
+std::string onboarding::encrypt_bundle(const std::string &raw_key, const std::string &nonce, const std::string &name, const std::string &version,
+                                       const std::string &plaintext) {
+  if (raw_key.size() != bundle_key_bytes) throw onboarding_error("bundle key must be 32 bytes", false);
+  if (nonce.size() != nonce_len) throw onboarding_error("nonce must be 12 bytes", false);
+  const std::string aad = aad_for(name, version);
+  const cipher_ctx_ptr ctx(EVP_CIPHER_CTX_new());
+  std::string out(plaintext.size() + 16, '\0');
+  std::string tag(tag_len, '\0');
+  int len = 0;
+  int total = 0;
+  bool ok = ctx && EVP_EncryptInit_ex(ctx.get(), EVP_aes_256_gcm(), nullptr, nullptr, nullptr) == 1 &&
+            EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_SET_IVLEN, static_cast<int>(nonce_len), nullptr) == 1 &&
+            EVP_EncryptInit_ex(ctx.get(), nullptr, nullptr, reinterpret_cast<const unsigned char *>(raw_key.data()),
+                               reinterpret_cast<const unsigned char *>(nonce.data())) == 1 &&
+            EVP_EncryptUpdate(ctx.get(), nullptr, &len, reinterpret_cast<const unsigned char *>(aad.data()), static_cast<int>(aad.size())) == 1;
+  if (ok && !plaintext.empty()) {
+    ok = EVP_EncryptUpdate(ctx.get(), reinterpret_cast<unsigned char *>(&out[0]), &len, reinterpret_cast<const unsigned char *>(plaintext.data()),
+                           static_cast<int>(plaintext.size())) == 1;
+    total = len;
+  }
+  if (ok) {
+    len = 0;
+    ok = EVP_EncryptFinal_ex(ctx.get(), reinterpret_cast<unsigned char *>(&out[0]) + total, &len) == 1;
+    total += len;
+  }
+  ok = ok && EVP_CIPHER_CTX_ctrl(ctx.get(), EVP_CTRL_GCM_GET_TAG, static_cast<int>(tag_len), &tag[0]) == 1;
+  if (!ok) throw onboarding_error("AES-256-GCM encryption failed", false);
+  out.resize(static_cast<std::size_t>(total));
+  std::string blob;
+  blob.reserve(header_len + out.size() + tag_len);
+  blob.append(magic, magic_len);
+  blob += raw_fingerprint(raw_key);
+  blob += nonce;
+  blob += out;
+  blob += tag;
+  return blob;
+}
+
+bool onboarding::open_bundle(const std::vector<std::string> &keys_b64, const std::string &name, const std::string &version, const std::string &bytes,
+                             const bool require_encrypted, std::string &plaintext, std::string &error) {
+  if (!is_encrypted_bundle(bytes)) {
+    if (require_encrypted) {
+      error = "bundle is not encrypted but this host requires encrypted bundles";
+      return false;
+    }
+    plaintext = bytes;
+    return true;
+  }
+  const std::string sealed_with = encrypted_bundle_fingerprint(bytes);
+  if (sealed_with.empty()) {
+    error = "encrypted bundle is truncated";
+    return false;
+  }
+  if (keys_b64.empty()) {
+    error = "bundle is encrypted (key " + sealed_with + ") but this host has no bundle key: add it with `nscp enroll --bundle-key`";
+    return false;
+  }
+  std::size_t index = 0;
+  for (const std::string &key_b64 : keys_b64) {
+    ++index;
+    std::string raw_key;
+    std::string key_error;
+    if (!parse_bundle_key(key_b64, raw_key, key_error)) {
+      // A key that cannot even be decoded is a configuration error, not a
+      // non-matching key: say so rather than reporting "no key matches".
+      error = "bundle key " + std::to_string(index) + " in the enrollment manifest is invalid: " + key_error;
+      return false;
+    }
+    std::string decrypt_error;
+    const unseal_status status = decrypt_bundle(raw_key, name, version, bytes, plaintext, decrypt_error);
+    if (status == unseal_status::ok) return true;
+    if (status == unseal_status::wrong_key) continue;
+    error = "encrypted bundle could not be opened: " + decrypt_error;
+    return false;
+  }
+  error = "no configured bundle key matches this bundle (sealed with key " + sealed_with + ")";
+  return false;
+}

--- a/libs/onboarding/digest.hpp
+++ b/libs/onboarding/digest.hpp
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2004-2026 Michael Medin
+// SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
+
+#pragma once
+
+#include <onboarding/onboarding.hpp>
+#include <openssl/evp.h>
+#include <string>
+
+// SHA-256 over a buffer and hex encoding of the result: the two helpers the
+// onboarding library needs in more than one translation unit (verify.cpp
+// digests a bundle, bundle_crypto.cpp fingerprints a key). Internal to
+// libs/onboarding - the public headers expose sha256_hex() instead, which is
+// these two composed.
+namespace onboarding {
+namespace detail {
+
+inline std::string sha256_raw(const std::string &bytes) {
+  unsigned char digest[EVP_MAX_MD_SIZE];
+  unsigned int length = 0;
+  if (EVP_Digest(bytes.data(), bytes.size(), digest, &length, EVP_sha256(), nullptr) != 1) {
+    throw onboarding_error("SHA-256 digest failed", false);
+  }
+  return std::string(reinterpret_cast<const char *>(digest), length);
+}
+
+inline std::string to_hex(const std::string &bytes) {
+  static const char digits[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(bytes.size() * 2);
+  for (const char c : bytes) {
+    const auto b = static_cast<unsigned char>(c);
+    out.push_back(digits[b >> 4]);
+    out.push_back(digits[b & 0x0f]);
+  }
+  return out;
+}
+
+}  // namespace detail
+}  // namespace onboarding

--- a/libs/onboarding/onboarding_test.cpp
+++ b/libs/onboarding/onboarding_test.cpp
@@ -687,10 +687,12 @@ TEST_F(OnboardingStateTest, RoundTripsBundleKeys) {
   onboarding::enrolled_identity saved = test_state();
   saved.bundle_keys.push_back("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=");
   saved.bundle_keys.push_back("a2tra2tra2tra2tra2tra2tra2tra2tra2tra2tra2s=");
+  saved.require_encrypted_bundles = true;
   onboarding::save_state(saved, path_);
   const boost::optional<onboarding::enrolled_identity> loaded = onboarding::load_state(path_);
   ASSERT_TRUE(loaded);
   EXPECT_EQ(loaded.value().bundle_keys, saved.bundle_keys) << "order matters: newest first is the rotation convention";
+  EXPECT_TRUE(loaded.value().require_encrypted_bundles);
 }
 
 TEST_F(OnboardingStateTest, AManifestWithoutBundleKeysStillLoads) {
@@ -703,11 +705,12 @@ TEST_F(OnboardingStateTest, AManifestWithoutBundleKeysStillLoads) {
     buffer << in.rdbuf();
     text = buffer.str();
   }
-  // Strip the member: the manifest is compact JSON and the member is last.
-  const std::string member = ",\"bundle_keys\":[]";
-  const std::string::size_type at = text.find(member);
-  ASSERT_NE(at, std::string::npos) << text;
-  text.erase(at, member.size());
+  // Strip both members: the manifest is compact JSON and they are last.
+  for (const std::string member : {std::string(",\"bundle_keys\":[]"), std::string(",\"require_encrypted_bundles\":false")}) {
+    const std::string::size_type at = text.find(member);
+    ASSERT_NE(at, std::string::npos) << text;
+    text.erase(at, member.size());
+  }
   {
     std::ofstream out(path_.c_str(), std::ios::binary | std::ios::trunc);
     out << text;
@@ -715,6 +718,7 @@ TEST_F(OnboardingStateTest, AManifestWithoutBundleKeysStillLoads) {
   const boost::optional<onboarding::enrolled_identity> loaded = onboarding::load_state(path_);
   ASSERT_TRUE(loaded);
   EXPECT_TRUE(loaded.value().bundle_keys.empty());
+  EXPECT_FALSE(loaded.value().require_encrypted_bundles);
 }
 
 TEST_F(OnboardingStateTest, MalformedBundleKeysAreCorrupt) {

--- a/libs/onboarding/onboarding_test.cpp
+++ b/libs/onboarding/onboarding_test.cpp
@@ -683,6 +683,59 @@ TEST_F(OnboardingStateTest, RoundTrip) {
   EXPECT_EQ(loaded.value().mtls_server_cert_pem, saved.mtls_server_cert_pem);
 }
 
+TEST_F(OnboardingStateTest, RoundTripsBundleKeys) {
+  onboarding::enrolled_identity saved = test_state();
+  saved.bundle_keys.push_back("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=");
+  saved.bundle_keys.push_back("a2tra2tra2tra2tra2tra2tra2tra2tra2tra2tra2s=");
+  onboarding::save_state(saved, path_);
+  const boost::optional<onboarding::enrolled_identity> loaded = onboarding::load_state(path_);
+  ASSERT_TRUE(loaded);
+  EXPECT_EQ(loaded.value().bundle_keys, saved.bundle_keys) << "order matters: newest first is the rotation convention";
+}
+
+TEST_F(OnboardingStateTest, AManifestWithoutBundleKeysStillLoads) {
+  // Written before the field existed: absent means none, not corrupt.
+  onboarding::save_state(test_state(), path_);
+  std::string text;
+  {
+    std::ifstream in(path_.c_str(), std::ios::binary);
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    text = buffer.str();
+  }
+  // Strip the member: the manifest is compact JSON and the member is last.
+  const std::string member = ",\"bundle_keys\":[]";
+  const std::string::size_type at = text.find(member);
+  ASSERT_NE(at, std::string::npos) << text;
+  text.erase(at, member.size());
+  {
+    std::ofstream out(path_.c_str(), std::ios::binary | std::ios::trunc);
+    out << text;
+  }
+  const boost::optional<onboarding::enrolled_identity> loaded = onboarding::load_state(path_);
+  ASSERT_TRUE(loaded);
+  EXPECT_TRUE(loaded.value().bundle_keys.empty());
+}
+
+TEST_F(OnboardingStateTest, MalformedBundleKeysAreCorrupt) {
+  onboarding::save_state(test_state(), path_);
+  std::string text;
+  {
+    std::ifstream in(path_.c_str(), std::ios::binary);
+    std::ostringstream buffer;
+    buffer << in.rdbuf();
+    text = buffer.str();
+  }
+  const std::string::size_type at = text.find("\"bundle_keys\":[]");
+  ASSERT_NE(at, std::string::npos);
+  text.replace(at, std::string("\"bundle_keys\":[]").size(), "\"bundle_keys\":\"not-a-list\"");
+  {
+    std::ofstream out(path_.c_str(), std::ios::binary | std::ios::trunc);
+    out << text;
+  }
+  EXPECT_THROW(onboarding::load_state(path_), onboarding::onboarding_error);
+}
+
 TEST_F(OnboardingStateTest, SaveOverwritesExistingState) {
   onboarding::save_state(test_state(), path_);
   onboarding::enrolled_identity renewed = test_state();

--- a/libs/onboarding/state.cpp
+++ b/libs/onboarding/state.cpp
@@ -40,6 +40,9 @@ std::string serialize_state(const onboarding::enrolled_identity &state) {
   object["server_url"] = state.server_url;
   object["mtls_url"] = state.mtls_url;
   object["mtls_server_cert_pem"] = state.mtls_server_cert_pem;
+  json::array bundle_keys;
+  for (const std::string &key : state.bundle_keys) bundle_keys.push_back(json::value(json::string_view(key.data(), key.size())));
+  object["bundle_keys"] = bundle_keys;
   return json::serialize(object);
 }
 
@@ -306,6 +309,17 @@ boost::optional<onboarding::enrolled_identity> onboarding::load_state(const std:
     result.server_url = read_state_string(root, "server_url", false);
     result.mtls_url = read_state_string(root, "mtls_url");
     result.mtls_server_cert_pem = read_state_string(root, "mtls_server_cert_pem");
+    // Added after the first manifests were written: absent means none, so an
+    // older manifest keeps loading. Present but malformed is corrupt, like
+    // every other field.
+    const json::value *bundle_keys = root.if_contains("bundle_keys");
+    if (bundle_keys != nullptr) {
+      if (!bundle_keys->is_array()) throw std::runtime_error("bundle_keys is not an array");
+      for (const json::value &key : bundle_keys->as_array()) {
+        if (!key.is_string()) throw std::runtime_error("bundle_keys entry is not a string");
+        result.bundle_keys.push_back(onboarding::detail::to_string(key.as_string()));
+      }
+    }
     return result;
   } catch (const std::exception &e) {
     throw onboarding_error("State file " + path + " is corrupt: " + e.what(), false);

--- a/libs/onboarding/state.cpp
+++ b/libs/onboarding/state.cpp
@@ -43,6 +43,7 @@ std::string serialize_state(const onboarding::enrolled_identity &state) {
   json::array bundle_keys;
   for (const std::string &key : state.bundle_keys) bundle_keys.push_back(json::value(json::string_view(key.data(), key.size())));
   object["bundle_keys"] = bundle_keys;
+  object["require_encrypted_bundles"] = state.require_encrypted_bundles;
   return json::serialize(object);
 }
 
@@ -319,6 +320,11 @@ boost::optional<onboarding::enrolled_identity> onboarding::load_state(const std:
         if (!key.is_string()) throw std::runtime_error("bundle_keys entry is not a string");
         result.bundle_keys.push_back(onboarding::detail::to_string(key.as_string()));
       }
+    }
+    const json::value *require_encrypted = root.if_contains("require_encrypted_bundles");
+    if (require_encrypted != nullptr) {
+      if (!require_encrypted->is_bool()) throw std::runtime_error("require_encrypted_bundles is not a boolean");
+      result.require_encrypted_bundles = require_encrypted->as_bool();
     }
     return result;
   } catch (const std::exception &e) {

--- a/libs/onboarding/sync.cpp
+++ b/libs/onboarding/sync.cpp
@@ -223,6 +223,7 @@ onboarding::desired_state onboarding::parse_desired_state(const std::string &bod
       info.name = detail::optional_string(b, "name", "");
       info.version = detail::optional_string(b, "version", "");
       info.priority = optional_int(b, "priority", 0);
+      info.format = detail::optional_string(b, "format", "");
       result.bundles.push_back(info);
     }
   }

--- a/libs/onboarding/sync_test.cpp
+++ b/libs/onboarding/sync_test.cpp
@@ -1172,6 +1172,22 @@ TEST(BundleKey, RejectsAnythingButThirtyTwoBase64Bytes) {
   EXPECT_EQ(error.find("secret"), std::string::npos);
 }
 
+TEST(BundleKey, RejectsPaddingThatIsNotTrailingPadding) {
+  // '=' is padding, so it only means anything at the end. A paste error that
+  // drops one into the middle keeps the length a multiple of four, so without
+  // the alphabet check the operator would be told the key is the wrong length
+  // (it is not) instead of that it is not base64.
+  std::string mangled = pinned_key_b64;
+  mangled[8] = '=';
+  std::string raw, error;
+  EXPECT_FALSE(onboarding::parse_bundle_key(mangled, raw, error));
+  EXPECT_NE(error.find("base64"), std::string::npos) << error;
+  // A whole quantum of padding is not a key either.
+  EXPECT_FALSE(onboarding::parse_bundle_key("====", raw, error));
+  EXPECT_NE(error.find("base64"), std::string::npos) << error;
+  EXPECT_FALSE(onboarding::parse_bundle_key(std::string(pinned_key_b64).substr(0, 40) + "A===", raw, error));
+}
+
 TEST(BundleKey, SplitsAnInstallerList) {
   const std::vector<std::string> keys = onboarding::split_bundle_keys(" a1==, b2== ;c3==\nd4== ");
   ASSERT_EQ(keys.size(), 4u);

--- a/libs/onboarding/sync_test.cpp
+++ b/libs/onboarding/sync_test.cpp
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-only
 
 #include <gtest/gtest.h>
-#include <onboarding/sync.hpp>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
@@ -13,6 +12,8 @@
 #include <cctype>
 #include <map>
 #include <memory>
+#include <onboarding/bundle_crypto.hpp>
+#include <onboarding/sync.hpp>
 #include <string>
 #include <vector>
 
@@ -1110,4 +1111,186 @@ TEST(SyncReportHostile, EmptyReportIsStillWellFormed) {
   EXPECT_TRUE(root.at("bundles_installed").as_array().empty());
   EXPECT_TRUE(root.at("errors").as_array().empty());
   EXPECT_TRUE(root.at("reported_tags").as_object().empty()) << "the server relies on the keys existing";
+}
+
+// --- encrypted bundles ("enc-v1") ---------------------------------------------
+//
+// The envelope is produced by the fleet server's browser code and its Rust
+// reference implementation; the agent must open it byte for byte. The fixed
+// vector below is the server's pinned key (bytes 00..1f) sealed with a fixed
+// nonce by an independent AES-256-GCM implementation, so a drift in framing,
+// AAD encoding or tag placement fails here rather than in the field.
+
+namespace {
+
+std::string from_hex(const std::string &hex) {
+  std::string out;
+  for (std::size_t i = 0; i + 1 < hex.size(); i += 2) out.push_back(static_cast<char>(std::stoul(hex.substr(i, 2), nullptr, 16)));
+  return out;
+}
+
+const char *pinned_key_b64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
+const char *pinned_fingerprint = "630dcd2966c43366";
+const char *pinned_blob_hex = "4e53454231630dcd2966c43366000102030405060708090a0b3167b56faa976318e145332dec299b8f64c8fa5351ed";
+
+std::string pinned_key() {
+  std::string raw, error;
+  EXPECT_TRUE(onboarding::parse_bundle_key(pinned_key_b64, raw, error)) << error;
+  return raw;
+}
+
+std::string other_key() { return std::string(32, 'k'); }
+
+const std::string fixed_nonce = from_hex("000102030405060708090a0b");
+
+}  // namespace
+
+TEST(BundleKey, ParsesTheOperatorForm) {
+  std::string raw, error;
+  ASSERT_TRUE(onboarding::parse_bundle_key(pinned_key_b64, raw, error)) << error;
+  ASSERT_EQ(raw.size(), 32u);
+  for (std::size_t i = 0; i < raw.size(); ++i) EXPECT_EQ(static_cast<unsigned char>(raw[i]), i);
+  EXPECT_EQ(onboarding::bundle_key_fingerprint(raw), pinned_fingerprint);
+}
+
+TEST(BundleKey, TrimsSurroundingWhitespace) {
+  std::string raw, error;
+  EXPECT_TRUE(onboarding::parse_bundle_key(std::string("  ") + pinned_key_b64 + "\r\n", raw, error)) << error;
+  EXPECT_EQ(onboarding::bundle_key_fingerprint(raw), pinned_fingerprint);
+}
+
+TEST(BundleKey, RejectsAnythingButThirtyTwoBase64Bytes) {
+  std::string raw, error;
+  EXPECT_FALSE(onboarding::parse_bundle_key("", raw, error));
+  EXPECT_FALSE(onboarding::parse_bundle_key("   ", raw, error));
+  EXPECT_FALSE(onboarding::parse_bundle_key("not base64!", raw, error));
+  EXPECT_FALSE(onboarding::parse_bundle_key("AAECAwQFBgcICQoLDA0ODw==", raw, error)) << "16 bytes";
+  EXPECT_FALSE(onboarding::parse_bundle_key(std::string(pinned_key_b64) + "AAAA", raw, error)) << "35 bytes";
+  EXPECT_FALSE(onboarding::parse_bundle_key("630dcd2966c43366", raw, error)) << "a fingerprint is not a key";
+  // The error is logged and reported; it must not carry the value.
+  EXPECT_FALSE(onboarding::parse_bundle_key("secretsecretsecretsecretsecretsecretsecr", raw, error));
+  EXPECT_EQ(error.find("secret"), std::string::npos);
+}
+
+TEST(BundleKey, SplitsAnInstallerList) {
+  const std::vector<std::string> keys = onboarding::split_bundle_keys(" a1==, b2== ;c3==\nd4== ");
+  ASSERT_EQ(keys.size(), 4u);
+  EXPECT_EQ(keys[0], "a1==");
+  EXPECT_EQ(keys[1], "b2==");
+  EXPECT_EQ(keys[2], "c3==");
+  EXPECT_EQ(keys[3], "d4==");
+  EXPECT_TRUE(onboarding::split_bundle_keys("").empty());
+  EXPECT_TRUE(onboarding::split_bundle_keys(" ,; ").empty());
+}
+
+TEST(BundleCrypto, OpensTheServersFixedVector) {
+  const std::string blob = from_hex(pinned_blob_hex);
+  ASSERT_EQ(blob.size(), 47u);
+  EXPECT_TRUE(onboarding::is_encrypted_bundle(blob));
+  EXPECT_EQ(onboarding::encrypted_bundle_fingerprint(blob), pinned_fingerprint);
+  std::string plaintext, error;
+  ASSERT_EQ(onboarding::decrypt_bundle(pinned_key(), "pinned", "0.1", blob, plaintext, error), onboarding::unseal_status::ok) << error;
+  EXPECT_EQ(plaintext, "vector");
+}
+
+TEST(BundleCrypto, SealsExactlyLikeTheServer) {
+  // Same key, nonce, AAD and plaintext as the vector: the bytes must match.
+  const std::string blob = onboarding::encrypt_bundle(pinned_key(), fixed_nonce, "pinned", "0.1", "vector");
+  EXPECT_EQ(blob, from_hex(pinned_blob_hex));
+}
+
+TEST(BundleCrypto, RoundTripsABundleSizedPayload) {
+  std::string payload(200000, '\0');
+  for (std::size_t i = 0; i < payload.size(); ++i) payload[i] = static_cast<char>(i * 7);
+  const std::string blob = onboarding::encrypt_bundle(other_key(), fixed_nonce, "big", "3.2.1", payload);
+  std::string plaintext, error;
+  ASSERT_EQ(onboarding::decrypt_bundle(other_key(), "big", "3.2.1", blob, plaintext, error), onboarding::unseal_status::ok) << error;
+  EXPECT_EQ(plaintext, payload);
+}
+
+TEST(BundleCrypto, NameAndVersionAreBoundIntoTheSeal) {
+  const std::string blob = onboarding::encrypt_bundle(pinned_key(), fixed_nonce, "secrets", "1.0.0", "zip");
+  std::string plaintext, error;
+  EXPECT_EQ(onboarding::decrypt_bundle(pinned_key(), "secrets", "1.0.1", blob, plaintext, error), onboarding::unseal_status::failed);
+  EXPECT_EQ(onboarding::decrypt_bundle(pinned_key(), "other", "1.0.0", blob, plaintext, error), onboarding::unseal_status::failed);
+  // The NUL separator: a shifted split of the same characters is not the
+  // same additional data.
+  EXPECT_EQ(onboarding::decrypt_bundle(pinned_key(), "secrets1", ".0.0", blob, plaintext, error), onboarding::unseal_status::failed);
+  EXPECT_EQ(onboarding::decrypt_bundle(pinned_key(), "secrets", "1.0.0", blob, plaintext, error), onboarding::unseal_status::ok);
+}
+
+TEST(BundleCrypto, TamperingIsDetected) {
+  const std::string blob = onboarding::encrypt_bundle(pinned_key(), fixed_nonce, "demo", "1.0", "zip-bytes");
+  std::string plaintext, error;
+  for (const std::size_t at : {std::size_t(13), std::size_t(25), blob.size() - 1}) {
+    std::string tampered = blob;
+    tampered[at] = static_cast<char>(tampered[at] ^ 0x01);
+    EXPECT_EQ(onboarding::decrypt_bundle(pinned_key(), "demo", "1.0", tampered, plaintext, error), onboarding::unseal_status::failed) << "byte " << at;
+  }
+}
+
+TEST(BundleCrypto, ReportsAnotherKeyAndTruncation) {
+  const std::string blob = onboarding::encrypt_bundle(pinned_key(), fixed_nonce, "demo", "1.0", "zip-bytes");
+  std::string plaintext, error;
+  EXPECT_EQ(onboarding::decrypt_bundle(other_key(), "demo", "1.0", blob, plaintext, error), onboarding::unseal_status::wrong_key);
+  EXPECT_EQ(onboarding::decrypt_bundle(pinned_key(), "demo", "1.0", "NSEB1short", plaintext, error), onboarding::unseal_status::corrupt);
+  EXPECT_EQ(onboarding::decrypt_bundle(pinned_key(), "demo", "1.0", blob.substr(0, 40), plaintext, error), onboarding::unseal_status::corrupt);
+  EXPECT_EQ(onboarding::decrypt_bundle(pinned_key(), "demo", "1.0", "PK\x03\x04plain zip", plaintext, error), onboarding::unseal_status::not_encrypted);
+  EXPECT_EQ(onboarding::encrypted_bundle_fingerprint("NSEB1short"), "");
+  EXPECT_FALSE(onboarding::is_encrypted_bundle("PK\x03\x04"));
+  EXPECT_FALSE(onboarding::is_encrypted_bundle("NSEB"));
+}
+
+TEST(BundleOpen, PassesPlainBundlesThroughUnlessRequired) {
+  const std::string zip = "PK\x03\x04 a plain zip";
+  std::string out, error;
+  EXPECT_TRUE(onboarding::open_bundle({}, "demo", "1.0", zip, false, out, error)) << error;
+  EXPECT_EQ(out, zip);
+  EXPECT_TRUE(onboarding::open_bundle({pinned_key_b64}, "demo", "1.0", zip, false, out, error)) << error;
+  EXPECT_FALSE(onboarding::open_bundle({pinned_key_b64}, "demo", "1.0", zip, true, out, error));
+  EXPECT_NE(error.find("requires encrypted"), std::string::npos);
+}
+
+TEST(BundleOpen, PicksTheKeyByFingerprintAndSkipsTheOthers) {
+  const std::string blob = onboarding::encrypt_bundle(pinned_key(), fixed_nonce, "demo", "1.0", "zip-bytes");
+  const std::string other_b64 = "a2tra2tra2tra2tra2tra2tra2tra2tra2tra2tra2s=";  // 32 x 'k'
+  std::string out, error;
+  EXPECT_TRUE(onboarding::open_bundle({other_b64, pinned_key_b64}, "demo", "1.0", blob, true, out, error)) << error;
+  EXPECT_EQ(out, "zip-bytes");
+}
+
+TEST(BundleOpen, ExplainsAMissingKeyWithTheFingerprint) {
+  const std::string blob = onboarding::encrypt_bundle(pinned_key(), fixed_nonce, "demo", "1.0", "zip-bytes");
+  const std::string other_b64 = "a2tra2tra2tra2tra2tra2tra2tra2tra2tra2tra2s=";
+  std::string out, error;
+  EXPECT_FALSE(onboarding::open_bundle({}, "demo", "1.0", blob, false, out, error));
+  EXPECT_NE(error.find(pinned_fingerprint), std::string::npos) << error;
+  EXPECT_NE(error.find("no bundle key"), std::string::npos) << error;
+  EXPECT_FALSE(onboarding::open_bundle({other_b64}, "demo", "1.0", blob, false, out, error));
+  EXPECT_NE(error.find(pinned_fingerprint), std::string::npos) << error;
+  EXPECT_EQ(error.find(pinned_key_b64), std::string::npos) << "no key material in the message";
+}
+
+TEST(BundleOpen, AMatchingKeyThatFailsToAuthenticateIsFatal) {
+  // Served under another version: the right key is present, the seal does
+  // not open. That is a substitution, not a reason to try the next key.
+  const std::string blob = onboarding::encrypt_bundle(pinned_key(), fixed_nonce, "demo", "1.0", "zip-bytes");
+  std::string out, error;
+  EXPECT_FALSE(onboarding::open_bundle({pinned_key_b64, pinned_key_b64}, "demo", "2.0", blob, false, out, error));
+  EXPECT_NE(error.find("authentication failed"), std::string::npos) << error;
+}
+
+TEST(BundleOpen, AnUnparsableConfiguredKeyIsAnError) {
+  const std::string blob = onboarding::encrypt_bundle(pinned_key(), fixed_nonce, "demo", "1.0", "zip-bytes");
+  std::string out, error;
+  EXPECT_FALSE(onboarding::open_bundle({"garbage"}, "demo", "1.0", blob, false, out, error));
+  EXPECT_NE(error.find("invalid"), std::string::npos) << error;
+}
+
+TEST(BundleOpen, DesiredStateCarriesTheAdvisoryFormat) {
+  const onboarding::desired_state state = onboarding::parse_desired_state(bundle_with("format", "enc-v1"));
+  ASSERT_EQ(state.bundles.size(), 1u);
+  EXPECT_EQ(state.bundles[0].format, "enc-v1");
+  const onboarding::desired_state plain = onboarding::parse_desired_state(bundle_with("priority", 100));
+  EXPECT_EQ(plain.bundles[0].format, "");
 }

--- a/libs/onboarding/verify.cpp
+++ b/libs/onboarding/verify.cpp
@@ -12,6 +12,8 @@
 #include <cctype>
 #include <memory>
 
+#include "digest.hpp"
+
 namespace {
 
 struct bio_deleter {
@@ -27,26 +29,8 @@ struct x509_deleter {
   void operator()(X509 *p) const { X509_free(p); }
 };
 
-std::string sha256_raw(const std::string &bytes) {
-  unsigned char digest[EVP_MAX_MD_SIZE];
-  unsigned int length = 0;
-  if (EVP_Digest(bytes.data(), bytes.size(), digest, &length, EVP_sha256(), nullptr) != 1) {
-    throw onboarding::onboarding_error("SHA-256 digest failed", false);
-  }
-  return std::string(reinterpret_cast<const char *>(digest), length);
-}
-
-std::string to_hex(const std::string &bytes) {
-  static const char *digits = "0123456789abcdef";
-  std::string out;
-  out.reserve(bytes.size() * 2);
-  for (const char c : bytes) {
-    const auto b = static_cast<unsigned char>(c);
-    out.push_back(digits[b >> 4]);
-    out.push_back(digits[b & 0x0f]);
-  }
-  return out;
-}
+using onboarding::detail::sha256_raw;
+using onboarding::detail::to_hex;
 
 std::string to_lower(std::string s) {
   std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });

--- a/modules/CommandClient/CommandClient.cpp
+++ b/modules/CommandClient/CommandClient.cpp
@@ -128,8 +128,17 @@ void client_handler::log_error(std::string module, std::string file, int line, s
 }
 
 bool CommandClient::loadModuleEx(std::string alias, NSCAPI::moduleLoadMode mode) {
-  client::cli_handler_ptr handler(new client_handler(get_core(), get_id()));
-  client.reset(new client::cli_client(handler));
+  // A settings reload re-enters this on the live module while the prompt is
+  // up, and the prompt's editor hooks and input thread reach the client
+  // through this pointer. Replacing it here handed them a freed object: the
+  // first completion refresh after a reload - a fleet configuration push
+  // being what hit it - dereferenced it and took the process down. The
+  // handler only carries the core pointer and the plugin id, neither of
+  // which changes on reload, so the client built at first load is kept.
+  if (!client) {
+    client::cli_handler_ptr handler(new client_handler(get_core(), get_id()));
+    client.reset(new client::cli_client(handler));
+  }
 
   try {
     sh::settings_registry settings(nscapi::settings_proxy::create(get_id(), get_core()));
@@ -241,23 +250,25 @@ std::shared_ptr<command_client::console_editor> CommandClient::make_editor() con
   std::shared_ptr<command_client::console_editor> editor(new command_client::console_editor());
 
   command_client::editor_hooks hooks;
-  client::cli_client *cli = client.get();
-  hooks.queries = [cli]() {
+  // Resolve the client when a hook runs rather than snapshotting the raw
+  // pointer: the editor outlives any one call to loadModuleEx, and a
+  // snapshot is exactly what a reload would leave dangling.
+  hooks.queries = [this]() {
     std::vector<command_client::editor_item> items;
-    for (const client::command_info &c : cli->list_queries()) items.push_back({c.name, c.description});
+    for (const client::command_info &c : client->list_queries()) items.push_back({c.name, c.description});
     return items;
   };
-  hooks.modules = [cli]() {
+  hooks.modules = [this]() {
     std::vector<command_client::editor_module> items;
-    for (const client::module_info &m : cli->list_modules()) items.push_back({m.name, m.description, m.loaded, m.enabled});
+    for (const client::module_info &m : client->list_modules()) items.push_back({m.name, m.description, m.loaded, m.enabled});
     return items;
   };
-  hooks.all_modules = [cli]() {
+  hooks.all_modules = [this]() {
     std::vector<command_client::editor_module> items;
-    for (const client::module_info &m : cli->list_all_modules()) items.push_back({m.name, m.description, m.loaded, m.enabled});
+    for (const client::module_info &m : client->list_all_modules()) items.push_back({m.name, m.description, m.loaded, m.enabled});
     return items;
   };
-  hooks.parameters = [cli](const std::string &query) { return cli->list_parameters(query); };
+  hooks.parameters = [this](const std::string &query) { return client->list_parameters(query); };
   editor->install(hooks);
 
   std::vector<command_client::editor_item> builtins;

--- a/service/NSClient++.cpp
+++ b/service/NSClient++.cpp
@@ -527,13 +527,6 @@ void NSClientT::boot_fleet_sync() {
     config.hostname = socket_helpers::expand_hostname(
         reg_key("hostname", "Hostname", "Hostname reported as a tag to the fleet server. Set to auto (default) to use this machine's hostname.", "auto"));
     config.tls_version = reg_key("tls version", "TLS version", "The TLS version used when connecting to the fleet server.", "tlsv1.2+");
-    settings_manager::get_core()->register_key(0xffff, path, "require encrypted bundles", "bool", "Require encrypted bundles",
-                                               "Refuse to apply any bundle that is not sealed with a bundle encryption key held by this host "
-                                               "(`nscp enroll --bundle-key`). The posture for a fleet server that is not trusted with plaintext "
-                                               "configuration: nothing it sends is applied unless a key holder produced it.",
-                                               "false", true, false);
-    const std::string require_encrypted = settings_manager::get_settings()->get_string(path, "require encrypted bundles", "false");
-    config.require_encrypted_bundles = require_encrypted == "true" || require_encrypted == "1" || require_encrypted == "yes";
     const std::string timeout = reg_key("timeout", "Request timeout",
                                         "How long a single request to the fleet server may take before it is abandoned and retried. A server that "
                                         "accepts the connection and then stops responding would otherwise stall the sync loop indefinitely.",

--- a/service/NSClient++.cpp
+++ b/service/NSClient++.cpp
@@ -527,6 +527,13 @@ void NSClientT::boot_fleet_sync() {
     config.hostname = socket_helpers::expand_hostname(
         reg_key("hostname", "Hostname", "Hostname reported as a tag to the fleet server. Set to auto (default) to use this machine's hostname.", "auto"));
     config.tls_version = reg_key("tls version", "TLS version", "The TLS version used when connecting to the fleet server.", "tlsv1.2+");
+    settings_manager::get_core()->register_key(0xffff, path, "require encrypted bundles", "bool", "Require encrypted bundles",
+                                               "Refuse to apply any bundle that is not sealed with a bundle encryption key held by this host "
+                                               "(`nscp enroll --bundle-key`). The posture for a fleet server that is not trusted with plaintext "
+                                               "configuration: nothing it sends is applied unless a key holder produced it.",
+                                               "false", true, false);
+    const std::string require_encrypted = settings_manager::get_settings()->get_string(path, "require encrypted bundles", "false");
+    config.require_encrypted_bundles = require_encrypted == "true" || require_encrypted == "1" || require_encrypted == "yes";
     const std::string timeout = reg_key("timeout", "Request timeout",
                                         "How long a single request to the fleet server may take before it is abandoned and retried. A server that "
                                         "accepts the connection and then stops responding would otherwise stall the sync loop indefinitely.",

--- a/service/cli_parser.cpp
+++ b/service/cli_parser.cpp
@@ -15,6 +15,7 @@
 #include <pid_file.hpp>
 #endif
 #ifdef HAVE_ONBOARDING
+#include <onboarding/bundle_crypto.hpp>
 #include <onboarding/onboarding.hpp>
 #endif
 #include <boost/algorithm/string/predicate.hpp>
@@ -782,6 +783,8 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     std::string state_file;
     bool force = false;
     bool insecure = false;
+    std::vector<std::string> bundle_keys;
+    bool update_bundle_keys = false;
 
     po::options_description enroll_desc("Enrollment options");
     // clang-format off
@@ -798,6 +801,8 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       ("state-file", po::value<std::string>(&state_file), "Where to store the enrolled identity (default: " DEFAULT_FLEET_STATE_LOCATION ")")
       ("force", po::bool_switch(&force), "Overwrite an existing enrollment state file")
       ("insecure", po::bool_switch(&insecure), "Allow an unauthenticated enrollment: plain HTTP, or HTTPS with --verify none. Either way the fleet server is not authenticated, so an on-path attacker can read the bootstrap token and supply the trust anchors this agent will use from then on - only on a trusted network or for testing")
+      ("bundle-key", po::value<std::vector<std::string> >(&bundle_keys)->composing(), "Bundle encryption key, as the fleet server showed it once when the key was created (base64 of 32 bytes). Needed to open bundles the operator sealed in the browser; the server never sees it. Stored in the enrollment manifest, never sent anywhere. Repeat for several keys while rotating, newest first")
+      ("update-bundle-keys", po::bool_switch(&update_bundle_keys), "Do not enroll: replace the bundle keys stored in this host's existing enrollment manifest with the --bundle-key values (none to remove them all). No server contact, no token needed")
     ;
     // clang-format on
 
@@ -809,6 +814,52 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     po::notify(vm);
 
     if (process_common_options("enroll", all)) return 1;
+
+    // Check every key before anything else happens: a paste error found after
+    // the token has been spent is a bootstrap token wasted.
+    std::vector<std::string> key_fingerprints;
+    for (std::size_t i = 0; i < bundle_keys.size(); ++i) {
+      std::string raw_key, key_error;
+      if (!onboarding::parse_bundle_key(bundle_keys[i], raw_key, key_error)) {
+        std::cerr << "Invalid --bundle-key (" << (i + 1) << " of " << bundle_keys.size() << "): " << key_error << "." << std::endl;
+        std::cerr << "Paste the key exactly as the fleet server showed it when it was created (44 base64 characters)." << std::endl;
+        return 1;
+      }
+      key_fingerprints.push_back(onboarding::bundle_key_fingerprint(raw_key));
+    }
+    const auto describe_keys = [&key_fingerprints]() -> std::string {
+      if (key_fingerprints.empty()) return "none (only plain bundles can be applied)";
+      std::string out = str::xtos(key_fingerprints.size()) + " (fingerprint";
+      out += key_fingerprints.size() == 1 ? " " : "s ";
+      for (std::size_t i = 0; i < key_fingerprints.size(); ++i) out += (i ? ", " : "") + key_fingerprints[i];
+      return out + ")";
+    };
+
+    if (update_bundle_keys) {
+      // Key rotation on an enrolled host: the identity stays, only the keys
+      // change. Deliberately separate from --force, which burns a token and
+      // makes the server forget the host.
+      if (!core_->load_configuration_1()) {
+        std::cerr << "Failed to load configuration" << std::endl;
+        return 1;
+      }
+      if (state_file.empty()) state_file = DEFAULT_FLEET_STATE_LOCATION;
+      state_file = core_->get_path()->expand_path(state_file);
+      boost::optional<onboarding::enrolled_identity> current = onboarding::load_state(state_file);
+      if (!current) {
+        std::cerr << "This host is not enrolled (" << state_file << " does not exist): enroll first, passing --bundle-key along with --server and --token."
+                  << std::endl;
+        return 1;
+      }
+      onboarding::enrolled_identity updated = current.value();
+      updated.bundle_keys = bundle_keys;
+      onboarding::save_state(updated, state_file);
+      std::cout << "Bundle keys updated." << std::endl;
+      std::cout << "  Identity stored in: " << state_file << std::endl;
+      std::cout << "  Bundle keys:        " << describe_keys() << std::endl;
+      std::cout << "  The fleet sync picks them up on the next service start." << std::endl;
+      return 0;
+    }
 
     if (request.server_url.empty() || request.bootstrap_token.empty()) {
       std::cerr << "Both --server and --token are required." << std::endl;
@@ -884,7 +935,8 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     const bool created_state_dir = !state_dir.empty() && boost::filesystem::create_directories(state_dir, fs_error);
 
     std::cout << "Enrolling with " << request.server_url << "..." << std::endl;
-    const onboarding::enrolled_identity state = onboarding::enroll(request);
+    onboarding::enrolled_identity state = onboarding::enroll(request);
+    state.bundle_keys = bundle_keys;
     onboarding::save_state(state, state_file);
 
     // Enrollment is normally run with sudo while the service runs unprivileged,
@@ -907,6 +959,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     std::cout << "Enrollment successful." << std::endl;
     std::cout << "  Identity stored in: " << state_file << std::endl;
     std::cout << "  Agent API (mTLS):   " << state.mtls_url << std::endl;
+    std::cout << "  Bundle keys:        " << describe_keys() << std::endl;
 
     // The core starts the fleet sync automatically whenever the enrollment
     // manifest written above exists - no module to enable. Only the include

--- a/service/cli_parser.cpp
+++ b/service/cli_parser.cpp
@@ -785,6 +785,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     bool insecure = false;
     std::vector<std::string> bundle_keys;
     bool update_bundle_keys = false;
+    bool require_encrypted_bundles = false;
     bool unenroll = false;
 
     po::options_description enroll_desc("Enrollment options");
@@ -803,7 +804,8 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       ("force", po::bool_switch(&force), "Overwrite an existing enrollment state file")
       ("insecure", po::bool_switch(&insecure), "Allow an unauthenticated enrollment: plain HTTP, or HTTPS with --verify none. Either way the fleet server is not authenticated, so an on-path attacker can read the bootstrap token and supply the trust anchors this agent will use from then on - only on a trusted network or for testing")
       ("bundle-key", po::value<std::vector<std::string> >(&bundle_keys)->composing(), "Bundle encryption key, as the fleet server showed it once when the key was created (base64 of 32 bytes). Needed to open bundles the operator sealed in the browser; the server never sees it. Stored in the enrollment manifest, never sent anywhere. Repeat for several keys while rotating, newest first")
-      ("update-bundle-keys", po::bool_switch(&update_bundle_keys), "Do not enroll: replace the bundle keys stored in this host's existing enrollment manifest with the --bundle-key values (none to remove them all). No server contact, no token needed")
+      ("require-encrypted-bundles", po::bool_switch(&require_encrypted_bundles), "Refuse every bundle that is not sealed with one of the bundle keys, plain ones included: the posture for a fleet server not trusted with plaintext configuration. Stored in the enrollment manifest with the keys, so the server cannot switch it off")
+      ("update-bundle-keys", po::bool_switch(&update_bundle_keys), "Do not enroll: replace the bundle keys stored in this host's existing enrollment manifest with the --bundle-key values (none to remove them all), and the encrypted-bundle requirement with whether --require-encrypted-bundles is given. No server contact, no token needed")
       ("unenroll", po::bool_switch(&unenroll), "Leave the fleet: delete the enrollment manifest (identity and bundle keys), the fleet-managed configuration, scripts and bundle cache, and the [/includes] fleet entry. Nothing is sent to the server; remove the host there as well")
     ;
     // clang-format on
@@ -912,10 +914,12 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       }
       onboarding::enrolled_identity updated = current.value();
       updated.bundle_keys = bundle_keys;
+      updated.require_encrypted_bundles = require_encrypted_bundles;
       onboarding::save_state(updated, state_file);
       std::cout << "Bundle keys updated." << std::endl;
       std::cout << "  Identity stored in: " << state_file << std::endl;
       std::cout << "  Bundle keys:        " << describe_keys() << std::endl;
+      std::cout << "  Encrypted bundles:  " << (require_encrypted_bundles ? "required" : "not required") << std::endl;
       std::cout << "  The fleet sync picks them up on the next service start." << std::endl;
       return 0;
     }
@@ -996,6 +1000,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     std::cout << "Enrolling with " << request.server_url << "..." << std::endl;
     onboarding::enrolled_identity state = onboarding::enroll(request);
     state.bundle_keys = bundle_keys;
+    state.require_encrypted_bundles = require_encrypted_bundles;
     onboarding::save_state(state, state_file);
 
     // Enrollment is normally run with sudo while the service runs unprivileged,
@@ -1019,6 +1024,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     std::cout << "  Identity stored in: " << state_file << std::endl;
     std::cout << "  Agent API (mTLS):   " << state.mtls_url << std::endl;
     std::cout << "  Bundle keys:        " << describe_keys() << std::endl;
+    std::cout << "  Encrypted bundles:  " << (require_encrypted_bundles ? "required" : "not required") << std::endl;
 
     // The core starts the fleet sync automatically whenever the enrollment
     // manifest written above exists - no module to enable. Only the include

--- a/service/cli_parser.cpp
+++ b/service/cli_parser.cpp
@@ -800,7 +800,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       ("verify", po::value<std::string>(&request.verify_mode), "TLS verify mode (default: certificate). 'none' disables server verification and requires --insecure")
       ("retries", po::value<unsigned int>(&request.max_attempts)->default_value(3), "Attempts for transient failures (rate limiting, server errors)")
       ("timeout", po::value<unsigned int>(&request.timeout_seconds)->default_value(60), "Seconds a single read or write to the fleet server may take before the attempt is abandoned. 0 waits forever, which lets an unresponsive server block the command indefinitely")
-      ("state-file", po::value<std::string>(&state_file), "Where to store the enrolled identity (default: " DEFAULT_FLEET_STATE_LOCATION ")")
+      ("state-file", po::value<std::string>(&state_file), "Where to store the enrolled identity (default: the /settings/fleet 'state file' setting, normally " DEFAULT_FLEET_STATE_LOCATION ")")
       ("force", po::bool_switch(&force), "Overwrite an existing enrollment state file")
       ("insecure", po::bool_switch(&insecure), "Allow an unauthenticated enrollment: plain HTTP, or HTTPS with --verify none. Either way the fleet server is not authenticated, so an on-path attacker can read the bootstrap token and supply the trust anchors this agent will use from then on - only on a trusted network or for testing")
       ("bundle-key", po::value<std::vector<std::string> >(&bundle_keys)->composing(), "Bundle encryption key, as the fleet server showed it once when the key was created (base64 of 32 bytes). Needed to open bundles the operator sealed in the browser; the server never sees it. Stored in the enrollment manifest, never sent anywhere. Repeat for several keys while rotating, newest first")
@@ -839,6 +839,20 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       return out + ")";
     };
 
+    // The service reads the manifest path out of the settings
+    // (NSClientT::boot_fleet_sync), so every subcommand has to resolve it the
+    // same way: resolving it anywhere else means writing - or looking for - a
+    // manifest the service never reads. Call this only after
+    // load_configuration_1(), which is what makes the settings readable.
+    const auto resolve_state_file = [this, &state_file]() {
+      if (state_file.empty()) state_file = settings_manager::get_settings()->get_string("/settings/fleet", "state file", DEFAULT_FLEET_STATE_LOCATION);
+      // A key that is present but empty is not a path: get_string only falls
+      // back to the default when the key is absent, so do it here too rather
+      // than resolving the empty string against the current directory.
+      if (state_file.empty()) state_file = DEFAULT_FLEET_STATE_LOCATION;
+      state_file = core_->get_path()->expand_path(state_file);
+    };
+
     if (unenroll) {
       // The reverse of enrollment. The include goes first: saving the
       // settings also rewrites every included file, so the fleet directory
@@ -852,8 +866,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
           std::cerr << "Failed to load configuration" << std::endl;
           return 1;
         }
-        if (state_file.empty()) state_file = settings_manager::get_settings()->get_string("/settings/fleet", "state file", DEFAULT_FLEET_STATE_LOCATION);
-        state_file = core_->get_path()->expand_path(state_file);
+        resolve_state_file();
         const std::string managed_path =
             core_->get_path()->expand_path(settings_manager::get_settings()->get_string("/settings/fleet", "managed path", "${" FLEET_FOLDER_KEY "}"));
         bool removed_any = false;
@@ -904,8 +917,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
         std::cerr << "Failed to load configuration" << std::endl;
         return 1;
       }
-      if (state_file.empty()) state_file = DEFAULT_FLEET_STATE_LOCATION;
-      state_file = core_->get_path()->expand_path(state_file);
+      resolve_state_file();
       boost::optional<onboarding::enrolled_identity> current = onboarding::load_state(state_file);
       if (!current) {
         std::cerr << "This host is not enrolled (" << state_file << " does not exist): enroll first, passing --bundle-key along with --server and --token."
@@ -953,8 +965,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       std::cerr << "Failed to load configuration" << std::endl;
       return 1;
     }
-    if (state_file.empty()) state_file = DEFAULT_FLEET_STATE_LOCATION;
-    state_file = core_->get_path()->expand_path(state_file);
+    resolve_state_file();
 
     // Enrollment is where this agent decides who the fleet server is: the
     // response carries the certificate every later call pins against and the

--- a/service/cli_parser.cpp
+++ b/service/cli_parser.cpp
@@ -785,6 +785,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
     bool insecure = false;
     std::vector<std::string> bundle_keys;
     bool update_bundle_keys = false;
+    bool unenroll = false;
 
     po::options_description enroll_desc("Enrollment options");
     // clang-format off
@@ -803,6 +804,7 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       ("insecure", po::bool_switch(&insecure), "Allow an unauthenticated enrollment: plain HTTP, or HTTPS with --verify none. Either way the fleet server is not authenticated, so an on-path attacker can read the bootstrap token and supply the trust anchors this agent will use from then on - only on a trusted network or for testing")
       ("bundle-key", po::value<std::vector<std::string> >(&bundle_keys)->composing(), "Bundle encryption key, as the fleet server showed it once when the key was created (base64 of 32 bytes). Needed to open bundles the operator sealed in the browser; the server never sees it. Stored in the enrollment manifest, never sent anywhere. Repeat for several keys while rotating, newest first")
       ("update-bundle-keys", po::bool_switch(&update_bundle_keys), "Do not enroll: replace the bundle keys stored in this host's existing enrollment manifest with the --bundle-key values (none to remove them all). No server contact, no token needed")
+      ("unenroll", po::bool_switch(&unenroll), "Leave the fleet: delete the enrollment manifest (identity and bundle keys), the fleet-managed configuration, scripts and bundle cache, and the [/includes] fleet entry. Nothing is sent to the server; remove the host there as well")
     ;
     // clang-format on
 
@@ -834,6 +836,63 @@ int cli_parser::parse_enroll(int argc, char *argv[]) {
       for (std::size_t i = 0; i < key_fingerprints.size(); ++i) out += (i ? ", " : "") + key_fingerprints[i];
       return out + ")";
     };
+
+    if (unenroll) {
+      // The reverse of enrollment. The include goes first: saving the
+      // settings also rewrites every included file, so the fleet directory
+      // must still exist at that point. Then the manifest (which is what
+      // makes the core start the sync at boot) and the directory the sync
+      // writes into. Each step is reported so a partial cleanup is visible,
+      // and a host that was never enrolled is not an error - there is simply
+      // nothing to remove.
+      try {
+        if (!core_->load_configuration_1()) {
+          std::cerr << "Failed to load configuration" << std::endl;
+          return 1;
+        }
+        if (state_file.empty()) state_file = settings_manager::get_settings()->get_string("/settings/fleet", "state file", DEFAULT_FLEET_STATE_LOCATION);
+        state_file = core_->get_path()->expand_path(state_file);
+        const std::string managed_path =
+            core_->get_path()->expand_path(settings_manager::get_settings()->get_string("/settings/fleet", "managed path", "${" FLEET_FOLDER_KEY "}"));
+        bool removed_any = false;
+        if (!settings_manager::get_settings()->get_string("/includes", "fleet", "").empty()) {
+          settings_manager::get_settings()->remove_key("/includes", "fleet");
+          settings_manager::get_settings()->save(false);
+          std::cout << "  Removed the [/includes] fleet entry from " << settings_manager::get_settings()->get_context() << std::endl;
+          removed_any = true;
+        }
+        boost::system::error_code remove_error;
+        if (boost::filesystem::exists(state_file, remove_error)) {
+          boost::filesystem::remove(state_file, remove_error);
+          if (remove_error) {
+            std::cerr << "Failed to remove the enrollment manifest " << state_file << ": " << remove_error.message() << std::endl;
+            return 1;
+          }
+          std::cout << "  Removed the identity and bundle keys: " << state_file << std::endl;
+          removed_any = true;
+        }
+        if (!managed_path.empty() && boost::filesystem::exists(managed_path, remove_error)) {
+          boost::filesystem::remove_all(managed_path, remove_error);
+          if (remove_error) {
+            std::cerr << "Failed to remove the fleet-managed configuration " << managed_path << ": " << remove_error.message() << std::endl;
+            return 1;
+          }
+          std::cout << "  Removed the fleet-managed configuration, scripts and bundle cache: " << managed_path << std::endl;
+          removed_any = true;
+        }
+        if (!removed_any) {
+          std::cout << "This host is not enrolled: nothing to remove." << std::endl;
+          return 0;
+        }
+        std::cout << "Unenrolled." << std::endl;
+        std::cout << "  Restart the service so it stops syncing; the sync loop is only started at boot when the manifest exists." << std::endl;
+        std::cout << "  The fleet server still lists this host: remove it there too. Its certificate is no longer used by anything." << std::endl;
+        return 0;
+      } catch (const std::exception &e) {
+        std::cerr << "Unenroll failed: " << utf8::utf8_from_native(e.what()) << std::endl;
+        return 1;
+      }
+    }
 
     if (update_bundle_keys) {
       // Key rotation on an enrolled host: the identity stays, only the keys

--- a/service/fleet_sync.cpp
+++ b/service/fleet_sync.cpp
@@ -497,7 +497,7 @@ bool fleet_sync::apply_state(const onboarding::desired_state &state, std::vector
       // what the signature covers); the plaintext zip only exists in staging
       // while this apply runs.
       std::string plaintext, open_error;
-      if (!onboarding::open_bundle(identity_.bundle_keys, bundle.name, bundle.version, bytes, config_.require_encrypted_bundles, plaintext, open_error)) {
+      if (!onboarding::open_bundle(identity_.bundle_keys, bundle.name, bundle.version, bytes, identity_.require_encrypted_bundles, plaintext, open_error)) {
         errors.push_back("Bundle " + bundle.id + ": " + open_error);
         return false;
       }
@@ -722,7 +722,7 @@ void fleet_sync::run() {
       fingerprints += onboarding::parse_bundle_key(key, raw, key_error) ? onboarding::bundle_key_fingerprint(raw) : "(invalid)";
     }
     log_debug("Bundle encryption keys configured: " + fingerprints);
-  } else if (config_.require_encrypted_bundles) {
+  } else if (identity_.require_encrypted_bundles) {
     log_error(
         "Encrypted bundles are required but this host holds no bundle key: nothing the fleet server sends can be applied (add one with "
         "`nscp enroll --bundle-key`)");

--- a/service/fleet_sync.cpp
+++ b/service/fleet_sync.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <iomanip>
 #include <net/http/client.hpp>
+#include <onboarding/bundle_crypto.hpp>
 #include <random>
 #include <sstream>
 #include <str/utf8.hpp>
@@ -458,6 +459,17 @@ bool fleet_sync::apply_state(const onboarding::desired_state &state, std::vector
   const fs::path managed(config_.managed_path);
   const fs::path staging = managed / "staging";
   std::vector<onboarding::installed_bundle> new_installed;
+  std::vector<fs::path> unsealed_archives;
+  // Whichever way this function leaves - swapped in, refused, or thrown out
+  // of - the unsealed plaintext goes with it. Every reader lives inside its
+  // loop iteration, so nothing holds the files open by then.
+  struct remove_on_exit {
+    std::vector<fs::path> &paths;
+    ~remove_on_exit() {
+      boost::system::error_code ignored_remove;
+      for (const fs::path &path : paths) fs::remove(path, ignored_remove);
+    }
+  } remove_unsealed{unsealed_archives};
   try {
     boost::system::error_code ignored;
     fs::remove_all(staging, ignored);
@@ -480,9 +492,25 @@ bool fleet_sync::apply_state(const onboarding::desired_state &state, std::vector
         return false;
       }
 
-      // The unzip reader is file-based; the verified cache file is the source.
+      // What was downloaded and verified may be a sealed envelope: open it
+      // with the key this host holds. The envelope stays in the cache (it is
+      // what the signature covers); the plaintext zip only exists in staging
+      // while this apply runs.
+      std::string plaintext, open_error;
+      if (!onboarding::open_bundle(identity_.bundle_keys, bundle.name, bundle.version, bytes, config_.require_encrypted_bundles, plaintext, open_error)) {
+        errors.push_back("Bundle " + bundle.id + ": " + open_error);
+        return false;
+      }
+      const bool sealed = onboarding::is_encrypted_bundle(bytes);
       const fs::path cached = managed / "cache" / (bundle.id + "-" + bundle.sha256.substr(0, 16) + ".zip");
-      bytes::unzip::reader reader(cached.string());
+      const fs::path unsealed = staging / (bundle.id + ".unsealed.zip");
+      if (sealed) {
+        write_file(unsealed, plaintext);
+        unsealed_archives.push_back(unsealed);
+      }
+      // The unzip reader is file-based: the verified cache file, or the
+      // plaintext just unsealed from it, is the source.
+      bytes::unzip::reader reader(sealed ? unsealed.string() : cached.string());
       if (!reader.is_open()) {
         errors.push_back("Bundle " + bundle.id + " is not a readable zip archive");
         return false;
@@ -683,6 +711,22 @@ void fleet_sync::run() {
   }
   identity_ = loaded.value();
   while (!identity_.mtls_url.empty() && identity_.mtls_url.back() == '/') identity_.mtls_url.pop_back();
+  // Fingerprints only: they are what the fleet server shows for a key, so an
+  // operator can see at a glance whether this host holds the key the bundles
+  // are sealed with. The key itself is never logged.
+  if (!identity_.bundle_keys.empty()) {
+    std::string fingerprints;
+    for (const std::string &key : identity_.bundle_keys) {
+      std::string raw, key_error;
+      if (!fingerprints.empty()) fingerprints += ", ";
+      fingerprints += onboarding::parse_bundle_key(key, raw, key_error) ? onboarding::bundle_key_fingerprint(raw) : "(invalid)";
+    }
+    log_debug("Bundle encryption keys configured: " + fingerprints);
+  } else if (config_.require_encrypted_bundles) {
+    log_error(
+        "Encrypted bundles are required but this host holds no bundle key: nothing the fleet server sends can be applied (add one with "
+        "`nscp enroll --bundle-key`)");
+  }
   fs::create_directories(fs::path(config_.managed_path));
   load_applied_state();
   recover_interrupted_apply();

--- a/service/fleet_sync.hpp
+++ b/service/fleet_sync.hpp
@@ -28,9 +28,6 @@ struct fleet_config {
   // accepts the connection and then stops responding would otherwise block the
   // sync thread for good - the host would stay enrolled but stop being managed.
   unsigned int timeout_seconds = 60;
-  // Refuse any bundle that is not a sealed envelope: the posture for a fleet
-  // server that is not trusted with plaintext configuration. Off by default.
-  bool require_encrypted_bundles = false;
   // Answers "does this host carry local configuration that outranks what we
   // send it?" for the state report. A callback rather than a captured bool
   // because the sync outlives configuration reloads - including the ones it

--- a/service/fleet_sync.hpp
+++ b/service/fleet_sync.hpp
@@ -28,6 +28,9 @@ struct fleet_config {
   // accepts the connection and then stops responding would otherwise block the
   // sync thread for good - the host would stay enrolled but stop being managed.
   unsigned int timeout_seconds = 60;
+  // Refuse any bundle that is not a sealed envelope: the posture for a fleet
+  // server that is not trusted with plaintext configuration. Off by default.
+  bool require_encrypted_bundles = false;
   // Answers "does this host carry local configuration that outranks what we
   // send it?" for the state report. A callback rather than a captured bool
   // because the sync outlives configuration reloads - including the ones it

--- a/tests/command-client-console.test.ts
+++ b/tests/command-client-console.test.ts
@@ -79,6 +79,27 @@ describe("nscp test console", () => {
     expect(out).not.toContain("/settings/cli/history file=");
   });
 
+  it("settings masks keys their module registered as sensitive", async () => {
+    // The dump ends up in tickets and chat windows. A key registered with
+    // add_password (here the script object's run-as password) must print as
+    // "***", the same masking the REST read paths and `nscp settings --list`
+    // apply. Unloaded modules cannot register anything, so only keys a loaded
+    // module declared sensitive are covered - the same contract as REST.
+    await nscp.configure({
+      "/modules": { CheckExternalScripts: "enabled" },
+      "/settings/external scripts/scripts": { secretive: "cmd /c echo hi" },
+      "/settings/external scripts/scripts/secretive": { user: "someone", password: "hunter2" },
+    });
+    try {
+      const out = await runConsole("settings\nexit\n");
+      expect(out).toContain("/settings/external scripts/scripts/secretive/password=***");
+      expect(out).toContain("/settings/external scripts/scripts/secretive/user=someone");
+      expect(out).not.toContain("hunter2");
+    } finally {
+      await nscp.configure({ "/modules": { CheckExternalScripts: "disabled" } });
+    }
+  });
+
   it("describes a query and its parameters", async () => {
     const out = await runConsole("desc check_ok\nexit\n");
     expect(out).toContain("check_ok");

--- a/tests/command-client-console.test.ts
+++ b/tests/command-client-console.test.ts
@@ -65,6 +65,20 @@ describe("nscp test console", () => {
     expect(out).toContain("check_ok");
   });
 
+  it("settings shows what is configured, not every registered key", async () => {
+    // The dump used to come from the registry: every key any loaded module
+    // declares, nearly all of them printed as a bare `key=` because nothing
+    // set them. Now it walks the settings store, so only what the
+    // configuration actually says is listed.
+    await nscp.configure({ "/settings/log": { level: "info" } });
+    const out = await runConsole("settings\nexit\n");
+    expect(out).toContain("/modules/CheckHelpers=enabled");
+    expect(out).toContain("/settings/log/level=info");
+    // Registered by CommandClient itself and never set: must not appear.
+    expect(out).not.toContain("/settings/cli/color=");
+    expect(out).not.toContain("/settings/cli/history file=");
+  });
+
   it("describes a query and its parameters", async () => {
     const out = await runConsole("desc check_ok\nexit\n");
     expect(out).toContain("check_ok");

--- a/tests/command-client-console.test.ts
+++ b/tests/command-client-console.test.ts
@@ -18,6 +18,7 @@
  *     agent is normally started under a supervisor — and how every other suite
  *     in this directory runs it.
  */
+import execa from "execa";
 import { NscpInstance } from "@fixtures/index";
 
 jest.setTimeout(120_000);
@@ -68,6 +69,45 @@ describe("nscp test console", () => {
     const out = await runConsole("desc check_ok\nexit\n");
     expect(out).toContain("check_ok");
     expect(out).toMatch(/Parameters/i);
+  });
+
+  it("keeps running commands after a module reload", async () => {
+    // A settings reload re-enters CommandClient::loadModuleEx on the live
+    // module while the console is up. It used to replace the client object
+    // the console was built on, leaving the prompt's completion hooks with a
+    // freed pointer: the first refresh after a reload - a fleet configuration
+    // push being what hit it - took the process down. The completion hooks
+    // only exist with a terminal and cannot be driven through a pipe, so this
+    // pins the half that can be: the reload lands while the console is
+    // running, and what is typed afterwards still runs on an intact client.
+    const overrides: string[] = [];
+    for (const [k, v] of Object.entries(nscp.pathOverrides))
+      overrides.push("--path-override", `${k}=${v}`);
+    const proc = execa(
+      process.env.NSCP_BIN as string,
+      ["test", "--settings", nscp.settingsFile, ...overrides],
+      {
+        cwd: nscp.workDir,
+        all: true,
+        timeout: 60_000,
+        reject: false,
+        env: process.env,
+      },
+    );
+    const stdin = proc.stdin;
+    if (!stdin) throw new Error("no stdin pipe");
+    stdin.write("reload\n");
+    // The reload is queued ("delayed,service") and runs on a core thread a
+    // moment later; give it time to complete before typing the next command
+    // so that command really does run after loadModuleEx has been re-entered.
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+    stdin.write("check_ok message=after-reload\nexit\n");
+    stdin.end();
+    const r = await proc;
+    const out = r.all ?? `${r.stdout}\n${r.stderr}`;
+    expect(out).toContain("after-reload");
+    expect(r.timedOut).toBe(false);
+    expect(r.exitCode).toBe(0);
   });
 
   it("exits on the exit command instead of running to the timeout", async () => {

--- a/tests/enroll-cli.test.ts
+++ b/tests/enroll-cli.test.ts
@@ -114,6 +114,71 @@ describe("nscp enroll (fleet onboarding CLI)", () => {
     expect(state.server_url).toBe(baseUrl);
   });
 
+  // A bundle encryption key in operator form: base64 of 32 bytes.
+  const bundleKey = Buffer.from(Array.from({ length: 32 }, (_, i) => i)).toString("base64");
+  const otherKey = Buffer.alloc(32, "k").toString("base64");
+  // First 8 bytes of SHA-256 over the raw key, as the fleet server shows it.
+  const pinnedFingerprint = "630dcd2966c43366";
+
+  it("stores --bundle-key in the manifest and reports its fingerprint", async () => {
+    const stateFile = path.join(nscp.scratch("enroll_bundle_key"), "agent-state.json");
+    const r = await enroll(["--state-file", stateFile, "--bundle-key", bundleKey]);
+    expect(r.exitCode).toBe(0);
+    const out = r.all ?? `${r.stdout}${r.stderr}`;
+    expect(out).toContain(`Bundle keys:        1 (fingerprint ${pinnedFingerprint})`);
+    expect(out).not.toContain(bundleKey);
+    expect(readState(stateFile).bundle_keys).toEqual([bundleKey]);
+    // The key never goes to the server.
+    expect(JSON.stringify(requests)).not.toContain(bundleKey);
+  });
+
+  it("keeps several --bundle-key values in the order given", async () => {
+    const stateFile = path.join(nscp.scratch("enroll_bundle_keys"), "agent-state.json");
+    const r = await enroll(["--state-file", stateFile, "--bundle-key", bundleKey, "--bundle-key", otherKey]);
+    expect(r.exitCode).toBe(0);
+    expect(readState(stateFile).bundle_keys).toEqual([bundleKey, otherKey]);
+  });
+
+  it("rejects a malformed --bundle-key before spending the token", async () => {
+    const stateFile = path.join(nscp.scratch("enroll_bad_key"), "agent-state.json");
+    const r = await enroll(["--state-file", stateFile, "--bundle-key", "not-a-key"]);
+    expect(r.exitCode).toBe(1);
+    expect(r.all ?? r.stderr).toMatch(/Invalid --bundle-key/);
+    expect(requests).toEqual([]);
+    expect(fs.existsSync(stateFile)).toBe(false);
+  });
+
+  it("rotates keys on an enrolled host with --update-bundle-keys, without a server", async () => {
+    const stateFile = path.join(nscp.scratch("enroll_rotate"), "agent-state.json");
+    expect((await enroll(["--state-file", stateFile, "--bundle-key", bundleKey])).exitCode).toBe(0);
+    const before = readState(stateFile);
+    requests = [];
+
+    const r = await nscp.run(["enroll", "--update-bundle-keys", "--state-file", stateFile, "--bundle-key", otherKey, "--bundle-key", bundleKey], {
+      allowFailure: true,
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.all ?? r.stdout).toContain("Bundle keys updated.");
+    expect(requests).toEqual([]);
+    const after = readState(stateFile);
+    expect(after.bundle_keys).toEqual([otherKey, bundleKey]);
+    // Only the keys changed: the identity is untouched.
+    expect(after.private_key_pem).toBe(before.private_key_pem);
+    expect(after.cert_pem).toBe(before.cert_pem);
+
+    // No keys at all removes them.
+    expect((await nscp.run(["enroll", "--update-bundle-keys", "--state-file", stateFile], { allowFailure: true })).exitCode).toBe(0);
+    expect(readState(stateFile).bundle_keys).toEqual([]);
+  });
+
+  it("refuses --update-bundle-keys on a host that is not enrolled", async () => {
+    const stateFile = path.join(nscp.scratch("enroll_rotate_none"), "agent-state.json");
+    const r = await nscp.run(["enroll", "--update-bundle-keys", "--state-file", stateFile, "--bundle-key", bundleKey], { allowFailure: true });
+    expect(r.exitCode).toBe(1);
+    expect(r.all ?? r.stderr).toMatch(/not enrolled/);
+    expect(fs.existsSync(stateFile)).toBe(false);
+  });
+
   it("passes --hostname and --os through to the enrollment request", async () => {
     const stateFile = path.join(nscp.scratch("enroll_tags"), "agent-state.json");
     const r = await enroll(["--state-file", stateFile, "--hostname", "web-01", "--os", "linux"]);

--- a/tests/enroll-cli.test.ts
+++ b/tests/enroll-cli.test.ts
@@ -407,6 +407,41 @@ describe("nscp enroll (fleet onboarding CLI)", () => {
     fs.rmSync(dir, { recursive: true, force: true });
   });
 
+  it("--unenroll removes the manifest, the fleet directory and the include", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "nscp-unenroll-"));
+    const own = new NscpInstance({ workDir: dir, pathOverrides: { "shared-path": dir } });
+    const bundleKeyB64 = Buffer.alloc(32, "u").toString("base64");
+    expect((await own.run(["enroll", "--server", baseUrl, "--token", "tok-1", "--insecure", "--bundle-key", bundleKeyB64], { allowFailure: true })).exitCode).toBe(0);
+    const manifest = path.join(dir, "security", "agent-state.json");
+    expect(fs.existsSync(manifest)).toBe(true);
+    // Something the sync would have written, to prove the whole directory goes.
+    fs.mkdirSync(path.join(dir, "fleet", "scripts", "demo"), { recursive: true });
+    fs.writeFileSync(path.join(dir, "fleet", "scripts", "demo", "x.txt"), "x");
+    fs.writeFileSync(path.join(dir, "fleet", "applied-state.json"), "{}");
+    requests = [];
+
+    const r = await own.run(["enroll", "--unenroll"], { allowFailure: true });
+    expect(r.exitCode).toBe(0);
+    const out = r.all ?? `${r.stdout}${r.stderr}`;
+    expect(out).toContain("Unenrolled.");
+    expect(out).toContain("Removed the identity and bundle keys");
+    expect(out).toContain("Removed the fleet-managed configuration");
+    expect(out).toContain("Removed the [/includes] fleet entry");
+    expect(fs.existsSync(manifest)).toBe(false);
+    expect(fs.existsSync(path.join(dir, "fleet"))).toBe(false);
+    const ini = fs.readFileSync(own.settingsFile, "utf8");
+    expect(ini).not.toMatch(/fleet\s*=/);
+    expect(ini).not.toContain("fleet.ini");
+    // Nothing goes to the server: leaving is a local act.
+    expect(requests).toEqual([]);
+
+    // A second run has nothing to do and says so, without failing.
+    const again = await own.run(["enroll", "--unenroll"], { allowFailure: true });
+    expect(again.exitCode).toBe(0);
+    expect(again.all ?? again.stdout).toContain("not enrolled: nothing to remove");
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
   // A local key beats the included fleet.ini: a lookup reads the local store
   // first and only falls back to an include when the key is absent. Silently
   // ignoring a fleet setting is a miserable thing to debug, so enrollment says

--- a/tests/enroll-cli.test.ts
+++ b/tests/enroll-cli.test.ts
@@ -128,8 +128,20 @@ describe("nscp enroll (fleet onboarding CLI)", () => {
     expect(out).toContain(`Bundle keys:        1 (fingerprint ${pinnedFingerprint})`);
     expect(out).not.toContain(bundleKey);
     expect(readState(stateFile).bundle_keys).toEqual([bundleKey]);
+    expect(readState(stateFile).require_encrypted_bundles).toBe(false);
+    expect(out).toContain("Encrypted bundles:  not required");
     // The key never goes to the server.
     expect(JSON.stringify(requests)).not.toContain(bundleKey);
+  });
+
+  it("stores --require-encrypted-bundles in the manifest, out of the server's reach", async () => {
+    const stateFile = path.join(nscp.scratch("enroll_require"), "agent-state.json");
+    const r = await enroll(["--state-file", stateFile, "--bundle-key", bundleKey, "--require-encrypted-bundles"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.all ?? r.stdout).toContain("Encrypted bundles:  required");
+    expect(readState(stateFile).require_encrypted_bundles).toBe(true);
+    // Not a setting: nothing the fleet-managed include could override.
+    expect(fs.readFileSync(nscp.settingsFile, "utf8")).not.toMatch(/require encrypted/);
   });
 
   it("keeps several --bundle-key values in the order given", async () => {
@@ -162,13 +174,22 @@ describe("nscp enroll (fleet onboarding CLI)", () => {
     expect(requests).toEqual([]);
     const after = readState(stateFile);
     expect(after.bundle_keys).toEqual([otherKey, bundleKey]);
+    expect(after.require_encrypted_bundles).toBe(false);
     // Only the keys changed: the identity is untouched.
     expect(after.private_key_pem).toBe(before.private_key_pem);
     expect(after.cert_pem).toBe(before.cert_pem);
 
-    // No keys at all removes them.
+    // The requirement travels with the update: given, it is on; omitted, off.
+    const required = await nscp.run(["enroll", "--update-bundle-keys", "--state-file", stateFile, "--bundle-key", bundleKey, "--require-encrypted-bundles"], {
+      allowFailure: true,
+    });
+    expect(required.exitCode).toBe(0);
+    expect(readState(stateFile).require_encrypted_bundles).toBe(true);
+
+    // No keys at all removes them, and the requirement with them.
     expect((await nscp.run(["enroll", "--update-bundle-keys", "--state-file", stateFile], { allowFailure: true })).exitCode).toBe(0);
     expect(readState(stateFile).bundle_keys).toEqual([]);
+    expect(readState(stateFile).require_encrypted_bundles).toBe(false);
   });
 
   it("refuses --update-bundle-keys on a host that is not enrolled", async () => {

--- a/tests/enroll-cli.test.ts
+++ b/tests/enroll-cli.test.ts
@@ -200,6 +200,33 @@ describe("nscp enroll (fleet onboarding CLI)", () => {
     expect(fs.existsSync(stateFile)).toBe(false);
   });
 
+  it("resolves the state file from the /settings/fleet setting the service reads", async () => {
+    // The service takes the manifest path from [/settings/fleet] state file
+    // (NSClientT::boot_fleet_sync), so enroll and --update-bundle-keys have to
+    // read the same key: resolving the default anywhere else writes a manifest
+    // the service never looks at. Own instance, so the setting does not leak
+    // into the rest of the suite.
+    const other = new NscpInstance();
+    const configured = path.join(other.scratch("fleet_state"), "configured-state.json");
+    await other.configure({ "/settings/fleet": { "state file": configured } });
+
+    const args = ["--server", baseUrl, "--token", "tok-1", "--insecure", "--bundle-key", bundleKey];
+    const enrolled = await other.run(["enroll", ...args], { allowFailure: true });
+    expect(enrolled.exitCode).toBe(0);
+    expect(fs.existsSync(configured)).toBe(true);
+    expect(readState(configured).cert_pem).toBe("CERT");
+    // Nothing was written to the built-in default location instead.
+    const fallback = path.join(other.pathOverrides["data-path"], "security", "agent-state.json");
+    expect(fs.existsSync(fallback)).toBe(false);
+
+    // The rotation path finds that same manifest without --state-file.
+    const rotated = await other.run(["enroll", "--update-bundle-keys", "--bundle-key", otherKey], {
+      allowFailure: true,
+    });
+    expect(rotated.exitCode).toBe(0);
+    expect(readState(configured).bundle_keys).toEqual([otherKey]);
+  });
+
   it("passes --hostname and --os through to the enrollment request", async () => {
     const stateFile = path.join(nscp.scratch("enroll_tags"), "agent-state.json");
     const r = await enroll(["--state-file", stateFile, "--hostname", "web-01", "--os", "linux"]);

--- a/tests/fleet-sync-encrypted.test.ts
+++ b/tests/fleet-sync-encrypted.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Encrypted fleet bundles ("enc-v1") end to end.
+ *
+ * The operator seals a bundle in the browser before uploading it, so the fleet
+ * server only ever stores and serves an NSEB1 envelope:
+ *
+ *   "NSEB1" | key fingerprint (8) | nonce (12) | AES-256-GCM ciphertext | tag (16)
+ *
+ * with `name || 0x00 || version` as the additional data. The key reaches the
+ * agent out of band (`nscp enroll --bundle-key`), never from the server. The
+ * server's SHA-256 and Ed25519 signature cover the envelope, so the download
+ * checks are unchanged and decryption is a step after them.
+ *
+ * Under test: a sealed bundle is opened and applied when the host holds the
+ * key; the plaintext never lands in the cache (only the envelope does); a
+ * bundle served under another name is refused, as is one sealed with a key
+ * this host does not hold; `require encrypted bundles` refuses a plain one.
+ * The envelope is built with node's own AES-GCM, an implementation
+ * independent of the agent's.
+ */
+import http from "http";
+import { AddressInfo } from "net";
+import crypto from "crypto";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { NscpInstance, makeZip, signBundle, makeCertPem } from "@fixtures/index";
+
+jest.setTimeout(180_000);
+
+interface SeenRequest {
+  method: string;
+  url: string;
+  body: any;
+}
+
+/** Seal `plaintext` exactly the way the fleet server's browser code does. */
+function seal(key: Buffer, name: string, version: string, plaintext: Buffer): Buffer {
+  const nonce = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv("aes-256-gcm", key, nonce);
+  cipher.setAAD(
+    Buffer.concat([Buffer.from(name, "utf8"), Buffer.from([0]), Buffer.from(version, "utf8")]),
+  );
+  const ct = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const fingerprint = crypto.createHash("sha256").update(key).digest().subarray(0, 8);
+  return Buffer.concat([
+    Buffer.from("NSEB1", "ascii"),
+    fingerprint,
+    nonce,
+    ct,
+    cipher.getAuthTag(),
+  ]);
+}
+
+describe("encrypted fleet bundles", () => {
+  let nscp: NscpInstance;
+  let workDir: string;
+  let server: http.Server;
+  let baseUrl: string;
+  let requests: SeenRequest[];
+
+  const signingKeys = crypto.generateKeyPairSync("ed25519");
+  const signingPubPem = signingKeys.publicKey.export({ type: "spki", format: "pem" }).toString();
+  const agentCertPem = makeCertPem(90);
+
+  const bundleKey = crypto.randomBytes(32);
+  const otherKey = crypto.randomBytes(32);
+  const fingerprintOf = (key: Buffer) =>
+    crypto.createHash("sha256").update(key).digest().subarray(0, 8).toString("hex");
+
+  const secretZip = makeZip([
+    { name: "bundle.toml", data: 'name = "sealed"\nversion = "1.0"\n' },
+    {
+      name: "config.json",
+      data: JSON.stringify({
+        modules: { CheckHelpers: "enabled" },
+        settings: { "fleet sealed": { "api token": "hunter2-sealed-value" } },
+      }),
+    },
+    { name: "scripts/sealed/secret.txt", data: "sealed script body\n" },
+  ]);
+  const sealedGood = seal(bundleKey, "sealed", "1.0", secretZip);
+  const sealedOther = seal(otherKey, "foreign", "1.0", secretZip);
+  const plainZip = makeZip([
+    { name: "bundle.toml", data: 'name = "plain"\nversion = "1.0"\n' },
+    { name: "config.json", data: JSON.stringify({ modules: { CheckHelpers: "enabled" } }) },
+  ]);
+
+  const sha = (b: Buffer) => crypto.createHash("sha256").update(b).digest("hex");
+
+  let phase: "sealed" | "relabelled" | "foreign" | "plain" | "plain-required";
+
+  function desiredStateFor(currentHash: string | null): { code: number; body: any } {
+    const entry = (id: string, name: string, version: string, bytes: Buffer, format: string) => ({
+      id,
+      name,
+      version,
+      sha256: sha(bytes),
+      signature: signBundle(signingKeys.privateKey, bytes),
+      url: `/agent/v1/bundles/${id}`,
+      priority: 100,
+      format,
+    });
+    const states = {
+      sealed: {
+        state_hash: "h-sealed",
+        bundles: [entry("b-sealed", "sealed", "1.0", sealedGood, "enc-v1")],
+      },
+      // Same envelope, same signature, but the server claims another version:
+      // the additional data no longer matches and the seal must not open.
+      relabelled: {
+        state_hash: "h-relabelled",
+        bundles: [entry("b-relabelled", "sealed", "2.0", sealedGood, "enc-v1")],
+      },
+      foreign: {
+        state_hash: "h-foreign",
+        bundles: [entry("b-foreign", "foreign", "1.0", sealedOther, "enc-v1")],
+      },
+      plain: {
+        state_hash: "h-plain",
+        bundles: [entry("b-plain", "plain", "1.0", plainZip, "plain")],
+      },
+      // The same plain bundle under a new hash, so a restarted agent that has
+      // already applied h-plain gets it offered again rather than a 304.
+      "plain-required": {
+        state_hash: "h-plain-required",
+        bundles: [entry("b-plain", "plain", "1.0", plainZip, "plain")],
+      },
+    };
+    const active = { next_poll_in_seconds: 1, merged_config_json: {}, ...states[phase] };
+    if (currentHash === active.state_hash) return { code: 304, body: { next_poll_in_seconds: 1 } };
+    return { code: 200, body: active };
+  }
+
+  beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "nscp-fleet-enc-"));
+    nscp = new NscpInstance({ workDir, pathOverrides: { "shared-path": workDir } });
+    requests = [];
+    phase = "sealed";
+    server = http.createServer((req, res) => {
+      let raw = "";
+      req.on("data", (chunk) => (raw += chunk));
+      req.on("end", () => {
+        let body: any = raw;
+        try {
+          body = JSON.parse(raw);
+        } catch {
+          /* keep raw */
+        }
+        requests.push({ method: req.method ?? "", url: req.url ?? "", body });
+        const parsed = new URL(req.url ?? "/", "http://x");
+        const bundles: Record<string, Buffer> = {
+          "/agent/v1/bundles/b-sealed": sealedGood,
+          "/agent/v1/bundles/b-relabelled": sealedGood,
+          "/agent/v1/bundles/b-foreign": sealedOther,
+          "/agent/v1/bundles/b-plain": plainZip,
+        };
+        if (req.method === "POST" && parsed.pathname === "/enroll/v1") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              cert_pem: agentCertPem,
+              ca_pem: "CA-PEM",
+              bundle_signing_pub_pem: signingPubPem,
+              server_url: baseUrl,
+              mtls_url: baseUrl,
+              mtls_server_cert_pem: "MTLS-PIN",
+            }),
+          );
+        } else if (parsed.pathname === "/agent/v1/heartbeat") {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end("{}");
+        } else if (parsed.pathname === "/agent/v1/desired-state") {
+          const r = desiredStateFor(parsed.searchParams.get("current_hash"));
+          res.writeHead(r.code, { "Content-Type": "application/json" });
+          res.end(JSON.stringify(r.body));
+        } else if (bundles[parsed.pathname]) {
+          const bytes = bundles[parsed.pathname];
+          // The real server picks the content type by sniffing the magic.
+          res.writeHead(200, {
+            "Content-Type":
+              bytes.subarray(0, 5).toString("ascii") === "NSEB1"
+                ? "application/octet-stream"
+                : "application/zip",
+          });
+          res.end(bytes);
+        } else if (
+          parsed.pathname === "/agent/v1/state-report" ||
+          parsed.pathname === "/agent/v1/renew"
+        ) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end("{}");
+        } else {
+          res.writeHead(404);
+          res.end("not found");
+        }
+      });
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    baseUrl = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterAll(async () => {
+    await nscp.stop();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  async function waitFor(
+    what: string,
+    predicate: () => boolean,
+    timeoutMs = 45_000,
+  ): Promise<void> {
+    const started = Date.now();
+    while (!predicate()) {
+      if (Date.now() - started > timeoutMs) throw new Error(`Timed out waiting for ${what}`);
+      await new Promise((r) => setTimeout(r, 150));
+    }
+  }
+  const stateReports = () => requests.filter((r) => r.url.startsWith("/agent/v1/state-report"));
+  const reportWithError = (needle: string) =>
+    stateReports().find(
+      (r) => Array.isArray(r.body?.errors) && r.body.errors.some((e: string) => e.includes(needle)),
+    );
+
+  it("stores the bundle key given at enrollment in the manifest, not the settings", async () => {
+    const r = await nscp.run(
+      [
+        "enroll",
+        "--server",
+        baseUrl,
+        "--token",
+        "tok-fleet",
+        "--insecure",
+        "--bundle-key",
+        bundleKey.toString("base64"),
+      ],
+      { allowFailure: true },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.all ?? r.stdout).toContain(`fingerprint ${fingerprintOf(bundleKey)}`);
+    const state = JSON.parse(
+      fs.readFileSync(path.join(workDir, "security", "agent-state.json"), "utf8"),
+    );
+    expect(state.bundle_keys).toEqual([bundleKey.toString("base64")]);
+    expect(fs.readFileSync(nscp.settingsFile, "utf8")).not.toContain(bundleKey.toString("base64"));
+  });
+
+  it("opens a sealed bundle and applies it, caching only the envelope", async () => {
+    nscp.start();
+    await waitFor("state report with the sealed hash", () =>
+      stateReports().some((r) => r.body?.applied_state_hash === "h-sealed"),
+    );
+    const report = stateReports().find((r) => r.body?.applied_state_hash === "h-sealed")!;
+    expect(report.body.errors).toEqual([]);
+    expect(report.body.bundles_installed).toEqual([{ id: "b-sealed", version: "1.0" }]);
+
+    const fleetIni = fs.readFileSync(path.join(workDir, "fleet", "fleet.ini"), "utf8");
+    expect(fleetIni).toContain("CheckHelpers=enabled");
+    expect(fleetIni).toContain("api token=hunter2-sealed-value");
+    expect(
+      fs.readFileSync(path.join(workDir, "fleet", "scripts", "sealed", "secret.txt"), "utf8"),
+    ).toContain("sealed script body");
+
+    // The cache holds what the signature covers: the envelope, not the zip.
+    const cached = fs.readFileSync(
+      path.join(workDir, "fleet", "cache", `b-sealed-${sha(sealedGood).substring(0, 16)}.zip`),
+    );
+    expect(cached.equals(sealedGood)).toBe(true);
+    expect(cached.includes("hunter2-sealed-value")).toBe(false);
+    // And the unsealed copy used for extraction is gone again.
+    const staging = path.join(workDir, "fleet", "staging");
+    if (fs.existsSync(staging)) {
+      expect(fs.readdirSync(staging).filter((f) => f.endsWith(".unsealed.zip"))).toEqual([]);
+    }
+  });
+
+  it("refuses the same envelope served under another version", async () => {
+    phase = "relabelled";
+    await waitFor(
+      "a report rejecting the relabelled bundle",
+      () => reportWithError("b-relabelled") !== undefined,
+    );
+    const report = reportWithError("b-relabelled")!;
+    // A failed apply reports no applied hash at all (the field is omitted).
+    expect(report.body.applied_state_hash ?? null).toBeNull();
+    expect(report.body.errors.join(" ")).toMatch(/authentication failed/);
+    // The previously applied configuration is untouched.
+    expect(fs.readFileSync(path.join(workDir, "fleet", "fleet.ini"), "utf8")).toContain(
+      "api token=hunter2-sealed-value",
+    );
+  });
+
+  it("names the missing key's fingerprint when it holds no matching key", async () => {
+    phase = "foreign";
+    await waitFor(
+      "a report rejecting the foreign bundle",
+      () => reportWithError("b-foreign") !== undefined,
+    );
+    const errors = reportWithError("b-foreign")!.body.errors.join(" ");
+    expect(errors).toContain(fingerprintOf(otherKey));
+    expect(errors).not.toContain(bundleKey.toString("base64"));
+    expect(errors).not.toContain(otherKey.toString("base64"));
+  });
+
+  it("still applies plain bundles unless encrypted ones are required", async () => {
+    phase = "plain";
+    await waitFor("the plain bundle applied", () =>
+      stateReports().some((r) => r.body?.applied_state_hash === "h-plain"),
+    );
+
+    await nscp.stop();
+    await nscp.configure({ "/settings/fleet": { "require encrypted bundles": "true" } });
+    requests = [];
+    phase = "plain-required";
+    nscp.start();
+    await waitFor(
+      "a report refusing the plain bundle",
+      () => reportWithError("b-plain") !== undefined,
+    );
+    expect(reportWithError("b-plain")!.body.errors.join(" ")).toMatch(/requires encrypted bundles/);
+    expect(stateReports().some((r) => r.body?.applied_state_hash === "h-plain-required")).toBe(
+      false,
+    );
+  });
+});

--- a/tests/fleet-sync-encrypted.test.ts
+++ b/tests/fleet-sync-encrypted.test.ts
@@ -14,7 +14,7 @@
  * Under test: a sealed bundle is opened and applied when the host holds the
  * key; the plaintext never lands in the cache (only the envelope does); a
  * bundle served under another name is refused, as is one sealed with a key
- * this host does not hold; `require encrypted bundles` refuses a plain one.
+ * this host does not hold; `--require-encrypted-bundles` refuses a plain one.
  * The envelope is built with node's own AES-GCM, an implementation
  * independent of the agent's.
  */
@@ -309,7 +309,14 @@ describe("encrypted fleet bundles", () => {
     );
 
     await nscp.stop();
-    await nscp.configure({ "/settings/fleet": { "require encrypted bundles": "true" } });
+    // The requirement lives in the manifest with the keys, not in a setting
+    // the fleet-managed include could reach.
+    const r = await nscp.run(
+      ["enroll", "--update-bundle-keys", "--bundle-key", bundleKey.toString("base64"), "--require-encrypted-bundles"],
+      { allowFailure: true },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(fs.readFileSync(nscp.settingsFile, "utf8")).not.toMatch(/require encrypted/);
     requests = [];
     phase = "plain-required";
     nscp.start();


### PR DESCRIPTION
## Summary

Started from a crash: `nscp test` died with an access violation right after a fleet server pushed configuration. The fix is here, and so is the fleet-side work that came up around it.

- **Fix: `nscp test` prompt survived neither a fleet push nor a `reload`.** A settings reload re-enters `CommandClient::loadModuleEx` on the live module, which replaced the `cli_client` the prompt's completion hooks held a raw pointer to. The next vocabulary refresh dereferenced freed memory. The client is now created once and the hooks resolve it through the module. The crash writer also names the faulting module now instead of printing a `wchar_t*` as a pointer.
- **Fix: `settings` at the prompt lists only what is configured**, by walking the settings store instead of the registry, and **masks keys their module registered as sensitive** (`***`), the same way REST and `nscp settings --list` do.
- **Feature: encrypted fleet bundles.** The agent opens the fleet server's `enc-v1` envelope (`NSEB1` | fingerprint | nonce | AES-256-GCM, with `name || 0x00 || version` as additional data). The key never comes from the server: `nscp enroll --bundle-key` (repeatable, `--update-bundle-keys` to rotate) and the `FLEET_BUNDLE_KEY` MSI property store it in the enrollment manifest. It is deliberately not a setting, since the fleet-managed include is part of the settings store and a compromised server could plant a key there. `nscp enroll --require-encrypted-bundles` (or `FLEET_REQUIRE_ENCRYPTED_BUNDLES=1`) refuses anything unsealed; it lives in the manifest too, so the server cannot switch it off.
- **Feature: `nscp enroll --unenroll`** removes the include, the manifest (identity and keys) and the fleet directory, reporting each step.

## Verification

- Decryption is pinned against the server's fixed key with a vector produced by node's AES-GCM; the integration suite seals bundles the same way. 38 new gtest cases, 159 in the onboarding binary.
- New integration suites/cases: `fleet-sync-encrypted.test.ts` (apply, ciphertext-only cache, relabelled version refused, missing key named by fingerprint, strict mode), enroll CLI (`--bundle-key` storing/ordering/rejecting/rotating, `--unenroll`), console (`settings` filtering and masking, reload survival). All fleet, enroll and console suites pass locally on Windows.
- The installer helper is a separate CMake project needing static-runtime Boost, absent locally; its source was compiled with `cl /Zs` and is clean. CI builds it for real.

## Docs

New "Encrypted bundles" and "Leaving the fleet" sections in the fleet guide, `FLEET_BUNDLE_KEY` in both MSI property tables, and two unreleased upgrade notes.

## Follow-ups not done

Downgrade refusal (remember the last applied version per bundle name) as the server docs suggest; showing key-fingerprint mismatches in the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSRHcYn26ukbUEjkaVpNDq


